### PR TITLE
Ecriture de la localisation des données dans les informations générales

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -10,6 +10,7 @@ const AdaptateurPersistanceMemoire = require('./adaptateurs/adaptateurPersistanc
 const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
 const Homologation = require('./modeles/homologation');
+const InformationsGenerales = require('./modeles/informationsGenerales');
 const Utilisateur = require('./modeles/utilisateur');
 
 const creeDepot = (config = {}) => {
@@ -121,6 +122,17 @@ const creeDepot = (config = {}) => {
         );
         caracteristiques.presentation = presentation;
         return metsAJourProprieteHomologation('caracteristiquesComplementaires', h, caracteristiques);
+      })
+  );
+
+  const ajouteLocalisationDonneesAHomologation = (idHomologation, localisationDonnees) => (
+    adaptateurPersistance.homologation(idHomologation)
+      .then((h) => {
+        const informationsGenerales = new InformationsGenerales(
+          h.informationsGenerales, referentiel
+        );
+        informationsGenerales.localisationDonnees = localisationDonnees;
+        return metsAJourProprieteHomologation('informationsGenerales', h, informationsGenerales);
       })
   );
 
@@ -247,6 +259,7 @@ const creeDepot = (config = {}) => {
     ajouteAvisExpertCyberAHomologation,
     ajouteCaracteristiquesAHomologation,
     ajouteInformationsGeneralesAHomologation,
+    ajouteLocalisationDonneesAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajoutePresentationAHomologation,

--- a/src/modeles/informationsGenerales.js
+++ b/src/modeles/informationsGenerales.js
@@ -14,6 +14,9 @@ class InformationsGenerales extends InformationsHomologation {
         'presentation',
         'statutDeploiement',
       ],
+      proprietesAtomiquesFacultatives: [
+        'localisationDonnees',
+      ],
       proprietesListes: [
         'donneesCaracterePersonnel',
         'fonctionnalites',

--- a/src/mss.js
+++ b/src/mss.js
@@ -281,7 +281,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
       );
       try {
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
+        const { localisationDonnees } = caracteristiques;
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
+          .then(() => depotDonnees.ajouteLocalisationDonneesAHomologation(
+            requete.params.id, localisationDonnees
+          ))
           .then(() => reponse.send({ idHomologation: requete.homologation.id }));
       } catch {
         reponse.status(422).send('Données invalides');

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -310,6 +310,21 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
+  it('ajoute une localisation des données à une homologation', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajouteLocalisationDonneesAHomologation('123', 'france')
+      .then(() => depot.homologation('123'))
+      .then(({ informationsGenerales: { localisationDonnees } }) => {
+        expect(localisationDonnees).to.equal('france');
+        done();
+      })
+      .catch(done);
+  });
+
   it('sait associer des parties prenantes à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [

--- a/test/modeles/informationsGenerales.spec.js
+++ b/test/modeles/informationsGenerales.spec.js
@@ -18,6 +18,7 @@ describe('Les informations générales', () => {
       donneesCaracterePersonnel: ['desDonnees'],
       fonctionnalites: ['uneFonctionnalite'],
       fonctionnalitesSpecifiques: [{ description: 'Une fonctionnalité' }],
+      localisationDonnees: 'france',
       typeService: ['unType'],
       nomService: 'Super Service',
       pointsAcces: [{ description: 'Une description' }],
@@ -30,6 +31,7 @@ describe('Les informations générales', () => {
     expect(infos.delaiAvantImpactCritique).to.equal('unDelai');
     expect(infos.donneesCaracterePersonnel).to.eql(['desDonnees']);
     expect(infos.fonctionnalites).to.eql(['uneFonctionnalite']);
+    expect(infos.localisationDonnees).to.equal('france');
     expect(infos.typeService).to.eql(['unType']);
     expect(infos.nomService).to.equal('Super Service');
     expect(infos.presenceResponsable).to.be('non');

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -613,6 +613,7 @@ describe('Le serveur MSS', () => {
   describe('quand requête POST sur `/api/homologation/:id/caracteristiquesComplementaires', () => {
     beforeEach(() => {
       depotDonnees.ajouteCaracteristiquesAHomologation = () => Promise.resolve();
+      depotDonnees.ajouteLocalisationDonneesAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -631,6 +632,34 @@ describe('Le serveur MSS', () => {
         },
         done
       );
+    });
+
+    it("demande au dépôt d'ajouter la localisation des données", (done) => {
+      referentiel.identifiantsLocalisationsDonnees = () => ['france'];
+
+      let localisationDonneesAjouteeAHomologation = false;
+      depotDonnees.ajouteLocalisationDonneesAHomologation = (
+        idHomologation, localisationDonnees
+      ) => {
+        try {
+          expect(localisationDonnees).to.equal('france');
+          expect(idHomologation).to.equal('456');
+          localisationDonneesAjouteeAHomologation = true;
+          return Promise.resolve();
+        } catch (e) {
+          return Promise.reject(done(e));
+        }
+      };
+
+      axios.post(
+        'http://localhost:1234/api/homologation/456/caracteristiquesComplementaires',
+        { localisationDonnees: 'france' },
+      )
+        .then(() => {
+          expect(localisationDonneesAjouteeAHomologation).to.be(true);
+          done();
+        })
+        .catch(done);
     });
 
     it("demande au dépôt d'associer les caractéristiques à l'homologation", (done) => {


### PR DESCRIPTION
Etape 1 du déplacement de **Localisation des données** dans Informations générales

Dans la page Caractéristiques complémentaires
Quand on sélectionne une localisation pour les données
Celle ci est persistée dans `caracteristiquesComplementaires` et dans `informationsGenerales`
<img width="660" alt="Capture d’écran 2022-01-03 à 14 56 31" src="https://user-images.githubusercontent.com/39462397/147938989-72b6fa59-056e-4120-b0ab-3fc694316fe2.png">
