### PR TITLE
Nouvel acteur homologation

### DIFF
--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -1,7 +1,0 @@
-.elements-ajoutables .item-ajoute{
-    margin-top: 1em;
-}
-
-.elements-ajoutables > .item-ajoute{
-    margin-bottom: 2em;
-}

--- a/public/assets/styles/homologation/formulaire.css
+++ b/public/assets/styles/homologation/formulaire.css
@@ -80,9 +80,18 @@ a.nouvel-item {
   position: relative;
 
   padding: 1em;
+  margin-top: 1em;
+  margin-bottom: 2em;
 
   border: solid 1px var(--liseres);
   border-radius: 5px;
+}
+
+.item-ajoute label {
+  display: inline-block;
+  margin: 0;
+  margin-left: 0.1em;
+  font-weight: normal;
 }
 
 .icone-suppression {

--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -1,7 +1,22 @@
-import parametres from '../modules/parametres.js';
+import parametres, { modifieParametresAvecItemsExtraits } from '../modules/parametres.js';
+import brancheElementsAjoutables from '../modules/brancheElementsAjoutables.js';
 import brancheInputsIdentite from '../modules/brancheInputsIdentite.js';
 
 $(() => {
+  brancheElementsAjoutables('acteurs-homologation', 'acteur-homologation', {
+    role: { label: 'Rôle au regard du projet' },
+    nom: { label: 'Nom / Prénom' },
+    fonction: { label: 'Fonction' },
+  });
+
+  const tousLesParametres = (selecteurFormulaire) => {
+    const params = parametres(selecteurFormulaire);
+    modifieParametresAvecItemsExtraits(
+      params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
+    );
+    return params;
+  };
+
   const idsInputsIdentite = [
     { idJeSuis: '#jeSuisPiloteProjet', idZoneSaisie: '#piloteProjet' },
     { idJeSuis: '#jeSuisExpertCybersecurite', idZoneSaisie: '#expertCybersecurite' },
@@ -17,7 +32,7 @@ $(() => {
       .map((ids) => ids.idZoneSaisie)
       .forEach((selecteur) => $(selecteur).removeAttr('disabled'));
 
-    const params = parametres('form#parties-prenantes');
+    const params = tousLesParametres('form#parties-prenantes');
 
     axios.post(`/api/homologation/${identifiantHomologation}/partiesPrenantes`, params)
       .then((reponse) => (window.location = `/homologation/${reponse.data.idHomologation}`));

--- a/public/modules/brancheElementsAjoutables.js
+++ b/public/modules/brancheElementsAjoutables.js
@@ -20,17 +20,25 @@ const brancheElementsAjoutables = (
   const selecteurLienAjout = `#ajout-element-${identifiantElement}`;
 
   const templateZoneSaisie = (nomElement, index, proprietes) => {
+    const label = (valeurLabel, idInputAssocie) => (
+      valeurLabel ? `<label for="${idInputAssocie}">${valeurLabel}</label>` : ''
+    );
+
     const $inputs = Object
       .keys(proprietes)
-      .map((cle) => $(
-        `<input
-          id="${cle}-${nomElement}-${index}"
-          name="${cle}-${nomElement}-${index}"
-          type="text"
-          value="${proprietes[cle].valeur}"
-          placeholder="${proprietes[cle].valeurExemple}"
-        >`
-      ));
+      .map((cle) => {
+        const id = `${cle}-${nomElement}-${index}`;
+        return $(
+          `${label(proprietes[cle].label, id)}
+          <input
+            id="${id}"
+            name="${id}"
+            type="text"
+            value="${proprietes[cle].valeur || ''}"
+            placeholder="${proprietes[cle].valeurExemple || ''}"
+          >`
+        );
+      });
     return $(`<div id="element-${nomElement}-${index}"></div>`).append($inputs);
   };
 

--- a/src/modeles/acteurHomologation.js
+++ b/src/modeles/acteurHomologation.js
@@ -1,0 +1,14 @@
+const InformationsHomologation = require('./informationsHomologation');
+
+class ActeurHomologation extends InformationsHomologation {
+  constructor(donnees) {
+    super({ proprietesAtomiquesRequises: ['role', 'nom', 'fonction'] });
+    this.renseigneProprietes(donnees);
+  }
+
+  static proprietes() {
+    return ['role', 'nom', 'fonction'];
+  }
+}
+
+module.exports = ActeurHomologation;

--- a/src/modeles/acteursHomologation.js
+++ b/src/modeles/acteursHomologation.js
@@ -1,0 +1,14 @@
+const ListeItems = require('./listeItems');
+const ActeurHomologation = require('./acteurHomologation');
+
+class ActeursHomologation extends ListeItems {
+  constructor(donnees) {
+    super(ActeurHomologation, { items: donnees.acteursHomologation });
+  }
+
+  static proprietesItem() {
+    return ActeurHomologation.proprietes();
+  }
+}
+
+module.exports = ActeursHomologation;

--- a/src/modeles/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes.js
@@ -1,3 +1,4 @@
+const ActeursHomologation = require('./acteursHomologation');
 const InformationsHomologation = require('./informationsHomologation');
 
 const descriptionPartiePrenante = (partiePrenante, fonction) => {
@@ -23,6 +24,9 @@ class PartiesPrenantes extends InformationsHomologation {
         'expertCybersecurite',
         'fonctionExpertCybersecurite',
       ],
+      listesAgregats: {
+        acteursHomologation: ActeursHomologation,
+      },
     });
 
     this.renseigneProprietes(donneesPartiesPrenantes);

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -1,6 +1,7 @@
 const express = require('express');
 
 const { ErreurModele } = require('../erreurs');
+const ActeursHomologation = require('../modeles/acteursHomologation');
 const AvisExpertCyber = require('../modeles/avisExpertCyber');
 const CaracteristiquesComplementaires = require('../modeles/caracteristiquesComplementaires');
 const DescriptionService = require('../modeles/descriptionService');
@@ -140,11 +141,16 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
     }
   });
 
-  routes.post('/:id/partiesPrenantes', middleware.trouveHomologation, (requete, reponse) => {
-    const partiesPrenantes = new PartiesPrenantes(requete.body);
-    depotDonnees.ajoutePartiesPrenantesAHomologation(requete.homologation.id, partiesPrenantes)
-      .then(() => reponse.send({ idHomologation: requete.homologation.id }));
-  });
+  routes.post('/:id/partiesPrenantes',
+    middleware.trouveHomologation,
+    middleware.aseptiseListes([
+      { nom: 'acteursHomologation', proprietes: ActeursHomologation.proprietesItem() },
+    ]),
+    (requete, reponse) => {
+      const partiesPrenantes = new PartiesPrenantes(requete.body);
+      depotDonnees.ajoutePartiesPrenantesAHomologation(requete.homologation.id, partiesPrenantes)
+        .then(() => reponse.send({ idHomologation: requete.homologation.id }));
+    });
 
   routes.post('/:id/risques', middleware.trouveHomologation, middleware.aseptise(
     '*',

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutables.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutables.pug
@@ -1,8 +1,11 @@
 mixin zoneSaisieElementAjoutable(donneesElement, nom, index)
   each valeur, cle in donneesElement
+    - var id = cle + '-' + nom + '-' + index;
+    if valeur.label
+      label(for = id) #{valeur.label}
     input(
-      id = cle + '-' + nom + '-' + index,
-      name = cle + '-' + nom + '-' + index,
+      id = id,
+      name = id,
       type = 'text',
       value != valeur.valeur,
       placeholder = valeur.valeurExemple

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesActeurHomologation.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesActeurHomologation.pug
@@ -1,0 +1,16 @@
+include ./elementsAjoutables
+
+mixin elementsAjoutablesActeurHomologation({ donnees = [] })
+  -
+    var donneesElements = donnees.map(({ role, nom, fonction }) => ({
+      role: ({ valeur: role, label: 'Rôle au regard du projet' }),
+      nom: ({ valeur: nom, label: 'Nom / Prénom' }),
+      fonction: ({ valeur: fonction, label: 'Fonction' })
+    }))
+
+  +elementsAjoutables({
+    identifiantConteneur: 'acteurs-homologation',
+    nom: 'acteur-homologation',
+    donneesElements,
+    texteLienAjouter: 'Ajouter un acteur'
+  })

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -1,5 +1,6 @@
 extends ./formulaire
 include ../fragments/inputIdentite
+include ../fragments/elementsAjoutables/elementsAjoutablesActeurHomologation
 
 block append styles
   link(href = '/statique/assets/styles/homologation/partiesPrenantes.css', rel = 'stylesheet')
@@ -29,6 +30,10 @@ block formulaire
       +inputIdentite({
         role: 'Responsable métier du projet',
         nomParametre: 'piloteProjet',
+      })
+
+      +elementsAjoutablesActeurHomologation({
+        donnees: [],
       })
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -33,7 +33,7 @@ block formulaire
       })
 
       +elementsAjoutablesActeurHomologation({
-        donnees: [],
+        donnees: homologation.partiesPrenantes.acteursHomologation.toJSON(),
       })
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›

--- a/test/modeles/acteurHomologation.spec.js
+++ b/test/modeles/acteurHomologation.spec.js
@@ -1,0 +1,27 @@
+const expect = require('expect.js');
+
+const ActeurHomologation = require('../../src/modeles/acteurHomologation');
+
+describe("Un acteur de l'homologation", () => {
+  const acteurHomologation = new ActeurHomologation({
+    role: 'DSI',
+    nom: 'John Doe',
+    fonction: 'Maire',
+  });
+
+  it('connaît son rôle', () => {
+    expect(acteurHomologation.role).to.equal('DSI');
+  });
+
+  it('connaît son nom', () => {
+    expect(acteurHomologation.nom).to.equal('John Doe');
+  });
+
+  it('connaît sa fonction', () => {
+    expect(acteurHomologation.fonction).to.equal('Maire');
+  });
+
+  it('donne les clés de ses propriétés', () => {
+    expect(ActeurHomologation.proprietes()).to.eql(['role', 'nom', 'fonction']);
+  });
+});

--- a/test/modeles/acteursHomologation.spec.js
+++ b/test/modeles/acteursHomologation.spec.js
@@ -1,0 +1,21 @@
+const expect = require('expect.js');
+
+const ActeursHomologation = require('../../src/modeles/acteursHomologation');
+
+const ils = it;
+
+describe("Les acteurs de l'homologation", () => {
+  ils('savent se dénombrer', () => {
+    const acteursHomologation = new ActeursHomologation(
+      { acteursHomologation: [
+        { role: 'DSI', nom: 'John', fonction: 'Directeur' },
+        { role: 'Responsable du service', nom: 'Joe', fonction: 'Maire' },
+      ] }
+    );
+    expect(acteursHomologation.nombre()).to.equal(2);
+  });
+
+  ils("donnent la liste des propriétés de l'acteur", () => {
+    expect(ActeursHomologation.proprietesItem()).to.eql(['role', 'nom', 'fonction']);
+  });
+});

--- a/test/modeles/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes.spec.js
@@ -14,6 +14,7 @@ describe("L'ensemble des parties prenantes", () => {
       fonctionPiloteProjet: 'Responsable métier',
       expertCybersecurite: 'Anna Dubreuil',
       fonctionExpertCybersecurite: 'RSSI',
+      acteursHomologation: [{ role: 'DSI', nom: 'John', fonction: 'Maire' }],
     });
 
     expect(partiesPrenantes.autoriteHomologation).to.equal('Jean Dupont');
@@ -24,6 +25,9 @@ describe("L'ensemble des parties prenantes", () => {
     expect(partiesPrenantes.fonctionPiloteProjet).to.equal('Responsable métier');
     expect(partiesPrenantes.expertCybersecurite).to.equal('Anna Dubreuil');
     expect(partiesPrenantes.fonctionExpertCybersecurite).to.equal('RSSI');
+    expect(partiesPrenantes.acteursHomologation.item(0).role).to.equal('DSI');
+    expect(partiesPrenantes.acteursHomologation.item(0).nom).to.equal('John');
+    expect(partiesPrenantes.acteursHomologation.item(0).fonction).to.equal('Maire');
 
     expect(partiesPrenantes.toJSON()).to.eql({
       autoriteHomologation: 'Jean Dupont',
@@ -34,6 +38,7 @@ describe("L'ensemble des parties prenantes", () => {
       fonctionPiloteProjet: 'Responsable métier',
       expertCybersecurite: 'Anna Dubreuil',
       fonctionExpertCybersecurite: 'RSSI',
+      acteursHomologation: [{ role: 'DSI', nom: 'John', fonction: 'Maire' }],
     });
   });
 

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -777,6 +777,15 @@ describe('Le serveur MSS', () => {
         })
         .catch(done);
     });
+
+    it("aseptise la liste des acteurs de l'homologation ainsi que son contenu", (done) => {
+      axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {})
+        .then(() => {
+          verifieAseptisationListe('acteursHomologation', ['role', 'nom', 'fonction']);
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('quand requête POST sur `/api/homologation/:id/risques`', () => {


### PR DESCRIPTION
Dans la page parties prenantes,
en bas de la liste des acteurs de l'homologation,
nous souhaitons avoir une possibilité d'ajouter des acteurs supplémentaires

MISE À JOUR avec des labels
<img width="752" alt="Capture d’écran 2022-02-03 à 14 48 36" src="https://user-images.githubusercontent.com/39462397/152355460-c5e662fd-6df8-428c-be36-fa5651a4101a.png">

