### PR TITLE
Changement informations générales pour description service dans le modèle

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -60,9 +60,9 @@ const creeDepot = (config = {}) => {
     return trouveDonneesHomologation(idOuHomologation).then(metsAJour);
   };
 
-  const metsAJourInformationsGeneralesHomologation = (homologationCible, informations) => (
-    metsAJourProprieteHomologation('informationsGenerales', homologationCible, informations)
-      .then(() => metsAJourProprieteHomologation('descriptionService', homologationCible, informations))
+  const metsAJourDescriptionServiceHomologation = (homologationCible, informations) => (
+    metsAJourProprieteHomologation('descriptionService', homologationCible, informations)
+      .then(() => metsAJourProprieteHomologation('informationsGenerales', homologationCible, informations))
   );
 
   const remplaceProprieteHomologation = (nomPropriete, idHomologation, propriete) => (
@@ -89,7 +89,7 @@ const creeDepot = (config = {}) => {
       .then((h) => !!h)
   );
 
-  const valideInformationsGenerales = (idUtilisateur, { nomService }, idHomologationMiseAJour) => {
+  const valideDescriptionService = (idUtilisateur, { nomService }, idHomologationMiseAJour) => {
     if (typeof nomService !== 'string' || !nomService) {
       return Promise.reject(new ErreurNomServiceManquant('Le nom du service ne peut pas être vide'));
     }
@@ -104,11 +104,11 @@ const creeDepot = (config = {}) => {
       ));
   };
 
-  const ajouteInformationsGeneralesAHomologation = (idHomologation, infos) => (
+  const ajouteDescriptionServiceAHomologation = (idHomologation, infos) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((h) => (
-        valideInformationsGenerales(h.idUtilisateur, infos, h.id)
-          .then(() => metsAJourInformationsGeneralesHomologation(h, infos))
+        valideDescriptionService(h.idUtilisateur, infos, h.id)
+          .then(() => metsAJourDescriptionServiceHomologation(h, infos))
       ))
   );
 
@@ -127,16 +127,16 @@ const creeDepot = (config = {}) => {
   const homologations = (idUtilisateur) => adaptateurPersistance.homologations(idUtilisateur)
     .then((hs) => hs.map((h) => new Homologation(h, referentiel)));
 
-  const nouvelleHomologation = (idUtilisateur, donneesInformationsGenerales) => {
+  const nouvelleHomologation = (idUtilisateur, donneesDescriptionService) => {
     const idHomologation = adaptateurUUID.genereUUID();
     const idAutorisation = adaptateurUUID.genereUUID();
     const donnees = {
       idUtilisateur,
-      informationsGenerales: donneesInformationsGenerales,
-      descriptionService: donneesInformationsGenerales,
+      descriptionService: donneesDescriptionService,
+      informationsGenerales: donneesDescriptionService,
     };
 
-    return valideInformationsGenerales(idUtilisateur, donneesInformationsGenerales)
+    return valideDescriptionService(idUtilisateur, donneesDescriptionService)
       .then(() => adaptateurPersistance.ajouteHomologation(idHomologation, donnees))
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
         idUtilisateur, idHomologation, type: 'createur',
@@ -246,7 +246,7 @@ const creeDepot = (config = {}) => {
     accesAutorise,
     ajouteAvisExpertCyberAHomologation,
     ajouteCaracteristiquesAHomologation,
-    ajouteInformationsGeneralesAHomologation,
+    ajouteDescriptionServiceAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajouteRisqueGeneralAHomologation,

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -63,7 +63,7 @@ class Homologation {
     return this.avisExpertCyber.descriptionExpiration();
   }
 
-  descriptionTypeService() { return this.informationsGenerales.descriptionTypeService(); }
+  descriptionTypeService() { return this.descriptionService.descriptionTypeService(); }
 
   descriptionStatutsMesures() {
     return Mesure.statutsPossibles().reduce((acc, s) => {
@@ -79,12 +79,12 @@ class Homologation {
   hebergeur() { return this.caracteristiquesComplementaires.descriptionHebergeur(); }
 
   localisationDonnees() {
-    return this.informationsGenerales.descriptionLocalisationDonnees();
+    return this.descriptionService.descriptionLocalisationDonnees();
   }
 
   mesuresSpecifiques() { return this.mesures.mesuresSpecifiques; }
 
-  nomService() { return this.informationsGenerales.nomService; }
+  nomService() { return this.descriptionService.nomService; }
 
   piloteProjet() { return this.partiesPrenantes.piloteProjet; }
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -5,10 +5,10 @@ const { ErreurModele } = require('./erreurs');
 const ActionsSaisie = require('./modeles/actionsSaisie');
 const AvisExpertCyber = require('./modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
+const DescriptionService = require('./modeles/descriptionService');
 const FonctionnalitesSpecifiques = require('./modeles/fonctionnalitesSpecifiques');
 const DonneesSensiblesSpecifiques = require('./modeles/donneesSensiblesSpecifiques');
 const Homologation = require('./modeles/homologation');
-const InformationsGenerales = require('./modeles/informationsGenerales');
 const InformationsHomologation = require('./modeles/informationsHomologation');
 const MesureGenerale = require('./modeles/mesureGenerale');
 const MesuresSpecifiques = require('./modeles/mesuresSpecifiques');
@@ -240,8 +240,8 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
       { nom: 'donneesSensiblesSpecifiques', proprietes: DonneesSensiblesSpecifiques.proprietesItem() },
     ]),
     (requete, reponse, suite) => {
-      const infosGenerales = new InformationsGenerales(requete.body, referentiel);
-      depotDonnees.ajouteInformationsGeneralesAHomologation(requete.params.id, infosGenerales)
+      const descriptionService = new DescriptionService(requete.body, referentiel);
+      depotDonnees.ajouteDescriptionServiceAHomologation(requete.params.id, descriptionService)
         .then(() => reponse.send({ idHomologation: requete.homologation.id }))
         .catch((e) => {
           if (e instanceof ErreurModele) {

--- a/src/vues/fragments/formulaireInformationsGenerales.pug
+++ b/src/vues/fragments/formulaireInformationsGenerales.pug
@@ -26,7 +26,7 @@ mixin formulaireInformationsGenerales(idHomologation)
         nom: 'typeService',
         titre: 'Type de service numérique',
         items: referentiel.typesService(),
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
       +inputChoix({
@@ -34,7 +34,7 @@ mixin formulaireInformationsGenerales(idHomologation)
         nom: 'provenanceService',
         titre: 'Provenance du service numérique',
         items: referentiel.provenancesService(),
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
       +inputChoix({
@@ -42,7 +42,7 @@ mixin formulaireInformationsGenerales(idHomologation)
         nom: 'statutDeploiement',
         titre: 'Statut',
         items: referentiel.statutsDeploiement(),
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
       label Présentation du service numérique
@@ -50,7 +50,7 @@ mixin formulaireInformationsGenerales(idHomologation)
           id = 'presentation',
           name = 'presentation',
           placeholder = 'ex : site internet de la médiathèque permettant de créer un compte utilisateur, de réserver, prolonger leur réservation de contenus multimédia.',
-        )= homologation.informationsGenerales.presentation
+        )= homologation.descriptionService.presentation
 
       label Accès au service numérique
         br
@@ -58,7 +58,7 @@ mixin formulaireInformationsGenerales(idHomologation)
           identifiantConteneur: 'points-acces',
           nom: 'point-acces',
           valeurExemple: 'exemple : https://www.adresse.fr, App Store, Play Store…',
-          donnees: homologation.informationsGenerales.pointsAcces.toJSON(),
+          donnees: homologation.descriptionService.pointsAcces.toJSON(),
           textBoutonAjouter: 'Ajouter un accès',
         })
 
@@ -68,13 +68,13 @@ mixin formulaireInformationsGenerales(idHomologation)
         nom: 'fonctionnalites',
         titre: 'Principales fonctionnalités offertes par le service numérique',
         items: referentiel.fonctionnalites(),
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
       +elementsAjoutables({
         identifiantConteneur: 'fonctionnalites-specifiques',
         nom: 'fonctionnalite',
-        donnees: homologation.informationsGenerales.fonctionnalitesSpecifiques.toJSON(),
+        donnees: homologation.descriptionService.fonctionnalitesSpecifiques.toJSON(),
         textBoutonAjouter: 'Ajouter une fonctionnalité',
       })
 
@@ -84,13 +84,13 @@ mixin formulaireInformationsGenerales(idHomologation)
         nom: 'donneesCaracterePersonnel',
         titre: 'Données à caractère personnel et autres données sensibles stockées par le service',
         items: referentiel.donneesCaracterePersonnel(),
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
       +elementsAjoutables({
               identifiantConteneur: 'donnees-sensibles-specifiques',
               nom: 'donnees-sensibles',
-              donnees: homologation.informationsGenerales.donneesSensiblesSpecifiques.toJSON(),
+              donnees: homologation.descriptionService.donneesSensiblesSpecifiques.toJSON(),
               textBoutonAjouter: 'Ajouter des données',
             })
 
@@ -100,7 +100,7 @@ mixin formulaireInformationsGenerales(idHomologation)
         nom: 'localisationDonnees',
         titre: 'Localisation des données',
         items: referentiel.localisationsDonnees(),
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
       +inputChoix({
@@ -108,13 +108,13 @@ mixin formulaireInformationsGenerales(idHomologation)
         nom: 'delaiAvantImpactCritique',
         titre: 'Estimation de la durée maximale acceptable de dysfonctionnement grave du service',
         items: referentiel.delaisAvantImpactCritique(),
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
       +inputOuiNon({
         nom: 'presenceResponsable',
         titre: "Une personne est-elle responsable de la sécurité des systèmes d'information au sein de votre organisation ?",
-        objetDonnees: homologation.informationsGenerales,
+        objetDonnees: homologation.descriptionService,
       })
 
     if idHomologation

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -12,6 +12,7 @@ const AdaptateurPersistanceMemoire = require('../src/adaptateurs/adaptateurPersi
 const AutorisationCreateur = require('../src/modeles/autorisations/autorisationCreateur');
 const AvisExpertCyber = require('../src/modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('../src/modeles/caracteristiquesComplementaires');
+const DescriptionService = require('../src/modeles/descriptionService');
 const Homologation = require('../src/modeles/homologation');
 const InformationsGenerales = require('../src/modeles/informationsGenerales');
 const MesureGenerale = require('../src/modeles/mesureGenerale');
@@ -61,8 +62,8 @@ describe('Le dépôt de données persistées en mémoire', () => {
   it("connaît toutes les homologations d'un utilisateur donné", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '123', idUtilisateur: '456', informationsGenerales: { nomService: 'Super Service' } },
-        { id: '789', idUtilisateur: '999', informationsGenerales: { nomService: 'Autre service' } },
+        { id: '123', idUtilisateur: '456', descriptionService: { nomService: 'Super Service' } },
+        { id: '789', idUtilisateur: '999', descriptionService: { nomService: 'Autre service' } },
       ],
       autorisations: [
         { idUtilisateur: '456', idHomologation: '123', type: 'createur' },
@@ -101,7 +102,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
   it('peut retrouver une homologation à partir de son identifiant', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '789', idUtilisateur: '999', informationsGenerales: { nomService: 'nom' } },
+        { id: '789', idUtilisateur: '999', descriptionService: { nomService: 'nom' } },
       ],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel: 'Le référentiel' });
@@ -119,7 +120,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
   it('sait associer une mesure spécifique à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '123', informationsGenerales: { nomService: 'nom' } },
+        { id: '123', descriptionService: { nomService: 'nom' } },
       ],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -150,7 +151,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         homologations: [{
           id: '123',
-          informationsGenerales: { nomService: 'Un service' },
+          descriptionService: { nomService: 'Un service' },
           mesuresGenerales: [{ id: 'identifiantMesure', statut: 'fait' }],
         }],
       });
@@ -171,7 +172,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
     it('sait associer une mesure à une homologation', (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         homologations: [
-          { id: '123', informationsGenerales: { nomService: 'Un service' } },
+          { id: '123', descriptionService: { nomService: 'Un service' } },
         ],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -192,7 +193,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
         homologations: [
           {
             id: '123',
-            informationsGenerales: { nomService: 'nom' },
+            descriptionService: { nomService: 'nom' },
             mesures: [{ id: 'identifiantMesure', statut: MesureGenerale.STATUT_PLANIFIE }],
           },
         ],
@@ -211,26 +212,8 @@ describe('Le dépôt de données persistées en mémoire', () => {
     });
   });
 
-  describe("sur demande de mise à jour des infos générales d'une homologation", () => {
-    it("met à jour les informations générales d'une homologation", (done) => {
-      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        homologations: [
-          { id: '123', informationsGenerales: { nomService: 'Super Service' } },
-        ],
-      });
-      const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-      const infos = new InformationsGenerales({ nomService: 'Nouveau Nom' });
-      depot.ajouteInformationsGeneralesAHomologation('123', infos)
-        .then(() => depot.homologation('123'))
-        .then(({ informationsGenerales }) => {
-          expect(informationsGenerales.nomService).to.equal('Nouveau Nom');
-          done();
-        })
-        .catch(done);
-    });
-
-    it('met à jour les informations générales dans description du service', (done) => {
+  describe("sur demande de mise à jour de la description du service d'une homologation", () => {
+    it("met à jour la description du service d'une homologation", (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         homologations: [
           { id: '123', descriptionService: { nomService: 'Super Service' } },
@@ -238,8 +221,8 @@ describe('Le dépôt de données persistées en mémoire', () => {
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-      const infos = new InformationsGenerales({ nomService: 'Nouveau Nom' });
-      depot.ajouteInformationsGeneralesAHomologation('123', infos)
+      const infos = new DescriptionService({ nomService: 'Nouveau Nom' });
+      depot.ajouteDescriptionServiceAHomologation('123', infos)
         .then(() => depot.homologation('123'))
         .then(({ descriptionService }) => {
           expect(descriptionService.nomService).to.equal('Nouveau Nom');
@@ -248,19 +231,37 @@ describe('Le dépôt de données persistées en mémoire', () => {
         .catch(done);
     });
 
+    it('met à jour la description du service dans informations générales', (done) => {
+      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        homologations: [
+          { id: '123', descriptionService: { nomService: 'Super Service' } },
+        ],
+      });
+      const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+      const infos = new InformationsGenerales({ nomService: 'Nouveau Nom' });
+      depot.ajouteDescriptionServiceAHomologation('123', infos)
+        .then(() => depot.homologation('123'))
+        .then(({ informationsGenerales }) => {
+          expect(informationsGenerales.nomService).to.equal('Nouveau Nom');
+          done();
+        })
+        .catch(done);
+    });
+
     it('lève une exception si le nom du service est absent', (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         homologations: [
-          { id: '123', informationsGenerales: { nomService: 'Super Service' } },
+          { id: '123', descriptionService: { nomService: 'Super Service' } },
         ],
       });
 
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-      const infos = new InformationsGenerales({ nomService: '' });
-      depot.ajouteInformationsGeneralesAHomologation('123', infos)
+      const infos = new DescriptionService({ nomService: '' });
+      depot.ajouteDescriptionServiceAHomologation('123', infos)
         .then(() => done(
-          'La mise à jour des informations générales aurait dû lever une exception'
+          'La mise à jour de la description du service aurait dû lever une exception'
         ))
         .catch((e) => {
           expect(e).to.be.an(ErreurNomServiceManquant);
@@ -273,16 +274,16 @@ describe('Le dépôt de données persistées en mémoire', () => {
     it("ne détecte pas de doublon sur le nom de service pour l'homologation en cours de mise à jour", (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         homologations: [
-          { id: '123', informationsGenerales: { nomService: 'Super Service', presenceResponsable: 'non' } },
+          { id: '123', descriptionService: { nomService: 'Super Service', presenceResponsable: 'non' } },
         ],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-      const infos = new InformationsGenerales({ nomService: 'Super Service', presenceResponsable: 'oui' });
-      depot.ajouteInformationsGeneralesAHomologation('123', infos)
+      const infos = new DescriptionService({ nomService: 'Super Service', presenceResponsable: 'oui' });
+      depot.ajouteDescriptionServiceAHomologation('123', infos)
         .then(() => depot.homologation('123'))
-        .then(({ informationsGenerales }) => {
-          expect(informationsGenerales.presenceResponsable).to.equal('oui');
+        .then(({ descriptionService }) => {
+          expect(descriptionService.presenceResponsable).to.equal('oui');
           done();
         })
         .catch(done);
@@ -292,7 +293,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
   it('sait associer des caractéristiques complémentaires à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '123', informationsGenerales: { nomService: 'nom' } },
+        { id: '123', descriptionService: { nomService: 'nom' } },
       ],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -314,7 +315,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [{
         id: '123',
-        informationsGenerales: { nomService: 'nom' },
+        descriptionService: { nomService: 'nom' },
         caracteristiquesComplementaires: { hebergeur: 'Un hébergeur' },
       }],
     });
@@ -336,7 +337,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
   it('sait associer des parties prenantes à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '123', informationsGenerales: { nomService: 'nom' } },
+        { id: '123', descriptionService: { nomService: 'nom' } },
       ],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -366,7 +367,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
 
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         homologations: [
-          { id: '123', informationsGenerales: { nomService: 'nom' } },
+          { id: '123', descriptionService: { nomService: 'nom' } },
         ],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -387,7 +388,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
   it('sait associer un risque spécifique à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '123', informationsGenerales: { nomService: 'nom' } },
+        { id: '123', descriptionService: { nomService: 'nom' } },
       ],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -408,7 +409,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [{
         id: '123',
-        informationsGenerales: { nomService: 'nom' },
+        descriptionService: { nomService: 'nom' },
         risquesSpecifiques: [{ description: 'Un ancien risque' }],
       }],
     });
@@ -429,7 +430,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
   it("sait associer un avis d'expert cyber à une homologation", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '123', informationsGenerales: { nomService: 'nom' } },
+        { id: '123', descriptionService: { nomService: 'nom' } },
       ],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -464,7 +465,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
         .then(() => depot.homologations('123'))
         .then((homologations) => {
           expect(homologations.length).to.equal(1);
-          expect(homologations[0].informationsGenerales.nomService).to.equal('Super Service');
+          expect(homologations[0].descriptionService.nomService).to.equal('Super Service');
           done();
         })
         .catch(done);
@@ -521,14 +522,14 @@ describe('Le dépôt de données persistées en mémoire', () => {
         .catch(done);
     });
 
-    it("duplique les données d'informations générales dans description du service", (done) => {
+    it('duplique les données de description du service dans informations générales', (done) => {
       depot.homologations('123')
         .then(() => depot.nouvelleHomologation('123', { nomService: 'Super Service' }))
         .then(() => depot.homologations('123'))
         .then((homologations) => {
           expect(homologations.length).to.equal(1);
-          expect(homologations[0].informationsGenerales.nomService).to.equal('Super Service');
           expect(homologations[0].descriptionService.nomService).to.equal('Super Service');
+          expect(homologations[0].informationsGenerales.nomService).to.equal('Super Service');
           done();
         })
         .catch(done);
@@ -643,7 +644,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
           { id: '456', email: 'sylvie.martin@mail.fr' },
         ],
         homologations: [{
-          id: '789', idUtilisateur: '123', informationsGenerales: { nomService: 'Un service existant' },
+          id: '789', idUtilisateur: '123', descriptionService: { nomService: 'Un service existant' },
         }],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -838,7 +839,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
       homologations: [
-        { id: '123', idUtilisateur: '999', informationsGenerales: { nomService: 'Un service' } },
+        { id: '123', idUtilisateur: '999', descriptionService: { nomService: 'Un service' } },
       ],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -854,7 +855,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
     it("supprime les homologations associées à l'utilisateur", (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
-        homologations: [{ id: '123', informationsGenerales: { nomService: 'Un service' } }],
+        homologations: [{ id: '123', descriptionService: { nomService: 'Un service' } }],
         autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -8,7 +8,7 @@ const MesureGenerale = require('../../src/modeles/mesureGenerale');
 describe('Une homologation', () => {
   it('connaît le nom du service', () => {
     const homologation = new Homologation({
-      id: '123', idUtilisateur: '456', informationsGenerales: { nomService: 'Super Service' },
+      id: '123', idUtilisateur: '456', descriptionService: { nomService: 'Super Service' },
     });
 
     expect(homologation.nomService()).to.equal('Super Service');
@@ -16,7 +16,7 @@ describe('Une homologation', () => {
 
   it('sait se convertir en JSON', () => {
     const homologation = new Homologation({
-      id: '123', idUtilisateur: '456', informationsGenerales: { nomService: 'Super Service' },
+      id: '123', idUtilisateur: '456', descriptionService: { nomService: 'Super Service' },
     });
 
     expect(homologation.toJSON()).to.eql({
@@ -34,7 +34,7 @@ describe('Une homologation', () => {
     const homologation = new Homologation({
       id: '123',
       idUtilisateur: '456',
-      informationsGenerales: { nomService: 'nom', typeService: ['unType', 'unAutre'] },
+      descriptionService: { nomService: 'nom', typeService: ['unType', 'unAutre'] },
     }, referentiel);
 
     expect(homologation.descriptionTypeService()).to.equal('Un type, Un autre');
@@ -56,7 +56,7 @@ describe('Une homologation', () => {
         structureDeveloppement: 'Une structure',
         hebergeur: 'Un hébergeur',
       },
-      informationsGenerales: {
+      descriptionService: {
         localisationDonnees: 'france',
       },
     }, referentiel);

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -499,7 +499,7 @@ describe('Le serveur MSS', () => {
 
   describe('quand requête PUT sur `/api/homologation/:id`', () => {
     beforeEach(() => {
-      depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.resolve();
+      depotDonnees.ajouteDescriptionServiceAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -546,10 +546,10 @@ describe('Le serveur MSS', () => {
     it("demande au dépôt de données de mettre à jour l'homologation", (done) => {
       idUtilisateurCourant = '123';
 
-      depotDonnees.ajouteInformationsGeneralesAHomologation = (
-        (identifiant, infosGenerales) => new Promise((resolve) => {
+      depotDonnees.ajouteDescriptionServiceAHomologation = (
+        (identifiant, descriptionService) => new Promise((resolve) => {
           expect(identifiant).to.equal('456');
-          expect(infosGenerales.nomService).to.equal('Nouveau Nom');
+          expect(descriptionService.nomService).to.equal('Nouveau Nom');
           resolve();
         })
       );
@@ -564,7 +564,7 @@ describe('Le serveur MSS', () => {
     });
 
     it('retourne une erreur HTTP 422 si la validation des données échoue', (done) => {
-      depotDonnees.ajouteInformationsGeneralesAHomologation = () => Promise.reject(
+      depotDonnees.ajouteDescriptionServiceAHomologation = () => Promise.reject(
         new ErreurNomServiceDejaExistant('oups')
       );
 


### PR DESCRIPTION
Remplacement dans le modèle de `informationsGenerales` et `InformationsGenerales` par `descriptionService` et `DescriptionService`

Il reste des _informationsGenerales_ dans 
- les vues et les scripts publiques (prochaine PR)
- l'adaptateur de persistance et l'adaptateur postgres
- dans les scripts de migrations (c'est normal)
- partout où c'est utilisé pour la double persistance (pour après)