### PR TITLE
Réplication de la persistance des données de description du service

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -150,7 +150,11 @@ const creeDepot = (config = {}) => {
   const nouvelleHomologation = (idUtilisateur, donneesInformationsGenerales) => {
     const idHomologation = adaptateurUUID.genereUUID();
     const idAutorisation = adaptateurUUID.genereUUID();
-    const donnees = { idUtilisateur, informationsGenerales: donneesInformationsGenerales };
+    const donnees = {
+      idUtilisateur,
+      informationsGenerales: donneesInformationsGenerales,
+      descriptionService: donneesInformationsGenerales,
+    };
 
     return valideInformationsGenerales(idUtilisateur, donneesInformationsGenerales)
       .then(() => adaptateurPersistance.ajouteHomologation(idHomologation, donnees))

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -62,6 +62,11 @@ const creeDepot = (config = {}) => {
     return trouveDonneesHomologation(idOuHomologation).then(metsAJour);
   };
 
+  const metsAJourInformationsGeneralesHomologation = (homologationCible, informations) => (
+    metsAJourProprieteHomologation('informationsGenerales', homologationCible, informations)
+      .then(() => metsAJourProprieteHomologation('descriptionService', homologationCible, informations))
+  );
+
   const remplaceProprieteHomologation = (nomPropriete, idHomologation, propriete) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((h) => {
@@ -105,7 +110,7 @@ const creeDepot = (config = {}) => {
     adaptateurPersistance.homologation(idHomologation)
       .then((h) => (
         valideInformationsGenerales(h.idUtilisateur, infos, h.id)
-          .then(() => metsAJourProprieteHomologation('informationsGenerales', h, infos))
+          .then(() => metsAJourInformationsGeneralesHomologation(h, infos))
       ))
   );
 
@@ -132,7 +137,7 @@ const creeDepot = (config = {}) => {
           h.informationsGenerales, referentiel
         );
         informationsGenerales.localisationDonnees = localisationDonnees;
-        return metsAJourProprieteHomologation('informationsGenerales', h, informationsGenerales);
+        return metsAJourInformationsGeneralesHomologation(h, informationsGenerales);
       })
   );
 

--- a/src/modeles/descriptionService.js
+++ b/src/modeles/descriptionService.js
@@ -1,0 +1,3 @@
+const DescriptionService = require('./informationsGenerales');
+
+module.exports = DescriptionService;

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -1,6 +1,7 @@
 const Referentiel = require('../referentiel');
 const AvisExpertCyber = require('./avisExpertCyber');
 const CaracteristiquesComplementaires = require('./caracteristiquesComplementaires');
+const DescriptionService = require('./descriptionService');
 const InformationsGenerales = require('./informationsGenerales');
 const Mesure = require('./mesure');
 const Mesures = require('./mesures');
@@ -33,7 +34,7 @@ class Homologation {
     this.id = id;
     this.idUtilisateur = idUtilisateur;
     this.informationsGenerales = new InformationsGenerales(informationsGenerales, referentiel);
-    this.descriptionService = new InformationsGenerales(descriptionService, referentiel);
+    this.descriptionService = new DescriptionService(descriptionService, referentiel);
     this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel);
     this.caracteristiquesComplementaires = new CaracteristiquesComplementaires(
       caracteristiquesComplementaires, referentiel,

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -20,6 +20,7 @@ class Homologation {
       id = '',
       idUtilisateur,
       informationsGenerales = {},
+      descriptionService = {},
       mesuresGenerales = [],
       mesuresSpecifiques = [],
       caracteristiquesComplementaires = {},
@@ -32,6 +33,7 @@ class Homologation {
     this.id = id;
     this.idUtilisateur = idUtilisateur;
     this.informationsGenerales = new InformationsGenerales(informationsGenerales, referentiel);
+    this.descriptionService = new InformationsGenerales(descriptionService, referentiel);
     this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel);
     this.caracteristiquesComplementaires = new CaracteristiquesComplementaires(
       caracteristiquesComplementaires, referentiel,

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -230,6 +230,24 @@ describe('Le dépôt de données persistées en mémoire', () => {
         .catch(done);
     });
 
+    it('met à jour les informations générales dans description du service', (done) => {
+      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        homologations: [
+          { id: '123', descriptionService: { nomService: 'Super Service' } },
+        ],
+      });
+      const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+      const infos = new InformationsGenerales({ nomService: 'Nouveau Nom' });
+      depot.ajouteInformationsGeneralesAHomologation('123', infos)
+        .then(() => depot.homologation('123'))
+        .then(({ descriptionService }) => {
+          expect(descriptionService.nomService).to.equal('Nouveau Nom');
+          done();
+        })
+        .catch(done);
+    });
+
     it('lève une exception si le nom du service est absent', (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         homologations: [
@@ -339,6 +357,21 @@ describe('Le dépôt de données persistées en mémoire', () => {
     depot.ajouteLocalisationDonneesAHomologation('123', 'france')
       .then(() => depot.homologation('123'))
       .then(({ informationsGenerales: { localisationDonnees } }) => {
+        expect(localisationDonnees).to.equal('france');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('ajoute une localisation des données à la description du service', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajouteLocalisationDonneesAHomologation('123', 'france')
+      .then(() => depot.homologation('123'))
+      .then(({ descriptionService: { localisationDonnees } }) => {
         expect(localisationDonnees).to.equal('france');
         done();
       })

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -532,6 +532,19 @@ describe('Le dépôt de données persistées en mémoire', () => {
         })
         .catch(done);
     });
+
+    it("duplique les données d'informations générales dans description du service", (done) => {
+      depot.homologations('123')
+        .then(() => depot.nouvelleHomologation('123', { nomService: 'Super Service' }))
+        .then(() => depot.homologations('123'))
+        .then((homologations) => {
+          expect(homologations.length).to.equal(1);
+          expect(homologations[0].informationsGenerales.nomService).to.equal('Super Service');
+          expect(homologations[0].descriptionService.nomService).to.equal('Super Service');
+          done();
+        })
+        .catch(done);
+    });
   });
 
   it("retourne l'utilisateur authentifié", (done) => {


### PR DESCRIPTION
Quand on crée ou modifie une homologation,
Les données dites informations générales sont persistées dans `informationsGenerales` ainsi que dans `descriptionService`
<img width="1195" alt="Capture d’écran 2022-01-06 à 17 53 05" src="https://user-images.githubusercontent.com/39462397/148420305-0e7f390a-75e3-4d08-8d88-fc13acd84ebd.png">
