### PR TITLE
Affichage initiales contributeurs

### DIFF
--- a/public/assets/images/pastille_bleu_anssi.svg
+++ b/public/assets/images/pastille_bleu_anssi.svg
@@ -1,0 +1,4 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12.5" cy="12.5" r="12" fill="#08416A"/>
+<circle cx="12.5" cy="12.5" r="12" stroke="#08416A"/>
+</svg>

--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -12,14 +12,14 @@
 }
 
 .homologation {
+  min-width: 0;
+
+  height: 12em;
   padding: 2em;
 
   border: solid 1px var(--liseres);
   border-radius: 5px;
   background: white;
-
-  font-weight: bold;
-  text-decoration: none;
 }
 
 .homologation:hover {
@@ -27,9 +27,67 @@
   background-color: inherit;
 }
 
-.homologation.existante {
+.titre-homologation {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  overflow-wrap: break-word;
+
   font-size: 1.5em;
+  font-weight: bold;
+}
+
+.homologation.existante {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+
   color: var(--texte-fonce);
+}
+
+.homologation p {
+  margin: 0.5em;
+
+  font-size: 0.8em;
+}
+
+.pastilles-contributeurs {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pastilles-contributeurs > div {
+  width: 2.5em;
+  height: 2.5em;
+}
+
+.pastille-contributeur {
+  cursor: default;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin-left: 0.3em;
+  box-sizing: border-box;
+
+  background-image: url(../images/pastille_bleu_anssi.svg);
+  background-repeat: no-repeat;
+  background-size: contain;
+
+}
+
+.pastille-contributeur .initiales {
+  font-size: 0.7em;
+  color: #fff;
+}
+
+.nouvelle.homologation {
+  color: var(--bleu-mise-en-avant);
+  font-weight: bold;
+  text-decoration: none;
 }
 
 .nouvelle.homologation .icone-ajout {

--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -1,13 +1,20 @@
 import $homologations from './modules/elementsDom/homologations.js';
 
 $(() => {
-  const ajouteConteneursHomologationDans = (placeholder, donneesHomologations) => {
+  const ajouteConteneursHomologationDans = (placeholder, donneesHomologations, idUtilisateur) => {
     const $conteneurHomologations = $(placeholder);
-    const $conteneursHomologation = $homologations(donneesHomologations);
+    const $conteneursHomologation = $homologations(donneesHomologations, idUtilisateur);
 
     $conteneurHomologations.prepend($conteneursHomologation);
   };
 
-  axios.get('/api/homologations')
-    .then((reponse) => ajouteConteneursHomologationDans('.homologations', reponse.data.homologations));
+  axios.get('/api/utilisateurCourant')
+    .then((reponse) => reponse.data.utilisateur.id)
+    .then((idUtilisateur) => axios
+      .get('/api/homologations')
+      .then((reponse) => ajouteConteneursHomologationDans(
+        '.homologations',
+        reponse.data.homologations,
+        idUtilisateur,
+      )));
 });

--- a/public/modules/elementsDom/homologations.js
+++ b/public/modules/elementsDom/homologations.js
@@ -1,18 +1,25 @@
-const $homologationExistante = (donneesHomologation) => {
+const $homologationExistante = (donneesHomologation, idUtilisateur) => {
+  const descriptionContributeur = (donneesContributeur) => {
+    let resultat = donneesContributeur.prenomNom;
+    if (donneesContributeur.id === idUtilisateur) resultat += ' (vous)';
+    return resultat;
+  };
+
+  const classePastillesContributeurs = 'pastilles-contributeurs';
+
   const $element = $(`
 <a class="homologation existante" href="/homologation/${donneesHomologation.id}">
   <div class="titre-homologation">${donneesHomologation.nomService}</div>
   <div class="contributeurs">
     <p>Contributeurs</p>
-    <div class="pastilles-contributeurs">
-    </div>
+    <div class="${classePastillesContributeurs}"></div>
   </div>
 </a>
   `);
 
   donneesHomologation.contributeurs.forEach((donneesContributeur) => {
-    $('.pastilles-contributeurs', $element).append($(`
-<div class="pastille-contributeur" title="${donneesContributeur.prenomNom}">
+    $(`.${classePastillesContributeurs}`, $element).append($(`
+<div class="pastille-contributeur" title="${descriptionContributeur(donneesContributeur)}">
   <div class="initiales">${donneesContributeur.initiales}</div>
 </div>
     `));
@@ -28,12 +35,16 @@ const $ajoutNouvelleHomologation = () => $(`
 </a>
 `);
 
-const $homologations = (donneesHomologations) => donneesHomologations.reduce(
-  ($acc, donneesHomologation) => {
-    const $conteneurHomologation = $homologationExistante(donneesHomologation);
-    return $acc.append($conteneurHomologation);
-  }, $(document.createDocumentFragment())
-)
-  .append($ajoutNouvelleHomologation());
+const $homologations = (donneesHomologations, idUtilisateur) => (
+  donneesHomologations
+    .reduce(($acc, donneesHomologation) => {
+      const $homologation = $homologationExistante(
+        donneesHomologation,
+        idUtilisateur,
+      );
+      return $acc.append($homologation);
+    }, $(document.createDocumentFragment()))
+    .append($ajoutNouvelleHomologation())
+);
 
 export default $homologations;

--- a/public/modules/elementsDom/homologations.js
+++ b/public/modules/elementsDom/homologations.js
@@ -1,8 +1,25 @@
-const $homologationExistante = (donneesHomologation) => $(`
+const $homologationExistante = (donneesHomologation) => {
+  const $element = $(`
 <a class="homologation existante" href="/homologation/${donneesHomologation.id}">
-  <div>${donneesHomologation.nomService}</div>
+  <div class="titre-homologation">${donneesHomologation.nomService}</div>
+  <div class="contributeurs">
+    <p>Contributeurs</p>
+    <div class="pastilles-contributeurs">
+    </div>
+  </div>
 </a>
-`);
+  `);
+
+  donneesHomologation.contributeurs.forEach((donneesContributeur) => {
+    $('.pastilles-contributeurs', $element).append($(`
+<div class="pastille-contributeur" title="${donneesContributeur.prenomNom}">
+  <div class="initiales">${donneesContributeur.initiales}</div>
+</div>
+    `));
+  });
+
+  return $element;
+};
 
 const $ajoutNouvelleHomologation = () => $(`
 <a class="nouvelle homologation" href="/homologation/creation">

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -17,9 +17,15 @@ const nouvelAdaptateur = (donnees = {}) => {
     donnees.autorisations.filter((a) => a.idUtilisateur === idUtilisateur)
   );
 
-  const homologation = (idHomologation) => Promise.resolve(
-    donnees.homologations.find((h) => h.id === idHomologation)
-  );
+  const homologation = (id) => {
+    const contributeurs = (idHomologation) => donnees.autorisations
+      .filter((a) => a.idHomologation === idHomologation && a.type === 'contributeur')
+      .map((a) => donnees.utilisateurs.find((u) => u.id === a.idUtilisateur));
+
+    const homologationTrouvee = donnees.homologations.find((h) => h.id === id);
+    if (homologationTrouvee) homologationTrouvee.contributeurs = contributeurs(id);
+    return Promise.resolve(homologationTrouvee);
+  };
 
   const homologations = (idUtilisateur) => autorisations(idUtilisateur)
     .then((as) => Promise.all(

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -7,6 +7,7 @@ const Mesures = require('./mesures');
 const PartiesPrenantes = require('./partiesPrenantes');
 const Risques = require('./risques');
 const RolesResponsabilites = require('./rolesResponsabilites');
+const Utilisateur = require('./utilisateur');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -19,6 +20,7 @@ class Homologation {
   constructor(donnees, referentiel = Referentiel.creeReferentielVide()) {
     const {
       id = '',
+      contributeurs = [],
       descriptionService = {},
       mesuresGenerales = [],
       mesuresSpecifiques = [],
@@ -31,6 +33,7 @@ class Homologation {
     } = donnees;
 
     this.id = id;
+    this.contributeurs = contributeurs.map((c) => new Utilisateur(c));
     this.descriptionService = new DescriptionService(descriptionService, referentiel);
     this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel);
     this.caracteristiquesComplementaires = new CaracteristiquesComplementaires(

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -117,6 +117,7 @@ class Homologation {
     return {
       id: this.id,
       nomService: this.nomService(),
+      contributeurs: this.contributeurs.map((c) => c.toJSON()),
     };
   }
 }

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -31,8 +31,20 @@ class Utilisateur extends Base {
     return this.adaptateurJWT.genereToken(this.id, this.cguAcceptees, callback);
   }
 
+  initiales() {
+    const premiereLettreMajuscule = (s) => (
+      typeof s === 'string' ? s.charAt(0).toUpperCase() : ''
+    );
+
+    return `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(this.nom)}`;
+  }
+
+  prenomNom() {
+    return `${this.prenom} ${this.nom}`;
+  }
+
   toJSON() {
-    return { prenomNom: `${this.prenom} ${this.nom}` };
+    return { prenomNom: this.prenomNom(), initiales: this.initiales() };
   }
 }
 

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -44,7 +44,7 @@ class Utilisateur extends Base {
   }
 
   toJSON() {
-    return { prenomNom: this.prenomNom(), initiales: this.initiales() };
+    return { id: this.id, prenomNom: this.prenomNom(), initiales: this.initiales() };
   }
 }
 

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -118,6 +118,29 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
+  it("associe ses contributeurs à l'homologation", (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      utilisateurs: [{ id: '111', email: 'createur@mail.fr' }, { id: '999', email: 'contributeur@mail.fr' }],
+      homologations: [
+        { id: '789', descriptionService: { nomService: 'nom' } },
+      ],
+      autorisations: [
+        { idHomologation: '789', idUtilisateur: '111', type: 'createur' },
+        { idHomologation: '789', idUtilisateur: '999', type: 'contributeur' },
+      ],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance, referentiel: 'Le référentiel' });
+
+    depot.homologation('789')
+      .then((homologation) => {
+        const { contributeurs } = homologation;
+        expect(contributeurs.length).to.equal(1);
+        expect(contributeurs[0].id).to.equal('999');
+        done();
+      })
+      .catch(done);
+  });
+
   it('sait associer une mesure spécifique à une homologation', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -4,6 +4,7 @@ const Referentiel = require('../../src/referentiel');
 const InformationsHomologation = require('../../src/modeles/informationsHomologation');
 const Homologation = require('../../src/modeles/homologation');
 const MesureGenerale = require('../../src/modeles/mesureGenerale');
+const Utilisateur = require('../../src/modeles/utilisateur');
 
 describe('Une homologation', () => {
   it('connaît le nom du service', () => {
@@ -12,6 +13,20 @@ describe('Une homologation', () => {
     });
 
     expect(homologation.nomService()).to.equal('Super Service');
+  });
+
+  it('connaît ses contributrices et contributeurs', () => {
+    const homologation = new Homologation({
+      id: '123',
+      contributeurs: [{ id: '456', prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' }],
+    });
+
+    const { contributeurs } = homologation;
+    expect(contributeurs.length).to.equal(1);
+
+    const contributeur = contributeurs[0];
+    expect(contributeur).to.be.an(Utilisateur);
+    expect(contributeur.id).to.equal('456');
   });
 
   it('sait se convertir en JSON', () => {

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -31,11 +31,16 @@ describe('Une homologation', () => {
 
   it('sait se convertir en JSON', () => {
     const homologation = new Homologation({
-      id: '123', idUtilisateur: '456', descriptionService: { nomService: 'Super Service' },
+      id: '123',
+      idUtilisateur: '456',
+      descriptionService: { nomService: 'Super Service' },
+      contributeurs: [{ prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' }],
     });
 
     expect(homologation.toJSON()).to.eql({
-      id: '123', nomService: 'Super Service',
+      id: '123',
+      nomService: 'Super Service',
+      contributeurs: [{ prenomNom: 'Jean Dupont', initiales: 'JD' }],
     });
   });
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -34,13 +34,13 @@ describe('Une homologation', () => {
       id: '123',
       idUtilisateur: '456',
       descriptionService: { nomService: 'Super Service' },
-      contributeurs: [{ prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' }],
+      contributeurs: [{ id: '999', prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' }],
     });
 
     expect(homologation.toJSON()).to.eql({
       id: '123',
       nomService: 'Super Service',
-      contributeurs: [{ prenomNom: 'Jean Dupont', initiales: 'JD' }],
+      contributeurs: [{ id: '999', prenomNom: 'Jean Dupont', initiales: 'JD' }],
     });
   });
 

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -21,7 +21,7 @@ describe('Un utilisateur', () => {
       id: '123', prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr', motDePasse: 'XXX',
     });
 
-    expect(utilisateur.toJSON()).to.eql({ prenomNom: 'Jean Dupont', initiales: 'JD' });
+    expect(utilisateur.toJSON()).to.eql({ id: '123', prenomNom: 'Jean Dupont', initiales: 'JD' });
   });
 
   it('sait générer son JWT', (done) => {

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -4,12 +4,24 @@ const { ErreurEmailManquant } = require('../../src/erreurs');
 const Utilisateur = require('../../src/modeles/utilisateur');
 
 describe('Un utilisateur', () => {
+  describe('sur demande de ses initiales', () => {
+    it('renvoie les initiales du prénom et du nom', () => {
+      const utilisateur = new Utilisateur({ prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' });
+      expect(utilisateur.initiales()).to.equal('JD');
+    });
+
+    it('reste robuste en cas de prénom ou de nom absent', () => {
+      const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
+      expect(utilisateur.initiales()).to.equal('');
+    });
+  });
+
   it('sait se convertir en JSON', () => {
     const utilisateur = new Utilisateur({
       id: '123', prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr', motDePasse: 'XXX',
     });
 
-    expect(utilisateur.toJSON()).to.eql({ prenomNom: 'Jean Dupont' });
+    expect(utilisateur.toJSON()).to.eql({ prenomNom: 'Jean Dupont', initiales: 'JD' });
   });
 
   it('sait générer son JWT', (done) => {


### PR DESCRIPTION
- Récupération des contributeurs en base
- Affichage des initiales dans une pastille bleue
- Affichage d'un tooltip avec prénom et nom complets
- Ajout dans le tooltip d'une mention « (vous) » quand il s'agit de l'utilisateur courant

<img width="257" alt="Screenshot 2022-02-22 at 10 51 13" src="https://user-images.githubusercontent.com/105624/155107176-e25ce356-8e77-4de0-9bf4-c7ee438a3e6c.png">

Note : pour tester l'affichage, il faut actuellement ajouter directement en base de données une autorisation sur le format suivant :
```javascript
{
  id: [uuid],
  donnees: {
    idUtilisateur: [identifiant de l'utilisateur contributeur],
    idHomologation: [identifiant de l'homologation à partager],
    type: 'contributeur',
  },
}
```