### PR TITLE
Factorisation de l'aseptisation des listes en un seul middleware

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -106,20 +106,31 @@ const middleware = (configuration = {}) => {
       .catch(suite);
   });
 
-  const aseptiseListe = (nomListe, proprietesParametre) => (
+  const aseptiseListes = (listes) => (
     (requete, reponse, suite) => {
-      requete.body[nomListe] &&= requete.body[nomListe].filter(
-        (element) => proprietesParametre.some((propriete) => element && element[propriete])
-      );
-      suite();
-    });
+      listes.forEach(({ nom, proprietes }) => {
+        requete.body[nom] &&= requete.body[nom].filter(
+          (element) => proprietes.some((propriete) => element && element[propriete])
+        );
+      });
+      const proprietesAAseptiser = listes.flatMap(({ nom, proprietes }) => (
+        proprietes.map((propriete) => `${nom}.*.${propriete}`)
+      ));
+      return aseptise(proprietesAAseptiser)(requete, reponse, suite);
+    }
+  );
+
+  const aseptiseListe = (nomListe, proprietesParametre) => (
+    aseptiseListes([{ nom: nomListe, proprietes: proprietesParametre }])
+  );
 
   return {
     aseptise,
+    aseptiseListe,
+    aseptiseListes,
     authentificationBasique,
     positionneHeaders,
     positionneHeadersAvecNonce,
-    aseptiseListe,
     repousseExpirationCookie,
     suppressionCookie,
     trouveHomologation,

--- a/src/mss.js
+++ b/src/mss.js
@@ -209,9 +209,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
 
   app.post('/api/homologation',
     middleware.verificationAcceptationCGU,
-    middleware.aseptise('nomService', 'pointsAcces.*.description', 'fonctionnalitesSpecifiques.*.description'),
-    middleware.aseptiseListe('pointsAcces', PointsAcces.proprietesItem()),
-    middleware.aseptiseListe('fonctionnalitesSpecifiques', FonctionnalitesSpecifiques.proprietesItem()),
+    middleware.aseptise('nomService'),
+    middleware.aseptiseListes([
+      { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
+      { nom: 'fonctionnalitesSpecifiques', proprietes: FonctionnalitesSpecifiques.proprietesItem() },
+    ]),
     (requete, reponse, suite) => {
       const {
         nomService,
@@ -261,9 +263,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
 
   app.put('/api/homologation/:id',
     middleware.trouveHomologation,
-    middleware.aseptise('nomService', 'pointsAcces.*.description', 'fonctionnalitesSpecifiques.*.description'),
-    middleware.aseptiseListe('pointsAcces', PointsAcces.proprietesItem()),
-    middleware.aseptiseListe('fonctionnalitesSpecifiques', FonctionnalitesSpecifiques.proprietesItem()),
+    middleware.aseptise('nomService'),
+    middleware.aseptiseListes([
+      { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
+      { nom: 'fonctionnalitesSpecifiques', proprietes: FonctionnalitesSpecifiques.proprietesItem() },
+    ]),
     (requete, reponse, suite) => {
       const infosGenerales = new InformationsGenerales(requete.body, referentiel);
       depotDonnees.ajouteInformationsGeneralesAHomologation(requete.params.id, infosGenerales)

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -351,13 +351,63 @@ describe('Le middleware MSS', () => {
   });
 
   describe("sur une demande d'aseptisation d'une liste", () => {
-    it('supprime les éléments dont les propriétés sont vides', (done) => {
+    it('supprime les éléments dont toutes les propriétés sont vides', (done) => {
       const middleware = Middleware();
       requete.body.listeAvecProprieteVide = [
         { description: 'une description' }, { description: null },
       ];
       middleware.aseptiseListe('listeAvecProprieteVide', ['description'])(requete, reponse, () => {
         expect(requete.body.listeAvecProprieteVide).to.have.length(1);
+        done();
+      });
+    });
+
+    it('conserve les éléments dont au moins une propriété est renseignée', (done) => {
+      const middleware = Middleware();
+      requete.body.listeAvecProprietesPartiellementVides = [
+        { description: 'une description', nom: null },
+      ];
+      middleware.aseptiseListe('listeAvecProprietesPartiellementVides', ['description', 'nom'])(requete, reponse, () => {
+        expect(requete.body.listeAvecProprietesPartiellementVides).to.have.length(1);
+        done();
+      });
+    });
+
+    it('ne supprime pas les éléments dont les propriétés sont des tableaux vides', (done) => {
+      const middleware = Middleware();
+      requete.body.listeAvecProprieteTableauVide = [
+        { description: [] },
+      ];
+      middleware.aseptiseListe('listeAvecProprieteTableauVide', ['description'])(requete, reponse, () => {
+        expect(requete.body.listeAvecProprieteTableauVide).to.have.length(1);
+        done();
+      });
+    });
+  });
+
+  describe("sur une demande d'aseptisation de plusieurs listes", () => {
+    it('supprime dans chaque liste les éléments dont toutes les propriétés sont vides', (done) => {
+      const middleware = Middleware();
+      requete.body.listeUn = [
+        { description: 'une description' }, { description: null },
+      ];
+      requete.body.listeDeux = [
+        { description: 'une description' }, { description: null },
+      ];
+      middleware.aseptiseListes([{ nom: 'listeUn', proprietes: ['description'] }, { nom: 'listeDeux', proprietes: ['description'] }])(requete, reponse, () => {
+        expect(requete.body.listeUn).to.have.length(1);
+        expect(requete.body.listeDeux).to.have.length(1);
+        done();
+      });
+    });
+
+    it('aseptise les paramètres en correspondants aux propriétés', (done) => {
+      const middleware = Middleware();
+      requete.body.listeUn = [
+        { description: '  une description  ' },
+      ];
+      middleware.aseptiseListes([{ nom: 'listeUn', proprietes: ['description'] }])(requete, reponse, () => {
+        expect(requete.body.listeUn[0].description).to.equal('une description');
         done();
       });
     });


### PR DESCRIPTION
dans les appels de créations d'homologations et de mises à jours des informations générales des homologations,
on devait aseptiser plusieurs listes.
Ce dev rassemble les appels en un unique middleware