### PR TITLE
Migration des parties prenantes dans les rôles et responsabilités

### DIFF
--- a/migrations/20220216134942_dupliquePartiesPrenantesDansRolesResponsabilites.js
+++ b/migrations/20220216134942_dupliquePartiesPrenantesDansRolesResponsabilites.js
@@ -1,0 +1,21 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.partiesPrenantes)
+      .map(({ id, donnees: { partiesPrenantes, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: {
+          partiesPrenantes, rolesResponsabilites: partiesPrenantes, ...autresDonnees,
+        } }));
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.rolesResponsabilites)
+      .map(({ id, donnees: { rolesResponsabilites, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: { ...autresDonnees } }));
+    return Promise.all(misesAJour);
+  });


### PR DESCRIPTION
2ieme étape pour passer de parties prenantes à rôles et responsabilités : la copie des données en base