### PR TITLE
[CORRECTION] Supprime avertissement seuil criticité trop élevé dans dossier homologation

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -98,11 +98,6 @@ class Homologation {
     return this.risques.risquesSpecifiques;
   }
 
-  seuilCriticiteTropEleve() {
-    const seuil = this.informationsGenerales.seuilCriticite();
-    return seuil === 'eleve' || seuil === 'critique';
-  }
-
   statistiquesMesures() {
     return this.mesures.statistiques();
   }

--- a/src/modeles/informationsGenerales.js
+++ b/src/modeles/informationsGenerales.js
@@ -48,12 +48,6 @@ class InformationsGenerales extends InformationsHomologation {
     return this.pointsAcces.nombre();
   }
 
-  seuilCriticite() {
-    return this.referentiel.criticite(
-      this.fonctionnalites, this.donneesCaracterePersonnel, this.delaiAvantImpactCritique
-    );
-  }
-
   static valide(donnees, referentiel) {
     const { statutDeploiement, localisationDonnees } = donnees;
 

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -66,20 +66,6 @@ nav.ne-pas-imprimer
 
   main
     h1.bleu Décision d'homologation de sécurité
-    if homologation.seuilCriticiteTropEleve()
-      section.alerte
-        div.
-          Compte tenu des risques auxquels votre service est susceptible de faire
-          face, aux vues des fonctionnalités offertes et de la sensibilité des
-          données traitées, l'ANSSI vous recommande de réaliser une démarche
-          d'homologation approfondie en vous appuyant sur le « guide d’homologation
-          en 9 étapes ».
-        br
-        div.
-          Celle-ci peut être effectuée en substitution ou en complément d'une
-          démarche via Mon Service Sécurisé. Le cas échéant, toutes les pièces
-          complémentaires au dossier d'homologation recommandées dans le guide en 9
-          étapes devront être jointes au dossier généré sur Mon Service Sécurisé.
 
     section.introduction
       h2!= homologation.nomService()

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -210,22 +210,4 @@ describe('Une homologation', () => {
       expect(homologation.statutSaisie('risques')).to.equal(InformationsHomologation.A_SAISIR);
     });
   });
-
-  it("déclare le seuil de criticité trop élevé s'il est `critique` ou `eleve`", () => {
-    const homologation = new Homologation({ id: '123' });
-    homologation.informationsGenerales = { seuilCriticite: () => 'critique' };
-    expect(homologation.seuilCriticiteTropEleve()).to.be(true);
-
-    homologation.informationsGenerales = { seuilCriticite: () => 'eleve' };
-    expect(homologation.seuilCriticiteTropEleve()).to.be(true);
-  });
-
-  it("déclare le seuil de criticité acceptable s'il est `moyen` ou `faible`", () => {
-    const homologation = new Homologation({ id: '123' });
-    homologation.informationsGenerales = { seuilCriticite: () => 'moyen' };
-    expect(homologation.seuilCriticiteTropEleve()).to.be(false);
-
-    homologation.informationsGenerales = { seuilCriticite: () => 'faible' };
-    expect(homologation.seuilCriticiteTropEleve()).to.be(false);
-  });
 });

--- a/test/modeles/informationsGenerales.spec.js
+++ b/test/modeles/informationsGenerales.spec.js
@@ -125,22 +125,4 @@ describe('Les informations générales', () => {
 
     expect(infos.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
   });
-
-  elles('délèguent au référentiel la détermination du seuil de criticité', () => {
-    const referentiel = {
-      criticite: (idFonctionnalites, idDonnees, idDelai) => {
-        expect(idFonctionnalites).to.eql(['f1', 'f2']);
-        expect(idDonnees).to.eql(['d1', 'd2']);
-        expect(idDelai).to.equal('unDelai');
-        return 'moyen';
-      },
-    };
-    const infos = new InformationsGenerales({
-      fonctionnalites: ['f1', 'f2'],
-      donneesCaracterePersonnel: ['d1', 'd2'],
-      delaiAvantImpactCritique: 'unDelai',
-    }, referentiel);
-
-    expect(infos.seuilCriticite()).to.equal('moyen');
-  });
 });


### PR DESCRIPTION
Cette partie du code est devenue obsolète suite au changement de l'algorithme de criticité