### PR TITLE
Force la version de node à 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:16
 
 RUN npm install -g npm
 


### PR DESCRIPTION
Problème de compatibilité entre Sqlite3 et node 17.
(note : dans une modification future, retirer Sqlite3 car non utilisé)