### PR TITLE
Import pdf

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const DepotDonnees = require('./src/depotDonnees');
 const Middleware = require('./src/middleware');
 const MSS = require('./src/mss');
 const Referentiel = require('./src/referentiel');
+const adaptateurChiffrement = require('./src/adaptateurs/adaptateurChiffrement');
 const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
 const adaptateurMail = require('./src/adaptateurs/adaptateurMail');
 const AdaptateurPostgres = require('./src/adaptateurs/adaptateurPostgres');
@@ -15,6 +16,7 @@ const depotDonnees = DepotDonnees.creeDepot({
   adaptateurJWT, adaptateurPersistance, adaptateurUUID, referentiel,
 });
 const middleware = Middleware({
+  adaptateurChiffrement,
   adaptateurJWT,
   depotDonnees,
   login: process.env.LOGIN_ADMIN,

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,0 +1,7 @@
+const bcrypt = require('bcrypt');
+
+const chaineChiffree = (chaineEnClair) => bcrypt.hash(chaineEnClair, 10);
+const nonce = () => chaineChiffree(`${Math.random()}`)
+  .then((s) => s.replace(/[/$.]/g, ''));
+
+module.exports = { nonce };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -12,6 +12,17 @@ const middleware = (configuration = {}) => {
     unauthorizedResponse: () => pug.renderFile('src/vues/accesRefuse.pug'),
   });
 
+  const positionneHeaders = (requete, reponse, suite) => {
+    reponse.set({
+      'content-security-policy': "default-src 'self'; script-src 'self' unpkg.com code.jquery.com",
+      'x-frame-options': 'deny',
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'no-referrer',
+    });
+
+    suite();
+  };
+
   const repousseExpirationCookie = (requete, reponse, suite) => {
     requete.session.maintenant = Math.floor(Date.now() / 60_000);
     suite();
@@ -74,6 +85,7 @@ const middleware = (configuration = {}) => {
   return {
     aseptise,
     authentificationBasique,
+    positionneHeaders,
     repousseExpirationCookie,
     suppressionCookie,
     trouveHomologation,

--- a/src/mss.js
+++ b/src/mss.js
@@ -38,16 +38,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     secure: avecCookieSecurise,
   }));
 
-  app.use((requete, reponse, suite) => {
-    reponse.set({
-      'content-security-policy': "default-src 'self'; script-src 'self' unpkg.com code.jquery.com",
-      'x-frame-options': 'deny',
-      'x-content-type-options': 'nosniff',
-      'referrer-policy': 'no-referrer',
-    });
-    suite();
-  });
-
+  app.use(middleware.positionneHeaders);
   app.use(middleware.repousseExpirationCookie);
 
   app.disable('x-powered-by');

--- a/src/mss.js
+++ b/src/mss.js
@@ -156,10 +156,13 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
       reponse.render('homologation/caracteristiquesComplementaires', { referentiel, homologation });
     });
 
-  app.get('/homologation/:id/decision', middleware.trouveHomologation, (requete, reponse) => {
-    const { homologation } = requete;
-    reponse.render('homologation/decision', { homologation, referentiel });
-  });
+  app.get('/homologation/:id/decision',
+    middleware.trouveHomologation,
+    middleware.positionneHeadersAvecNonce,
+    (requete, reponse) => {
+      const { homologation, nonce } = requete;
+      reponse.render('homologation/decision', { homologation, referentiel, nonce });
+    });
 
   app.get('/homologation/:id/edition', middleware.trouveHomologation, (requete, reponse) => {
     const { homologation } = requete;

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -27,10 +27,10 @@ mixin mesuresPaginees({ titreAnnexe, titreSection, donnees })
 
 doctype html
 meta(charset='utf-8')
-script(src='https://code.jquery.com/jquery-3.6.0.min.js')
-script(src='https://unpkg.com/dompurify/dist/purify.min.js')
-script(src='https://unpkg.com/html2canvas/dist/html2canvas.min.js')
-script(src='https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js')
+script(nonce = nonce, src='https://code.jquery.com/jquery-3.6.0.min.js')
+script(nonce = nonce, src='https://unpkg.com/dompurify/dist/purify.min.js')
+script(nonce = nonce, src='https://unpkg.com/html2canvas/dist/html2canvas.min.js')
+script(nonce = nonce, src='https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js')
 
 include ../fragments/diagnostics
 
@@ -107,9 +107,13 @@ nav.ne-pas-imprimer
           li
             .nombre-mesures= `${statistiquesMesures.retenues(idCategorie)} mesures de`
             .type-mesure= referentiel.descriptionCategorie(idCategorie)
+            style(nonce = nonce).
+              #!{idCategorie} .barre-mesures-misesEnOeuvre {
+                !{style}
+              }
             .barre(id = idCategorie)
               .barre-mesures-retenues
-              .barre-mesures-misesEnOeuvre(style = style)
+              .barre-mesures-misesEnOeuvre
 
 .page
   main

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -89,16 +89,11 @@ describe('Le serveur MSS', () => {
     }, ...params);
   };
 
