### PR TITLE
Permets le transfert d'autorisations depuis une console d'administration

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -1,0 +1,22 @@
+const donneesReferentiel = require('./donneesReferentiel');
+const DepotDonnees = require('./src/depotDonnees');
+const Referentiel = require('./src/referentiel');
+const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
+const AdaptateurPostgres = require('./src/adaptateurs/adaptateurPostgres');
+const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
+
+class ConsoleAdministration {
+  constructor(environnementNode = (process.env.NODE_ENV || 'development')) {
+    const adaptateurPersistance = AdaptateurPostgres.nouvelAdaptateur(environnementNode);
+    const referentiel = Referentiel.creeReferentiel(donneesReferentiel);
+    this.depotDonnees = DepotDonnees.creeDepot({
+      adaptateurJWT, adaptateurPersistance, adaptateurUUID, referentiel,
+    });
+  }
+
+  transfereAutorisations(idUtilisateurSource, idUtilisateurCible) {
+    return this.depotDonnees.transfereAutorisations(idUtilisateurSource, idUtilisateurCible);
+  }
+}
+
+module.exports = ConsoleAdministration;

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -78,6 +78,12 @@ const nouvelAdaptateur = (donnees = {}) => {
 
   const supprimeAutorisations = () => Promise.resolve(donnees.autorisations = []);
 
+  const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => (
+    autorisations(idUtilisateurSource)
+      .then((as) => as.map((a) => Promise.resolve(a.idUtilisateur = idUtilisateurCible)))
+      .then((transferts) => Promise.all(transferts))
+  );
+
   return {
     ajouteAutorisation,
     ajouteHomologation,
@@ -93,6 +99,7 @@ const nouvelAdaptateur = (donnees = {}) => {
     supprimeHomologations,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    transfereAutorisations,
     utilisateur,
     utilisateurAvecEmail,
     utilisateurAvecIdReset,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -89,6 +89,12 @@ const nouvelAdaptateur = (env) => {
 
   const supprimeAutorisations = () => knex('autorisations').del();
 
+  const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => knex('autorisations')
+    .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateurSource)
+    .update({
+      donnees: knex.raw("(jsonb_set(donnees::jsonb, '{ idUtilisateur }', '??'))::json", idUtilisateurCible),
+    });
+
   return {
     ajouteAutorisation,
     ajouteHomologation,
@@ -106,6 +112,7 @@ const nouvelAdaptateur = (env) => {
     supprimeHomologations,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    transfereAutorisations,
     utilisateur,
     utilisateurAvecEmail,
     utilisateurAvecIdReset,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -5,6 +5,7 @@ const {
   ErreurNomServiceDejaExistant,
   ErreurNomServiceManquant,
   ErreurUtilisateurExistant,
+  ErreurUtilisateurInexistant,
 } = require('./erreurs');
 const AdaptateurPersistanceMemoire = require('./adaptateurs/adaptateurPersistanceMemoire');
 const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
@@ -242,6 +243,18 @@ const creeDepot = (config = {}) => {
   const accesAutorise = (idUtilisateur, idHomologation) => autorisations(idUtilisateur)
     .then((as) => as.some((a) => a.idHomologation === idHomologation));
 
+  const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => {
+    const verifieUtilisateurExiste = (id) => utilisateurExiste(id)
+      .then((existe) => {
+        if (!existe) throw new ErreurUtilisateurInexistant(`L'utilisateur "${id}" n'existe pas`);
+      });
+
+    return verifieUtilisateurExiste(idUtilisateurSource)
+      .then(() => verifieUtilisateurExiste(idUtilisateurCible))
+      .then(() => adaptateurPersistance
+        .transfereAutorisations(idUtilisateurSource, idUtilisateurCible));
+  };
+
   return {
     accesAutorise,
     ajouteAvisExpertCyberAHomologation,
@@ -263,6 +276,7 @@ const creeDepot = (config = {}) => {
     supprimeHomologation,
     supprimeIdResetMotDePassePourUtilisateur,
     supprimeUtilisateur,
+    transfereAutorisations,
     utilisateur,
     utilisateurAFinaliser,
     utilisateurAuthentifie,

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -15,6 +15,7 @@ class ErreurRisqueInconnu extends ErreurModele {}
 class ErreurStatutDeploiementInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
 class ErreurUtilisateurExistant extends ErreurModele {}
+class ErreurUtilisateurInexistant extends ErreurModele {}
 
 module.exports = {
   ErreurAvisInvalide,
@@ -34,4 +35,5 @@ module.exports = {
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,
   ErreurUtilisateurExistant,
+  ErreurUtilisateurInexistant,
 };


### PR DESCRIPTION
Note :
- quand on aura introduit le rôle « collaborateur », il ne faudra transférer que
  les autorisations de type « créateur »