### PR TITLE
Suppression attribut `homologation.idUtilisateur`

### DIFF
--- a/migrations/20220118162341_suppressionColonneHomologationsIdUtilisateur.js
+++ b/migrations/20220118162341_suppressionColonneHomologationsIdUtilisateur.js
@@ -1,0 +1,23 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const suppressions = lignes
+      .map(({ id, donnees: { idUtilisateur, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: { ...autresDonnees } }));
+
+    return Promise.all(suppressions);
+  });
+
+exports.down = (knex) => knex('autorisations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees: { type } }) => type === 'createur')
+      .map(({ donnees: { idHomologation, idUtilisateur } }) => knex('homologations')
+        .where({ id: idHomologation })
+        .first()
+        .then(({ donnees }) => knex('homologations')
+          .where({ id: idHomologation })
+          .update({ donnees: Object.assign(donnees, { idUtilisateur }) })));
+
+    return Promise.all(misesAJour);
+  });

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -104,10 +104,10 @@ const creeDepot = (config = {}) => {
       ));
   };
 
-  const ajouteDescriptionServiceAHomologation = (idHomologation, infos) => (
+  const ajouteDescriptionServiceAHomologation = (idUtilisateur, idHomologation, infos) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((h) => (
-        valideDescriptionService(h.idUtilisateur, infos, h.id)
+        valideDescriptionService(idUtilisateur, infos, h.id)
           .then(() => metsAJourDescriptionServiceHomologation(h, infos))
       ))
   );

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -19,7 +19,6 @@ class Homologation {
   constructor(donnees, referentiel = Referentiel.creeReferentielVide()) {
     const {
       id = '',
-      idUtilisateur,
       informationsGenerales = {},
       descriptionService = {},
       mesuresGenerales = [],
@@ -32,7 +31,6 @@ class Homologation {
     } = donnees;
 
     this.id = id;
-    this.idUtilisateur = idUtilisateur;
     this.informationsGenerales = new InformationsGenerales(informationsGenerales, referentiel);
     this.descriptionService = new DescriptionService(descriptionService, referentiel);
     this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel);

--- a/src/mss.js
+++ b/src/mss.js
@@ -241,7 +241,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
     ]),
     (requete, reponse, suite) => {
       const descriptionService = new DescriptionService(requete.body, referentiel);
-      depotDonnees.ajouteDescriptionServiceAHomologation(requete.params.id, descriptionService)
+      depotDonnees.ajouteDescriptionServiceAHomologation(
+        requete.idUtilisateurCourant,
+        requete.params.id,
+        descriptionService
+      )
         .then(() => reponse.send({ idHomologation: requete.homologation.id }))
         .catch((e) => {
           if (e instanceof ErreurModele) {

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -14,7 +14,6 @@ const AvisExpertCyber = require('../src/modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('../src/modeles/caracteristiquesComplementaires');
 const DescriptionService = require('../src/modeles/descriptionService');
 const Homologation = require('../src/modeles/homologation');
-const InformationsGenerales = require('../src/modeles/informationsGenerales');
 const MesureGenerale = require('../src/modeles/mesureGenerale');
 const MesureSpecifique = require('../src/modeles/mesureSpecifique');
 const MesuresSpecifiques = require('../src/modeles/mesuresSpecifiques');
@@ -215,14 +214,14 @@ describe('Le dépôt de données persistées en mémoire', () => {
   describe("sur demande de mise à jour de la description du service d'une homologation", () => {
     it("met à jour la description du service d'une homologation", (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        homologations: [
-          { id: '123', descriptionService: { nomService: 'Super Service' } },
-        ],
+        autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
+        utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
+        homologations: [{ id: '123', informationsGenerales: { nomService: 'Super Service' } }],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-      const infos = new DescriptionService({ nomService: 'Nouveau Nom' });
-      depot.ajouteDescriptionServiceAHomologation('123', infos)
+      const description = new DescriptionService({ nomService: 'Nouveau Nom' });
+      depot.ajouteDescriptionServiceAHomologation('999', '123', description)
         .then(() => depot.homologation('123'))
         .then(({ descriptionService }) => {
           expect(descriptionService.nomService).to.equal('Nouveau Nom');
@@ -233,14 +232,14 @@ describe('Le dépôt de données persistées en mémoire', () => {
 
     it('met à jour la description du service dans informations générales', (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        homologations: [
-          { id: '123', descriptionService: { nomService: 'Super Service' } },
-        ],
+        autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
+        utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
+        homologations: [{ id: '123', informationsGenerales: { nomService: 'Super Service' } }],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-      const infos = new InformationsGenerales({ nomService: 'Nouveau Nom' });
-      depot.ajouteDescriptionServiceAHomologation('123', infos)
+      const description = new DescriptionService({ nomService: 'Nouveau Nom' });
+      depot.ajouteDescriptionServiceAHomologation('999', '123', description)
         .then(() => depot.homologation('123'))
         .then(({ informationsGenerales }) => {
           expect(informationsGenerales.nomService).to.equal('Nouveau Nom');
@@ -251,15 +250,14 @@ describe('Le dépôt de données persistées en mémoire', () => {
 
     it('lève une exception si le nom du service est absent', (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        homologations: [
-          { id: '123', descriptionService: { nomService: 'Super Service' } },
-        ],
+        autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
+        utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
+        homologations: [{ id: '123', informationsGenerales: { nomService: 'Super Service' } }],
       });
-
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-      const infos = new DescriptionService({ nomService: '' });
-      depot.ajouteDescriptionServiceAHomologation('123', infos)
+      const description = new DescriptionService({ nomService: '' });
+      depot.ajouteDescriptionServiceAHomologation('999', '123', description)
         .then(() => done(
           'La mise à jour de la description du service aurait dû lever une exception'
         ))
@@ -273,14 +271,16 @@ describe('Le dépôt de données persistées en mémoire', () => {
 
     it("ne détecte pas de doublon sur le nom de service pour l'homologation en cours de mise à jour", (done) => {
       const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
+        utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
         homologations: [
           { id: '123', descriptionService: { nomService: 'Super Service', presenceResponsable: 'non' } },
         ],
       });
       const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-      const infos = new DescriptionService({ nomService: 'Super Service', presenceResponsable: 'oui' });
-      depot.ajouteDescriptionServiceAHomologation('123', infos)
+      const description = new DescriptionService({ nomService: 'Super Service', presenceResponsable: 'oui' });
+      depot.ajouteDescriptionServiceAHomologation('999', '123', description)
         .then(() => depot.homologation('123'))
         .then(({ descriptionService }) => {
           expect(descriptionService.presenceResponsable).to.equal('oui');

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -144,6 +144,7 @@ describe('Le serveur MSS', () => {
     },
 
     trouveHomologation: (requete, reponse, suite) => {
+      requete.idUtilisateurCourant = idUtilisateurCourant;
       requete.homologation = new Homologation({ id: '456' });
       rechercheHomologationEffectuee = true;
       suite();
@@ -547,11 +548,12 @@ describe('Le serveur MSS', () => {
       idUtilisateurCourant = '123';
 
       depotDonnees.ajouteDescriptionServiceAHomologation = (
-        (identifiant, descriptionService) => new Promise((resolve) => {
-          expect(identifiant).to.equal('456');
-          expect(descriptionService.nomService).to.equal('Nouveau Nom');
-          resolve();
-        })
+        (idUtilisateur, idHomologation, infosGenerales) => {
+          expect(idUtilisateur).to.equal('123');
+          expect(idHomologation).to.equal('456');
+          expect(infosGenerales.nomService).to.equal('Nouveau Nom');
+          return Promise.resolve();
+        }
       );
 
       axios.put('http://localhost:1234/api/homologation/456', { nomService: 'Nouveau Nom' })


### PR DESCRIPTION
… Dans le code et en base.

Cette PR fait suite à la #68 

La suite sera :
- ajouter un collaborateur existant
- accéder à des homologations avec le rôle « collaborateur »
- interdire aux collaborateurs d'inviter d'autres collaborateurs