### PR TITLE
Renommer le titre d'informations générales et le texte autour

### DIFF
--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -5,11 +5,11 @@ block append styles
 
 mixin formulaireInformationsGenerales(idHomologation)
   form.homologation#homologation
-    h1 Décrivez le service numérique
-    h2 Informations générales
+    h1 Première étape de la constitution de votre dossier
+    h2 Description du service
     p.
-      Ces informations nous permettront de vous proposer des mesures de
-      sécurité adaptées.
+      Présentez les caractéristiques de votre service numérique à homologuer pour recevoir des recommandations personnalisées.
+      Ces informations pourront être complétées ou modifiées ultérieurement.
     section
       label Nom du service numérique à homologuer
         br


### PR DESCRIPTION
Dans la page informations générales,
le titre et les textes autour subissent un renommage
<img width="658" alt="Capture d’écran 2022-01-05 à 16 45 00" src="https://user-images.githubusercontent.com/39462397/148246306-657a2858-bc99-43b0-8279-1eae2245c91e.png">
