### PR TITLE
Renommage provenance du service

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -12,11 +12,11 @@ module.exports = {
 
   provenancesService: {
     developpement: {
-      description: 'Il a été développé pour votre organisation, en interne ou par un prestataire',
+      description: 'Développé en interne ou par un prestataire au profit de votre organisation',
       exemple: 'site internet de la commune',
     },
     achat: {
-      description: "Le service a été acheté sur étagère auprès d'un fournisseur",
+      description: 'Acheté sur étagère auprès d’un fournisseur ou obtenu à titre gratuit',
       exemple: 'service de visioconférence',
     },
   },

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -13,11 +13,9 @@ module.exports = {
   provenancesService: {
     developpement: {
       description: 'Développé en interne ou par un prestataire au profit de votre organisation',
-      exemple: 'site internet de la commune',
     },
     achat: {
       description: 'Acheté sur étagère auprès d’un fournisseur ou obtenu à titre gratuit',
-      exemple: 'service de visioconférence',
     },
   },
 

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -31,7 +31,7 @@ mixin formulaireInformationsGenerales(idHomologation)
       +inputChoix({
         type: 'checkbox',
         nom: 'provenanceService',
-        titre: 'Quelle est la provenance du service numérique ?',
+        titre: 'Provenance du service numérique',
         items: referentiel.provenancesService(),
         objetDonnees: homologation.informationsGenerales,
       })


### PR DESCRIPTION
Dans la page Informations générales
Dans la question relative à la provenance du service
-> le titre est reformulé
-> les choix sont reformulés
-> les exemples illustrants les choix sont supprimés