### PR TITLE
Modification du texte de la description dans la page description du service

### DIFF
--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -9,7 +9,7 @@ mixin formulaireDescriptionService(idHomologation)
     h1.action Description du service
     p.
       Présentez les caractéristiques de votre service numérique à homologuer pour recevoir des recommandations personnalisées.
-      Ces informations pourront être complétées ou modifiées ultérieurement.
+      Ces informations peuvent être complétées ou modifiées à tout instant.
     section
       label Nom du service numérique à homologuer
         br


### PR DESCRIPTION
Dans la page Description du service,
nous souhaitons modifier le texte de la description apparaissant en dessous du titre