### PR TITLE
Montée de version de npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       },
       "engines": {
         "node": "16",
-        "npm": "7"
+        "npm": "8"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
Dans package-lock npm était à 7 alors qu'il est à 8 dans package.json