### PR TITLE
Modification question temps dysfonctionnement

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -139,24 +139,16 @@ module.exports = {
   },
 
   delaisAvantImpactCritique: {
-    immediat: {
-      description: 'Immédiatement',
+    moinsUneHeure: {
+      description: "Moins d'une heure",
       seuilCriticite: 'critique',
-    },
-    uneHeure: {
-      description: 'Une heure',
-      seuilCriticite: 'eleve',
     },
     uneJournee: {
       description: 'Une journée',
       seuilCriticite: 'moyen',
     },
-    uneSemaine: {
-      description: 'Une semaine',
-      seuilCriticite: 'faible',
-    },
-    unMois: {
-      description: 'Un mois ou plus',
+    plusUneJournee: {
+      description: "Plus d'une journée",
       seuilCriticite: 'faible',
     },
   },

--- a/migrations/20211210164225_modifieValeurDelaiAvantImpactCritique.js
+++ b/migrations/20211210164225_modifieValeurDelaiAvantImpactCritique.js
@@ -1,0 +1,37 @@
+const allerAvant = (delaiAvantImpactCritique) => {
+  switch (delaiAvantImpactCritique) {
+    case 'immediat':
+    case 'uneHeure': return 'moinsUneHeure';
+    case 'uneSemaine':
+    case 'unMois': return 'plusUneJournee';
+    default: return delaiAvantImpactCritique;
+  }
+};
+
+const retourArriere = (delaiAvantImpactCritique) => {
+  switch (delaiAvantImpactCritique) {
+    case 'moinsUneHeure': return 'immediat';
+    case 'plusUneJournee': return 'uneSemaine';
+    default: return delaiAvantImpactCritique;
+  }
+};
+
+const miseAJourDelaiAvantImpactCritique = (fonctionMiseAJour) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.informationsGenerales)
+      .map(({ id, donnees }) => {
+        donnees.informationsGenerales.delaiAvantImpactCritique = fonctionMiseAJour(
+          donnees.informationsGenerales.delaiAvantImpactCritique
+        );
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees });
+      });
+
+    return Promise.all(misesAJour);
+  });
+
+exports.up = miseAJourDelaiAvantImpactCritique(allerAvant);
+
+exports.down = miseAJourDelaiAvantImpactCritique(retourArriere);

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -74,7 +74,7 @@ mixin formulaireInformationsGenerales(idHomologation)
       +inputChoix({
         type: 'radio',
         nom: 'delaiAvantImpactCritique',
-        titre: 'Au bout de combien de temps le dysfonctionnement grave de votre service aura-t-il un impact critique pour votre organisation ou pour les usagers ?',
+        titre: 'Estimation de la durée maximale acceptable de dysfonctionnement grave du service',
         items: referentiel.delaisAvantImpactCritique(),
         objetDonnees: homologation.informationsGenerales,
       })


### PR DESCRIPTION
Dans la page Informations générales,
La question _Au bout de combien de temps le dysfonctionnement grave de votre service aura-t-il un impact critique pour votre organisation ou pour les usagers ?_ évolue 
- il y a seulement 3 choix
- le texte est différent
![image](https://user-images.githubusercontent.com/39462397/146409690-27d04e66-ae26-4954-b253-15e15fbbb730.png)


-> ce dev entraine une migration de données incluse