### PR TITLE
[MIGRATION] Ajout autorisation de type `createur` pour chaque homologation existante en base

### DIFF
--- a/migrations/20220103141419_dupliqueLienHomologationUtilisateurDansAutorisation.js
+++ b/migrations/20220103141419_dupliqueLienHomologationUtilisateurDansAutorisation.js
@@ -1,0 +1,23 @@
+const uuid = require('uuid');
+
+const ajouteAutorisationCreateurSiInexistante = (knex, idUtilisateur, idHomologation) => knex('autorisations')
+  .then((lignes) => {
+    const autorisationsExistantes = lignes.filter(({ donnees }) => (
+      donnees.idHomologation === idHomologation
+        && donnees.idUtilisateur === idUtilisateur
+        && donnees.type === 'createur'
+    ));
+    if (autorisationsExistantes.length > 0) return Promise.resolve();
+
+    return knex('autorisations')
+      .insert({ id: uuid.v4(), donnees: { idHomologation, idUtilisateur, type: 'createur' } });
+  });
+
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => Promise.all(
+    lignes.map(({ id, donnees: { idUtilisateur } }) => (
+      ajouteAutorisationCreateurSiInexistante(knex, idUtilisateur, id)
+    ))
+  ));
+
+exports.down = (knex) => knex('autorisations').del();


### PR DESCRIPTION
Cette PR fait suite à #40

La suite sera :
- transfert du code exploitant la relation directe entre une homologation et un utilisateur
- suppression de la colonne Homologation.idUtilisateur

… Puis :
- ajouter un collaborateur existant
- accéder à des homologations avec le rôle « collaborateur »
- interdire aux collaborateurs d'inviter d'autres collaborateurs