### PR TITLE
Déplacement de la saisie de l'hébergement

### DIFF
--- a/public/assets/styles/homologation/partiesPrenantes.css
+++ b/public/assets/styles/homologation/partiesPrenantes.css
@@ -1,11 +1,11 @@
-.saisie-identite {
+.saisie-role-responsabilite {
     border: 1px solid var(--liseres);
     border-radius: 3px;
     padding: 1em;
     margin-top: 1em;
 }
 
-.saisie-identite label {
+.saisie-role-responsabilite label {
     display: inline-block;
     margin: 0;
     margin-left: 0.1em;

--- a/public/homologation/avisExpertCyber.js
+++ b/public/homologation/avisExpertCyber.js
@@ -1,4 +1,4 @@
-import parametres from '../modules/parametres.js';
+import parametres from '../modules/parametres.mjs';
 
 const conditionneAffichageRenouvellement = (selecteurAvis, selecteurRenouvellement, condition) => {
   const $avis = $(selecteurAvis);

--- a/public/homologation/caracteristiquesComplementaires.js
+++ b/public/homologation/caracteristiquesComplementaires.js
@@ -1,5 +1,5 @@
 import { brancheAjoutItem, peupleListeItems } from '../modules/saisieListeItems.js';
-import { parametresAvecItemsExtraits } from '../modules/parametres.js';
+import { parametresAvecItemsExtraits } from '../modules/parametres.mjs';
 
 $(() => {
   let indexMaxEntitesExternes = 0;

--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -1,5 +1,5 @@
 import { brancheAjoutItem, peupleListeItems } from '../modules/saisieListeItems.js';
-import { parametresAvecItemsExtraits } from '../modules/parametres.js';
+import { parametresAvecItemsExtraits } from '../modules/parametres.mjs';
 import texteHTML from '../modules/texteHTML.js';
 
 $(() => {

--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -1,4 +1,4 @@
-import parametres, { modifieParametresAvecItemsExtraits } from '../modules/parametres.mjs';
+import parametres, { modifieParametresAvecItemsExtraits, modifieParametresGroupementElements } from '../modules/parametres.mjs';
 import brancheElementsAjoutables from '../modules/brancheElementsAjoutables.js';
 import brancheInputsIdentite from '../modules/brancheInputsIdentite.js';
 
@@ -13,6 +13,9 @@ $(() => {
     const params = parametres(selecteurFormulaire);
     modifieParametresAvecItemsExtraits(
       params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
+    );
+    modifieParametresGroupementElements(
+      params, 'partiesPrenantes', 'hebergement'
     );
     return params;
   };

--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -1,4 +1,4 @@
-import parametres, { modifieParametresAvecItemsExtraits } from '../modules/parametres.js';
+import parametres, { modifieParametresAvecItemsExtraits } from '../modules/parametres.mjs';
 import brancheElementsAjoutables from '../modules/brancheElementsAjoutables.js';
 import brancheInputsIdentite from '../modules/brancheInputsIdentite.js';
 

--- a/public/homologation/risques.js
+++ b/public/homologation/risques.js
@@ -1,4 +1,4 @@
-import { parametresAvecItemsExtraits } from '../modules/parametres.js';
+import { parametresAvecItemsExtraits } from '../modules/parametres.mjs';
 import { brancheAjoutItem, peupleListeItems } from '../modules/saisieListeItems.js';
 import texteHTML from '../modules/texteHTML.js';
 

--- a/public/modules/manipulationTexte.mjs
+++ b/public/modules/manipulationTexte.mjs
@@ -1,0 +1,2 @@
+export const capitalise = (mot) => (mot.charAt(0).toUpperCase() + mot.slice(1));
+export const decapitalise = (mot) => (mot.charAt(0).toLowerCase() + mot.slice(1));

--- a/public/modules/parametres.js
+++ b/public/modules/parametres.js
@@ -1,3 +1,0 @@
-import parametres, { parametresAvecItemsExtraits, modifieParametresAvecItemsExtraits } from './parametres.mjs';
-
-export { parametres as default, parametresAvecItemsExtraits, modifieParametresAvecItemsExtraits };

--- a/public/modules/parametres.mjs
+++ b/public/modules/parametres.mjs
@@ -1,3 +1,5 @@
+import { capitalise, decapitalise } from './manipulationTexte.mjs';
+
 const avecPremierElementCommeValeurs = (params, nomsParamsAtomiques) => {
   const resultat = params;
   Object.keys(params).forEach((clef) => {
@@ -51,9 +53,41 @@ const modifieParametresAvecItemsExtraits = (params, nomListeItems, sourceRegExpP
 
   return Object.assign(params, donneesItems);
 };
+
+const modifieParametresGroupementElements = (params, nomListe, nomParametre) => {
+  const donneesFormatees = { [nomListe]: {} };
+
+  Object.keys(params)
+    .filter((param) => !!param.match(new RegExp(`^${nomParametre}\\w*$`)))
+    .forEach((param) => {
+      if (params[param]) {
+        const resultat = param.match(new RegExp(`^${nomParametre}(\\w*)$`));
+        const propriete = decapitalise(resultat[1]);
+        donneesFormatees[nomListe][nomParametre] = (
+          donneesFormatees[nomListe][nomParametre] || {}
+        );
+        donneesFormatees[nomListe][nomParametre][propriete] = params[param];
+      }
+      delete params[param];
+    });
+
+  donneesFormatees[nomListe] = Object.keys(donneesFormatees[nomListe]).map((cle) => (
+    {
+      ...donneesFormatees[nomListe][cle],
+      type: capitalise(cle),
+    }));
+
+  return Object.assign(params, donneesFormatees);
+};
+
 const parametresAvecItemsExtraits = (selecteurForm, nomListeItems, sourceRegExpParamsItem) => {
   const params = parametres(selecteurForm);
   return modifieParametresAvecItemsExtraits(params, nomListeItems, sourceRegExpParamsItem);
 };
 
-export { parametres as default, parametresAvecItemsExtraits, modifieParametresAvecItemsExtraits };
+export default parametres;
+export {
+  parametresAvecItemsExtraits,
+  modifieParametresAvecItemsExtraits,
+  modifieParametresGroupementElements,
+};

--- a/public/modules/soumetsHomologation.js
+++ b/public/modules/soumetsHomologation.js
@@ -1,4 +1,4 @@
-import parametres, { modifieParametresAvecItemsExtraits } from './parametres.js';
+import parametres, { modifieParametresAvecItemsExtraits } from './parametres.mjs';
 import listesAvecItemsExtraits from '../homologation/formulaireDescriptionService.js';
 
 const fermeModale = () => {

--- a/public/utilisateur/edition.js
+++ b/public/utilisateur/edition.js
@@ -1,4 +1,4 @@
-import parametres from '../modules/parametres.js';
+import parametres from '../modules/parametres.mjs';
 
 $(() => {
   const $formulaire = $('form.utilisateur#edition');

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -15,7 +15,6 @@ const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisati
 const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const Homologation = require('./modeles/homologation');
 const PartiesPrenantes = require('./modeles/partiesPrenantes');
-const Hebergement = require('./modeles/partiesPrenantes/hebergement');
 const DeveloppementFourniture = require('./modeles/partiesPrenantes/developpementFourniture');
 const Utilisateur = require('./modeles/utilisateur');
 
@@ -137,9 +136,6 @@ const creeDepot = (config = {}) => {
         );
         return metsAJourProprieteHomologation('partiesPrenantes', homologationTrouvee, new PartiesPrenantes(partiesPrenantes, referentiel));
       })
-  );
-  const ajouteHebergementARolesResponsabilites = ajoutePartiePrenanteAHomologation(
-    Hebergement.name
   );
 
   const ajouteDeveloppementFournitureAHomologation = ajoutePartiePrenanteAHomologation(
@@ -303,7 +299,6 @@ const creeDepot = (config = {}) => {
     ajouteDescriptionServiceAHomologation,
     ajouteDeveloppementFournitureAHomologation,
     ajouteHebergementAHomologation,
-    ajouteHebergementARolesResponsabilites,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajouteRisqueGeneralAHomologation,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -12,9 +12,9 @@ const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
 const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
+const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const Homologation = require('./modeles/homologation');
 const PartiesPrenantes = require('./modeles/partiesPrenantes');
-const ListePartiesPrenantes = require('./modeles/partiesPrenantes/partiesPrenantes');
 const Hebergement = require('./modeles/partiesPrenantes/hebergement');
 const DeveloppementFourniture = require('./modeles/partiesPrenantes/developpementFourniture');
 const Utilisateur = require('./modeles/utilisateur');
@@ -138,20 +138,29 @@ const creeDepot = (config = {}) => {
         return metsAJourProprieteHomologation('partiesPrenantes', homologationTrouvee, new PartiesPrenantes(partiesPrenantes, referentiel));
       })
   );
-  const ajouteHebergementAHomologation = ajoutePartiePrenanteAHomologation(Hebergement.name);
+  const ajouteHebergementARolesResponsabilites = ajoutePartiePrenanteAHomologation(
+    Hebergement.name
+  );
 
   const ajouteDeveloppementFournitureAHomologation = ajoutePartiePrenanteAHomologation(
     DeveloppementFourniture.name
   );
 
-  const ajoutePartiesPrenantesAHomologation = (idHomologation, partiesPrenantes) => (
+  const ajouteHebergementAHomologation = (idHomologation, nomHebergement) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((homologationTrouvee) => {
-        partiesPrenantes.partiesPrenantes = new ListePartiesPrenantes(
-          { partiesPrenantes: homologationTrouvee.partiesPrenantes?.partiesPrenantes }
+        const { caracteristiquesComplementaires = {} } = homologationTrouvee;
+        caracteristiquesComplementaires.hebergeur = nomHebergement;
+        return metsAJourProprieteHomologation(
+          'caracteristiquesComplementaires',
+          homologationTrouvee,
+          new CaracteristiquesComplementaires(caracteristiquesComplementaires, referentiel)
         );
-        return metsAJourProprieteHomologation('partiesPrenantes', idHomologation, partiesPrenantes);
       })
+  );
+
+  const ajoutePartiesPrenantesAHomologation = (...params) => (
+    metsAJourProprieteHomologation('partiesPrenantes', ...params)
   );
 
   const ajouteAvisExpertCyberAHomologation = (...params) => (
@@ -294,6 +303,7 @@ const creeDepot = (config = {}) => {
     ajouteDescriptionServiceAHomologation,
     ajouteDeveloppementFournitureAHomologation,
     ajouteHebergementAHomologation,
+    ajouteHebergementARolesResponsabilites,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajouteRisqueGeneralAHomologation,

--- a/src/modeles/caracteristiquesComplementaires.js
+++ b/src/modeles/caracteristiquesComplementaires.js
@@ -5,9 +5,8 @@ const Referentiel = require('../referentiel');
 class CaracteristiquesComplementaires extends InformationsHomologation {
   constructor(donneesCaracteristiques = {}, referentiel = Referentiel.creeReferentielVide()) {
     super({
-      proprietesAtomiquesRequises: [
-        'structureDeveloppement', 'hebergeur',
-      ],
+      proprietesAtomiquesRequises: ['structureDeveloppement'],
+      proprietesAtomiquesFacultatives: ['hebergeur'],
       listesAgregats: { entitesExternes: EntitesExternes },
     });
     this.renseigneProprietes(donneesCaracteristiques);

--- a/src/modeles/partiesPrenantes/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes/partiesPrenantes.js
@@ -1,10 +1,15 @@
 const ElementsFabricables = require('../elementsFabricables');
 const fabriquePartiePrenante = require('./fabriquePartiePrenante');
+const { estHebergement } = require('./typePartiePrenante');
 
 class PartiesPrenantes extends ElementsFabricables {
   constructor(donnees = {}) {
     const { partiesPrenantes = [] } = donnees;
     super(fabriquePartiePrenante, { items: partiesPrenantes });
+  }
+
+  hebergement() {
+    return this.tous().find(estHebergement)?.toJSON();
   }
 }
 

--- a/src/modeles/partiesPrenantes/typePartiePrenante.js
+++ b/src/modeles/partiesPrenantes/typePartiePrenante.js
@@ -1,0 +1,5 @@
+const Hebergement = require('./hebergement');
+
+exports.estHebergement = (partiePrenante) => (
+  partiePrenante.constructor.name === Hebergement.name
+);

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -91,11 +91,6 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
           .then(() => (
-            depotDonnees.ajouteHebergementARolesResponsabilites(
-              requete.params.id, caracteristiques.hebergeur
-            )
-          ))
-          .then(() => (
             depotDonnees.ajouteDeveloppementFournitureAHomologation(
               requete.params.id, caracteristiques.structureDeveloppement
             )

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -91,7 +91,7 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
           .then(() => (
-            depotDonnees.ajouteHebergementAHomologation(
+            depotDonnees.ajouteHebergementARolesResponsabilites(
               requete.params.id, caracteristiques.hebergeur
             )
           ))
@@ -158,8 +158,13 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
     ]),
     (requete, reponse) => {
       const partiesPrenantes = new PartiesPrenantes(requete.body);
-      depotDonnees.ajoutePartiesPrenantesAHomologation(requete.homologation.id, partiesPrenantes)
-        .then(() => reponse.send({ idHomologation: requete.homologation.id }));
+      const nomHebergement = partiesPrenantes.partiesPrenantes?.hebergement()?.nom;
+      const idHomologation = requete.homologation.id;
+      depotDonnees.ajouteHebergementAHomologation(requete.homologation.id, nomHebergement)
+        .then(() => depotDonnees.ajoutePartiesPrenantesAHomologation(
+          idHomologation, partiesPrenantes
+        ))
+        .then(() => reponse.send({ idHomologation }));
     });
 
   routes.post('/:id/risques', middleware.trouveHomologation, middleware.aseptise(

--- a/src/vues/fragments/inputIdentite.pug
+++ b/src/vues/fragments/inputIdentite.pug
@@ -1,6 +1,6 @@
 mixin inputIdentite({ role, nomParametre })
   label(for='aucuneAction')= role
-    .saisie-identite
+    .saisie-role-responsabilite
       label(for = nomParametre) Nom / Prénom
       input(
         id = nomParametre, name = nomParametre, type = 'text',

--- a/src/vues/fragments/inputPartiePrenante.pug
+++ b/src/vues/fragments/inputPartiePrenante.pug
@@ -1,0 +1,28 @@
+mixin inputPartiePrenante({ categorie, nomParametre, donnees })
+  label= categorie
+    .saisie-role-responsabilite
+      -
+        const proprietes = [
+          {
+            nom: 'nom',
+            parametre: `${nomParametre}Nom`,
+            libelle: "Nom de l'entité externe ou interne",
+          },
+          {
+            nom: 'natureAcces',
+            parametre: `${nomParametre}NatureAcces`,
+            libelle: "Nature de l'accès au service numérique (facultatif)",
+          },
+          {
+            nom: 'pointContact',
+            parametre: `${nomParametre}PointContact`,
+            libelle: "Point de contact (facultatif)",
+          }
+        ];
+
+      each propriete in proprietes
+        label(for = propriete.parametre)= propriete.libelle
+        input(
+          id = propriete.parametre, name = propriete.parametre, type = 'text',
+          value != donnees ? donnees[propriete.nom] : ''
+        )

--- a/src/vues/homologation/caracteristiquesComplementaires.pug
+++ b/src/vues/homologation/caracteristiquesComplementaires.pug
@@ -15,12 +15,6 @@ block formulaire
           value = homologation.caracteristiquesComplementaires.structureDeveloppement,
         )
 
-      label Nom de l'hébergeur
-        input(
-          id = 'hebergeur', name = 'hebergeur', type = 'text',
-          value = homologation.caracteristiquesComplementaires.hebergeur,
-        )
-
       label Entités externes disposant d'un accès privilégié au service
         p.
           Listez les tierces parties ayant un accès privilégié au service qui

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -1,5 +1,6 @@
 extends ./formulaire
 include ../fragments/inputIdentite
+include ../fragments/inputPartiePrenante
 include ../fragments/elementsAjoutables/elementsAjoutablesActeurHomologation
 
 block append styles
@@ -34,6 +35,15 @@ block formulaire
 
       +elementsAjoutablesActeurHomologation({
         donnees: homologation.partiesPrenantes.acteursHomologation.toJSON(),
+      })
+
+    section
+      h3 Parties prenantes
+
+      +inputPartiePrenante({
+        categorie: 'Hébergement du service',
+        nomParametre: 'hebergement',
+        donnees: {},
       })
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -43,7 +43,7 @@ block formulaire
       +inputPartiePrenante({
         categorie: 'Hébergement du service',
         nomParametre: 'hebergement',
-        donnees: {},
+        donnees: homologation.partiesPrenantes.partiesPrenantes.hebergement(),
       })
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -318,25 +318,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it("met à jour les parties prenantes avec l'hébergement", (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-        caracteristiquesComplementaires: { hebergeur: 'Un hébergeur' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteHebergementARolesResponsabilites('123', 'Un hébergeur')
-      .then(() => depot.homologation('123'))
-      .then(({ partiesPrenantes }) => {
-        expect(partiesPrenantes.partiesPrenantes.item(0).nom).to.equal('Un hébergeur');
-        done();
-      })
-      .catch(done);
-  });
-
   it("met à jour les parties prenantes avec l'entité développeur / fournisseur du service", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [{

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -328,7 +328,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-    depot.ajouteHebergementAHomologation('123', 'Un hébergeur')
+    depot.ajouteHebergementARolesResponsabilites('123', 'Un hébergeur')
       .then(() => depot.homologation('123'))
       .then(({ partiesPrenantes }) => {
         expect(partiesPrenantes.partiesPrenantes.item(0).nom).to.equal('Un hébergeur');
@@ -415,23 +415,19 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it("sait conserver l'hébergement quand les parties prenantes sont écrites", (done) => {
+  it("met à jour les caractéristiques complémentaires avec l'hébergeur", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        {
-          id: '123',
-          descriptionService: { nomService: 'nom' },
-          partiesPrenantes: { partiesPrenantes: [{ type: 'Hebergement', nom: 'hébergeur' }] },
-        },
-      ],
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+      }],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-    const pp = new PartiesPrenantes({ autoriteHomologation: 'Jean Dupont' });
-    depot.ajoutePartiesPrenantesAHomologation('123', pp)
+    depot.ajouteHebergementAHomologation('123', 'Un hébergeur')
       .then(() => depot.homologation('123'))
-      .then(({ partiesPrenantes }) => {
-        expect(partiesPrenantes.partiesPrenantes.item(0).nom).to.equal('hébergeur');
+      .then(({ caracteristiquesComplementaires }) => {
+        expect(caracteristiquesComplementaires.hebergeur).to.equal('Un hébergeur');
         done();
       })
       .catch(done);

--- a/test/modeles/caracteristiquesComplementaires.spec.js
+++ b/test/modeles/caracteristiquesComplementaires.spec.js
@@ -49,8 +49,8 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
   describe('sur demande du statut de saisie', () => {
     describe("quand aucune entité externe n'a été saisie", () => {
       it('détermine le statut de saisie de manière standard', () => {
-        const caracteristiques = new CaracteristiquesComplementaires({ hebergeur: 'Un hébergeur' });
-        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.A_COMPLETER);
+        const caracteristiques = new CaracteristiquesComplementaires({ structureDeveloppement: 'Une structure' });
+        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
       });
     });
 

--- a/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
@@ -12,4 +12,12 @@ describe('Les parties prenantes', () => {
 
     expect(partiesPrenantes.toJSON()).to.eql([{ type: 'Hebergement', nom: 'hébergeur' }]);
   });
+
+  elles("savent transmettre l'hébergement", () => {
+    const partiesPrenantes = new PartiesPrenantes(
+      { partiesPrenantes: [{ type: 'Hebergement', nom: 'hébergeur' }] }
+    );
+
+    expect(partiesPrenantes.hebergement()).to.eql({ type: 'Hebergement', nom: 'hébergeur' });
+  });
 });

--- a/test/modeles/partiesPrenantes/typePartiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/typePartiePrenante.spec.js
@@ -1,0 +1,17 @@
+const expect = require('expect.js');
+
+const { estHebergement } = require('../../../src/modeles/partiesPrenantes/typePartiePrenante');
+const Hebergement = require('../../../src/modeles/partiesPrenantes/hebergement');
+const PartiePrenante = require('../../../src/modeles/partiesPrenantes/partiePrenante');
+
+describe('Le type de partie prenante', () => {
+  it('renseigne si une partie prenante est un hébergement', () => {
+    const partiePrenante = new Hebergement({ nom: 'hébergeur' });
+    expect(estHebergement(partiePrenante)).to.be(true);
+  });
+
+  it("renseigne si une partie prenante n'est pas un hébergement", () => {
+    const partiePrenante = new PartiePrenante({ nom: 'nom' });
+    expect(estHebergement(partiePrenante)).to.be(false);
+  });
+});

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -583,6 +583,7 @@ describe('Le serveur MSS', () => {
       depotDonnees.ajouteCaracteristiquesAHomologation = () => Promise.resolve();
       depotDonnees.ajouteHebergementAHomologation = () => Promise.resolve();
       depotDonnees.ajouteDeveloppementFournitureAHomologation = () => Promise.resolve();
+      depotDonnees.ajouteHebergementARolesResponsabilites = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -630,7 +631,7 @@ describe('Le serveur MSS', () => {
     it("demande au dépôt d'ajouter l'hébergeur dans les parties prenantes", (done) => {
       let hebergementAjoute = false;
 
-      depotDonnees.ajouteHebergementAHomologation = (
+      depotDonnees.ajouteHebergementARolesResponsabilites = (
         (idHomologation, hebergeur) => new Promise((resolve) => {
           expect(idHomologation).to.equal('456');
           expect(hebergeur).to.equal('Un hébergeur');
@@ -793,9 +794,10 @@ describe('Le serveur MSS', () => {
   });
 
   describe('quand requête POST sur `/api/homologation/:id/partiesPrenantes`', () => {
-    beforeEach(() => (
-      depotDonnees.ajoutePartiesPrenantesAHomologation = () => new Promise((resolve) => resolve())
-    ));
+    beforeEach(() => {
+      depotDonnees.ajoutePartiesPrenantesAHomologation = () => new Promise((resolve) => resolve());
+      depotDonnees.ajouteHebergementAHomologation = () => new Promise((resolve) => resolve());
+    });
 
     it("recherche l'homologation correspondante", (done) => {
       verifieRechercheHomologation({
@@ -832,6 +834,30 @@ describe('Le serveur MSS', () => {
       axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {})
         .then(() => {
           verifieAseptisationListe('acteursHomologation', ['role', 'nom', 'fonction']);
+          done();
+        })
+        .catch(done);
+    });
+
+    it("demande au dépôt d'ajouter l'hébergement dans les caractéristiques complémentaires", (done) => {
+      let hebergeurAjoute = false;
+
+      depotDonnees.ajouteHebergementAHomologation = (
+        (idHomologation, nomHebergeur) => new Promise((resolve) => {
+          expect(idHomologation).to.equal('456');
+          expect(nomHebergeur).to.equal('Un hébergeur');
+          hebergeurAjoute = true;
+          resolve();
+        })
+      );
+
+      axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {
+        partiesPrenantes: [{ type: 'Hebergement', nom: 'Un hébergeur' }],
+      })
+        .then((reponse) => {
+          expect(hebergeurAjoute).to.be(true);
+          expect(reponse.status).to.equal(200);
+          expect(reponse.data).to.eql({ idHomologation: '456' });
           done();
         })
         .catch(done);

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -583,7 +583,6 @@ describe('Le serveur MSS', () => {
       depotDonnees.ajouteCaracteristiquesAHomologation = () => Promise.resolve();
       depotDonnees.ajouteHebergementAHomologation = () => Promise.resolve();
       depotDonnees.ajouteDeveloppementFournitureAHomologation = () => Promise.resolve();
-      depotDonnees.ajouteHebergementARolesResponsabilites = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -621,30 +620,6 @@ describe('Le serveur MSS', () => {
       })
         .then((reponse) => {
           expect(caracteristiquesAjoutees).to.be(true);
-          expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.eql({ idHomologation: '456' });
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt d'ajouter l'hébergeur dans les parties prenantes", (done) => {
-      let hebergementAjoute = false;
-
-      depotDonnees.ajouteHebergementARolesResponsabilites = (
-        (idHomologation, hebergeur) => new Promise((resolve) => {
-          expect(idHomologation).to.equal('456');
-          expect(hebergeur).to.equal('Un hébergeur');
-          hebergementAjoute = true;
-          resolve();
-        })
-      );
-
-      axios.post('http://localhost:1234/api/homologation/456/caracteristiquesComplementaires', {
-        hebergeur: 'Un hébergeur',
-      })
-        .then((reponse) => {
-          expect(hebergementAjoute).to.be(true);
           expect(reponse.status).to.equal(200);
           expect(reponse.data).to.eql({ idHomologation: '456' });
           done();


### PR DESCRIPTION
Dans la page parties prenantes nous pouvons ajouter les informations d'hébergement.
Dans la page Caractéristique complémentaires, il n'y a plus la possibilité de voir ou modifier le nom de l'hébergeur.

Note : les données de l'hébergeur restent sauvegarder dans les caractéristiques complémentaires

<img width="763" alt="Capture d’écran 2022-02-10 à 16 49 56" src="https://user-images.githubusercontent.com/39462397/153444272-803474a3-ab59-4f66-a6d4-16283115b2f9.png">
