### PR TITLE
Déplacement de la présentation du service dans les propriétés d'informations générales

### DIFF
--- a/migrations/20211206151020_copieColonnePresentationDansInformationsGenerales.js
+++ b/migrations/20211206151020_copieColonnePresentationDansInformationsGenerales.js
@@ -1,0 +1,34 @@
+const miseAJour = (contientDonneesCiblees, actionMiseAJour) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(contientDonneesCiblees)
+      .map(({ id, donnees }) => {
+        const donneesModifiees = actionMiseAJour(donnees);
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: donneesModifiees });
+      });
+    return Promise.all(misesAJour);
+  });
+
+const contientCaracteristiquesComplementaires = ({ donnees }) => (
+  donnees.caracteristiquesComplementaires
+);
+
+const copieDansInformationsGenerales = (donnees) => {
+  donnees.informationsGenerales.presentation = (
+    donnees.caracteristiquesComplementaires.presentation
+  );
+  return donnees;
+};
+
+const contientInformationsGenerales = ({ donnees }) => donnees.informationsGenerales;
+
+const supprimeDansInformationsGenerales = (donnees) => {
+  delete donnees.informationsGenerales.presentation;
+  return donnees;
+};
+
+exports.up = miseAJour(contientCaracteristiquesComplementaires, copieDansInformationsGenerales);
+
+exports.down = miseAJour(contientInformationsGenerales, supprimeDansInformationsGenerales);

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -8,6 +8,7 @@ const {
 } = require('./erreurs');
 const AdaptateurPersistanceMemoire = require('./adaptateurs/adaptateurPersistanceMemoire');
 const Homologation = require('./modeles/homologation');
+const InformationsGenerales = require('./modeles/informationsGenerales');
 const Utilisateur = require('./modeles/utilisateur');
 
 const creeDepot = (config = {}) => {
@@ -108,6 +109,16 @@ const creeDepot = (config = {}) => {
 
   const ajouteCaracteristiquesAHomologation = (...params) => (
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
+  );
+
+  const ajoutePresentationAHomologation = (idHomologation, presentation) => (
+    adaptateurPersistance.homologation(idHomologation)
+      .then((h) => {
+        const informationsGenerales = new InformationsGenerales(h.informationsGenerales);
+        informationsGenerales.proprietesAtomiquesRequises.push('presentation');
+        informationsGenerales.presentation = presentation;
+        return metsAJourProprieteHomologation('informationsGenerales', h, informationsGenerales);
+      })
   );
 
   const ajoutePartiesPrenantesAHomologation = (...params) => (
@@ -230,6 +241,7 @@ const creeDepot = (config = {}) => {
     ajouteInformationsGeneralesAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
+    ajoutePresentationAHomologation,
     ajouteRisqueGeneralAHomologation,
     homologation,
     homologationExiste,

--- a/src/modeles/informationsGenerales.js
+++ b/src/modeles/informationsGenerales.js
@@ -16,6 +16,7 @@ class InformationsGenerales extends InformationsHomologation {
         'donneesCaracterePersonnel',
         'fonctionnalites',
         'typeService',
+        'presentation',
         'provenanceService',
       ],
       listesAgregats: {

--- a/src/mss.js
+++ b/src/mss.js
@@ -270,7 +270,9 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
       );
       try {
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
+        const { presentation } = caracteristiques;
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
+          .then(() => depotDonnees.ajoutePresentationAHomologation(requete.params.id, presentation))
           .then(() => reponse.send({ idHomologation: requete.homologation.id }));
       } catch {
         reponse.status(422).send('Données invalides');

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -270,7 +270,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
       homologations: [{
         id: '123',
         informationsGenerales: { nomService: 'nom' },
-        caracteristiquesComplementaires: { presentation: 'Une présentation' },
+        caracteristiquesComplementaires: { hebergeur: 'Un hébergeur' },
       }],
     });
     const referentiel = Referentiel.creeReferentiel({ localisationsDonnees: { france: {} } });
@@ -282,8 +282,23 @@ describe('Le dépôt de données persistées en mémoire', () => {
     depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.presentation).to.equal('Une présentation');
+        expect(caracteristiquesComplementaires.hebergeur).to.equal('Un hébergeur');
         expect(caracteristiquesComplementaires.localisationDonnees).to.equal('france');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('ajoute une présentation à une homologation', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajoutePresentationAHomologation('123', 'Une présentation')
+      .then(() => depot.homologation('123'))
+      .then(({ informationsGenerales: { presentation } }) => {
+        expect(presentation).to.equal('Une présentation');
         done();
       })
       .catch(done);

--- a/test/modeles/informationsGenerales.spec.js
+++ b/test/modeles/informationsGenerales.spec.js
@@ -18,6 +18,7 @@ describe('Les informations générales', () => {
       nomService: 'Super Service',
       pointsAcces: [{ description: 'Une description' }],
       presenceResponsable: 'non',
+      presentation: 'Une présentation du service',
       provenanceService: ['uneProvenance'],
     });
 
@@ -28,6 +29,7 @@ describe('Les informations générales', () => {
     expect(infos.typeService).to.eql(['unType']);
     expect(infos.nomService).to.equal('Super Service');
     expect(infos.presenceResponsable).to.be('non');
+    expect(infos.presentation).to.equal('Une présentation du service');
     expect(infos.provenanceService).to.eql(['uneProvenance']);
 
     expect(infos.nombrePointsAcces()).to.equal(1);


### PR DESCRIPTION
Dans la page _Caractéristiques complémentaires_ 
quand on saisit une **présentation**
Les données sont persistées avec Informations générales

-> migration de données pour les anciennes présentations
-> ~nouvel aiguillage des présentations~