### PR TITLE
Déplacement de la présentation dans la page informations génerales

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -7,6 +7,7 @@ const {
   ErreurUtilisateurExistant,
 } = require('./erreurs');
 const AdaptateurPersistanceMemoire = require('./adaptateurs/adaptateurPersistanceMemoire');
+const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const Homologation = require('./modeles/homologation');
 const InformationsGenerales = require('./modeles/informationsGenerales');
 const Utilisateur = require('./modeles/utilisateur');
@@ -107,16 +108,31 @@ const creeDepot = (config = {}) => {
       ))
   );
 
+  const ajoutePresentationAHomologation = (idHomologation, presentation) => (
+    adaptateurPersistance.homologation(idHomologation)
+      .then((homologationTrouvee) => {
+        const informationsGenerales = new InformationsGenerales(
+          homologationTrouvee.informationsGenerales,
+          referentiel
+        );
+        informationsGenerales.presentation = presentation;
+        return metsAJourProprieteHomologation('informationsGenerales', homologationTrouvee, informationsGenerales);
+      })
+  );
+
   const ajouteCaracteristiquesAHomologation = (...params) => (
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
   );
 
-  const ajoutePresentationAHomologation = (idHomologation, presentation) => (
+  const ajoutePresentationACaracteristiques = (idHomologation, presentation) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((h) => {
-        const informationsGenerales = new InformationsGenerales(h.informationsGenerales);
-        informationsGenerales.presentation = presentation;
-        return metsAJourProprieteHomologation('informationsGenerales', h, informationsGenerales);
+        const caracteristiques = new CaracteristiquesComplementaires(
+          h.caracteristiquesComplementaires,
+          referentiel
+        );
+        caracteristiques.presentation = presentation;
+        return metsAJourProprieteHomologation('caracteristiquesComplementaires', h, caracteristiques);
       })
   );
 
@@ -240,6 +256,7 @@ const creeDepot = (config = {}) => {
     ajouteInformationsGeneralesAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
+    ajoutePresentationACaracteristiques,
     ajoutePresentationAHomologation,
     ajouteRisqueGeneralAHomologation,
     homologation,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -9,7 +9,6 @@ const {
 const AdaptateurPersistanceMemoire = require('./adaptateurs/adaptateurPersistanceMemoire');
 const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const Homologation = require('./modeles/homologation');
-const InformationsGenerales = require('./modeles/informationsGenerales');
 const Utilisateur = require('./modeles/utilisateur');
 
 const creeDepot = (config = {}) => {
@@ -108,23 +107,11 @@ const creeDepot = (config = {}) => {
       ))
   );
 
-  const ajoutePresentationAHomologation = (idHomologation, presentation) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((homologationTrouvee) => {
-        const informationsGenerales = new InformationsGenerales(
-          homologationTrouvee.informationsGenerales,
-          referentiel
-        );
-        informationsGenerales.presentation = presentation;
-        return metsAJourProprieteHomologation('informationsGenerales', homologationTrouvee, informationsGenerales);
-      })
-  );
-
   const ajouteCaracteristiquesAHomologation = (...params) => (
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
   );
 
