### PR TITLE
Arrêt de la persistance de la présentation dans les caractéristiques complémentaire

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -117,18 +117,6 @@ const creeDepot = (config = {}) => {
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
   );
 
-  const ajoutePresentationAHomologation = (idHomologation, presentation) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((h) => {
-        const caracteristiques = new CaracteristiquesComplementaires(
-          h.caracteristiquesComplementaires,
-          referentiel
-        );
-        caracteristiques.presentation = presentation;
-        return metsAJourProprieteHomologation('caracteristiquesComplementaires', h, caracteristiques);
-      })
-  );
-
   const ajouteLocalisationDonneesAHomologation = (idHomologation, localisationDonnees) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((homologationTrouvee) => {
@@ -275,7 +263,6 @@ const creeDepot = (config = {}) => {
     ajouteLocalisationDonneesAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
-    ajoutePresentationAHomologation,
     ajouteRisqueGeneralAHomologation,
     autorisations,
     homologation,

--- a/src/mss.js
+++ b/src/mss.js
@@ -245,10 +245,6 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         statutDeploiement,
       })
         .then((idHomologation) => {
-          depotDonnees.ajoutePresentationAHomologation(idHomologation, presentation);
-          return Promise.resolve(idHomologation);
-        })
-        .then((idHomologation) => {
           depotDonnees.ajouteLocalisationDonneesAHomologation(
             idHomologation, localisationDonnees
           );
@@ -271,11 +267,6 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     (requete, reponse, suite) => {
       const infosGenerales = new InformationsGenerales(requete.body, referentiel);
       depotDonnees.ajouteInformationsGeneralesAHomologation(requete.params.id, infosGenerales)
-        .then(() => (
-          depotDonnees.ajoutePresentationAHomologation(
-            requete.params.id, infosGenerales.presentation
-          )
-        ))
         .then(() => depotDonnees.ajouteLocalisationDonneesAHomologation(
           requete.params.id, infosGenerales.localisationDonnees
         ))

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -334,21 +334,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it('ajoute une présentation à une homologation en caractéristique complémentaire', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajoutePresentationAHomologation('123', 'Une présentation')
-      .then(() => depot.homologation('123'))
-      .then(({ caracteristiquesComplementaires: { presentation } }) => {
-        expect(presentation).to.equal('Une présentation');
-        done();
-      })
-      .catch(done);
-  });
-
   it('ajoute une localisation des données à une homologation', (done) => {
     const referentiel = Referentiel.creeReferentiel({
       localisationsDonnees: { france: {} },

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -401,7 +401,6 @@ describe('Le serveur MSS', () => {
   describe('quand requête POST sur `/api/homologation`', () => {
     beforeEach(() => {
       depotDonnees.nouvelleHomologation = () => Promise.resolve();
-      depotDonnees.ajoutePresentationAHomologation = () => Promise.resolve();
       depotDonnees.ajouteLocalisationDonneesAHomologation = () => Promise.resolve();
     });
 
@@ -434,22 +433,6 @@ describe('Le serveur MSS', () => {
       axios.post('http://localhost:1234/api/homologation', {})
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt de données d'ajouter la présentation aux caractéristiques", (done) => {
-      let appelleAjoutePresentationAHomologation = false;
-      depotDonnees.ajoutePresentationAHomologation = (idHomologation, presentation) => {
-        appelleAjoutePresentationAHomologation = true;
-        expect(presentation).to.equal('Une présentation');
-        return Promise.resolve();
-      };
-
-      axios.post('http://localhost:1234/api/homologation', { presentation: 'Une présentation' })
-        .then(() => {
-          expect(appelleAjoutePresentationAHomologation).to.be(true);
           done();
         })
         .catch(done);
@@ -534,7 +517,6 @@ describe('Le serveur MSS', () => {
   describe('quand requête PUT sur `/api/homologation/:id`', () => {
     beforeEach(() => {
       depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.resolve();
-      depotDonnees.ajoutePresentationAHomologation = () => Promise.resolve();
       depotDonnees.ajouteLocalisationDonneesAHomologation = () => Promise.resolve();
     });
 
@@ -565,22 +547,6 @@ describe('Le serveur MSS', () => {
       axios.put('http://localhost:1234/api/homologation/456', {})
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt de données d'ajouter la présentation aux caractéristiques", (done) => {
-      let appelleAjoutePresentationAHomologation = false;
-      depotDonnees.ajoutePresentationAHomologation = (idHomologation, presentation) => {
-        appelleAjoutePresentationAHomologation = true;
-        expect(presentation).to.equal('Une présentation');
-        return Promise.resolve();
-      };
-
-      axios.put('http://localhost:1234/api/homologation/456', { presentation: 'Une présentation' })
-        .then(() => {
-          expect(appelleAjoutePresentationAHomologation).to.be(true);
           done();
         })
         .catch(done);


### PR DESCRIPTION
La présentation du service ne se trouve plus dans la page caractéristiques complémentaires et la persistance se fait en double dans `infonrmationsGenerales` et 'caracteristiquesComplementaires`
Ce dev propose de stopper la persistance dans `caracrteristiquesComplementaires` qui n'est plus utilisée