### PR TITLE
Suppression du choix autres données sensibles

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -136,11 +136,6 @@ module.exports = {
       description: 'Données de niveau « Diffusion Restreinte »',
       seuilCriticite: 'critique',
     },
-    autre: {
-      description: 'Autre données sensibles',
-      exemple: "documents sensibles internes à l'administration.",
-      seuilCriticite: 'faible',
-    },
   },
 
   delaisAvantImpactCritique: {

--- a/migrations/20220121083346_integreAutresDonneesSensiblesDansDonneesSensiblesSupplementaires.js
+++ b/migrations/20220121083346_integreAutresDonneesSensiblesDansDonneesSensiblesSupplementaires.js
@@ -1,0 +1,56 @@
+const DESCRIPTION_PAR_DEFAUT_AUTRES_DONNEES_SENSIBLES = 'Autres données sensibles';
+const IDENTIFIANT_AUTRES_DONNEES_SENSIBLES = 'autre';
+
+const deplace = (filtreAutresDonneesSensibles, fonctionMiseAJour) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(filtreAutresDonneesSensibles)
+      .map(({ id, donnees }) => {
+        donnees.descriptionService = fonctionMiseAJour(donnees.descriptionService);
+        donnees.informationsGenerales = fonctionMiseAJour(donnees.informationsGenerales);
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees });
+      });
+
+    return Promise.all(misesAJour);
+  });
+
+const autresDonneesSensiblesGeneriques = ({ donnees }) => (
+  donnees.descriptionService
+    ?.donneesCaracterePersonnel
+    ?.indexOf?.(IDENTIFIANT_AUTRES_DONNEES_SENSIBLES) > -1
+);
+
+const versDonneesSensiblesSpecifiques = (descriptionService) => {
+  descriptionService.donneesSensiblesSpecifiques ||= [];
+  descriptionService.donneesSensiblesSpecifiques.push(
+    { description: DESCRIPTION_PAR_DEFAUT_AUTRES_DONNEES_SENSIBLES }
+  );
+
+  descriptionService.donneesCaracterePersonnel = descriptionService.donneesCaracterePersonnel
+    .filter((f) => f !== IDENTIFIANT_AUTRES_DONNEES_SENSIBLES);
+
+  return descriptionService;
+};
+
+const autresDonneesSensiblesSpecifiques = ({ donnees }) => (
+  donnees.descriptionService
+    ?.donneesSensiblesSpecifiques
+    ?.some?.((f) => f.description === DESCRIPTION_PAR_DEFAUT_AUTRES_DONNEES_SENSIBLES)
+);
+
+const versDonneesSensiblesGeneriques = (descriptionService) => {
+  descriptionService.donneesCaracterePersonnel ||= [];
+  descriptionService.donneesCaracterePersonnel.push(IDENTIFIANT_AUTRES_DONNEES_SENSIBLES);
+
+  descriptionService.donneesSensiblesSpecifiques = descriptionService
+    .donneesSensiblesSpecifiques
+    .filter((f) => f?.description !== DESCRIPTION_PAR_DEFAUT_AUTRES_DONNEES_SENSIBLES);
+
+  return descriptionService;
+};
+
+exports.up = deplace(autresDonneesSensiblesGeneriques, versDonneesSensiblesSpecifiques);
+
+exports.down = deplace(autresDonneesSensiblesSpecifiques, versDonneesSensiblesGeneriques);


### PR DESCRIPTION
Dans la page description du service,
dans la partie _Données à caractère personnel et autres données sensibles stockées par le service_,
la case à cocher **Autre données sensibles** est supprimé et à la place on intègre **Autre données sensibles** dans une zone de saisie de données sensibles
<img width="811" alt="Capture d’écran 2022-01-21 à 11 13 08" src="https://user-images.githubusercontent.com/39462397/150510102-8f87b42a-209f-48a4-a126-ae8aa2866f64.png">
