### PR TITLE
Ajuste la taille du texte dans les zones de saisies libres pour firefox

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -91,6 +91,7 @@ textarea {
   background: var(--fond-pale);
 
   font-family: "Marianne";
+  font-size: 0.93em;
 }
 
 select {


### PR DESCRIPTION
Dans le navigateur internet au renard flamboyant,
les zones de saisies libres (text area) ont une taille de font plus grande que sur le navigateur chrome.

Après modification :
<img width="513" alt="Capture d’écran 2022-02-08 à 11 57 45" src="https://user-images.githubusercontent.com/39462397/152973852-153a3718-8341-46f6-9056-f93c5bfebf65.png">
