### PR TITLE
Persistance du développement / fourniture dans les parties prenantes

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -15,6 +15,8 @@ const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisati
 const Homologation = require('./modeles/homologation');
 const PartiesPrenantes = require('./modeles/partiesPrenantes');
 const ListePartiesPrenantes = require('./modeles/partiesPrenantes/partiesPrenantes');
+const Hebergement = require('./modeles/partiesPrenantes/hebergement');
+const DeveloppementFourniture = require('./modeles/partiesPrenantes/developpementFourniture');
 const Utilisateur = require('./modeles/utilisateur');
 
 const creeDepot = (config = {}) => {
@@ -121,13 +123,25 @@ const creeDepot = (config = {}) => {
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
   );
 
-  const ajouteHebergementAHomologation = (idHomologation, hebergeur) => (
+  const ajoutePartiePrenanteAHomologation = (typePartiePrenante) => (
+    idHomologation, nomPartiePrenante
+  ) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((homologationTrouvee) => {
         const { partiesPrenantes = {} } = homologationTrouvee;
-        partiesPrenantes.partiesPrenantes = [{ type: 'Hebergement', nom: hebergeur }];
+        partiesPrenantes.partiesPrenantes ||= [];
+        partiesPrenantes.partiesPrenantes = partiesPrenantes.partiesPrenantes
+          .filter((partiePrenante) => partiePrenante.type !== typePartiePrenante);
+        partiesPrenantes.partiesPrenantes.push(
+          { type: typePartiePrenante, nom: nomPartiePrenante }
+        );
         return metsAJourProprieteHomologation('partiesPrenantes', homologationTrouvee, new PartiesPrenantes(partiesPrenantes, referentiel));
       })
+  );
+  const ajouteHebergementAHomologation = ajoutePartiePrenanteAHomologation(Hebergement.name);
+
+  const ajouteDeveloppementFournitureAHomologation = ajoutePartiePrenanteAHomologation(
+    DeveloppementFourniture.name
   );
 
   const ajoutePartiesPrenantesAHomologation = (idHomologation, partiesPrenantes) => (
@@ -278,6 +292,7 @@ const creeDepot = (config = {}) => {
     ajouteAvisExpertCyberAHomologation,
     ajouteCaracteristiquesAHomologation,
     ajouteDescriptionServiceAHomologation,
+    ajouteDeveloppementFournitureAHomologation,
     ajouteHebergementAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,

--- a/src/modeles/partiesPrenantes/developpementFourniture.js
+++ b/src/modeles/partiesPrenantes/developpementFourniture.js
@@ -1,0 +1,3 @@
+const PartiePrenante = require('./partiePrenante');
+
+module.exports = class DeveloppementFourniture extends PartiePrenante {};

--- a/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
+++ b/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
@@ -1,11 +1,15 @@
+const DeveloppementFourniture = require('./developpementFourniture');
 const Hebergement = require('./hebergement');
 const { ErreurTypeInconnu } = require('../../erreurs');
 
 const fabriquePartiePrenante = {
   cree: (donnees) => {
     const { type } = donnees;
-    if (type !== 'Hebergement') throw new ErreurTypeInconnu(`Le type "${type}" est inconnu`);
-    return new Hebergement(donnees);
+    switch (type) {
+      case Hebergement.name: return new Hebergement(donnees);
+      case DeveloppementFourniture.name: return new DeveloppementFourniture(donnees);
+      default: throw new ErreurTypeInconnu(`Le type "${type}" est inconnu`);
+    }
   },
 };
 

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -95,6 +95,11 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
               requete.params.id, caracteristiques.hebergeur
             )
           ))
+          .then(() => (
+            depotDonnees.ajouteDeveloppementFournitureAHomologation(
+              requete.params.id, caracteristiques.structureDeveloppement
+            )
+          ))
           .then(() => reponse.send({ idHomologation: requete.homologation.id }));
       } catch {
         reponse.status(422).send('Données invalides');

--- a/test/modeles/partiesPrenantes/developpementFourniture.spec.js
+++ b/test/modeles/partiesPrenantes/developpementFourniture.spec.js
@@ -1,0 +1,10 @@
+const expect = require('expect.js');
+
+const DeveloppementFourniture = require('../../../src/modeles/partiesPrenantes/developpementFourniture');
+
+describe('Un développement / fourniture', () => {
+  it('sait se décrire en JSON', () => {
+    const developpementFourniture = new DeveloppementFourniture({ nom: 'Mss' });
+    expect(developpementFourniture.toJSON()).to.eql({ type: 'DeveloppementFourniture', nom: 'Mss' });
+  });
+});

--- a/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
@@ -2,12 +2,18 @@ const expect = require('expect.js');
 
 const { ErreurTypeInconnu } = require('../../../src/erreurs');
 const fabriquePartiePrenante = require('../../../src/modeles/partiesPrenantes/fabriquePartiePrenante');
+const DeveloppementFourniture = require('../../../src/modeles/partiesPrenantes/developpementFourniture');
 const Hebergement = require('../../../src/modeles/partiesPrenantes/hebergement');
 
 describe('La fabrique de partie prenante', () => {
   it('fabrique des hébergements', () => {
     const hebergement = fabriquePartiePrenante.cree({ type: 'Hebergement', nom: 'Un hébergeur' });
     expect(hebergement).to.be.an(Hebergement);
+  });
+
+  it('fabrique des développements / fournitures de service', () => {
+    const developpementFourniture = fabriquePartiePrenante.cree({ type: 'DeveloppementFourniture', nom: 'Mss' });
+    expect(developpementFourniture).to.be.a(DeveloppementFourniture);
   });
 
   it('retourne une erreur si le type est inconnu', () => {

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -582,6 +582,7 @@ describe('Le serveur MSS', () => {
     beforeEach(() => {
       depotDonnees.ajouteCaracteristiquesAHomologation = () => Promise.resolve();
       depotDonnees.ajouteHebergementAHomologation = () => Promise.resolve();
+      depotDonnees.ajouteDeveloppementFournitureAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -643,6 +644,30 @@ describe('Le serveur MSS', () => {
       })
         .then((reponse) => {
           expect(hebergementAjoute).to.be(true);
+          expect(reponse.status).to.equal(200);
+          expect(reponse.data).to.eql({ idHomologation: '456' });
+          done();
+        })
+        .catch(done);
+    });
+
+    it("demande au dépôt d'ajouter la structure ayant développé dans les parties prenantes", (done) => {
+      let structureDeveloppementAjoutee = false;
+
+      depotDonnees.ajouteDeveloppementFournitureAHomologation = (
+        (idHomologation, structureDeveloppement) => new Promise((resolve) => {
+          expect(idHomologation).to.equal('456');
+          expect(structureDeveloppement).to.equal('Une structure');
+          structureDeveloppementAjoutee = true;
+          resolve();
+        })
+      );
+
+      axios.post('http://localhost:1234/api/homologation/456/caracteristiquesComplementaires', {
+        structureDeveloppement: 'Une structure',
+      })
+        .then((reponse) => {
+          expect(structureDeveloppementAjoutee).to.be(true);
           expect(reponse.status).to.equal(200);
           expect(reponse.data).to.eql({ idHomologation: '456' });
           done();


### PR DESCRIPTION
Dans la page caractéristiques complémentaires,
Quand on enregistre une **structure ayant développé le service numérique**
Les données doivent aussi être sauvegardées dans les parties prenantes