### PR TITLE
Double enregistrement des parties prenantes en rôles et responsabilités

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -16,6 +16,7 @@ const CaracteristiquesComplementaires = require('./modeles/caracteristiquesCompl
 const Homologation = require('./modeles/homologation');
 const PartiesPrenantes = require('./modeles/partiesPrenantes');
 const DeveloppementFourniture = require('./modeles/partiesPrenantes/developpementFourniture');
+const RolesResponsabilites = require('./modeles/rolesResponsabilites');
 const Utilisateur = require('./modeles/utilisateur');
 
 const creeDepot = (config = {}) => {
@@ -153,9 +154,12 @@ const creeDepot = (config = {}) => {
       })
   );
 
-  const ajoutePartiesPrenantesAHomologation = (...params) => (
-    metsAJourProprieteHomologation('partiesPrenantes', ...params)
-  );
+  const ajoutePartiesPrenantesAHomologation = (...params) => {
+    const [idHomologation, partiesPrenantes] = params;
+
+    return metsAJourProprieteHomologation('partiesPrenantes', ...params)
+      .then(() => metsAJourProprieteHomologation('rolesResponsabilites', idHomologation, new RolesResponsabilites(partiesPrenantes.toJSON())));
+  };
 
   const ajouteAvisExpertCyberAHomologation = (...params) => (
     metsAJourProprieteHomologation('avisExpertCyber', ...params)

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -6,6 +6,7 @@ const Mesure = require('./mesure');
 const Mesures = require('./mesures');
 const PartiesPrenantes = require('./partiesPrenantes');
 const Risques = require('./risques');
+const RolesResponsabilites = require('./rolesResponsabilites');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -25,6 +26,7 @@ class Homologation {
       partiesPrenantes = {},
       risquesGeneraux = [],
       risquesSpecifiques = [],
+      rolesResponsabilites = {},
       avisExpertCyber = {},
     } = donnees;
 
@@ -35,6 +37,7 @@ class Homologation {
       caracteristiquesComplementaires, referentiel,
     );
     this.partiesPrenantes = new PartiesPrenantes(partiesPrenantes);
+    this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);
     this.risques = new Risques(
       { risquesGeneraux, risquesSpecifiques },
       referentiel,

--- a/src/modeles/rolesResponsabilites.js
+++ b/src/modeles/rolesResponsabilites.js
@@ -1,0 +1,3 @@
+const PartiesPrenantes = require('./partiesPrenantes');
+
+module.exports = class RolesResponsabilites extends PartiesPrenantes {};

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -414,6 +414,26 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
+  it('sait enregistrer les parties prenantes en rôles et responsabilités', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+      }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    const partiesPrenantes = new PartiesPrenantes({ autoriteHomologation: 'Jean Dupont' });
+    depot.ajoutePartiesPrenantesAHomologation('123', partiesPrenantes)
+      .then(() => depot.homologation('123'))
+      .then(({ rolesResponsabilites }) => {
+        expect(rolesResponsabilites).to.be.ok();
+        expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean Dupont');
+        done();
+      })
+      .catch(done);
+  });
+
   it("met à jour les caractéristiques complémentaires avec l'hébergeur", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [{


### PR DESCRIPTION
Dans l'objectif de renommer **parties prenantes** en **rôles et responsabilités**,
La 1° étape est de dupliquer la persistance 