### PR TITLE
Introduction notion métier d'« autorisation »

### DIFF
--- a/migrations/20211229123645_creationTableAcces.js
+++ b/migrations/20211229123645_creationTableAcces.js
@@ -1,0 +1,8 @@
+exports.up = (knex) => knex.schema
+  .createTable('acces', (table) => {
+    table.uuid('id');
+    table.primary('id');
+    table.json('donnees');
+  });
+
+exports.down = (knex) => knex.schema.dropTable('acces');

--- a/migrations/20211229141624_renommeTableAccesEnAutorisations.js
+++ b/migrations/20211229141624_renommeTableAccesEnAutorisations.js
@@ -1,0 +1,3 @@
+exports.up = (knex) => knex.schema.renameTable('acces', 'autorisations');
+
+exports.down = (knex) => knex.schema.renameTable('autorisations', 'acces');

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -1,4 +1,4 @@
-const nouvelAdaptateur = (donnees = { utilisateurs: [], homologations: [] }) => {
+const nouvelAdaptateur = (donnees = { utilisateurs: [], homologations: [], autorisations: [] }) => {
   const ajouteHomologation = (id, donneesHomologation) => {
     donnees.homologations.push(Object.assign(donneesHomologation, { id }));
     return Promise.resolve();
@@ -65,14 +65,28 @@ const nouvelAdaptateur = (donnees = { utilisateurs: [], homologations: [] }) => 
     donnees.utilisateurs.find((u) => u.idResetMotDePasse === idReset)
   );
 
+  const autorisations = (idUtilisateur) => Promise.resolve(
+    donnees.autorisations.filter((a) => a.idUtilisateur === idUtilisateur)
+  );
+
+  const ajouteAutorisation = (id, donneesAutorisation) => {
+    donnees.autorisations.push(Object.assign(donneesAutorisation, { id }));
+    return Promise.resolve();
+  };
+
+  const supprimeAutorisations = () => Promise.resolve(donnees.autorisations = []);
+
   return {
+    ajouteAutorisation,
     ajouteHomologation,
     ajouteUtilisateur,
+    autorisations,
     homologation,
     homologationAvecNomService,
     homologations,
     metsAJourHomologation,
     metsAJourUtilisateur,
+    supprimeAutorisations,
     supprimeHomologation,
     supprimeHomologations,
     supprimeUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -77,16 +77,27 @@ const nouvelAdaptateur = (env) => {
     'utilisateurs', 'idResetMotDePasse', idReset
   );
 
+  const autorisations = (idUtilisateur) => knex('autorisations')
+    .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
+    .then((rows) => rows.map(convertisLigneEnObjet));
+
+  const ajouteAutorisation = (...params) => ajouteLigneDansTable('autorisations', ...params);
+
+  const supprimeAutorisations = () => knex('autorisations').del();
+
   return {
+    ajouteAutorisation,
     ajouteHomologation,
     ajouteUtilisateur,
     arreteTout,
+    autorisations,
     homologation,
     homologationAvecNomService,
     homologations,
     metsAJourHomologation,
     metsAJourUtilisateur,
     nbUtilisateurs,
+    supprimeAutorisations,
     supprimeHomologation,
     supprimeHomologations,
     supprimeUtilisateur,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -7,8 +7,8 @@ const {
   ErreurUtilisateurExistant,
 } = require('./erreurs');
 const AdaptateurPersistanceMemoire = require('./adaptateurs/adaptateurPersistanceMemoire');
-const AutorisationCreateur = require('./modeles/autorisationCreateur');
 const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
+const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
 const Homologation = require('./modeles/homologation');
 const Utilisateur = require('./modeles/utilisateur');
 
@@ -241,7 +241,7 @@ const creeDepot = (config = {}) => {
   );
 
   const autorisations = (idUtilisateur) => adaptateurPersistance.autorisations(idUtilisateur)
-    .then((as) => as.map((a) => new AutorisationCreateur(a)));
+    .then((as) => as.map((a) => FabriqueAutorisation.fabrique(a)));
 
   return {
     ajouteAvisExpertCyberAHomologation,

--- a/src/modeles/autorisationCreateur.js
+++ b/src/modeles/autorisationCreateur.js
@@ -1,0 +1,10 @@
+const Base = require('./base');
+
+class AutorisationCreateur extends Base {
+  constructor(donnees = {}) {
+    super({ proprietesAtomiquesRequises: ['id', 'idUtilisateur', 'idHomologation'] });
+    this.renseigneProprietes(donnees);
+  }
+}
+
+module.exports = AutorisationCreateur;

--- a/src/modeles/autorisations/autorisationCreateur.js
+++ b/src/modeles/autorisations/autorisationCreateur.js
@@ -1,4 +1,4 @@
-const Base = require('./base');
+const Base = require('../base');
 
 class AutorisationCreateur extends Base {
   constructor(donnees = {}) {

--- a/src/modeles/autorisations/fabriqueAutorisation.js
+++ b/src/modeles/autorisations/fabriqueAutorisation.js
@@ -1,0 +1,5 @@
+const AutorisationCreateur = require('./autorisationCreateur');
+
+const fabrique = ({ type, ...autresDonnees }) => new AutorisationCreateur(autresDonnees);
+
+module.exports = { fabrique };

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -9,6 +9,7 @@ const {
   ErreurUtilisateurExistant,
 } = require('../src/erreurs');
 const AdaptateurPersistanceMemoire = require('../src/adaptateurs/adaptateurPersistanceMemoire');
+const AutorisationCreateur = require('../src/modeles/autorisationCreateur');
 const AvisExpertCyber = require('../src/modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('../src/modeles/caracteristiquesComplementaires');
 const Homologation = require('../src/modeles/homologation');
@@ -428,6 +429,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
         homologations: [],
+        autorisations: [],
       });
       depot = DepotDonnees.creeDepot({ adaptateurPersistance, adaptateurUUID });
     });
@@ -440,6 +442,22 @@ describe('Le dépôt de données persistées en mémoire', () => {
         .then((homologations) => {
           expect(homologations.length).to.equal(1);
           expect(homologations[0].informationsGenerales.nomService).to.equal('Super Service');
+          done();
+        })
+        .catch(done);
+    });
+
+    it("déclare un accès entre l'utilisateur et l'homologation", (done) => {
+      depot.autorisations('123')
+        .then((as) => expect(as.length).to.equal(0))
+        .then(() => depot.nouvelleHomologation('123', { nomService: 'SuperService' }))
+        .then(() => depot.autorisations('123'))
+        .then((as) => {
+          expect(as.length).to.equal(1);
+          const autorisation = as[0];
+          expect(autorisation).to.be.an(AutorisationCreateur);
+          expect(autorisation.idHomologation).to.equal('unUUID');
+          expect(autorisation.idUtilisateur).to.equal('123');
           done();
         })
         .catch(done);

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -9,7 +9,7 @@ const {
   ErreurUtilisateurExistant,
 } = require('../src/erreurs');
 const AdaptateurPersistanceMemoire = require('../src/adaptateurs/adaptateurPersistanceMemoire');
-const AutorisationCreateur = require('../src/modeles/autorisationCreateur');
+const AutorisationCreateur = require('../src/modeles/autorisations/autorisationCreateur');
 const AvisExpertCyber = require('../src/modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('../src/modeles/caracteristiquesComplementaires');
 const Homologation = require('../src/modeles/homologation');

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -190,6 +190,7 @@ describe('Le serveur MSS', () => {
     DepotDonnees.creeDepotVide()
       .then((depot) => {
         depotDonnees = depot;
+        depotDonnees.nouvelleHomologation = () => Promise.resolve();
         serveur = MSS.creeServeur(depotDonnees, middleware, referentiel, adaptateurMail, false);
         serveur.ecoute(1234, done);
       });


### PR DESCRIPTION
Cette PR est essentiellement une préparation de l'implémentation du mode collaboratif. Pour l'instant, à chaque création d'homologation, en plus de rattacher l'utilisateur à l'homologation, on crée un enregistrement dans la table `autorisations`.

La suite sera :
- migration : ajouter une autorisation de type `'createur'` pour chaque homologation existante en base
- transfert du code exploitant la relation directe entre une homologation et un utilisateur
- suppression de la colonne `Homologation.idUtilisateur`

… Puis :
- ajouter un collaborateur existant
- accéder à des homologations avec le rôle « collaborateur »
- interdire aux collaborateurs d'inviter d'autres collaborateurs