### PR TITLE
Modification des acteurs de l'homologations

### DIFF
--- a/public/assets/styles/homologation/partiesPrenantes.css
+++ b/public/assets/styles/homologation/partiesPrenantes.css
@@ -1,0 +1,13 @@
+.saisie-identite {
+    border: .3px solid;
+    border-color: var(--liseres);
+    padding: .5em;
+    margin-top: 0.6em;
+}
+
+.saisie-identite label {
+    display: inline-block;
+    margin: 0;
+    margin-left: 0.1em;
+    font-weight: normal;
+}

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -49,6 +49,10 @@ class Homologation {
 
   autoriteHomologation() { return this.partiesPrenantes.autoriteHomologation; }
 
+  delegueProtectionDonnees() {
+    return this.partiesPrenantes.delegueProtectionDonnees;
+  }
+
   descriptionAutoriteHomologation() {
     return this.partiesPrenantes.descriptionAutoriteHomologation();
   }

--- a/src/modeles/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes.js
@@ -16,6 +16,8 @@ class PartiesPrenantes extends InformationsHomologation {
       proprietesAtomiquesRequises: [
         'autoriteHomologation',
         'fonctionAutoriteHomologation',
+        'delegueProtectionDonnees',
+        'fonctionDelegueProtectionDonnees',
         'piloteProjet',
         'fonctionPiloteProjet',
         'expertCybersecurite',
@@ -44,6 +46,12 @@ class PartiesPrenantes extends InformationsHomologation {
 
   descriptionExpertCybersecurite() {
     return descriptionPartiePrenante(this.expertCybersecurite, this.fonctionExpertCybersecurite);
+  }
+
+  descriptionDelegueProtectionDonnees() {
+    return descriptionPartiePrenante(
+      this.delegueProtectionDonnees, this.fonctionDelegueProtectionDonnees
+    );
   }
 }
 

--- a/src/vues/fragments/inputIdentite.pug
+++ b/src/vues/fragments/inputIdentite.pug
@@ -1,31 +1,17 @@
-mixin inputIdentite({ role, descriptif = '', nomParametre, raccourciVisible = false })
+mixin inputIdentite({ role, nomParametre })
   label(for='aucuneAction')= role
-    p= descriptif
+    .saisie-identite
+      label(for = nomParametre) Nom / Prénom
+      input(
+        id = nomParametre, name = nomParametre, type = 'text',
+        placeholder = 'Exemple : Dujardin Jean',
+        value != homologation.partiesPrenantes[nomParametre]
+      )
 
-    - const nomParamCapitalise = `${nomParametre.charAt(0).toUpperCase()}${nomParametre.slice(1)}`
-
-    if raccourciVisible
-      - const nomParamJeSuis = `jeSuis${nomParamCapitalise}`
-      input(id = nomParamJeSuis, name = nomParamJeSuis, type = 'checkbox')
-      label(for = nomParamJeSuis) Je suis cette personne
-
-    input(
-      id = nomParametre, name = nomParametre, type = 'text',
-      placeholder = 'Prénom et nom',
-      value != homologation.partiesPrenantes[nomParametre]
-    )
-
-    - const nomParamFonction = `fonction${nomParamCapitalise}`
-    input(
-      id = nomParamFonction, name = nomParamFonction, type = 'text',
-      placeholder = 'Fonction',
-      value = homologation.partiesPrenantes[nomParamFonction]
-    )
-
-mixin inputIdentiteExpertCyber
-  +inputIdentite({
-    role: 'Spécialiste cybersécurité',
-    descriptif: "Personne en capacité de donner un avis sur la sécurité numérique du projet. Cette personne ne devrait pas être celle ayant développé ou fourni le service (ex. responsable de la sécurité des systèmes d'information de l'entité, prestataire de conseil en sécurité)",
-    nomParametre: 'expertCybersecurite',
-    raccourciVisible: true
-  })
+      - const nomParamFonction = `fonction${nomParametre.charAt(0).toUpperCase()}${nomParametre.slice(1)}`
+      label(for = nomParamFonction) Fonction
+      input(
+        id = nomParamFonction, name = nomParamFonction, type = 'text',
+        placeholder = 'Exemple : Direction générale des services, maire',
+        value = homologation.partiesPrenantes[nomParamFonction]
+      )

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -6,16 +6,13 @@ block formulaire
     h1.action Parties prenantes
 
     section
-      h3 Autorité d'homologation
+      h3 Acteurs de l'homologation
 
       +inputIdentite({
         role: "Autorité d'homologation",
         descriptif: "Personne en capacité de prendre la responsabilité de la mise en ligne d'un service (ex. directeur·ice général·e des services, maire ou adjoint·e au maire)",
         nomParametre: 'autoriteHomologation',
       })
-
-    section
-      h3 Équipe chargée du projet d'homologation
 
       +inputIdentite({
         role: 'Responsable métier du projet',

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -22,6 +22,11 @@ block formulaire
       })
 
       +inputIdentite({
+        role: 'Délégué(e) à la protection des données à caractère personnel',
+        nomParametre: 'delegueProtectionDonnees',
+      })
+
+      +inputIdentite({
         role: 'Responsable métier du projet',
         nomParametre: 'piloteProjet',
       })

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -1,6 +1,9 @@
 extends ./formulaire
 include ../fragments/inputIdentite
 
+block append styles
+  link(href = '/statique/assets/styles/homologation/partiesPrenantes.css', rel = 'stylesheet')
+
 block formulaire
   form.homologation#parties-prenantes
     h1.action Parties prenantes
@@ -10,18 +13,18 @@ block formulaire
 
       +inputIdentite({
         role: "Autorité d'homologation",
-        descriptif: "Personne en capacité de prendre la responsabilité de la mise en ligne d'un service (ex. directeur·ice général·e des services, maire ou adjoint·e au maire)",
         nomParametre: 'autoriteHomologation',
       })
 
       +inputIdentite({
-        role: 'Responsable métier du projet',
-        descriptif: 'Personne pilote du projet au niveau métier (ex. chef·fe du projet, responsable métier)',
-        nomParametre: 'piloteProjet',
-        raccourciVisible: true
+        role: 'Spécialiste cybersécurité',
+        nomParametre: 'expertCybersecurite',
       })
 
-      +inputIdentiteExpertCyber
+      +inputIdentite({
+        role: 'Responsable métier du projet',
+        nomParametre: 'piloteProjet',
+      })
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -73,6 +73,7 @@ describe('Une homologation', () => {
       partiesPrenantes: {
         autoriteHomologation: 'Jean Dupont',
         fonctionAutoriteHomologation: 'Maire',
+        delegueProtectionDonnees: 'Rémi Fassol',
         piloteProjet: 'Sylvie Martin',
         expertCybersecurite: 'Anna Dubreuil',
       },
@@ -80,6 +81,7 @@ describe('Une homologation', () => {
 
     expect(homologation.autoriteHomologation()).to.equal('Jean Dupont');
     expect(homologation.fonctionAutoriteHomologation()).to.equal('Maire');
+    expect(homologation.delegueProtectionDonnees()).to.equal('Rémi Fassol');
     expect(homologation.piloteProjet()).to.equal('Sylvie Martin');
     expect(homologation.expertCybersecurite()).to.equal('Anna Dubreuil');
   });

--- a/test/modeles/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes.spec.js
@@ -7,6 +7,8 @@ describe("L'ensemble des parties prenantes", () => {
   it('connaît ses constituants', () => {
     const partiesPrenantes = new PartiesPrenantes({
       autoriteHomologation: 'Jean Dupont',
+      delegueProtectionDonnees: 'Rémi Fassol',
+      fonctionDelegueProtectionDonnees: 'DSI',
       fonctionAutoriteHomologation: 'Maire',
       piloteProjet: 'Sylvie Martin',
       fonctionPiloteProjet: 'Responsable métier',
@@ -16,6 +18,8 @@ describe("L'ensemble des parties prenantes", () => {
 
     expect(partiesPrenantes.autoriteHomologation).to.equal('Jean Dupont');
     expect(partiesPrenantes.fonctionAutoriteHomologation).to.equal('Maire');
+    expect(partiesPrenantes.delegueProtectionDonnees).to.equal('Rémi Fassol');
+    expect(partiesPrenantes.fonctionDelegueProtectionDonnees).to.equal('DSI');
     expect(partiesPrenantes.piloteProjet).to.equal('Sylvie Martin');
     expect(partiesPrenantes.fonctionPiloteProjet).to.equal('Responsable métier');
     expect(partiesPrenantes.expertCybersecurite).to.equal('Anna Dubreuil');
@@ -24,6 +28,8 @@ describe("L'ensemble des parties prenantes", () => {
     expect(partiesPrenantes.toJSON()).to.eql({
       autoriteHomologation: 'Jean Dupont',
       fonctionAutoriteHomologation: 'Maire',
+      delegueProtectionDonnees: 'Rémi Fassol',
+      fonctionDelegueProtectionDonnees: 'DSI',
       piloteProjet: 'Sylvie Martin',
       fonctionPiloteProjet: 'Responsable métier',
       expertCybersecurite: 'Anna Dubreuil',
@@ -109,6 +115,15 @@ describe("L'ensemble des parties prenantes", () => {
     });
 
     expect(partiesPrenantes.descriptionExpertCybersecurite()).to.equal('Jean Dupont (RSSI)');
+  });
+
+  it('présente les informations relatives au ou à la déléguée à la protection des données', () => {
+    const partiesPrenantes = new PartiesPrenantes({
+      delegueProtectionDonnees: 'Jean Dupont',
+      fonctionDelegueProtectionDonnees: 'DSI',
+    });
+
+    expect(partiesPrenantes.descriptionDelegueProtectionDonnees()).to.equal('Jean Dupont (DSI)');
   });
 
   it('détermine le statut de saisie', () => {


### PR DESCRIPTION
Dans la page _Parties prenantes_

- Les acteurs qui étaient en 2 groupes sont dans un seul
- Les descriptions et les _je suis cette personne_ disparaissent
- Quelques textes sont changés
- On ajoute un nouvel acteur **le(a) délégué(e) à la protection des données**
<img width="613" alt="Capture d’écran 2022-01-19 à 16 56 29" src="https://user-images.githubusercontent.com/39462397/150167411-6acb7442-a396-43d1-9821-41b264f99df4.png">

_Note Bonus : comment intègre-t-on ce nouvel acteur dans la Décision ?_