### PR TITLE
Utilise les autorisations, plutôt que `homologation.idUtilisateur`

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -40,16 +40,20 @@ const nouvelAdaptateur = (env) => {
 
   const homologationAvecNomService = (idUtilisateur, nomService, idHomologationMiseAJour = '') => (
     knex('homologations')
-      .whereRaw('not id::text=?', idHomologationMiseAJour)
-      .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
-      .whereRaw("donnees#>>'{informationsGenerales,nomService}'=?", nomService)
+      .join('autorisations', knex.raw("(autorisations.donnees->>'idHomologation')::uuid"), 'homologations.id')
+      .whereRaw("autorisations.donnees->>'idUtilisateur'=?", idUtilisateur)
+      .whereRaw('not homologations.id::text=?', idHomologationMiseAJour)
+      .whereRaw("homologations.donnees#>>'{informationsGenerales,nomService}'=?", nomService)
+      .select('homologations.*')
       .first()
       .then(convertisLigneEnObjet)
       .catch(() => undefined)
   );
 
   const homologations = (idUtilisateur) => knex('homologations')
-    .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
+    .join('autorisations', knex.raw("(autorisations.donnees->>'idHomologation')::uuid"), 'homologations.id')
+    .whereRaw("autorisations.donnees->>'idUtilisateur'=?", idUtilisateur)
+    .select('homologations.*')
     .then((rows) => rows.map(convertisLigneEnObjet));
 
   const metsAJourHomologation = (...params) => metsAJourTable('homologations', ...params);

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -255,7 +255,11 @@ const creeDepot = (config = {}) => {
   const autorisations = (idUtilisateur) => adaptateurPersistance.autorisations(idUtilisateur)
     .then((as) => as.map((a) => FabriqueAutorisation.fabrique(a)));
 
+  const accesAutorise = (idUtilisateur, idHomologation) => autorisations(idUtilisateur)
+    .then((as) => as.some((a) => a.idHomologation === idHomologation));
+
   return {
+    accesAutorise,
     ajouteAvisExpertCyberAHomologation,
     ajouteCaracteristiquesAHomologation,
     ajouteInformationsGeneralesAHomologation,

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -64,6 +64,10 @@ describe('Le dépôt de données persistées en mémoire', () => {
         { id: '123', idUtilisateur: '456', informationsGenerales: { nomService: 'Super Service' } },
         { id: '789', idUtilisateur: '999', informationsGenerales: { nomService: 'Autre service' } },
       ],
+      autorisations: [
+        { idUtilisateur: '456', idHomologation: '123', type: 'createur' },
+        { idUtilisateur: '999', idHomologation: '789', type: 'createur' },
+      ],
     });
 
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel: 'Le référentiel' });
@@ -75,6 +79,22 @@ describe('Le dépôt de données persistées en mémoire', () => {
         expect(homologations[0].referentiel).to.equal('Le référentiel');
         done();
       })
+      .catch(done);
+  });
+
+  it("vérifie que l'utilisateur a accès à l'homologation", (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      autorisations: [
+        { idUtilisateur: '456', idHomologation: '123', type: 'createur' },
+      ],
+    });
+
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+    depot.accesAutorise('456', '123')
+      .then((accesAutorise) => expect(accesAutorise).to.be(true))
+      .then(() => depot.accesAutorise('456', '999'))
+      .then((accesAutorise) => expect(accesAutorise).to.be(false))
+      .then(() => done())
       .catch(done);
   });
 
@@ -601,8 +621,9 @@ describe('Le dépôt de données persistées en mémoire', () => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
         homologations: [{
-          id: '789', idUtilisateur: '123', informationsGenerales: { nomService: 'Un service existant' },
+          id: '789', informationsGenerales: { nomService: 'Un service existant' },
         }],
+        autorisations: [{ idUtilisateur: '123', idHomologation: '789', type: 'createur' }],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
@@ -636,8 +657,12 @@ describe('Le dépôt de données persistées en mémoire', () => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
         homologations: [
-          { id: '888', idUtilisateur: '123', informationsGenerales: { nomService: 'Un service existant' } },
-          { id: '999', idUtilisateur: '123', informationsGenerales: { nomService: 'Un nom de service' } },
+          { id: '888', informationsGenerales: { nomService: 'Un service existant' } },
+          { id: '999', informationsGenerales: { nomService: 'Un nom de service' } },
+        ],
+        autorisations: [
+          { idUtilisateur: '123', idHomologation: '888', type: 'createur' },
+          { idUtilisateur: '123', idHomologation: '999', type: 'createur' },
         ],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -828,9 +853,8 @@ describe('Le dépôt de données persistées en mémoire', () => {
     it("supprime les homologations associées à l'utilisateur", (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
-        homologations: [
-          { id: '123', idUtilisateur: '999', informationsGenerales: { nomService: 'Un service' } },
-        ],
+        homologations: [{ id: '123', informationsGenerales: { nomService: 'Un service' } }],
+        autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
@@ -844,7 +868,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
     it("supprime l'utilisateur", (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
-        homologations: [],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -13,9 +13,7 @@ const prepareVerificationReponse = (reponse, status, ...params) => {
       expect(s).to.equal(status);
       return reponse;
     } catch (e) {
-      /* eslint-disable no-console */
-      console.log(e);
-      /* eslint-enable no-console */
+      suite(e);
       return undefined;
     }
   };
@@ -182,8 +180,8 @@ describe('Le middleware MSS', () => {
     });
 
     it("renvoie une erreur HTTP 403 si l'utilisateur courant n'a pas accès à l'homologation", (done) => {
-      const homologation = { idUtilisateur: 'unAutreIdentifiantQueCeluiUtilisateurCourant' };
-      depotDonnees.homologation = () => Promise.resolve(homologation);
+      depotDonnees.homologation = () => Promise.resolve({});
+      depotDonnees.accesAutorise = () => Promise.resolve(false);
       const middleware = Middleware({ adaptateurJWT, depotDonnees });
 
       prepareVerificationReponse(reponse, 403, "Accès à l'homologation refusé", done);
@@ -203,13 +201,16 @@ describe('Le middleware MSS', () => {
     });
 
     it("retourne l'homologation trouvée et appelle le middleware suivant", (done) => {
-      const homologation = { idUtilisateur: '999' };
+      const homologation = {};
       depotDonnees.homologation = () => Promise.resolve(homologation);
+      depotDonnees.accesAutorise = () => Promise.resolve(true);
       const middleware = Middleware({ adaptateurJWT, depotDonnees });
 
       middleware.trouveHomologation(requete, reponse, () => {
-        expect(requete.homologation).to.equal(homologation);
-        done();
+        try {
+          expect(requete.homologation).to.equal(homologation);
+          done();
+        } catch (e) { done(e); }
       });
     });
   });


### PR DESCRIPTION
Cette PR fait suite à #50

La suite sera :
- suppression de la colonne Homologation.idUtilisateur

… Puis :
- ajouter un collaborateur existant
- accéder à des homologations avec le rôle « collaborateur »
- interdire aux collaborateurs d'inviter d'autres collaborateurs