### PR TITLE
Renommer le bouton enregistrer de description du service

### DIFF
--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -93,9 +93,9 @@ mixin formulaireInformationsGenerales(idHomologation)
       })
 
     if idHomologation
-      .bouton#diagnostic(identifiant = idHomologation) Enregistrer &nbsp;&nbsp;›
+      .bouton#diagnostic(identifiant = idHomologation) Enregistrer
     else
-      .bouton#diagnostic Continuer &nbsp;&nbsp;›
+      .bouton#diagnostic Valider
 
 
   script(id = 'donnees-points-acces', type = 'application/json').


### PR DESCRIPTION
Dans la page description du service,
le bouton **Enregistrer** devient **Enregistrer et revenir à l'espace personnel**