### PR TITLE
Revoie calcul statut saisie avis expert cyber

### DIFF
--- a/src/modeles/avisExpertCyber.js
+++ b/src/modeles/avisExpertCyber.js
@@ -24,7 +24,10 @@ const valide = (donnees, referentiel) => {
 
 class AvisExpertCyber extends InformationsHomologation {
   constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide()) {
-    super({ proprietesAtomiquesRequises: ['avis', 'dateRenouvellement', 'commentaire'] });
+    super({
+      proprietesAtomiquesRequises: ['avis', 'dateRenouvellement'],
+      proprietesAtomiquesFacultatives: ['commentaire'],
+    });
     valide(donnees, referentiel);
     this.renseigneProprietes(donnees);
 
@@ -40,6 +43,11 @@ class AvisExpertCyber extends InformationsHomologation {
   defavorable() { return this.avis === AVIS.DEFAVORABLE; }
 
   inconnu() { return typeof this.avis === 'undefined'; }
+
+  proprieteSaisie(nomPropriete) {
+    return (nomPropriete === 'dateRenouvellement' && this.defavorable())
+      || super.proprieteSaisie(nomPropriete);
+  }
 }
 
 Object.assign(AvisExpertCyber, AVIS);

--- a/test/modeles/avisExpertCyber.spec.js
+++ b/test/modeles/avisExpertCyber.spec.js
@@ -19,6 +19,11 @@ describe("L'avis de l'expert Cyber", () => {
     expect(avisExpert.commentaire).to.equal('Un commentaire');
   });
 
+  it('accepte le commentaire comme information facultative', () => {
+    const avisExpert = new AvisExpertCyber();
+    expect(avisExpert.proprietesAtomiquesFacultatives).to.eql(['commentaire']);
+  });
+
   it("détecte si l'expert a donné un avis", () => {
     const avisExpert = new AvisExpertCyber();
     expect(avisExpert.favorable()).to.be(false);
@@ -90,6 +95,12 @@ describe("L'avis de l'expert Cyber", () => {
     const avisExpert = new AvisExpertCyber({
       avis: AvisExpertCyber.FAVORABLE, dateRenouvellement: 'unAn', commentaire: 'Un commentaire',
     }, referentiel);
+
+    expect(avisExpert.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
+  });
+
+  it("n'exige pas que la date de renouvellement soit renseignée si l'avis est négatif", () => {
+    const avisExpert = new AvisExpertCyber({ avis: AvisExpertCyber.DEFAVORABLE }, referentiel);
 
     expect(avisExpert.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
   });


### PR DESCRIPTION
- Rends le commentaire facultatif
- N'exige pas de date de renouvellement d'homologation si avis défavorable