### PR TITLE
Visibilité de la zone de saisie vide des points d'accès

### DIFF
--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -1,0 +1,7 @@
+.elements-ajoutables label{
+    margin-top: 1em;
+}
+
+.elements-ajoutables > label{
+    margin-bottom: 2em;
+}

--- a/src/vues/fragments/elementsAjoutables.pug
+++ b/src/vues/fragments/elementsAjoutables.pug
@@ -1,15 +1,20 @@
-mixin elementsAjoutables({ identifiantConteneur, nom, valeurExemple = '', donnees = [], texteLienAjouter = 'Ajouter' })
-  div(id = identifiantConteneur)
-    each value, index in donnees
-      label.item-ajoute
-        .icone-suppression
-        input(
-          id = 'description-' + nom + '-' + index,
-          name = 'description-' + nom + '-' + index,
-          type = 'text',
-          value != value.description,
-          placeholder = valeurExemple
-        )
+mixin zoneSaisie(nom, index, description, valeurExemple)
+  label.item-ajoute
+    .icone-suppression
+    input(
+      id = 'description-' + nom + '-' + index,
+      name = 'description-' + nom + '-' + index,
+      type = 'text',
+      value != description,
+      placeholder = valeurExemple
+    )
+
+mixin elementsAjoutables({ identifiantConteneur, nom, valeurExemple = '', donnees = [], texteLienAjouter = 'Ajouter', zoneSaisieVideVisible = false })
+  div(id = identifiantConteneur class = 'elements-ajoutables')
+    if zoneSaisieVideVisible && donnees.length === 0
+      +zoneSaisie(nom, 0, '', valeurExemple)
+    each valeur, index in donnees
+      +zoneSaisie(nom, index, valeur.description, valeurExemple)
   a(
     class = 'nouvel-item',
     id = 'ajout-element-' + nom

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -3,6 +3,7 @@ include ./elementsAjoutables
 
 block append styles
   link(href = '/statique/assets/styles/modale.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/homologation/descriptionService.css', rel = 'stylesheet')
 
 mixin formulaireDescriptionService(idHomologation)
   form.homologation#homologation
@@ -60,6 +61,7 @@ mixin formulaireDescriptionService(idHomologation)
           valeurExemple: 'exemple : https://www.adresse.fr, App Store, Play Store…',
           donnees: homologation.descriptionService.pointsAcces.toJSON(),
           texteLienAjouter: 'Ajouter un accès',
+          zoneSaisieVideVisible: true,
         })
 
     section

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -59,7 +59,7 @@ mixin formulaireDescriptionService(idHomologation)
           nom: 'point-acces',
           valeurExemple: 'exemple : https://www.adresse.fr, App Store, Play Store…',
           donnees: homologation.descriptionService.pointsAcces.toJSON(),
-          textBoutonAjouter: 'Ajouter un accès',
+          texteLienAjouter: 'Ajouter un accès',
         })
 
     section
@@ -75,7 +75,7 @@ mixin formulaireDescriptionService(idHomologation)
         identifiantConteneur: 'fonctionnalites-specifiques',
         nom: 'fonctionnalite',
         donnees: homologation.descriptionService.fonctionnalitesSpecifiques.toJSON(),
-        textBoutonAjouter: 'Ajouter une fonctionnalité',
+        texteLienAjouter: 'Ajouter une fonctionnalité',
       })
 
     section
@@ -91,7 +91,7 @@ mixin formulaireDescriptionService(idHomologation)
               identifiantConteneur: 'donnees-sensibles-specifiques',
               nom: 'donnees-sensibles',
               donnees: homologation.descriptionService.donneesSensiblesSpecifiques.toJSON(),
-              textBoutonAjouter: 'Ajouter des données',
+              texteLienAjouter: 'Ajouter des données',
             })
 
     section


### PR DESCRIPTION
Dans la page description du service, au niveau des points d'accès
nous souhaitons qu'une zone de saisie vide apparaisse quand il n'y a pas de points d'accès

- j'ai corrigé une erreur sur l'affichage du label du lien `ajouter`
- j'ai arrangé le style car la zone de saisie était collé au titre _Accès au service numérique_

<img width="789" alt="Capture d’écran 2022-01-18 à 15 45 13" src="https://user-images.githubusercontent.com/39462397/149959236-a6f627f9-6e23-4b93-b6fc-84de79005f0b.png">
