### PR TITLE
Arrêt de la persistance de la localisation dans les caractéristiques complémentaire

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -7,7 +7,6 @@ const {
   ErreurUtilisateurExistant,
 } = require('./erreurs');
 const AdaptateurPersistanceMemoire = require('./adaptateurs/adaptateurPersistanceMemoire');
-const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
 const Homologation = require('./modeles/homologation');
 const Utilisateur = require('./modeles/utilisateur');
@@ -115,18 +114,6 @@ const creeDepot = (config = {}) => {
 
   const ajouteCaracteristiquesAHomologation = (...params) => (
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
-  );
-
-  const ajouteLocalisationDonneesAHomologation = (idHomologation, localisationDonnees) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((homologationTrouvee) => {
-        const caracteristiquesComplementaires = new CaracteristiquesComplementaires(
-          homologationTrouvee.caracteristiquesComplementaires,
-          referentiel
-        );
-        caracteristiquesComplementaires.localisationDonnees = localisationDonnees;
-        return metsAJourProprieteHomologation('caracteristiquesComplementaires', homologationTrouvee, caracteristiquesComplementaires);
-      })
   );
 
   const ajoutePartiesPrenantesAHomologation = (...params) => (
@@ -260,7 +247,6 @@ const creeDepot = (config = {}) => {
     ajouteAvisExpertCyberAHomologation,
     ajouteCaracteristiquesAHomologation,
     ajouteInformationsGeneralesAHomologation,
-    ajouteLocalisationDonneesAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajouteRisqueGeneralAHomologation,

--- a/src/mss.js
+++ b/src/mss.js
@@ -244,12 +244,6 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         pointsAcces,
         statutDeploiement,
       })
-        .then((idHomologation) => {
-          depotDonnees.ajouteLocalisationDonneesAHomologation(
-            idHomologation, localisationDonnees
-          );
-          return Promise.resolve(idHomologation);
-        })
         .then((idHomologation) => reponse.json({ idHomologation }))
         .catch((e) => {
           if (e instanceof ErreurModele) reponse.status(422).send(e.message);
@@ -267,9 +261,6 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     (requete, reponse, suite) => {
       const infosGenerales = new InformationsGenerales(requete.body, referentiel);
       depotDonnees.ajouteInformationsGeneralesAHomologation(requete.params.id, infosGenerales)
-        .then(() => depotDonnees.ajouteLocalisationDonneesAHomologation(
-          requete.params.id, infosGenerales.localisationDonnees
-        ))
         .then(() => reponse.send({ idHomologation: requete.homologation.id }))
         .catch((e) => {
           if (e instanceof ErreurModele) {

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -18,7 +18,6 @@ const MesureGenerale = require('../src/modeles/mesureGenerale');
 const MesureSpecifique = require('../src/modeles/mesureSpecifique');
 const MesuresSpecifiques = require('../src/modeles/mesuresSpecifiques');
 const PartiesPrenantes = require('../src/modeles/partiesPrenantes');
-const Referentiel = require('../src/referentiel');
 const RisqueGeneral = require('../src/modeles/risqueGeneral');
 const RisqueSpecifique = require('../src/modeles/risqueSpecifique');
 const RisquesSpecifiques = require('../src/modeles/risquesSpecifiques');
@@ -329,24 +328,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .then(({ caracteristiquesComplementaires }) => {
         expect(caracteristiquesComplementaires.hebergeur).to.equal('Un hébergeur');
         expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
-        done();
-      })
-      .catch(done);
-  });
-
-  it('ajoute une localisation des données à une homologation', (done) => {
-    const referentiel = Referentiel.creeReferentiel({
-      localisationsDonnees: { france: {} },
-    });
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{ id: '123', informationsGenerales: { nomService: 'nom' } }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel });
-
-    depot.ajouteLocalisationDonneesAHomologation('123', 'france')
-      .then(() => depot.homologation('123'))
-      .then(({ caracteristiquesComplementaires: { localisationDonnees } }) => {
-        expect(localisationDonnees).to.equal('france');
         done();
       })
       .catch(done);

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -401,7 +401,6 @@ describe('Le serveur MSS', () => {
   describe('quand requête POST sur `/api/homologation`', () => {
     beforeEach(() => {
       depotDonnees.nouvelleHomologation = () => Promise.resolve();
-      depotDonnees.ajouteLocalisationDonneesAHomologation = () => Promise.resolve();
     });
 
     it("vérifie que l'utilisateur est authentifié", (done) => {
@@ -433,30 +432,6 @@ describe('Le serveur MSS', () => {
       axios.post('http://localhost:1234/api/homologation', {})
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt de données d'ajouter la localisation des données aux caractéristiques", (done) => {
-      referentiel.identifiantsLocalisationsDonnees = () => ['france'];
-
-      let appelleAjouteLocalisationDonneesAHomologation = false;
-      depotDonnees.ajouteLocalisationDonneesAHomologation = (
-        idHomologation, localisationDonnees
-      ) => {
-        try {
-          expect(localisationDonnees).to.equal('france');
-          appelleAjouteLocalisationDonneesAHomologation = true;
-          return Promise.resolve();
-        } catch (e) {
-          return Promise.reject(done(e));
-        }
-      };
-
-      axios.post('http://localhost:1234/api/homologation', { localisationDonnees: 'france' })
-        .then(() => {
-          expect(appelleAjouteLocalisationDonneesAHomologation).to.be(true);
           done();
         })
         .catch(done);
@@ -517,7 +492,6 @@ describe('Le serveur MSS', () => {
   describe('quand requête PUT sur `/api/homologation/:id`', () => {
     beforeEach(() => {
       depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.resolve();
-      depotDonnees.ajouteLocalisationDonneesAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -547,31 +521,6 @@ describe('Le serveur MSS', () => {
       axios.put('http://localhost:1234/api/homologation/456', {})
         .then(() => {
           verifieAseptisationListe('fonctionnalitesSpecifiques', ['description']);
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt de données d'ajouter la localisation des données aux caractéristiques", (done) => {
-      referentiel.identifiantsLocalisationsDonnees = () => ['france'];
-
-      let appelleAjouteLocalisationDonneesAHomologation = false;
-      depotDonnees.ajouteLocalisationDonneesAHomologation = (
-        idHomologation, localisationDonnees
-      ) => {
-        try {
-          expect(localisationDonnees).to.equal('france');
-          expect(idHomologation).to.equal('456');
-          appelleAjouteLocalisationDonneesAHomologation = true;
-          return Promise.resolve();
-        } catch (e) {
-          return Promise.reject(done(e));
-        }
-      };
-
-      axios.put('http://localhost:1234/api/homologation/456', { localisationDonnees: 'france' })
-        .then(() => {
-          expect(appelleAjouteLocalisationDonneesAHomologation).to.be(true);
           done();
         })
         .catch(done);


### PR DESCRIPTION
La localisation des données ne se trouve plus dans la page caractéristiques complémentaires et la persistance se fait en double dans `informationsGenerales` et `caracteristiquesComplementaires`. Ce dev propose de stopper la persistance dans `caracteristiquesComplementaires` qui n'est plus utilisée.