-  const ajoutePresentationACaracteristiques = (idHomologation, presentation) => (
+  const ajoutePresentationAHomologation = (idHomologation, presentation) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((h) => {
         const caracteristiques = new CaracteristiquesComplementaires(
@@ -256,7 +243,6 @@ const creeDepot = (config = {}) => {
     ajouteInformationsGeneralesAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
-    ajoutePresentationACaracteristiques,
     ajoutePresentationAHomologation,
     ajouteRisqueGeneralAHomologation,
     homologation,

--- a/src/modeles/caracteristiquesComplementaires.js
+++ b/src/modeles/caracteristiquesComplementaires.js
@@ -18,8 +18,9 @@ class CaracteristiquesComplementaires extends InformationsHomologation {
   constructor(donneesCaracteristiques = {}, referentiel = Referentiel.creeReferentielVide()) {
     super({
       proprietesAtomiquesRequises: [
-        'presentation', 'structureDeveloppement', 'hebergeur', 'localisationDonnees',
+        'structureDeveloppement', 'hebergeur', 'localisationDonnees',
       ],
+      proprietesAtomiquesFacultatives: ['presentation'],
       listesAgregats: { entitesExternes: EntitesExternes },
     });
     valide(donneesCaracteristiques, referentiel);

--- a/src/modeles/informationsGenerales.js
+++ b/src/modeles/informationsGenerales.js
@@ -11,10 +11,8 @@ class InformationsGenerales extends InformationsHomologation {
         'delaiAvantImpactCritique',
         'nomService',
         'presenceResponsable',
-        'statutDeploiement',
-      ],
-      proprietesAtomiquesFacultatives: [
         'presentation',
+        'statutDeploiement',
       ],
       proprietesListes: [
         'donneesCaracterePersonnel',

--- a/src/mss.js
+++ b/src/mss.js
@@ -222,6 +222,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         donneesCaracterePersonnel,
         delaiAvantImpactCritique,
         presenceResponsable,
+        presentation,
         pointsAcces,
         statutDeploiement,
       } = requete.body;
@@ -235,9 +236,14 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         donneesCaracterePersonnel,
         delaiAvantImpactCritique,
         presenceResponsable,
+        presentation,
         pointsAcces,
         statutDeploiement,
       })
+        .then((idHomologation) => {
+          depotDonnees.ajoutePresentationACaracteristiques(idHomologation, presentation);
+          return Promise.resolve(idHomologation);
+        })
         .then((idHomologation) => reponse.json({ idHomologation }))
         .catch((e) => {
           if (e instanceof ErreurModele) reponse.status(422).send(e.message);
@@ -253,6 +259,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     (requete, reponse, suite) => {
       const infosGenerales = new InformationsGenerales(requete.body, referentiel);
       depotDonnees.ajouteInformationsGeneralesAHomologation(requete.params.id, infosGenerales)
+        .then(() => (
+          depotDonnees.ajoutePresentationACaracteristiques(
+            requete.params.id, infosGenerales.presentation
+          )
+        ))
         .then(() => reponse.send({ idHomologation: requete.homologation.id }))
         .catch((e) => {
           if (e instanceof ErreurModele) {
@@ -272,7 +283,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
         const { presentation } = caracteristiques;
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
-          .then(() => depotDonnees.ajoutePresentationAHomologation(requete.params.id, presentation))
+          .then(() => (
+            depotDonnees.ajoutePresentationAHomologation(
+              requete.params.id, presentation, referentiel
+            )
+          ))
           .then(() => reponse.send({ idHomologation: requete.homologation.id }));
       } catch {
         reponse.status(422).send('Données invalides');

--- a/src/mss.js
+++ b/src/mss.js
@@ -241,7 +241,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         statutDeploiement,
       })
         .then((idHomologation) => {
-          depotDonnees.ajoutePresentationACaracteristiques(idHomologation, presentation);
+          depotDonnees.ajoutePresentationAHomologation(idHomologation, presentation);
           return Promise.resolve(idHomologation);
         })
         .then((idHomologation) => reponse.json({ idHomologation }))
@@ -260,7 +260,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
       const infosGenerales = new InformationsGenerales(requete.body, referentiel);
       depotDonnees.ajouteInformationsGeneralesAHomologation(requete.params.id, infosGenerales)
         .then(() => (
-          depotDonnees.ajoutePresentationACaracteristiques(
+          depotDonnees.ajoutePresentationAHomologation(
             requete.params.id, infosGenerales.presentation
           )
         ))
@@ -281,13 +281,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
       );
       try {
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
-        const { presentation } = caracteristiques;
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
-          .then(() => (
-            depotDonnees.ajoutePresentationAHomologation(
-              requete.params.id, presentation, referentiel
-            )
-          ))
           .then(() => reponse.send({ idHomologation: requete.homologation.id }));
       } catch {
         reponse.status(422).send('Données invalides');

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -44,6 +44,13 @@ mixin formulaireInformationsGenerales(idHomologation)
         objetDonnees: homologation.informationsGenerales,
       })
 
+      label Présentation du service numérique
+        textarea(
+          id = 'presentation',
+          name = 'presentation',
+          placeholder = 'ex : site internet de la médiathèque permettant de créer un compte utilisateur, de réserver, prolonger leur réservation de contenus multimédia.',
+        )= homologation.informationsGenerales.presentation
+
       label Accès au service numérique
         br
         #points-acces

--- a/src/vues/homologation/caracteristiquesComplementaires.pug
+++ b/src/vues/homologation/caracteristiquesComplementaires.pug
@@ -10,11 +10,6 @@ block formulaire
     h2 Caractéristiques complémentaires
 
     section
-      label Présentation du service numérique
-        p Présentez en quelques lignes l'objet du service numérique, son rôle, ses utilisateurs, etc.
-        textarea(
-          id = 'presentation', name = 'presentation',
-        )= homologation.caracteristiquesComplementaires.presentation
 
       label Structure ayant développé le service numérique
         input(

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -8,7 +8,6 @@ const {
   ErreurNomServiceManquant,
   ErreurUtilisateurExistant,
 } = require('../src/erreurs');
-const Referentiel = require('../src/referentiel');
 const AdaptateurPersistanceMemoire = require('../src/adaptateurs/adaptateurPersistanceMemoire');
 const AvisExpertCyber = require('../src/modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('../src/modeles/caracteristiquesComplementaires');
@@ -96,49 +95,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it('renseigne les mesures associées à une homologation', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        informationsGenerales: { nomService: 'Un service' },
-        mesuresGenerales: [{ id: 'identifiantMesure', statut: 'fait' }],
-      }],
-    });
-    const referentiel = Referentiel.creeReferentiel({ mesures: { identifiantMesure: {} } });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel });
-
-    depot.homologation('123')
-      .then(({ mesures: { mesuresGenerales } }) => {
-        expect(mesuresGenerales.nombre()).to.equal(1);
-
-        const mesure = mesuresGenerales.item(0);
-        expect(mesure).to.be.a(MesureGenerale);
-        expect(mesure.id).to.equal('identifiantMesure');
-        done();
-      })
-      .catch(done);
-  });
-
-  it('sait associer une mesure générale à une homologation', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        { id: '123', informationsGenerales: { nomService: 'Un service' } },
-      ],
-    });
-    const referentiel = Referentiel.creeReferentiel({ mesures: { identifiantMesure: {} } });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel });
-    const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: MesureGenerale.STATUT_FAIT }, referentiel);
-
-    depot.ajouteMesureGeneraleAHomologation('123', mesure)
-      .then(() => depot.homologation('123'))
-      .then(({ mesures: { mesuresGenerales } }) => {
-        expect(mesuresGenerales.nombre()).to.equal(1);
-        expect(mesuresGenerales.item(0).id).to.equal('identifiantMesure');
-        done();
-      })
-      .catch(done);
-  });
-
   it('sait associer une mesure spécifique à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
@@ -159,28 +115,79 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it("met à jour les données de la mesure si elle est déjà associée à l'homologation", (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        {
-          id: '123',
-          informationsGenerales: { nomService: 'nom' },
-          mesures: [{ id: 'identifiantMesure', statut: MesureGenerale.STATUT_PLANIFIE }],
-        },
-      ],
-    });
-    const referentiel = Referentiel.creeReferentiel({ mesures: { identifiantMesure: {} } });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel });
+  describe('concernant les mesures générales', () => {
+    let valideMesure;
 
-    const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: MesureGenerale.STATUT_FAIT }, referentiel);
-    depot.ajouteMesureGeneraleAHomologation('123', mesure)
-      .then(() => depot.homologation('123'))
-      .then(({ mesures: { mesuresGenerales } }) => {
-        expect(mesuresGenerales.nombre()).to.equal(1);
-        expect(mesuresGenerales.item(0).statut).to.equal(MesureGenerale.STATUT_FAIT);
-        done();
-      })
-      .catch(done);
+    before(() => {
+      valideMesure = MesureGenerale.valide;
+      MesureGenerale.valide = () => {};
+    });
+
+    after(() => (MesureGenerale.valide = valideMesure));
+
+    it('renseigne les mesures associées à une homologation', (done) => {
+      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        homologations: [{
+          id: '123',
+          informationsGenerales: { nomService: 'Un service' },
+          mesuresGenerales: [{ id: 'identifiantMesure', statut: 'fait' }],
+        }],
+      });
+      const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+      depot.homologation('123')
+        .then(({ mesures: { mesuresGenerales } }) => {
+          expect(mesuresGenerales.nombre()).to.equal(1);
+
+          const mesure = mesuresGenerales.item(0);
+          expect(mesure).to.be.a(MesureGenerale);
+          expect(mesure.id).to.equal('identifiantMesure');
+          done();
+        })
+        .catch(done);
+    });
+
+    it('sait associer une mesure à une homologation', (done) => {
+      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        homologations: [
+          { id: '123', informationsGenerales: { nomService: 'Un service' } },
+        ],
+      });
+      const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+      const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: MesureGenerale.STATUT_FAIT });
+
+      depot.ajouteMesureGeneraleAHomologation('123', mesure)
+        .then(() => depot.homologation('123'))
+        .then(({ mesures: { mesuresGenerales } }) => {
+          expect(mesuresGenerales.nombre()).to.equal(1);
+          expect(mesuresGenerales.item(0).id).to.equal('identifiantMesure');
+          done();
+        })
+        .catch(done);
+    });
+
+    it("met à jour les données de la mesure si elle est déjà associée à l'homologation", (done) => {
+      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        homologations: [
+          {
+            id: '123',
+            informationsGenerales: { nomService: 'nom' },
+            mesures: [{ id: 'identifiantMesure', statut: MesureGenerale.STATUT_PLANIFIE }],
+          },
+        ],
+      });
+      const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+      const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: MesureGenerale.STATUT_FAIT });
+      depot.ajouteMesureGeneraleAHomologation('123', mesure)
+        .then(() => depot.homologation('123'))
+        .then(({ mesures: { mesuresGenerales } }) => {
+          expect(mesuresGenerales.nombre()).to.equal(1);
+          expect(mesuresGenerales.item(0).statut).to.equal(MesureGenerale.STATUT_FAIT);
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe("sur demande de mise à jour des infos générales d'une homologation", () => {
@@ -244,22 +251,21 @@ describe('Le dépôt de données persistées en mémoire', () => {
   });
 
   it('sait associer des caractéristiques complémentaires à une homologation', (done) => {
-    const referentiel = Referentiel.creeReferentiel({ localisationsDonnees: { france: {} } });
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
         { id: '123', informationsGenerales: { nomService: 'nom' } },
       ],
     });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
     const caracteristiques = new CaracteristiquesComplementaires({
-      localisationDonnees: 'france',
-    }, referentiel);
+      structureDeveloppement: 'Une structure',
+    });
 
     depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.localisationDonnees).to.equal('france');
