### PR TITLE
[CORRECTION] Désaseptise les valeurs des éléments ajoutables avant de les afficher

### DIFF
--- a/src/vues/fragments/elementsAjoutables.pug
+++ b/src/vues/fragments/elementsAjoutables.pug
@@ -7,7 +7,7 @@ mixin elementsAjoutables({ identifiantConteneur, nom, valeurExemple = '', donnee
           id = 'description-' + nom + '-' + index,
           name = 'description-' + nom + '-' + index,
           type = 'text',
-          value = value.description,
+          value != value.description,
           placeholder = valeurExemple
         )
   a(


### PR DESCRIPTION
… Pour que l'affichage ne soit pas
<img width="250" alt="Screenshot 2022-01-18 at 16 15 57" src="https://user-images.githubusercontent.com/105624/149965537-0fdcc19a-4c0c-431f-8c83-410e30548c2a.png">

