### PR TITLE
Affichage carte « nouvelle homologation »

### DIFF
--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -33,7 +33,7 @@
   color: #2f3a43;
 }
 
-.nouvelle.homologation .icone_ajout {
+.nouvelle.homologation .icone-ajout {
   width: 4em;
   height: 4em;
 

--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -1,20 +1,9 @@
+import $homologations from './modules/elementsDom/homologations.js';
+
 $(() => {
-  const creeConteneurHomologation = (donneesHomologation) => $(`
-<a class="homologation existante" href="/homologation/${donneesHomologation.id}">
-  <div>${donneesHomologation.nomService}</div>
-</a>
-  `);
-
-  const creeConteneursHomologation = (donneesHomologations) => donneesHomologations.reduce(
-    ($acc, donneesHomologation) => {
-      const $conteneurHomologation = creeConteneurHomologation(donneesHomologation);
-      return $acc.append($conteneurHomologation);
-    }, $(document.createDocumentFragment())
-  );
-
   const ajouteConteneursHomologationDans = (placeholder, donneesHomologations) => {
     const $conteneurHomologations = $(placeholder);
-    const $conteneursHomologation = creeConteneursHomologation(donneesHomologations);
+    const $conteneursHomologation = $homologations(donneesHomologations);
 
     $conteneurHomologations.prepend($conteneursHomologation);
   };

--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -1,6 +1,4 @@
-/* eslint-disable func-names */
-
-(function () {
+$(() => {
   const creeConteneurHomologation = (donneesHomologation) => $(`
 <a class="homologation existante" href="/homologation/${donneesHomologation.id}">
   <div>${donneesHomologation.nomService}</div>
@@ -21,10 +19,6 @@
     $conteneurHomologations.prepend($conteneursHomologation);
   };
 
-  window.addEventListener('load', () => {
-    axios.get('/api/homologations', { headers: { 'x-id-utilisateur': '456' } })
-      .then((reponse) => ajouteConteneursHomologationDans('.homologations', reponse.data.homologations));
-  });
-}());
-
-/* eslint-enable func-names */
+  axios.get('/api/homologations', { headers: { 'x-id-utilisateur': '456' } })
+    .then((reponse) => ajouteConteneursHomologationDans('.homologations', reponse.data.homologations));
+});

--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -8,6 +8,6 @@ $(() => {
     $conteneurHomologations.prepend($conteneursHomologation);
   };
 
-  axios.get('/api/homologations', { headers: { 'x-id-utilisateur': '456' } })
+  axios.get('/api/homologations')
     .then((reponse) => ajouteConteneursHomologationDans('.homologations', reponse.data.homologations));
 });

--- a/public/modules/elementsDom/homologations.js
+++ b/public/modules/elementsDom/homologations.js
@@ -1,0 +1,14 @@
+const $homologationExistante = (donneesHomologation) => $(`
+<a class="homologation existante" href="/homologation/${donneesHomologation.id}">
+  <div>${donneesHomologation.nomService}</div>
+</a>
+`);
+
+const $homologations = (donneesHomologations) => donneesHomologations.reduce(
+  ($acc, donneesHomologation) => {
+    const $conteneurHomologation = $homologationExistante(donneesHomologation);
+    return $acc.append($conteneurHomologation);
+  }, $(document.createDocumentFragment())
+);
+
+export default $homologations;

--- a/public/modules/elementsDom/homologations.js
+++ b/public/modules/elementsDom/homologations.js
@@ -4,11 +4,19 @@ const $homologationExistante = (donneesHomologation) => $(`
 </a>
 `);
 
+const $ajoutNouvelleHomologation = () => $(`
+<a class="nouvelle homologation" href="/homologation/creation">
+  <div class="icone-ajout"></div>
+  <div>Créer un nouveau projet d'homologation</div>
+</a>
+`);
+
 const $homologations = (donneesHomologations) => donneesHomologations.reduce(
   ($acc, donneesHomologation) => {
     const $conteneurHomologation = $homologationExistante(donneesHomologation);
     return $acc.append($conteneurHomologation);
   }, $(document.createDocumentFragment())
-);
+)
+  .append($ajoutNouvelleHomologation());
 
 export default $homologations;

--- a/src/vues/espacePersonnel.pug
+++ b/src/vues/espacePersonnel.pug
@@ -8,7 +8,7 @@ block main
     h1 Mon espace personnel
     .homologations
       a.nouvelle.homologation(href='/homologation/creation')
-        .icone_ajout
+        .icone-ajout
         div Créer un nouveau projet d'homologation
 
   script(type="module", src="/statique/espacePersonnel.js")

--- a/src/vues/espacePersonnel.pug
+++ b/src/vues/espacePersonnel.pug
@@ -7,8 +7,5 @@ block main
   .suivi-homologations.marges-fixes
     h1 Mon espace personnel
     .homologations
-      a.nouvelle.homologation(href='/homologation/creation')
-        .icone-ajout
-        div Créer un nouveau projet d'homologation
 
   script(type="module", src="/statique/espacePersonnel.js")


### PR DESCRIPTION
Jusqu'à présent, la carte « nouvelle homologation » s'affichait avant que les cartes homologation soient peuplées avec les données récupérées du serveur.

Cette PR assure qu'on n'affiche la carte « nouvelle homologation » qu'une fois les autres cartes affichées.