### PR TITLE
Correction du style du cadre des saisies d'identités

### DIFF
--- a/public/assets/styles/homologation/partiesPrenantes.css
+++ b/public/assets/styles/homologation/partiesPrenantes.css
@@ -1,8 +1,8 @@
 .saisie-identite {
-    border: .3px solid;
-    border-color: var(--liseres);
-    padding: .5em;
-    margin-top: 0.6em;
+    border: 1px solid var(--liseres);
+    border-radius: 3px;
+    padding: 1em;
+    margin-top: 1em;
 }
 
 .saisie-identite label {


### PR DESCRIPTION
Dans la page parties prenantes
le cadre n'était pas conforme aux autres