### PR TITLE
Renommer le choix des principales fonctionnalités de service

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -42,6 +42,10 @@ module.exports = {
       description: 'Paiement en ligne',
       seuilCriticite: 'eleve',
     },
+    signatureElectronique: {
+      description: 'Dispositif de signature électronique',
+      seuilCriticite: 'eleve',
+    },
     compte: {
       description: 'Création de compte (utilisateurs avec comptes)',
       seuilCriticite: 'faible',

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -26,25 +26,9 @@ module.exports = {
       description: 'Inscription à une newsletter',
       seuilCriticite: 'faible',
     },
-    compte: {
-      description: 'Création de compte (utilisateurs avec comptes)',
-      seuilCriticite: 'faible',
-    },
-    formulaire: {
-      description: 'Formulaire administratif ou démarche en ligne',
-      seuilCriticite: 'faible',
-    },
     questionnaire: {
       description: 'Questionnaires, sondages',
       seuilCriticite: 'faible',
-    },
-    reservation: {
-      description: 'Outils de réservation (livres, places, salles, etc.)',
-      seuilCriticite: 'faible',
-    },
-    paiement: {
-      description: 'Paiement en ligne, conservation de données bancaires',
-      seuilCriticite: 'eleve',
     },
     reseauSocial: {
       description: 'Réseau social, forum, commentaires',
@@ -53,6 +37,14 @@ module.exports = {
     visionconference: {
       description: 'Audio, visioconférence',
       seuilCriticite: 'moyen',
+    },
+    paiement: {
+      description: 'Paiement en ligne',
+      seuilCriticite: 'eleve',
+    },
+    compte: {
+      description: 'Création de compte (utilisateurs avec comptes)',
+      seuilCriticite: 'faible',
     },
     messagerie: {
       description: 'Messagerie instantanée',
@@ -66,9 +58,17 @@ module.exports = {
       description: 'Stockage de documents',
       seuilCriticite: 'moyen',
     },
+    formulaire: {
+      description: 'Formulaire administratif ou démarche en ligne',
+      seuilCriticite: 'faible',
+    },
     edition: {
       description: 'Édition collaborative (documents, murs collaboratifs, etc.)',
       seuilCriticite: 'moyen',
+    },
+    reservation: {
+      description: 'Outils de réservation (livres, places, salles, etc.)',
+      seuilCriticite: 'faible',
     },
     autre: {
       description: 'Autres fonctionnalités permettant des échanges de données',

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -46,7 +46,7 @@ mixin formulaireInformationsGenerales(idHomologation)
       +inputChoix({
         type: 'checkbox',
         nom: 'fonctionnalites',
-        titre: 'Le service numérique inclut-il une ou plusieurs des fonctionnalités suivantes ?',
+        titre: 'Principales fonctionnalités offertes par le service numérique',
         items: referentiel.fonctionnalites(),
         objetDonnees: homologation.informationsGenerales,
       })


### PR DESCRIPTION
- Renommer le titre du block
- Renommer les choix selon les nouveaux textes
- Ajouter Signature électronique qui n'est pas présent

J'ai laissé intentionnellement _Autres fonctionnalités permettant des échanges de données_ car la possibilité d'ajout manuellement n'est pas encore là

Le seuil critique de Signature électronique reste à définir