### PR TITLE
Correction de la mise à jour du développement fourniture vide

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -122,25 +122,23 @@ const creeDepot = (config = {}) => {
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
   );
 
-  const ajoutePartiePrenanteAHomologation = (typePartiePrenante) => (
-    idHomologation, nomPartiePrenante
-  ) => (
-    adaptateurPersistance.homologation(idHomologation)
+  const ajouteDeveloppementFournitureAHomologation = (idHomologation, nomPartiePrenante) => {
+    if (!nomPartiePrenante) {
+      return Promise.resolve();
+    }
+
+    return adaptateurPersistance.homologation(idHomologation)
       .then((homologationTrouvee) => {
         const { partiesPrenantes = {} } = homologationTrouvee;
         partiesPrenantes.partiesPrenantes ||= [];
         partiesPrenantes.partiesPrenantes = partiesPrenantes.partiesPrenantes
-          .filter((partiePrenante) => partiePrenante.type !== typePartiePrenante);
+          .filter((partiePrenante) => partiePrenante.type !== DeveloppementFourniture.name);
         partiesPrenantes.partiesPrenantes.push(
-          { type: typePartiePrenante, nom: nomPartiePrenante }
+          { type: DeveloppementFourniture.name, nom: nomPartiePrenante }
         );
         return metsAJourProprieteHomologation('partiesPrenantes', homologationTrouvee, new PartiesPrenantes(partiesPrenantes, referentiel));
-      })
-  );
-
-  const ajouteDeveloppementFournitureAHomologation = ajoutePartiePrenanteAHomologation(
-    DeveloppementFourniture.name
-  );
+      });
+  };
 
   const ajouteHebergementAHomologation = (idHomologation, nomHebergement) => (
     adaptateurPersistance.homologation(idHomologation)

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -337,6 +337,24 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
+  it('ne met pas à jour les parties prenantes avec avec une entité développeur / fournisseur du service vide', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+      }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajouteDeveloppementFournitureAHomologation('123', '')
+      .then(() => depot.homologation('123'))
+      .then(({ partiesPrenantes }) => {
+        expect(partiesPrenantes.partiesPrenantes.nombre()).to.equal(0);
+        done();
+      })
+      .catch(done);
+  });
+
   it("conserve les anciennes parties prenantes lors de la mise à jour avec l'entité développeur / fournisseur du service", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [{


### PR DESCRIPTION
Quand ont enregistre les caractéristique complémentaires vide,
dans la page de synthèse les parties prenantes (vide) apparaissent _à compléter_
