### PR TITLE
Nettoyage des propriétés non utilisées des caractéristiques complémentaires

### DIFF
--- a/src/modeles/caracteristiquesComplementaires.js
+++ b/src/modeles/caracteristiquesComplementaires.js
@@ -8,9 +8,6 @@ class CaracteristiquesComplementaires extends InformationsHomologation {
       proprietesAtomiquesRequises: [
         'structureDeveloppement', 'hebergeur',
       ],
-      proprietesAtomiquesFacultatives: [
-        'presentation', 'localisationDonnees',
-      ],
       listesAgregats: { entitesExternes: EntitesExternes },
     });
     this.renseigneProprietes(donneesCaracteristiques);

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -86,7 +86,7 @@ class Homologation {
 
   piloteProjet() { return this.partiesPrenantes.piloteProjet; }
 
-  presentation() { return this.caracteristiquesComplementaires.presentation; }
+  presentation() { return this.descriptionService.presentation; }
 
   risquesPrincipaux() {
     return this.risques.principaux();

--- a/test/modeles/caracteristiquesComplementaires.spec.js
+++ b/test/modeles/caracteristiquesComplementaires.spec.js
@@ -6,17 +6,13 @@ const InformationsHomologation = require('../../src/modeles/informationsHomologa
 describe("L'ensemble des caractéristiques complémentaires", () => {
   it('connaît ses constituants', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
-      presentation: 'Une présentation',
       structureDeveloppement: 'Une structure',
       hebergeur: 'Un hébergeur',
-      localisationDonnees: 'france',
       entitesExternes: [{ nom: 'Un nom' }],
     });
 
-    expect(caracteristiques.presentation).to.equal('Une présentation');
     expect(caracteristiques.structureDeveloppement).to.equal('Une structure');
     expect(caracteristiques.hebergeur).to.equal('Un hébergeur');
-    expect(caracteristiques.localisationDonnees).to.equal('france');
     expect(caracteristiques.nombreEntitesExternes()).to.equal(1);
   });
 
@@ -27,31 +23,25 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
 
   it('sait se présenter au format JSON', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
-      presentation: 'Une présentation',
       structureDeveloppement: 'Une structure',
       hebergeur: 'Un hébergeur',
-      localisationDonnees: 'france',
       entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
     });
 
     expect(caracteristiques.toJSON()).to.eql({
-      presentation: 'Une présentation',
       structureDeveloppement: 'Une structure',
       hebergeur: 'Un hébergeur',
-      localisationDonnees: 'france',
       entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
     });
   });
 
   it('presente un JSON partiel si certaines caractéristiques ne sont pas définies', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
-      presentation: 'Une présentation',
-      hebergeur: '',
+      hebergeur: 'ovh',
     });
 
     expect(caracteristiques.toJSON()).to.eql({
-      presentation: 'Une présentation',
-      hebergeur: '',
+      hebergeur: 'ovh',
       entitesExternes: [],
     });
   });
@@ -67,10 +57,8 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
     describe("quand au moins une entité externe n'a été que partiellement saisie", () => {
       it('a pour statut de saisie A_COMPLETER', () => {
         const caracteristiques = new CaracteristiquesComplementaires({
-          presentation: 'Une présentation',
           structureDeveloppement: 'Une structure',
           hebergeur: 'Un hébergeur',
-          localisationDonnees: 'france',
           entitesExternes: [{ nom: 'Un nom, mais pas de contact' }],
         });
 
@@ -81,10 +69,8 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
     describe('quand toutes les entités externes sont complètement saisies', () => {
       it('a pour statut COMPLETES si tous les autres champs sont remplis', () => {
         const caracteristiques = new CaracteristiquesComplementaires({
-          presentation: 'Une présentation',
           structureDeveloppement: 'Une structure',
           hebergeur: 'Un hébergeur',
-          localisationDonnees: 'france',
           entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
         });
 
@@ -93,7 +79,6 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
 
       it("a pour statut A_COMPLETER si un des autres champs n'est pas saisi", () => {
         const caracteristiques = new CaracteristiquesComplementaires({
-          presentation: 'Une présentation',
           entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
         });
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -52,12 +52,12 @@ describe('Une homologation', () => {
     const homologation = new Homologation({
       id: '123',
       caracteristiquesComplementaires: {
-        presentation: 'Une présentation',
         structureDeveloppement: 'Une structure',
         hebergeur: 'Un hébergeur',
       },
       descriptionService: {
         localisationDonnees: 'france',
+        presentation: 'Une présentation',
       },
     }, referentiel);
 


### PR DESCRIPTION
Après le déplacement de la présentation et de la localisation des données dans description du service,
il était bon de retirer les propriétés non utilisées dans les caractéristiques complémentaires

Note : correction de la récupération de la présentation dans homologation