### PR TITLE
Déplacement entités externes Partie 1

### DIFF
--- a/src/modeles/listeItems.js
+++ b/src/modeles/listeItems.js
@@ -31,6 +31,10 @@ class ListeItems extends InformationsHomologation {
   tous() {
     return this.items;
   }
+
+  toutes() {
+    return this.tous();
+  }
 }
 
 module.exports = ListeItems;

--- a/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
+++ b/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
@@ -1,5 +1,6 @@
 const DeveloppementFourniture = require('./developpementFourniture');
 const Hebergement = require('./hebergement');
+const PartiePrenanteSpecifique = require('./partiePrenanteSpecifique');
 const { ErreurTypeInconnu } = require('../../erreurs');
 
 const fabriquePartiePrenante = {
@@ -8,6 +9,7 @@ const fabriquePartiePrenante = {
     switch (type) {
       case Hebergement.name: return new Hebergement(donnees);
       case DeveloppementFourniture.name: return new DeveloppementFourniture(donnees);
+      case PartiePrenanteSpecifique.name: return new PartiePrenanteSpecifique(donnees);
       default: throw new ErreurTypeInconnu(`Le type "${type}" est inconnu`);
     }
   },

--- a/src/modeles/partiesPrenantes/partiePrenanteSpecifique.js
+++ b/src/modeles/partiesPrenantes/partiePrenanteSpecifique.js
@@ -1,0 +1,6 @@
+const PartiePrenante = require('./partiePrenante');
+
+class PartiePrenanteSpecifique extends PartiePrenante {
+}
+
+module.exports = PartiePrenanteSpecifique;

--- a/src/modeles/partiesPrenantes/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes/partiesPrenantes.js
@@ -1,6 +1,6 @@
 const ElementsFabricables = require('../elementsFabricables');
 const fabriquePartiePrenante = require('./fabriquePartiePrenante');
-const { estHebergement, estDeveloppementFourniture } = require('./typePartiePrenante');
+const { estDeveloppementFourniture, estHebergement, estSpecifique } = require('./typePartiePrenante');
 
 class PartiesPrenantes extends ElementsFabricables {
   constructor(donnees = {}) {
@@ -18,6 +18,12 @@ class PartiesPrenantes extends ElementsFabricables {
 
   developpementFourniture() {
     return this.type(estDeveloppementFourniture);
+  }
+
+  specifiques() {
+    return this.tous()
+      .filter(estSpecifique)
+      .map((partiePrenante) => partiePrenante.toJSON());
   }
 }
 

--- a/src/modeles/partiesPrenantes/typePartiePrenante.js
+++ b/src/modeles/partiesPrenantes/typePartiePrenante.js
@@ -1,10 +1,13 @@
 const Hebergement = require('./hebergement');
 const DeveloppementFourniture = require('./developpementFourniture');
+const PartiePrenanteSpecifique = require('./partiePrenanteSpecifique');
 
 const estType = (Type) => (objet) => (
   objet.constructor.name === Type.name
 );
 
+exports.estDeveloppementFourniture = estType(DeveloppementFourniture);
+
 exports.estHebergement = estType(Hebergement);
 
-exports.estDeveloppementFourniture = estType(DeveloppementFourniture);
+exports.estSpecifique = estType(PartiePrenanteSpecifique);

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -90,6 +90,11 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
       try {
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
+          .then(() => (
+            depotDonnees.ajoutePartiesPrenantesSpecifiquesAHomologation(
+              requete.params.id, caracteristiques.entitesExternes.toutes()
+            )
+          ))
           .then(() => reponse.send({ idHomologation: requete.homologation.id }));
       } catch {
         reponse.status(422).send('Données invalides');

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -340,6 +340,86 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
+  it('met à jour les parties prenantes avec les parties prenantes spécifiques', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+      }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    const entitesExternes = [{ nom: 'nom', contact: 'contact', acces: 'acces' }];
+
+    depot.ajoutePartiesPrenantesSpecifiquesAHomologation('123', entitesExternes)
+      .then(() => depot.homologation('123'))
+      .then(({ partiesPrenantes }) => {
+        expect(partiesPrenantes.partiesPrenantes.item(0).nom).to.equal('nom');
+        expect(partiesPrenantes.partiesPrenantes.item(0).natureAcces).to.equal('acces');
+        expect(partiesPrenantes.partiesPrenantes.item(0).pointContact).to.equal('contact');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('conserve les anciennes parties prenantes lors de la mise à jour avec les parties prenantes spécifiques', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+        partiesPrenantes: { partiesPrenantes: [{ type: 'Hebergement', nom: 'hébergeur' }] },
+      }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajoutePartiesPrenantesSpecifiquesAHomologation('123', [{ nom: 'nom' }])
+      .then(() => depot.homologation('123'))
+      .then(({ partiesPrenantes }) => {
+        expect(partiesPrenantes.partiesPrenantes.tous()).to.have.length(2);
+        expect(partiesPrenantes.partiesPrenantes.specifiques()[0].nom).to.equal('nom');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('écrase les anciennes parties prenantes spécifique lors de la mise à jour de celles-ci dans les parties prenantes', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+        partiesPrenantes: { partiesPrenantes: [{ type: 'PartiePrenanteSpecifique', nom: 'ancien nom' }] },
+      }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajoutePartiesPrenantesSpecifiquesAHomologation('123', [{ nom: 'nom' }])
+      .then(() => depot.homologation('123'))
+      .then(({ partiesPrenantes }) => {
+        expect(partiesPrenantes.partiesPrenantes.nombre()).to.equal(1);
+        expect(partiesPrenantes.partiesPrenantes.item(0).nom).to.equal('nom');
+        done();
+      })
+      .catch(done);
+  });
+
+  it('ne met pas à jour les parties prenantes avec des entités externes vides', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+      }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajoutePartiesPrenantesSpecifiquesAHomologation('123', [])
+      .then(() => depot.homologation('123'))
+      .then(({ partiesPrenantes }) => {
+        expect(partiesPrenantes.partiesPrenantes.nombre()).to.equal(0);
+        done();
+      })
+      .catch(done);
+  });
+
   it('sait associer des parties prenantes à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [

--- a/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
@@ -4,6 +4,7 @@ const { ErreurTypeInconnu } = require('../../../src/erreurs');
 const fabriquePartiePrenante = require('../../../src/modeles/partiesPrenantes/fabriquePartiePrenante');
 const DeveloppementFourniture = require('../../../src/modeles/partiesPrenantes/developpementFourniture');
 const Hebergement = require('../../../src/modeles/partiesPrenantes/hebergement');
+const PartiePrenanteSpecifique = require('../../../src/modeles/partiesPrenantes/partiePrenanteSpecifique');
 
 describe('La fabrique de partie prenante', () => {
   it('fabrique des hébergements', () => {
@@ -14,6 +15,11 @@ describe('La fabrique de partie prenante', () => {
   it('fabrique des développements / fournitures de service', () => {
     const developpementFourniture = fabriquePartiePrenante.cree({ type: 'DeveloppementFourniture', nom: 'Mss' });
     expect(developpementFourniture).to.be.a(DeveloppementFourniture);
+  });
+
+  it('fabrique des parties prenantes spécifiques', () => {
+    const partiePrenanteSpecifique = fabriquePartiePrenante.cree({ type: 'PartiePrenanteSpecifique', nom: 'Partie' });
+    expect(partiePrenanteSpecifique).to.be.a(PartiePrenanteSpecifique);
   });
 
   it('retourne une erreur si le type est inconnu', () => {

--- a/test/modeles/partiesPrenantes/partiePrenanteSpecifique.spec.js
+++ b/test/modeles/partiesPrenantes/partiePrenanteSpecifique.spec.js
@@ -1,0 +1,10 @@
+const expect = require('expect.js');
+
+const PartiePrenanteSpecifique = require('../../../src/modeles/partiesPrenantes/partiePrenanteSpecifique');
+
+describe('Une partie prenante spécifique', () => {
+  it('sait se décrire en JSON', () => {
+    const partiePrenanteSpecifique = new PartiePrenanteSpecifique({ nom: 'partie' });
+    expect(partiePrenanteSpecifique.toJSON()).to.eql({ type: 'PartiePrenanteSpecifique', nom: 'partie' });
+  });
+});

--- a/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
@@ -28,4 +28,16 @@ describe('Les parties prenantes', () => {
 
     expect(partiesPrenantes.developpementFourniture()).to.eql({ type: 'DeveloppementFourniture', nom: 'structure' });
   });
+
+  elles('savent transmettre les parties prenantes spécifiques', () => {
+    const partiesPrenantes = new PartiesPrenantes(
+      { partiesPrenantes: [
+        { type: 'PartiePrenanteSpecifique', nom: 'une partie' },
+        { type: 'PartiePrenanteSpecifique', nom: 'une autre partie' },
+      ] }
+    );
+
+    expect(partiesPrenantes.specifiques()).to.have.length(2);
+    expect(partiesPrenantes.specifiques()[0]).to.eql({ type: 'PartiePrenanteSpecifique', nom: 'une partie' });
+  });
 });

--- a/test/modeles/partiesPrenantes/typePartiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/typePartiePrenante.spec.js
@@ -1,9 +1,10 @@
 const expect = require('expect.js');
 
-const { estHebergement, estDeveloppementFourniture } = require('../../../src/modeles/partiesPrenantes/typePartiePrenante');
+const { estDeveloppementFourniture, estHebergement, estSpecifique } = require('../../../src/modeles/partiesPrenantes/typePartiePrenante');
 const DeveloppementFourniture = require('../../../src/modeles/partiesPrenantes/developpementFourniture');
 const Hebergement = require('../../../src/modeles/partiesPrenantes/hebergement');
 const PartiePrenante = require('../../../src/modeles/partiesPrenantes/partiePrenante');
+const PartiePrenanteSpecifique = require('../../../src/modeles/partiesPrenantes/partiePrenanteSpecifique');
 
 describe('Le type de partie prenante', () => {
   it('renseigne si une partie prenante est un hébergement', () => {
@@ -24,5 +25,15 @@ describe('Le type de partie prenante', () => {
   it("renseigne si une partie prenante n'est pas de type développement fourniture", () => {
     const partiePrenante = new PartiePrenante({ nom: 'nom' });
     expect(estDeveloppementFourniture(partiePrenante)).to.be(false);
+  });
+
+  it('renseigne si une partie prenante est une spécifique', () => {
+    const partiePrenante = new PartiePrenanteSpecifique({ nom: 'une partie' });
+    expect(estSpecifique(partiePrenante)).to.be(true);
+  });
+
+  it("renseigne si une partie prenante n'est pas une spécifique", () => {
+    const partiePrenante = new PartiePrenante({ nom: 'nom' });
+    expect(estSpecifique(partiePrenante)).to.be(false);
   });
 });


### PR DESCRIPTION
Dans l'aventure du déplacement des entités externes dans les rôles et responsabilités,
La première étape est d'enregistrer l'information dans les caractéristiques complémentaires et dans les parties prenantes.