### PR TITLE
Renommer nature du service en type de service dans la page informations générales

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -4,10 +4,10 @@ const expiration = (duree) => `${duree.charAt(0).toUpperCase()}${duree.slice(1)}
 module.exports = {
   seuilsCriticites: ['critique', 'eleve', 'moyen', 'faible'],
 
-  naturesService: {
+  typesService: {
     siteInternet: { description: 'Site Internet' },
     applicationMobile: { description: 'Application Mobile' },
-    api: { description: 'API' },
+    api: { description: "API mise à disposition par l'organisation" },
   },
 
   provenancesService: {

--- a/jeuDonnees.js
+++ b/jeuDonnees.js
@@ -21,7 +21,7 @@ module.exports = {
     {
       id: '123',
       idUtilisateur: '456',
-      informationsGenerales: { nomService: 'Super Service', natureService: ['api'] },
+      informationsGenerales: { nomService: 'Super Service', typeService: ['api'] },
       mesures: [
         // gouvernance
         { id: 'limitationInterconnexions', statut: 'fait' },
@@ -45,7 +45,7 @@ module.exports = {
     {
       id: '789',
       idUtilisateur: '999',
-      informationsGenerales: { nomService: 'Un autre service', natureService: ['siteInternet'] },
+      informationsGenerales: { nomService: 'Un autre service', typeService: ['siteInternet'] },
     },
   ],
 };

--- a/migrations/20211209094517_renommageColonneNatureService.js
+++ b/migrations/20211209094517_renommageColonneNatureService.js
@@ -1,0 +1,28 @@
+function miseAJourInformationsGenerales(modifie) {
+  return (knex) => knex('homologations')
+    .then((lignes) => {
+      const misesAJour = lignes
+        .filter(({ donnees }) => donnees.informationsGenerales)
+        .map(({ id, donnees: { informationsGenerales, ...autresDonnees } }) => {
+          modifie(informationsGenerales);
+          return knex('homologations')
+            .where({ id })
+            .update({ donnees: { informationsGenerales, ...autresDonnees } });
+        });
+      return Promise.all(misesAJour);
+    });
+}
+
+function changeNatureServiceEnTypeService(informationsGenerales) {
+  informationsGenerales.typeService = informationsGenerales.natureService;
+  delete informationsGenerales.natureService;
+}
+
+function changeTypeServiceEnNatureService(informationsGenerales) {
+  informationsGenerales.natureService = informationsGenerales.typeService;
+  delete informationsGenerales.typeService;
+}
+
+exports.up = miseAJourInformationsGenerales(changeNatureServiceEnTypeService);
+
+exports.down = miseAJourInformationsGenerales(changeTypeServiceEnNatureService);

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -61,7 +61,7 @@ class Homologation {
     return this.avisExpertCyber.descriptionExpiration();
   }
 
-  descriptionNatureService() { return this.informationsGenerales.descriptionNatureService(); }
+  descriptionTypeService() { return this.informationsGenerales.descriptionTypeService(); }
 
   descriptionStatutsMesures() {
     return Mesure.statutsPossibles().reduce((acc, s) => {

--- a/src/modeles/informationsGenerales.js
+++ b/src/modeles/informationsGenerales.js
@@ -12,7 +12,7 @@ class InformationsGenerales extends InformationsHomologation {
     ], [
       'donneesCaracterePersonnel',
       'fonctionnalites',
-      'natureService',
+      'typeService',
       'provenanceService',
     ], {
       pointsAcces: PointsAcces,
@@ -22,8 +22,8 @@ class InformationsGenerales extends InformationsHomologation {
     this.referentiel = referentiel;
   }
 
-  descriptionNatureService() {
-    return this.referentiel.natureService(this.natureService);
+  descriptionTypeService() {
+    return this.referentiel.typeService(this.typeService);
   }
 
   nombrePointsAcces() {

--- a/src/mss.js
+++ b/src/mss.js
@@ -213,7 +213,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     (requete, reponse, suite) => {
       const {
         nomService,
-        natureService,
+        typeService,
         provenanceService,
         dejaMisEnLigne,
         fonctionnalites,
@@ -225,7 +225,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
 
       depotDonnees.nouvelleHomologation(requete.idUtilisateurCourant, {
         nomService,
-        natureService,
+        typeService,
         provenanceService,
         dejaMisEnLigne,
         fonctionnalites,

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -14,7 +14,7 @@ const creeReferentiel = (donneesReferentiel) => {
   const mesureIndispensable = (idMesure) => !!donnees.mesures[idMesure].indispensable;
   const mesures = () => donnees.mesures;
   const identifiantsMesures = () => Object.keys(mesures());
-  const naturesService = () => donnees.naturesService;
+  const typesService = () => donnees.typesService;
   const provenancesService = () => donnees.provenancesService;
   const risques = () => donnees.risques;
   const identifiantsRisques = () => Object.keys(donnees.risques);
@@ -34,9 +34,9 @@ const creeReferentiel = (donneesReferentiel) => {
   };
 
   const natureService = (identifiants) => {
-    if (identifiants.length === 0) return 'Nature du service non renseignée';
+    if (identifiants.length === 0) return 'Type de service non renseignée';
     return identifiants
-      .map((identifiant) => naturesService()[identifiant].description)
+      .map((identifiant) => typesService()[identifiant].description)
       .join(', ');
   };
 
@@ -100,7 +100,7 @@ const creeReferentiel = (donneesReferentiel) => {
     mesureIndispensable,
     mesures,
     natureService,
-    naturesService,
+    typesService,
     provenancesService,
     recharge,
     risques,
@@ -119,7 +119,7 @@ const creeReferentielVide = () => creeReferentiel({
   localisationsDonnees: {},
   mesures: {},
   risques: {},
-  naturesService: {},
+  typesService: {},
   provenancesService: {},
   seuilsCriticites: [],
   statutsMesures: {},

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -33,7 +33,7 @@ const creeReferentiel = (donneesReferentiel) => {
     return localisationsDonnees()[identifiant].description;
   };
 
-  const natureService = (identifiants) => {
+  const typeService = (identifiants) => {
     if (identifiants.length === 0) return 'Type de service non renseignée';
     return identifiants
       .map((identifiant) => typesService()[identifiant].description)
@@ -99,7 +99,7 @@ const creeReferentiel = (donneesReferentiel) => {
     localisationsDonnees,
     mesureIndispensable,
     mesures,
-    natureService,
+    typeService,
     typesService,
     provenancesService,
     recharge,

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -23,8 +23,8 @@ mixin formulaireInformationsGenerales(idHomologation)
       +inputChoix({
         type: 'checkbox',
         nom: 'natureService',
-        titre: 'Quelle est la nature du service numérique ?',
-        items: referentiel.naturesService(),
+        titre: 'Type de service numérique',
+        items: referentiel.typesService(),
         objetDonnees: homologation.informationsGenerales,
       })
 

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -22,7 +22,7 @@ mixin formulaireInformationsGenerales(idHomologation)
 
       +inputChoix({
         type: 'checkbox',
-        nom: 'natureService',
+        nom: 'typeService',
         titre: 'Type de service numérique',
         items: referentiel.typesService(),
         objetDonnees: homologation.informationsGenerales,

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -70,7 +70,7 @@ nav.ne-pas-imprimer
       h2!= homologation.nomService()
       dl
         dt Type :
-        dd= homologation.descriptionNatureService()
+        dd= homologation.descriptionTypeService()
         dt Objet :
         dd= homologation.presentation()
         dt Développé par :

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -24,25 +24,25 @@ describe('Une homologation', () => {
     });
   });
 
-  it('sait décrire la nature du service', () => {
+  it('sait décrire le type service', () => {
     const referentiel = Referentiel.creeReferentiel({
       typesService: {
-        uneNature: { description: 'Une nature' },
-        uneAutre: { description: 'Une autre' },
+        unType: { description: 'Un type' },
+        unAutre: { description: 'Un autre' },
       },
     });
     const homologation = new Homologation({
       id: '123',
       idUtilisateur: '456',
-      informationsGenerales: { nomService: 'nom', natureService: ['uneNature', 'uneAutre'] },
+      informationsGenerales: { nomService: 'nom', typeService: ['unType', 'unAutre'] },
     }, referentiel);
 
-    expect(homologation.descriptionNatureService()).to.equal('Une nature, Une autre');
+    expect(homologation.descriptionTypeService()).to.equal('Un type, Un autre');
   });
 
-  it("se comporte correctement si la nature du service n'est pas présente", () => {
+  it("se comporte correctement si le type service n'est pas présente", () => {
     const homologation = new Homologation({ id: '123' });
-    expect(homologation.descriptionNatureService()).to.equal('Type de service non renseignée');
+    expect(homologation.descriptionTypeService()).to.equal('Type de service non renseignée');
   });
 
   it('connaît ses caractéristiques complémentaires', () => {

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -26,7 +26,7 @@ describe('Une homologation', () => {
 
   it('sait décrire la nature du service', () => {
     const referentiel = Referentiel.creeReferentiel({
-      naturesService: {
+      typesService: {
         uneNature: { description: 'Une nature' },
         uneAutre: { description: 'Une autre' },
       },
@@ -42,7 +42,7 @@ describe('Une homologation', () => {
 
   it("se comporte correctement si la nature du service n'est pas présente", () => {
     const homologation = new Homologation({ id: '123' });
-    expect(homologation.descriptionNatureService()).to.equal('Nature du service non renseignée');
+    expect(homologation.descriptionNatureService()).to.equal('Type de service non renseignée');
   });
 
   it('connaît ses caractéristiques complémentaires', () => {

--- a/test/modeles/informationsGenerales.spec.js
+++ b/test/modeles/informationsGenerales.spec.js
@@ -13,7 +13,7 @@ describe('Les informations générales', () => {
       delaiAvantImpactCritique: 'unDelai',
       donneesCaracterePersonnel: ['desDonnees'],
       fonctionnalites: ['uneFonctionnalite'],
-      natureService: ['uneNature'],
+      typeService: ['unType'],
       nomService: 'Super Service',
       pointsAcces: [{ description: 'Une description' }],
       presenceResponsable: 'non',
@@ -24,7 +24,7 @@ describe('Les informations générales', () => {
     expect(infos.delaiAvantImpactCritique).to.equal('unDelai');
     expect(infos.donneesCaracterePersonnel).to.eql(['desDonnees']);
     expect(infos.fonctionnalites).to.eql(['uneFonctionnalite']);
-    expect(infos.natureService).to.eql(['uneNature']);
+    expect(infos.typeService).to.eql(['unType']);
     expect(infos.nomService).to.equal('Super Service');
     expect(infos.presenceResponsable).to.be('non');
     expect(infos.provenanceService).to.eql(['uneProvenance']);
@@ -32,23 +32,23 @@ describe('Les informations générales', () => {
     expect(infos.nombrePointsAcces()).to.equal(1);
   });
 
-  elles('décrivent la nature du service', () => {
+  elles('décrivent le type service', () => {
     const referentiel = Referentiel.creeReferentiel({
       typesService: {
-        uneNature: { description: 'Une nature' },
-        uneAutre: { description: 'Une autre' },
+        unType: { description: 'Un type' },
+        unAutre: { description: 'Un autre' },
       },
     });
     const infos = new InformationsGenerales({
-      nomService: 'nom', natureService: ['uneNature', 'uneAutre'],
+      nomService: 'nom', typeService: ['unType', 'unAutre'],
     }, referentiel);
 
-    expect(infos.descriptionNatureService()).to.equal('Une nature, Une autre');
+    expect(infos.descriptionTypeService()).to.equal('Un type, Un autre');
   });
 
-  elles("se comportent correctement si la nature du service n'est pas présente", () => {
+  elles("se comportent correctement si le type de service n'est pas présent", () => {
     const infos = new InformationsGenerales();
-    expect(infos.descriptionNatureService()).to.equal('Type de service non renseignée');
+    expect(infos.descriptionTypeService()).to.equal('Type de service non renseignée');
   });
 
   elles("détectent qu'elles sont encore à saisir", () => {

--- a/test/modeles/informationsGenerales.spec.js
+++ b/test/modeles/informationsGenerales.spec.js
@@ -34,7 +34,7 @@ describe('Les informations générales', () => {
 
   elles('décrivent la nature du service', () => {
     const referentiel = Referentiel.creeReferentiel({
-      naturesService: {
+      typesService: {
         uneNature: { description: 'Une nature' },
         uneAutre: { description: 'Une autre' },
       },
@@ -48,7 +48,7 @@ describe('Les informations générales', () => {
 
   elles("se comportent correctement si la nature du service n'est pas présente", () => {
     const infos = new InformationsGenerales();
-    expect(infos.descriptionNatureService()).to.equal('Nature du service non renseignée');
+    expect(infos.descriptionNatureService()).to.equal('Type de service non renseignée');
   });
 
   elles("détectent qu'elles sont encore à saisir", () => {

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -456,7 +456,7 @@ describe('Le serveur MSS', () => {
         expect(idUtilisateur).to.equal('123');
         expect(donneesHomologation).to.eql({
           nomService: 'Super Service',
-          natureService: undefined,
+          typeService: undefined,
           provenanceService: undefined,
           dejaMisEnLigne: undefined,
           fonctionnalites: undefined,

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -3,26 +3,26 @@ const expect = require('expect.js');
 const Referentiel = require('../src/referentiel');
 
 describe('Le référentiel', () => {
-  it("sait décrire la nature du service à partir d'identifiants", () => {
+  it("sait décrire le type de service à partir d'identifiants", () => {
     const referentiel = Referentiel.creeReferentiel({
       typesService: { siteInternet: { description: 'Site internet' } },
     });
-    expect(referentiel.natureService(['siteInternet'])).to.equal('Site internet');
+    expect(referentiel.typeService(['siteInternet'])).to.equal('Site internet');
   });
 
-  it('sait décrire la nature du service à partir de plusieurs identifiants', () => {
+  it('sait décrire le type de service à partir de plusieurs identifiants', () => {
     const referentiel = Referentiel.creeReferentiel({
       typesService: {
         siteInternet: { description: 'Site internet' },
         api: { description: "API mise à disposition par l'organisation" },
       },
     });
-    expect(referentiel.natureService(['siteInternet', 'api'])).to.equal("Site internet, API mise à disposition par l'organisation");
+    expect(referentiel.typeService(['siteInternet', 'api'])).to.equal("Site internet, API mise à disposition par l'organisation");
   });
 
-  it('donne une description par défaut si aucun identifiant de nature service', () => {
+  it('donne une description par défaut si aucun identifiant de type de service', () => {
     const referentiel = Referentiel.creeReferentielVide();
-    expect(referentiel.natureService([])).to.equal('Type de service non renseignée');
+    expect(referentiel.typeService([])).to.equal('Type de service non renseignée');
   });
 
   it('sait décrire la localisation des données', () => {
@@ -38,7 +38,7 @@ describe('Le référentiel', () => {
     expect(referentiel.localisationDonnees()).to.equal('Localisation des données non renseignée');
   });
 
-  it('connaît la liste des différentes natures de service possibles', () => {
+  it('connaît la liste des différents types de service possibles', () => {
     const referentiel = Referentiel.creeReferentiel({ typesService: { uneClef: 'une valeur' } });
     expect(referentiel.typesService()).to.eql({ uneClef: 'une valeur' });
   });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -5,24 +5,24 @@ const Referentiel = require('../src/referentiel');
 describe('Le référentiel', () => {
   it("sait décrire la nature du service à partir d'identifiants", () => {
     const referentiel = Referentiel.creeReferentiel({
-      naturesService: { siteInternet: { description: 'Site internet' } },
+      typesService: { siteInternet: { description: 'Site internet' } },
     });
     expect(referentiel.natureService(['siteInternet'])).to.equal('Site internet');
   });
 
   it('sait décrire la nature du service à partir de plusieurs identifiants', () => {
     const referentiel = Referentiel.creeReferentiel({
-      naturesService: {
+      typesService: {
         siteInternet: { description: 'Site internet' },
-        api: { description: 'API' },
+        api: { description: "API mise à disposition par l'organisation" },
       },
     });
-    expect(referentiel.natureService(['siteInternet', 'api'])).to.equal('Site internet, API');
+    expect(referentiel.natureService(['siteInternet', 'api'])).to.equal("Site internet, API mise à disposition par l'organisation");
   });
 
   it('donne une description par défaut si aucun identifiant de nature service', () => {
     const referentiel = Referentiel.creeReferentielVide();
-    expect(referentiel.natureService([])).to.equal('Nature du service non renseignée');
+    expect(referentiel.natureService([])).to.equal('Type de service non renseignée');
   });
 
   it('sait décrire la localisation des données', () => {
@@ -39,8 +39,8 @@ describe('Le référentiel', () => {
   });
 
   it('connaît la liste des différentes natures de service possibles', () => {
-    const referentiel = Referentiel.creeReferentiel({ naturesService: { uneClef: 'une valeur' } });
-    expect(referentiel.naturesService()).to.eql({ uneClef: 'une valeur' });
+    const referentiel = Referentiel.creeReferentiel({ typesService: { uneClef: 'une valeur' } });
+    expect(referentiel.typesService()).to.eql({ uneClef: 'une valeur' });
   });
 
   it('connaît la liste des différentes provenances de service possibles', () => {
@@ -264,12 +264,12 @@ describe('Le référentiel', () => {
 
   it('peut être construit sans donnée', () => {
     const referentiel = Referentiel.creeReferentielVide();
-    expect(referentiel.naturesService()).to.eql({});
+    expect(referentiel.typesService()).to.eql({});
   });
 
   it("peut être rechargé avec d'autres données", () => {
     const referentiel = Referentiel.creeReferentielVide();
-    referentiel.recharge({ naturesService: { uneClef: 'une valeur' } });
-    expect(referentiel.naturesService()).to.eql({ uneClef: 'une valeur' });
+    referentiel.recharge({ typesService: { uneClef: 'une valeur' } });
+    expect(referentiel.typesService()).to.eql({ uneClef: 'une valeur' });
   });
 });


### PR DESCRIPTION
Dans la page informations générales, la question _Quelle est la nature du service numérique_ devient _Type de service numérique_
![image](https://user-images.githubusercontent.com/39462397/144626028-1e132061-6433-4fc4-975d-741664ec9d89.png)
~~Je n'ai pas changé volontairement les types persistés~~