### PR TITLE
Convertis login en minuscules

### DIFF
--- a/migrations/20220111092352_conversionEmailsEnMinuscules.js
+++ b/migrations/20220111092352_conversionEmailsEnMinuscules.js
@@ -1,0 +1,9 @@
+exports.up = (knex) => knex('utilisateurs')
+  .then((lignes) => Promise.all(
+    lignes.map(({ id, donnees }) => {
+      donnees.email = donnees.email.toLowerCase();
+      return knex('utilisateurs').where({ id }).update({ donnees });
+    })
+  ));
+
+exports.down = () => {};

--- a/src/mss.js
+++ b/src/mss.js
@@ -497,7 +497,8 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
   });
 
   app.post('/api/token', (requete, reponse, suite) => {
-    const { login, motDePasse } = requete.body;
+    const login = requete.body.login?.toLowerCase();
+    const { motDePasse } = requete.body;
     depotDonnees.utilisateurAuthentifie(login, motDePasse)
       .then((utilisateur) => {
         if (utilisateur) {

--- a/src/mss.js
+++ b/src/mss.js
@@ -428,7 +428,9 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
   });
 
   app.post('/api/utilisateur', middleware.aseptise('prenom', 'nom', 'email'), (requete, reponse, suite) => {
-    const { prenom, nom, email } = requete.body;
+    const { prenom, nom } = requete.body;
+    const email = requete.body.email?.toLowerCase();
+
     depotDonnees.nouvelUtilisateur({ prenom, nom, email })
       .then((utilisateur) => (
         adaptateurMail.envoieMessageFinalisationInscription(
@@ -449,7 +451,8 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
   });
 
   app.post('/api/reinitialisationMotDePasse', (requete, reponse, suite) => {
-    const { email } = requete.body;
+    const email = requete.body.email?.toLowerCase();
+
     depotDonnees.reinitialiseMotDePasse(email)
       .then((utilisateur) => {
         if (utilisateur) {

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -1019,6 +1019,17 @@ describe('Le serveur MSS', () => {
       );
     });
 
+    it("convertis l'email en minuscules", (done) => {
+      depotDonnees.nouvelUtilisateur = ({ email }) => {
+        expect(email).to.equal('jean.dupont@mail.fr');
+        return Promise.resolve(utilisateur);
+      };
+
+      axios.post('http://localhost:1234/api/utilisateur', { email: 'Jean.DUPONT@mail.fr' })
+        .then(() => done())
+        .catch(done);
+    });
+
     it("demande au dépôt de créer l'utilisateur", (done) => {
       const donneesRequete = { prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' };
 
@@ -1107,6 +1118,27 @@ describe('Le serveur MSS', () => {
     beforeEach(() => (
       depotDonnees.reinitialiseMotDePasse = () => Promise.resolve(utilisateur)
     ));
+
+    it("convertis l'email en minuscules", (done) => {
+      depotDonnees.reinitialiseMotDePasse = (email) => {
+        expect(email).to.equal('jean.dupont@mail.fr');
+        return Promise.resolve(utilisateur);
+      };
+
+      axios.post(
+        'http://localhost:1234/api/reinitialisationMotDePasse', { email: 'Jean.DUPONT@mail.fr' }
+      )
+        .then(() => done())
+        .catch(done);
+    });
+
+    it("échoue silencieusement si l'email n'est pas renseigné", (done) => {
+      depotDonnees.nouvelUtilisateur = () => Promise.resolve();
+
+      axios.post('http://localhost:1234/api/reinitialisationMotDePasse')
+        .then(() => done())
+        .catch(done);
+    });
 
     it('demande au dépôt de réinitialiser le mot de passe', (done) => {
       depotDonnees.reinitialiseMotDePasse = (email) => new Promise((resolve) => {

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -1260,6 +1260,24 @@ describe('Le serveur MSS', () => {
   });
 
   describe('quand requête POST sur `/api/token`', () => {
+    it("authentifie l'utilisateur avec le login en minuscules", (done) => {
+      const utilisateur = { toJSON: () => {}, genereToken: () => {} };
+
+      depotDonnees.utilisateurAuthentifie = (login, motDePasse) => {
+        try {
+          expect(login).to.equal('jean.dupont@mail.fr');
+          expect(motDePasse).to.equal('mdp_12345');
+          return Promise.resolve(utilisateur);
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      axios.post('http://localhost:1234/api/token', { login: 'Jean.DUPONT@mail.fr', motDePasse: 'mdp_12345' })
+        .then(() => done())
+        .catch(done);
+    });
+
     describe("avec authentification réussie de l'utilisateur", () => {
       beforeEach(() => {
         const utilisateur = {
@@ -1267,13 +1285,7 @@ describe('Le serveur MSS', () => {
           genereToken: () => 'un token',
         };
 
-        depotDonnees.utilisateurAuthentifie = (login, motDePasse) => new Promise(
-          (resolve) => {
-            expect(login).to.equal('jean.dupont@mail.fr');
-            expect(motDePasse).to.equal('mdp_12345');
-            resolve(utilisateur);
-          }
-        );
+        depotDonnees.utilisateurAuthentifie = () => Promise.resolve(utilisateur);
       });
 
       it("retourne les informations de l'utilisateur", (done) => {
@@ -1310,7 +1322,7 @@ describe('Le serveur MSS', () => {
           401, "L'authentification a échoué", {
             method: 'post',
             url: 'http://localhost:1234/api/token',
-            data: { login: 'jean.dupont@mail.fr', motDePasse: 'mdp_12345' },
+            data: {},
           }, done
         );
       });


### PR DESCRIPTION
Cela permet de ne pas avoir à tenir compte de la casse dans les adresses mail qui sont saisies pour les inscription.