### PR TITLE
Duplications des informations générales en description du service

### DIFF
--- a/migrations/20220110160004_dupliqueInformationsGeneralesDansDescriptionService.js
+++ b/migrations/20220110160004_dupliqueInformationsGeneralesDansDescriptionService.js
@@ -1,0 +1,21 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.informationsGenerales)
+      .map(({ id, donnees: { informationsGenerales, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: {
+          informationsGenerales, descriptionService: informationsGenerales, ...autresDonnees,
+        } }));
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.descriptionService)
+      .map(({ id, donnees: { descriptionService, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: { ...autresDonnees } }));
+    return Promise.all(misesAJour);
+  });


### PR DESCRIPTION
Note : ce dev ce trouvera après https://github.com/betagouv/mon-service-securise/pull/62

Dans la persistance nous souhaitons que la colonne `descriptionService` soit la copie de `informationsGenerales`

<img width="1134" alt="Capture d’écran 2022-01-10 à 17 21 18" src="https://user-images.githubusercontent.com/39462397/148801565-adfec915-db3b-4557-841c-0b329061f394.png">
