### PR TITLE
Suppression de l'ancienne fonctionnalité Autres

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -81,10 +81,6 @@ module.exports = {
       description: 'Outils de réservation (livres, places, salles, etc.)',
       seuilCriticite: 'faible',
     },
-    autre: {
-      description: 'Autres fonctionnalités permettant des échanges de données',
-      seuilCriticite: 'faible',
-    },
   },
 
   donneesCaracterePersonnel: {

--- a/migrations/20211216163509_integreAutreFonctionnaliteAvecFonctionnalitesSpecifiques.js
+++ b/migrations/20211216163509_integreAutreFonctionnaliteAvecFonctionnalitesSpecifiques.js
@@ -1,0 +1,56 @@
+const DESCRIPTION_PAR_DEFAUT_AUTRES_FONCTIONNALITES = 'Autres fonctionnalités permettant des échanges de données';
+const IDENTIFIANT_AUTRE_FONCTIONNALITE = 'autre';
+
+const deplace = (filtreAutresFonctionnalites, fonctionMiseAJour) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(filtreAutresFonctionnalites)
+      .map(({ id, donnees }) => {
+        donnees.informationsGenerales = fonctionMiseAJour(donnees.informationsGenerales);
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees });
+      });
+
+    return Promise.all(misesAJour);
+  });
+
+const autresFonctionnalitesGeneriques = ({ donnees }) => (
+  donnees.informationsGenerales
+  && Array.isArray(donnees.informationsGenerales.fonctionnalites)
+  && donnees.informationsGenerales.fonctionnalites.indexOf(IDENTIFIANT_AUTRE_FONCTIONNALITE) !== -1
+);
+
+const versFonctionnalitesSpecifiques = (informationsGenerales) => {
+  informationsGenerales.fonctionnalitesSpecifiques ||= [];
+  informationsGenerales.fonctionnalitesSpecifiques.push(
+    { description: DESCRIPTION_PAR_DEFAUT_AUTRES_FONCTIONNALITES }
+  );
+
+  informationsGenerales.fonctionnalites = informationsGenerales.fonctionnalites
+    .filter((f) => f !== IDENTIFIANT_AUTRE_FONCTIONNALITE);
+
+  return informationsGenerales;
+};
+
+const autresFonctionnalitesSpecifiques = ({ donnees }) => (
+  donnees.informationsGenerales
+  && Array.isArray(donnees.informationsGenerales.fonctionnalitesSpecifiques)
+  && donnees.informationsGenerales.fonctionnalitesSpecifiques
+    .some((f) => f.description === DESCRIPTION_PAR_DEFAUT_AUTRES_FONCTIONNALITES)
+);
+
+const versFonctionnalitesGeneriques = (informationsGenerales) => {
+  informationsGenerales.fonctionnalites ||= [];
+  informationsGenerales.fonctionnalites.push(IDENTIFIANT_AUTRE_FONCTIONNALITE);
+
+  informationsGenerales.fonctionnalitesSpecifiques = informationsGenerales
+    .fonctionnalitesSpecifiques
+    .filter((f) => f?.description !== DESCRIPTION_PAR_DEFAUT_AUTRES_FONCTIONNALITES);
+
+  return informationsGenerales;
+};
+
+exports.up = deplace(autresFonctionnalitesGeneriques, versFonctionnalitesSpecifiques);
+
+exports.down = deplace(autresFonctionnalitesSpecifiques, versFonctionnalitesGeneriques);


### PR DESCRIPTION
Dans la page Informations générales,
nous avons mis à disposition une possibilité pour renseigner les _autres fonctionnalités_
Le choix _Autres fonctionnalités permettant des échanges de données_ va disparaitre
À la place il y aura un champ dans _autres fonctionnalités_ avec la valeur _Autres fonctionnalités permettant des échanges de données_
<img width="821" alt="Capture d’écran 2021-12-23 à 15 31 35" src="https://user-images.githubusercontent.com/39462397/147254412-625d84a0-e844-4993-a47f-fadbcceeef38.png">
