### PR TITLE
Correction du passage à la ligne du titre quand il rencontre un bouton

### DIFF
--- a/public/assets/styles/homologation.css
+++ b/public/assets/styles/homologation.css
@@ -30,10 +30,8 @@
 }
 
 .tableau-bord .bouton {
-  position: absolute;
-  top: 0;
-  right: 0;
-
+  margin: 1em 0.5em 0.2em 1em;
+  float: right;
   padding: 1em 1.5em;
 
   font-size: 0.8em;

--- a/src/vues/homologation.pug
+++ b/src/vues/homologation.pug
@@ -23,8 +23,8 @@ block main
 
   .details-homologation.marges-fixes
     .tableau-bord
-      h1!= homologation.nomService()
       a.bouton(href = `/homologation/${homologation.id}/decision`) Voir le document d'homologation
+      h1!= homologation.nomService()
 
       each actions, descriptionSection in actionsDeSaisie
         section


### PR DESCRIPTION
Dans la page de synthèse,
Quand le nom de l'homologation est très long
Le titre doit passé à la ligne et non sous le bouton
![Capture d’écran 2022-01-11 à 11 25 03](https://user-images.githubusercontent.com/39462397/148929009-a4f12b1e-51b3-40a5-b990-548764b000cc.png)
