### PR TITLE
Déplacement entités externes Partie 2

### DIFF
--- a/migrations/20220221142354_copieEntitesExternesDansPartiesPrenantes.js
+++ b/migrations/20220221142354_copieEntitesExternesDansPartiesPrenantes.js
@@ -1,0 +1,45 @@
+const miseAJour = (contientDonneesCiblees, actionMiseAJour) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(contientDonneesCiblees)
+      .map(({ id, donnees }) => {
+        const donneesModifiees = actionMiseAJour(donnees);
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: donneesModifiees });
+      });
+    return Promise.all(misesAJour);
+  });
+
+const contientEntitesExternes = ({ donnees }) => (
+  donnees?.caracteristiquesComplementaires?.entitesExternes
+);
+
+const copieDansPartiesPrenantes = (donnees) => {
+  donnees.partiesPrenantes ||= {};
+  donnees.partiesPrenantes.partiesPrenantes ||= [];
+  donnees.partiesPrenantes.partiesPrenantes = donnees.partiesPrenantes.partiesPrenantes
+    .filter((partiePrenante) => partiePrenante.type !== 'PartiePrenanteSpecifique');
+
+  donnees.caracteristiquesComplementaires.entitesExternes.map((entiteExterne) => ({
+    type: 'PartiePrenanteSpecifique',
+    nom: entiteExterne.nom,
+    natureAcces: entiteExterne.acces,
+    pointContact: entiteExterne.contact,
+  })).forEach((partiePrenante) => donnees.partiesPrenantes.partiesPrenantes.push(partiePrenante));
+
+  return donnees;
+};
+
+const contientPartiesPrenantes = ({ donnees }) => donnees?.partiesPrenantes?.partiesPrenantes;
+
+const supprimeDansPartiesPrenantes = (donnees) => {
+  donnees.partiesPrenantes.partiesPrenantes = donnees.partiesPrenantes.partiesPrenantes
+    .filter((partiePrenante) => partiePrenante.type !== 'PartiePrenanteSpecifique');
+
+  return donnees;
+};
+
+exports.up = miseAJour(contientEntitesExternes, copieDansPartiesPrenantes);
+
+exports.down = miseAJour(contientPartiesPrenantes, supprimeDansPartiesPrenantes);


### PR DESCRIPTION
Dans l'aventure du déplacement des entités externes dans les rôles et responsabilités,
La deuxième étape est de migrer les entités externes des caractéristiques complémentaires dans les parties prenantes.