### PR TITLE
Migration de l'hébergeur vers l'hébergement des parties prenantes

### DIFF
--- a/migrations/20220121103422_copieColonneHebergeurDansPartiesPrenantes.js
+++ b/migrations/20220121103422_copieColonneHebergeurDansPartiesPrenantes.js
@@ -1,0 +1,44 @@
+const miseAJour = (contientDonneesCiblees, actionMiseAJour) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(contientDonneesCiblees)
+      .map(({ id, donnees }) => {
+        const donneesModifiees = actionMiseAJour(donnees);
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: donneesModifiees });
+      });
+    return Promise.all(misesAJour);
+  });
+
+const contientHebergeur = ({ donnees }) => (
+  donnees?.caracteristiquesComplementaires?.hebergeur
+);
+
+const copieDansPartiesPrenantes = (donnees) => {
+  donnees.partiesPrenantes ||= {};
+  donnees.partiesPrenantes.partiesPrenantes ||= [];
+  donnees.partiesPrenantes.partiesPrenantes = donnees.partiesPrenantes.partiesPrenantes
+    .filter((partiePrenante) => partiePrenante.type !== 'Hebergement');
+  donnees.partiesPrenantes.partiesPrenantes.push({
+    type: 'Hebergement',
+    nom: donnees.caracteristiquesComplementaires.hebergeur,
+  });
+
+  return donnees;
+};
+
+const contientPartiesPrenantes = ({ donnees }) => donnees.partiesPrenantes;
+
+const supprimeDansPartiesPrenantes = (donnees) => {
+  if (donnees.partiesPrenantes.partiesPrenantes) {
+    donnees.partiesPrenantes.partiesPrenantes = donnees.partiesPrenantes.partiesPrenantes
+      .filter((partiePrenante) => partiePrenante.type !== 'Hebergement');
+  }
+
+  return donnees;
+};
+
+exports.up = miseAJour(contientHebergeur, copieDansPartiesPrenantes);
+
+exports.down = miseAJour(contientPartiesPrenantes, supprimeDansPartiesPrenantes);


### PR DESCRIPTION
Dans les caractéristiques complémentaires, il y a le nom de l'hébergeur.
Nous voulons dans l'avenir que ce nom ainsi que d'autre informations concernant l'hébergement se trouve dans les parties prenantes

-> étape n°2 : duplication des données persistées