### PR TITLE
Changement pour description service dans l'appel pour récupérer les homologations

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -29,7 +29,7 @@ const nouvelAdaptateur = (donnees = {}) => {
   const homologationAvecNomService = (idUtilisateur, nomService, idHomologationMiseAJour) => (
     homologations(idUtilisateur)
       .then((hs) => hs.find((h) => (
-        h.id !== idHomologationMiseAJour && h.informationsGenerales?.nomService === nomService
+        h.id !== idHomologationMiseAJour && h.descriptionService?.nomService === nomService
       )))
   );
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -43,7 +43,7 @@ const nouvelAdaptateur = (env) => {
       .join('autorisations', knex.raw("(autorisations.donnees->>'idHomologation')::uuid"), 'homologations.id')
       .whereRaw("autorisations.donnees->>'idUtilisateur'=?", idUtilisateur)
       .whereRaw('not homologations.id::text=?', idHomologationMiseAJour)
-      .whereRaw("homologations.donnees#>>'{informationsGenerales,nomService}'=?", nomService)
+      .whereRaw("homologations.donnees#>>'{descriptionService,nomService}'=?", nomService)
       .select('homologations.*')
       .first()
       .then(convertisLigneEnObjet)

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -623,7 +623,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
         homologations: [{
-          id: '789', informationsGenerales: { nomService: 'Un service existant' },
+          id: '789', descriptionService: { nomService: 'Un service existant' },
         }],
         autorisations: [{ idUtilisateur: '123', idHomologation: '789', type: 'createur' }],
       });
@@ -659,8 +659,8 @@ describe('Le dépôt de données persistées en mémoire', () => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
         homologations: [
-          { id: '888', informationsGenerales: { nomService: 'Un service existant' } },
-          { id: '999', informationsGenerales: { nomService: 'Un nom de service' } },
+          { id: '888', descriptionService: { nomService: 'Un service existant' } },
+          { id: '999', descriptionService: { nomService: 'Un nom de service' } },
         ],
         autorisations: [
           { idUtilisateur: '123', idHomologation: '888', type: 'createur' },


### PR DESCRIPTION
Quand on souhaite récupérer des homologations avec un nom d'homologation (cas : quand on crée une homologation pour vérifier si le nom existe déjà) on utilise `descriptionService` à la place de `informationsGenerales`