### PR TITLE
Ajout manuel des données sensibles

### DIFF
--- a/public/homologation/formulaireInformationsGenerales.js
+++ b/public/homologation/formulaireInformationsGenerales.js
@@ -5,11 +5,13 @@ const sourceRegExpParamsItem = (nomIndicatif) => `^(description)-${nomIndicatif}
 const listesAvecItemsExtraits = [
   { cle: 'pointsAcces', nomIndicatif: 'point-acces' },
   { cle: 'fonctionnalitesSpecifiques', nomIndicatif: 'fonctionnalite' },
+  { cle: 'donneesSensiblesSpecifiques', nomIndicatif: 'donnees-sensibles' },
 ].map((valeur) => (
   { ...valeur, sourceRegExpParamsItem: sourceRegExpParamsItem(valeur.nomIndicatif) }
 ));
 
 $(() => {
+  brancheElementsAjoutables('donnees-sensibles-specifiques', 'donnees-sensibles');
   brancheElementsAjoutables('fonctionnalites-specifiques', 'fonctionnalite');
   brancheElementsAjoutables('points-acces', 'point-acces', 'exemple : https://www.adresse.fr, App Store, Play Store…');
 });

--- a/src/modeles/donneesSensiblesSpecifiques.js
+++ b/src/modeles/donneesSensiblesSpecifiques.js
@@ -1,0 +1,9 @@
+const ItemsAvecDescription = require('./itemsAvecDescription');
+
+class DonneesSensiblesSpecifiques extends ItemsAvecDescription {
+  constructor(donnees) {
+    super({ items: donnees.donneesSensiblesSpecifiques });
+  }
+}
+
+module.exports = DonneesSensiblesSpecifiques;

--- a/src/modeles/informationsGenerales.js
+++ b/src/modeles/informationsGenerales.js
@@ -1,4 +1,5 @@
 const { ErreurStatutDeploiementInvalide, ErreurLocalisationDonneesInvalide } = require('../erreurs');
+const DonneesSensiblesSpecifiques = require('./donneesSensiblesSpecifiques');
 const FonctionnalitesSpecifiques = require('./fonctionnalitesSpecifiques');
 const InformationsHomologation = require('./informationsHomologation');
 const PointsAcces = require('./pointsAcces');
@@ -22,8 +23,9 @@ class InformationsGenerales extends InformationsHomologation {
         'provenanceService',
       ],
       listesAgregats: {
-        pointsAcces: PointsAcces,
+        donneesSensiblesSpecifiques: DonneesSensiblesSpecifiques,
         fonctionnalitesSpecifiques: FonctionnalitesSpecifiques,
+        pointsAcces: PointsAcces,
       },
     });
     InformationsGenerales.valide(donnees, referentiel);
@@ -38,6 +40,10 @@ class InformationsGenerales extends InformationsHomologation {
 
   descriptionTypeService() {
     return this.referentiel.typeService(this.typeService);
+  }
+
+  nombreDonneesSensiblesSpecifiques() {
+    return this.donneesSensiblesSpecifiques.nombre();
   }
 
   nombreFonctionnalitesSpecifiques() {

--- a/src/mss.js
+++ b/src/mss.js
@@ -6,6 +6,7 @@ const ActionsSaisie = require('./modeles/actionsSaisie');
 const AvisExpertCyber = require('./modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const FonctionnalitesSpecifiques = require('./modeles/fonctionnalitesSpecifiques');
+const DonneesSensiblesSpecifiques = require('./modeles/donneesSensiblesSpecifiques');
 const Homologation = require('./modeles/homologation');
 const InformationsGenerales = require('./modeles/informationsGenerales');
 const InformationsHomologation = require('./modeles/informationsHomologation');
@@ -189,6 +190,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     middleware.aseptiseListes([
       { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
       { nom: 'fonctionnalitesSpecifiques', proprietes: FonctionnalitesSpecifiques.proprietesItem() },
+      { nom: 'donneesSensiblesSpecifiques', proprietes: DonneesSensiblesSpecifiques.proprietesItem() },
     ]),
     (requete, reponse, suite) => {
       const {
@@ -198,6 +200,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         fonctionnalites,
         fonctionnalitesSpecifiques,
         donneesCaracterePersonnel,
+        donneesSensiblesSpecifiques,
         delaiAvantImpactCritique,
         localisationDonnees,
         presenceResponsable,
@@ -213,6 +216,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         fonctionnalites,
         fonctionnalitesSpecifiques,
         donneesCaracterePersonnel,
+        donneesSensiblesSpecifiques,
         delaiAvantImpactCritique,
         localisationDonnees,
         presenceResponsable,
@@ -233,6 +237,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     middleware.aseptiseListes([
       { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
       { nom: 'fonctionnalitesSpecifiques', proprietes: FonctionnalitesSpecifiques.proprietesItem() },
+      { nom: 'donneesSensiblesSpecifiques', proprietes: DonneesSensiblesSpecifiques.proprietesItem() },
     ]),
     (requete, reponse, suite) => {
       const infosGenerales = new InformationsGenerales(requete.body, referentiel);

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -90,7 +90,7 @@ mixin formulaireInformationsGenerales(idHomologation)
       +elementsAjoutables({
               identifiantConteneur: 'donnees-sensibles-specifiques',
               nom: 'donnees-sensibles',
-              donnees: {},
+              donnees: homologation.informationsGenerales.donneesSensiblesSpecifiques.toJSON(),
               textBoutonAjouter: 'Ajouter des données',
             })
 

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -87,6 +87,13 @@ mixin formulaireInformationsGenerales(idHomologation)
         objetDonnees: homologation.informationsGenerales,
       })
 
+      +elementsAjoutables({
+              identifiantConteneur: 'donnees-sensibles-specifiques',
+              nom: 'donnees-sensibles',
+              donnees: {},
+              textBoutonAjouter: 'Ajouter des données',
+            })
+
     section
       +inputChoix({
         type: 'radio',

--- a/test/modeles/donneesSensiblesSpecifiques.spec.js
+++ b/test/modeles/donneesSensiblesSpecifiques.spec.js
@@ -1,0 +1,15 @@
+const expect = require('expect.js');
+
+const DonneesSensiblesSpecifiques = require('../../src/modeles/donneesSensiblesSpecifiques');
+
+const elles = it;
+
+describe('Les donnees sensibles spécifiques', () => {
+  elles("se construisent avec le bon nom d'item", () => {
+    const donneesSensiblesSpecifiques = new DonneesSensiblesSpecifiques(
+      { donneesSensiblesSpecifiques: [] }
+    );
+
+    expect(donneesSensiblesSpecifiques.nombre()).to.equal(0);
+  });
+});

--- a/test/modeles/informationsGenerales.spec.js
+++ b/test/modeles/informationsGenerales.spec.js
@@ -17,6 +17,7 @@ describe('Les informations générales', () => {
     const infos = new InformationsGenerales({
       delaiAvantImpactCritique: 'unDelai',
       donneesCaracterePersonnel: ['desDonnees'],
+      donneesSensiblesSpecifiques: [{ description: 'Des données sensibles' }],
       fonctionnalites: ['uneFonctionnalite'],
       fonctionnalitesSpecifiques: [{ description: 'Une fonctionnalité' }],
       localisationDonnees: 'france',
@@ -40,8 +41,9 @@ describe('Les informations générales', () => {
     expect(infos.provenanceService).to.eql(['uneProvenance']);
     expect(infos.statutDeploiement).to.eql('unStatut');
 
-    expect(infos.nombrePointsAcces()).to.equal(1);
+    expect(infos.nombreDonneesSensiblesSpecifiques()).to.equal(1);
     expect(infos.nombreFonctionnalitesSpecifiques()).to.equal(1);
+    expect(infos.nombrePointsAcces()).to.equal(1);
   });
 
   elles('décrivent le type service', () => {

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -427,11 +427,18 @@ describe('Le serveur MSS', () => {
     });
 
     it('aseptise la liste des fonctionnalités spécifiques ainsi que son contenu', (done) => {
-      depotDonnees.nouvelleHomologation = () => Promise.resolve();
-
       axios.post('http://localhost:1234/api/homologation', {})
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('aseptise la liste des données sensibles spécifiques ainsi que son contenu', (done) => {
+      axios.post('http://localhost:1234/api/homologation', {})
+        .then(() => {
+          verifieAseptisationListe('donneesSensiblesSpecifiques', ['description']);
           done();
         })
         .catch(done);
@@ -469,6 +476,7 @@ describe('Le serveur MSS', () => {
           fonctionnalites: undefined,
           fonctionnalitesSpecifiques: undefined,
           donneesCaracterePersonnel: undefined,
+          donneesSensiblesSpecifiques: undefined,
           delaiAvantImpactCritique: undefined,
           localisationDonnees: undefined,
           presenceResponsable: undefined,
@@ -521,6 +529,15 @@ describe('Le serveur MSS', () => {
       axios.put('http://localhost:1234/api/homologation/456', {})
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('aseptise la liste des données sensibles spécifiques ainsi que son contenu', (done) => {
+      axios.put('http://localhost:1234/api/homologation/456', {})
+        .then(() => {
+          verifieAseptisationListe('donneesSensiblesSpecifiques', ['description']);
           done();
         })
         .catch(done);


### PR DESCRIPTION
Dans la page Informations générales
En dessous de la sélection des _Données à caractère personnel et autres données sensibles stockées par le service_
Ajout d'une possibilité de renseigner manuellement d'autres données sensibles
<img width="834" alt="Capture d’écran 2021-12-29 à 15 11 34" src="https://user-images.githubusercontent.com/39462397/147671055-9fb38950-7195-4bd4-829d-e395ea211130.png">