-  const verifieValeurHeader = (valeurHeader, regExpValeurAttendue, suite) => {
-    expect(valeurHeader).to.match(regExpValeurAttendue);
+  const verifieJetonDepose = (reponse, suite) => {
+    const valeurHeader = reponse.headers['set-cookie'][0];
+    expect(valeurHeader).to.match(/^token=.+; path=\/; expires=.+; samesite=strict; httponly$/);
     suite();
   };
-
-  const verifieJetonDepose = (reponse, suite) => verifieValeurHeader(
-    reponse.headers['set-cookie'][0],
-    /^token=.+; path=\/; expires=.+; samesite=strict; httponly$/,
-    suite
-  );
 
   const middleware = {
     aseptise: (...nomsParametres) => (requete, reponse, suite) => {

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -47,11 +47,16 @@ describe('Le serveur MSS', () => {
   let expirationCookieRepoussee;
   let idUtilisateurCourant;
   let headersPositionnes;
+  let headersAvecNoncePositionnes;
   let parametresAseptises;
   let rechercheHomologationEffectuee;
   let suppressionCookieEffectuee;
   let verificationJWTMenee;
   let verificationCGUMenee;
+
+  const verifieRequetePositionneHeadersAvecNonce = (...params) => {
+    verifieRequeteChangeEtat({ lectureEtat: () => headersAvecNoncePositionnes }, ...params);
+  };
 
   const verifieRequeteExigeSuppressionCookie = (...params) => {
     verifieRequeteChangeEtat({ lectureEtat: () => suppressionCookieEffectuee }, ...params);
@@ -111,6 +116,11 @@ describe('Le serveur MSS', () => {
       suite();
     },
 
+    positionneHeadersAvecNonce: (requete, reponse, suite) => {
+      headersAvecNoncePositionnes = true;
+      suite();
+    },
+
     repousseExpirationCookie: (requete, reponse, suite) => {
       expirationCookieRepoussee = true;
       suite();
@@ -150,6 +160,7 @@ describe('Le serveur MSS', () => {
     expirationCookieRepoussee = false;
     headersPositionnes = false;
     idUtilisateurCourant = undefined;
+    headersAvecNoncePositionnes = false;
     parametresAseptises = [];
     rechercheHomologationEffectuee = false;
     suppressionCookieEffectuee = false;
@@ -310,6 +321,10 @@ describe('Le serveur MSS', () => {
   describe('quand requête GET sur `/homologation/:id/decision`', () => {
     it("recherche l'homologation correspondante", (done) => {
       verifieRechercheHomologation('http://localhost:1234/homologation/456/decision', done);
+    });
+
+    it('sert la page avec un nonce', (done) => {
+      verifieRequetePositionneHeadersAvecNonce('http://localhost:1234/homologation/456/decision', done);
     });
   });
 


### PR DESCRIPTION
[CORRECTION] Affiche correctement  barres de statistiques mesures

Le header Content-Security-Policy forçait la directive `style-src` à `'self'` (héritée de `default-src`), ce qui empêchait la prise en compte du style créé à la volée pour les barres de statistiques. L'utilisation d'un nonce permet de régler ce problème.

⚠️  LIMITATION : pour une raison inconnue, la génération du PDF sous Firefox continue de ne pas prendre en compte le style créé à la volée. Cela fonctionne correctement avec Safari et Chrome. L'ajout d'une directive `script-src 'strict-dynamic'` ne semble pas aider. [Un ticket d'incident a été ouvert](https://github.com/niklasvh/html2canvas/issues/2760).