### PR TITLE
Retrait de la déclaration d'une feuille de style supprimée

### DIFF
--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -3,7 +3,6 @@ include ./elementsAjoutables/elementsAjoutablesDescription
 
 block append styles
   link(href = '/statique/assets/styles/modale.css', rel = 'stylesheet')
-  link(href = '/statique/assets/styles/homologation/descriptionService.css', rel = 'stylesheet')
 
 mixin formulaireDescriptionService(idHomologation)
   form.homologation#homologation


### PR DESCRIPTION
Dans la page Description du service on pouvait voir dans la console des outils du développeur une erreur

La raison est l'oublie de retrait de l'importation d'une feuille de style après la suppression de cette dernière 