+        expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
         done();
       })
       .catch(done);
@@ -273,17 +279,16 @@ describe('Le dépôt de données persistées en mémoire', () => {
         caracteristiquesComplementaires: { hebergeur: 'Un hébergeur' },
       }],
     });
-    const referentiel = Referentiel.creeReferentiel({ localisationsDonnees: { france: {} } });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
     const caracteristiques = new CaracteristiquesComplementaires({
-      localisationDonnees: 'france',
-    }, referentiel);
+      structureDeveloppement: 'Une structure',
+    });
     depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires }) => {
         expect(caracteristiquesComplementaires.hebergeur).to.equal('Un hébergeur');
-        expect(caracteristiquesComplementaires.localisationDonnees).to.equal('france');
+        expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
         done();
       })
       .catch(done);
@@ -298,6 +303,21 @@ describe('Le dépôt de données persistées en mémoire', () => {
     depot.ajoutePresentationAHomologation('123', 'Une présentation')
       .then(() => depot.homologation('123'))
       .then(({ informationsGenerales: { presentation } }) => {
+        expect(presentation).to.equal('Une présentation');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('ajoute une présentation à une homologation en caractéristique complémentaire', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajoutePresentationACaracteristiques('123', 'Une présentation')
+      .then(() => depot.homologation('123'))
+      .then(({ caracteristiquesComplementaires: { presentation } }) => {
         expect(presentation).to.equal('Une présentation');
         done();
       })
@@ -322,25 +342,37 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it('sait associer un risque général à une homologation', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        { id: '123', informationsGenerales: { nomService: 'nom' } },
-      ],
-    });
-    const referentiel = Referentiel.creeReferentiel({ risques: { unRisque: {} } });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel });
+  describe('concernant les risques généraux', () => {
+    let valideRisque;
 
-    const risque = new RisqueGeneral({ id: 'unRisque', commentaire: 'Un commentaire' }, referentiel);
-    depot.ajouteRisqueGeneralAHomologation('123', risque)
-      .then(() => depot.homologation('123'))
-      .then(({ risques }) => {
-        expect(risques.risquesGeneraux.nombre()).to.equal(1);
-        expect(risques.risquesGeneraux.item(0)).to.be.a(RisqueGeneral);
-        expect(risques.risquesGeneraux.item(0).id).to.equal('unRisque');
-        done();
-      })
-      .catch(done);
+    before(() => {
+      valideRisque = RisqueGeneral.valide;
+      RisqueGeneral.valide = () => {};
+    });
+
+    after(() => (RisqueGeneral.valide = valideRisque));
+
+    it('sait associer un risque général à une homologation', (done) => {
+      RisqueGeneral.valide = () => {};
+
+      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        homologations: [
+          { id: '123', informationsGenerales: { nomService: 'nom' } },
+        ],
+      });
+      const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+      const risque = new RisqueGeneral({ id: 'unRisque', commentaire: 'Un commentaire' });
+      depot.ajouteRisqueGeneralAHomologation('123', risque)
+        .then(() => depot.homologation('123'))
+        .then(({ risques }) => {
+          expect(risques.risquesGeneraux.nombre()).to.equal(1);
+          expect(risques.risquesGeneraux.item(0)).to.be.a(RisqueGeneral);
+          expect(risques.risquesGeneraux.item(0).id).to.equal('unRisque');
+          done();
+        })
+        .catch(done);
+    });
   });
 
   it('sait associer un risque spécifique à une homologation', (done) => {

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -294,28 +294,13 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it('ajoute une présentation à une homologation', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajoutePresentationAHomologation('123', 'Une présentation')
-      .then(() => depot.homologation('123'))
-      .then(({ informationsGenerales: { presentation } }) => {
-        expect(presentation).to.equal('Une présentation');
-        done();
-      })
-      .catch(done);
-  });
-
   it('ajoute une présentation à une homologation en caractéristique complémentaire', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-    depot.ajoutePresentationACaracteristiques('123', 'Une présentation')
+    depot.ajoutePresentationAHomologation('123', 'Une présentation')
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires: { presentation } }) => {
         expect(presentation).to.equal('Une présentation');

--- a/test/modeles/caracteristiquesComplementaires.spec.js
+++ b/test/modeles/caracteristiquesComplementaires.spec.js
@@ -88,7 +88,7 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
   describe('sur demande du statut de saisie', () => {
     describe("quand aucune entité externe n'a été saisie", () => {
       it('détermine le statut de saisie de manière standard', () => {
-        const caracteristiques = new CaracteristiquesComplementaires({ presentation: 'Une présentation' });
+        const caracteristiques = new CaracteristiquesComplementaires({ hebergeur: 'Un hébergeur' });
         expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.A_COMPLETER);
       });
     });

--- a/test/modeles/informationsGenerales.spec.js
+++ b/test/modeles/informationsGenerales.spec.js
@@ -85,6 +85,7 @@ describe('Les informations générales', () => {
       nomService: 'Super Service',
       delaiAvantImpactCritique: 'uneJournee',
       presenceResponsable: 'oui',
+      presentation: 'Une présentation',
       statutDeploiement: 'accessible',
     }, referentielAvecStatutValide('accessible'));
 

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -400,6 +400,11 @@ describe('Le serveur MSS', () => {
   });
 
   describe('quand requête POST sur `/api/homologation`', () => {
+    beforeEach(() => {
+      depotDonnees.nouvelleHomologation = () => Promise.resolve();
+      depotDonnees.ajoutePresentationACaracteristiques = () => Promise.resolve();
+    });
+
     it("vérifie que l'utilisateur est authentifié", (done) => {
       verifieRequeteExigeAcceptationCGU(
         { method: 'post', url: 'http://localhost:1234/api/homologation' }, done
@@ -415,8 +420,6 @@ describe('Le serveur MSS', () => {
     });
 
     it("aseptise la liste des points d'accès des descriptions vides", (done) => {
-      depotDonnees.nouvelleHomologation = () => Promise.resolve();
-
       axios.post('http://localhost:1234/api/homologation', {})
         .then(() => {
           verifieAseptisationListe('pointsAcces', ['description']);
@@ -431,6 +434,22 @@ describe('Le serveur MSS', () => {
       axios.post('http://localhost:1234/api/homologation', {})
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
+          done();
+        })
+        .catch(done);
+    });
+
+    it("demande au dépôt de données d'ajouter la présentation aux caractéristiques", (done) => {
+      let appelleAjoutePresentationACaracteristiques = false;
+      depotDonnees.ajoutePresentationACaracteristiques = (idHomologation, presentation) => {
+        appelleAjoutePresentationACaracteristiques = true;
+        expect(presentation).to.equal('Une présentation');
+        return Promise.resolve();
+      };
+
+      axios.post('http://localhost:1234/api/homologation', { presentation: 'Une présentation' })
+        .then(() => {
+          expect(appelleAjoutePresentationACaracteristiques).to.be(true);
           done();
         })
         .catch(done);
@@ -470,6 +489,7 @@ describe('Le serveur MSS', () => {
           donneesCaracterePersonnel: undefined,
           delaiAvantImpactCritique: undefined,
           presenceResponsable: undefined,
+          presentation: undefined,
           pointsAcces: undefined,
           statutDeploiement: undefined,
         });
@@ -487,9 +507,10 @@ describe('Le serveur MSS', () => {
   });
 
   describe('quand requête PUT sur `/api/homologation/:id`', () => {
-    beforeEach(() => (
-      depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.resolve()
-    ));
+    beforeEach(() => {
+      depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.resolve();
+      depotDonnees.ajoutePresentationACaracteristiques = () => Promise.resolve();
+    });
 
     it("recherche l'homologation correspondante", (done) => {
       verifieRechercheHomologation(
@@ -513,8 +534,6 @@ describe('Le serveur MSS', () => {
         ],
       });
 
-      depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.resolve();
-
       axios.put('http://localhost:1234/api/homologation/456', { pointsAcces })
         .then(() => {
           verifieAseptisationListe('pointsAcces', ['description']);
@@ -536,6 +555,22 @@ describe('Le serveur MSS', () => {
       axios.put('http://localhost:1234/api/homologation/456', { fonctionnalitesSpecifiques })
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
+          done();
+        })
+        .catch(done);
+    });
+
+    it("demande au dépôt de données d'ajouter la présentation aux caractéristiques", (done) => {
+      let appelleAjoutePresentationACaracteristiques = false;
+      depotDonnees.ajoutePresentationACaracteristiques = (idHomologation, presentation) => {
+        appelleAjoutePresentationACaracteristiques = true;
+        expect(presentation).to.equal('Une présentation');
+        return Promise.resolve();
+      };
+
+      axios.put('http://localhost:1234/api/homologation/456', { presentation: 'Une présentation' })
+        .then(() => {
+          expect(appelleAjoutePresentationACaracteristiques).to.be(true);
           done();
         })
         .catch(done);

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -402,7 +402,7 @@ describe('Le serveur MSS', () => {
   describe('quand requête POST sur `/api/homologation`', () => {
     beforeEach(() => {
       depotDonnees.nouvelleHomologation = () => Promise.resolve();
-      depotDonnees.ajoutePresentationACaracteristiques = () => Promise.resolve();
+      depotDonnees.ajoutePresentationAHomologation = () => Promise.resolve();
     });
 
     it("vérifie que l'utilisateur est authentifié", (done) => {
@@ -440,16 +440,16 @@ describe('Le serveur MSS', () => {
     });
 
     it("demande au dépôt de données d'ajouter la présentation aux caractéristiques", (done) => {
-      let appelleAjoutePresentationACaracteristiques = false;
-      depotDonnees.ajoutePresentationACaracteristiques = (idHomologation, presentation) => {
-        appelleAjoutePresentationACaracteristiques = true;
+      let appelleAjoutePresentationAHomologation = false;
+      depotDonnees.ajoutePresentationAHomologation = (idHomologation, presentation) => {
+        appelleAjoutePresentationAHomologation = true;
         expect(presentation).to.equal('Une présentation');
         return Promise.resolve();
       };
 
       axios.post('http://localhost:1234/api/homologation', { presentation: 'Une présentation' })
         .then(() => {
-          expect(appelleAjoutePresentationACaracteristiques).to.be(true);
+          expect(appelleAjoutePresentationAHomologation).to.be(true);
           done();
         })
         .catch(done);
@@ -509,7 +509,7 @@ describe('Le serveur MSS', () => {
   describe('quand requête PUT sur `/api/homologation/:id`', () => {
     beforeEach(() => {
       depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.resolve();
-      depotDonnees.ajoutePresentationACaracteristiques = () => Promise.resolve();
+      depotDonnees.ajoutePresentationAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -561,16 +561,16 @@ describe('Le serveur MSS', () => {
     });
 
     it("demande au dépôt de données d'ajouter la présentation aux caractéristiques", (done) => {
-      let appelleAjoutePresentationACaracteristiques = false;
-      depotDonnees.ajoutePresentationACaracteristiques = (idHomologation, presentation) => {
-        appelleAjoutePresentationACaracteristiques = true;
+      let appelleAjoutePresentationAHomologation = false;
+      depotDonnees.ajoutePresentationAHomologation = (idHomologation, presentation) => {
+        appelleAjoutePresentationAHomologation = true;
         expect(presentation).to.equal('Une présentation');
         return Promise.resolve();
       };
 
       axios.put('http://localhost:1234/api/homologation/456', { presentation: 'Une présentation' })
         .then(() => {
-          expect(appelleAjoutePresentationACaracteristiques).to.be(true);
+          expect(appelleAjoutePresentationAHomologation).to.be(true);
           done();
         })
         .catch(done);
@@ -612,7 +612,6 @@ describe('Le serveur MSS', () => {
   describe('quand requête POST sur `/api/homologation/:id/caracteristiquesComplementaires', () => {
     beforeEach(() => {
       depotDonnees.ajouteCaracteristiquesAHomologation = () => Promise.resolve();
-      depotDonnees.ajoutePresentationAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -631,29 +630,6 @@ describe('Le serveur MSS', () => {
         },
         done
       );
-    });
-
-    it("demande au dépôt d'ajouter la présentation", (done) => {
-      let presentationAjouteeAHomologation = false;
-      depotDonnees.ajoutePresentationAHomologation = (idHomologation, presentation) => {
-        try {
-          expect(presentation).to.equal('Une présentation');
-          presentationAjouteeAHomologation = true;
-          return Promise.resolve();
-        } catch (e) {
-          return Promise.reject(done(e));
-        }
-      };
-
-      axios.post(
-        'http://localhost:1234/api/homologation/456/caracteristiquesComplementaires',
-        { presentation: 'Une présentation' },
-      )
-        .then(() => {
-          expect(presentationAjouteeAHomologation).to.be(true);
-          done();
-        })
-        .catch(done);
     });
 
     it("demande au dépôt d'associer les caractéristiques à l'homologation", (done) => {


### PR DESCRIPTION
La présentation du service passe de la page **Caractéristiques complémentaires** à **Informations générales**

-> La persistance s'effectue toujours dans les 2 objets **informationsGenerales** et **caracteristiquesComplementaires**
<img width="756" alt="Capture d’écran 2021-12-29 à 11 09 39" src="https://user-images.githubusercontent.com/39462397/147651485-7f3d176d-5de0-48dd-a3ee-9ee07b98245a.png">
