### PR TITLE
Suppression la localisation des données des caractéristiques complémentaires

### DIFF
--- a/migrations/20220119083758_supprimeColonneLocalisationDonneesDeCaracteristiques.js
+++ b/migrations/20220119083758_supprimeColonneLocalisationDonneesDeCaracteristiques.js
@@ -1,0 +1,28 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => (donnees.caracteristiquesComplementaires))
+      .map(({ id, donnees: { caracteristiquesComplementaires, ...autresDonnees } }) => {
+        delete caracteristiquesComplementaires.localisationDonnees;
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: { caracteristiquesComplementaires, ...autresDonnees } });
+      });
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.descriptionService)
+      .map(({ id, donnees }) => {
+        donnees.caracteristiquesComplementaires ||= {};
+        donnees.caracteristiquesComplementaires.localisationDonnees = (
+          donnees.descriptionService.localisationDonnees
+        );
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees });
+      });
+    return Promise.all(misesAJour);
+  });


### PR DESCRIPTION
Dans la persistance,
On supprime la localisation des données des caractéristiques complémentaires car elle n'est plus utilisée