### PR TITLE
Suppression la présentation des caractéristiques complémentaires

### DIFF
--- a/migrations/20220118145349_supprimeColonnePresentationDeCaracteristiques.js
+++ b/migrations/20220118145349_supprimeColonnePresentationDeCaracteristiques.js
@@ -1,0 +1,30 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => (donnees.caracteristiquesComplementaires))
+      .map(({ id, donnees: { caracteristiquesComplementaires, ...autresDonnees } }) => {
+        delete caracteristiquesComplementaires.presentation;
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: { caracteristiquesComplementaires, ...autresDonnees } });
+      });
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => (
+        donnees.descriptionService
+      ))
+      .map(({ id, donnees }) => {
+        donnees.caracteristiquesComplementaires ||= {};
+        donnees.caracteristiquesComplementaires.presentation = (
+          donnees.descriptionService.presentation
+        );
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees });
+      });
+    return Promise.all(misesAJour);
+  });


### PR DESCRIPTION
Dans la persistance, 
On supprime la présentation des caractéristiques complémentaires car elle n'est plus utilisée