### PR TITLE
[CORRECTION] Affiche correctement avis expert dans document homologation

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -100,10 +100,6 @@ class Homologation {
     return this.mesures.statistiques();
   }
 
-  mesuresNonSaisies() {
-    return this.mesures.nonSaisies();
-  }
-
   statutSaisie(nomInformationsHomologation) {
     return this[nomInformationsHomologation].statutSaisie();
   }

--- a/src/vues/fragments/diagnostics.pug
+++ b/src/vues/fragments/diagnostics.pug
@@ -2,7 +2,7 @@ block append styles
   link(href='/statique/assets/styles/diagnostics.css', rel='stylesheet')
 
 mixin disque(valeurCalculee, valeurReference, couleur)
-  if !homologation.mesuresNonSaisies() && valeurCalculee === valeurReference
+  if valeurCalculee === valeurReference
     .disque(class = couleur)
   else
     .disque


### PR DESCRIPTION
Actuellement, si aucune information sur les mesures n'est saisie, la pastille
rouge ou verte ne s'affiche pas dans le document d'homologation.

<img width="744" alt="Screenshot 2022-01-21 at 11 37 16" src="https://user-images.githubusercontent.com/105624/150513288-78b34cfe-cb0f-41bc-b1e7-4ad33937b0d8.png">

Ce commit corrige le problème.