### PR TITLE
Déplacement du développement / fourniture de service dans les parties prenantes

### DIFF
--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -13,8 +13,8 @@ $(() => {
     modifieParametresAvecItemsExtraits(
       params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
     );
-    modifieParametresGroupementElements(
-      params, 'partiesPrenantes', 'hebergement'
+    ['hebergement', 'developpementFourniture'].forEach(
+      (identifiant) => modifieParametresGroupementElements(params, 'partiesPrenantes', identifiant)
     );
     return params;
   };

--- a/public/modules/parametres.mjs
+++ b/public/modules/parametres.mjs
@@ -55,7 +55,7 @@ const modifieParametresAvecItemsExtraits = (params, nomListeItems, sourceRegExpP
 };
 
 const modifieParametresGroupementElements = (params, nomListe, nomParametre) => {
-  const donneesFormatees = { [nomListe]: {} };
+  const donneesFormatees = {};
 
   Object.keys(params)
     .filter((param) => !!param.match(new RegExp(`^${nomParametre}\\w*$`)))
@@ -63,21 +63,22 @@ const modifieParametresGroupementElements = (params, nomListe, nomParametre) => 
       if (params[param]) {
         const resultat = param.match(new RegExp(`^${nomParametre}(\\w*)$`));
         const propriete = decapitalise(resultat[1]);
-        donneesFormatees[nomListe][nomParametre] = (
-          donneesFormatees[nomListe][nomParametre] || {}
+        donneesFormatees[nomParametre] = (
+          donneesFormatees[nomParametre] || {}
         );
-        donneesFormatees[nomListe][nomParametre][propriete] = params[param];
+        donneesFormatees[nomParametre][propriete] = params[param];
       }
       delete params[param];
     });
 
-  donneesFormatees[nomListe] = Object.keys(donneesFormatees[nomListe]).map((cle) => (
+  const listeFormatee = Object.keys(donneesFormatees).map((cle) => (
     {
-      ...donneesFormatees[nomListe][cle],
+      ...donneesFormatees[cle],
       type: capitalise(cle),
     }));
 
-  return Object.assign(params, donneesFormatees);
+  params[nomListe] = [...(params[nomListe] || []), ...listeFormatee];
+  return params;
 };
 
 const parametresAvecItemsExtraits = (selecteurForm, nomListeItems, sourceRegExpParamsItem) => {

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -141,11 +141,11 @@ const creeDepot = (config = {}) => {
       });
   };
 
-  const ajouteHebergementAHomologation = (idHomologation, nomHebergement) => (
+  const ajouteAuxCaracteristiquesComplementaires = (propriete) => (idHomologation, nom) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((homologationTrouvee) => {
         const { caracteristiquesComplementaires = {} } = homologationTrouvee;
-        caracteristiquesComplementaires.hebergeur = nomHebergement;
+        caracteristiquesComplementaires[propriete] = nom;
         return metsAJourProprieteHomologation(
           'caracteristiquesComplementaires',
           homologationTrouvee,
@@ -153,6 +153,10 @@ const creeDepot = (config = {}) => {
         );
       })
   );
+
+  const ajouteStructureDeveloppementAHomologation = ajouteAuxCaracteristiquesComplementaires('structureDeveloppement');
+
+  const ajouteHebergementAHomologation = ajouteAuxCaracteristiquesComplementaires('hebergeur');
 
   const ajoutePartiesPrenantesAHomologation = (...params) => {
     const [idHomologation, partiesPrenantes] = params;
@@ -304,6 +308,7 @@ const creeDepot = (config = {}) => {
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajouteRisqueGeneralAHomologation,
+    ajouteStructureDeveloppementAHomologation,
     autorisations,
     homologation,
     homologationExiste,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -14,8 +14,6 @@ const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurP
 const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
 const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const Homologation = require('./modeles/homologation');
-const PartiesPrenantes = require('./modeles/partiesPrenantes');
-const DeveloppementFourniture = require('./modeles/partiesPrenantes/developpementFourniture');
 const RolesResponsabilites = require('./modeles/rolesResponsabilites');
 const Utilisateur = require('./modeles/utilisateur');
 
@@ -122,24 +120,6 @@ const creeDepot = (config = {}) => {
   const ajouteCaracteristiquesAHomologation = (...params) => (
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
   );
-
-  const ajouteDeveloppementFournitureAHomologation = (idHomologation, nomPartiePrenante) => {
-    if (!nomPartiePrenante) {
-      return Promise.resolve();
-    }
-
-    return adaptateurPersistance.homologation(idHomologation)
-      .then((homologationTrouvee) => {
-        const { partiesPrenantes = {} } = homologationTrouvee;
-        partiesPrenantes.partiesPrenantes ||= [];
-        partiesPrenantes.partiesPrenantes = partiesPrenantes.partiesPrenantes
-          .filter((partiePrenante) => partiePrenante.type !== DeveloppementFourniture.name);
-        partiesPrenantes.partiesPrenantes.push(
-          { type: DeveloppementFourniture.name, nom: nomPartiePrenante }
-        );
-        return metsAJourProprieteHomologation('partiesPrenantes', homologationTrouvee, new PartiesPrenantes(partiesPrenantes, referentiel));
-      });
-  };
 
   const ajouteAuxCaracteristiquesComplementaires = (propriete) => (idHomologation, nom) => (
     adaptateurPersistance.homologation(idHomologation)
@@ -303,7 +283,6 @@ const creeDepot = (config = {}) => {
     ajouteAvisExpertCyberAHomologation,
     ajouteCaracteristiquesAHomologation,
     ajouteDescriptionServiceAHomologation,
-    ajouteDeveloppementFournitureAHomologation,
     ajouteHebergementAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,

--- a/src/modeles/caracteristiquesComplementaires.js
+++ b/src/modeles/caracteristiquesComplementaires.js
@@ -5,8 +5,7 @@ const Referentiel = require('../referentiel');
 class CaracteristiquesComplementaires extends InformationsHomologation {
   constructor(donneesCaracteristiques = {}, referentiel = Referentiel.creeReferentielVide()) {
     super({
-      proprietesAtomiquesRequises: ['structureDeveloppement'],
-      proprietesAtomiquesFacultatives: ['hebergeur'],
+      proprietesAtomiquesFacultatives: ['hebergeur', 'structureDeveloppement'],
       listesAgregats: { entitesExternes: EntitesExternes },
     });
     this.renseigneProprietes(donneesCaracteristiques);

--- a/src/modeles/partiesPrenantes/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes/partiesPrenantes.js
@@ -1,6 +1,6 @@
 const ElementsFabricables = require('../elementsFabricables');
 const fabriquePartiePrenante = require('./fabriquePartiePrenante');
-const { estHebergement } = require('./typePartiePrenante');
+const { estHebergement, estDeveloppementFourniture } = require('./typePartiePrenante');
 
 class PartiesPrenantes extends ElementsFabricables {
   constructor(donnees = {}) {
@@ -8,8 +8,16 @@ class PartiesPrenantes extends ElementsFabricables {
     super(fabriquePartiePrenante, { items: partiesPrenantes });
   }
 
+  type(estType) {
+    return this.tous().find(estType)?.toJSON();
+  }
+
   hebergement() {
-    return this.tous().find(estHebergement)?.toJSON();
+    return this.type(estHebergement);
+  }
+
+  developpementFourniture() {
+    return this.type(estDeveloppementFourniture);
   }
 }
 

--- a/src/modeles/partiesPrenantes/typePartiePrenante.js
+++ b/src/modeles/partiesPrenantes/typePartiePrenante.js
@@ -1,5 +1,10 @@
 const Hebergement = require('./hebergement');
+const DeveloppementFourniture = require('./developpementFourniture');
 
-exports.estHebergement = (partiePrenante) => (
-  partiePrenante.constructor.name === Hebergement.name
+const estType = (Type) => (objet) => (
+  objet.constructor.name === Type.name
 );
+
+exports.estHebergement = estType(Hebergement);
+
+exports.estDeveloppementFourniture = estType(DeveloppementFourniture);

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -154,8 +154,13 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
     (requete, reponse) => {
       const partiesPrenantes = new PartiesPrenantes(requete.body);
       const nomHebergement = partiesPrenantes.partiesPrenantes?.hebergement()?.nom;
+      const nomStructureDeveloppement = partiesPrenantes
+        .partiesPrenantes?.developpementFourniture()?.nom;
       const idHomologation = requete.homologation.id;
       depotDonnees.ajouteHebergementAHomologation(requete.homologation.id, nomHebergement)
+        .then(() => depotDonnees.ajouteStructureDeveloppementAHomologation(
+          requete.homologation.id, nomStructureDeveloppement
+        ))
         .then(() => depotDonnees.ajoutePartiesPrenantesAHomologation(
           idHomologation, partiesPrenantes
         ))

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -90,11 +90,6 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
       try {
         const caracteristiques = new CaracteristiquesComplementaires(requete.body, referentiel);
         depotDonnees.ajouteCaracteristiquesAHomologation(requete.params.id, caracteristiques)
-          .then(() => (
-            depotDonnees.ajouteDeveloppementFournitureAHomologation(
-              requete.params.id, caracteristiques.structureDeveloppement
-            )
-          ))
           .then(() => reponse.send({ idHomologation: requete.homologation.id }));
       } catch {
         reponse.status(422).send('Données invalides');

--- a/src/vues/homologation/caracteristiquesComplementaires.pug
+++ b/src/vues/homologation/caracteristiquesComplementaires.pug
@@ -9,12 +9,6 @@ block formulaire
 
     section
 
-      label Structure ayant développé le service numérique
-        input(
-          id = 'structure-developpement', name = 'structureDeveloppement', type = 'text',
-          value = homologation.caracteristiquesComplementaires.structureDeveloppement,
-        )
-
       label Entités externes disposant d'un accès privilégié au service
         p.
           Listez les tierces parties ayant un accès privilégié au service qui

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -49,7 +49,7 @@ block formulaire
       +inputPartiePrenante({
         categorie: 'Développement / fourniture du service',
         nomParametre: 'developpementFourniture',
-        donnees: {},
+        donnees: homologation.partiesPrenantes.partiesPrenantes.developpementFourniture(),
       })
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -46,6 +46,12 @@ block formulaire
         donnees: homologation.partiesPrenantes.partiesPrenantes.hebergement(),
       })
 
+      +inputPartiePrenante({
+        categorie: 'Développement / fourniture du service',
+        nomParametre: 'developpementFourniture',
+        donnees: {},
+      })
+
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›
 
   script(type = 'module', src = '/statique/homologation/partiesPrenantes.js')

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -19,7 +19,6 @@ const MesureGenerale = require('../src/modeles/mesureGenerale');
 const MesureSpecifique = require('../src/modeles/mesureSpecifique');
 const MesuresSpecifiques = require('../src/modeles/mesuresSpecifiques');
 const PartiesPrenantes = require('../src/modeles/partiesPrenantes');
-const DeveloppementFourniture = require('../src/modeles/partiesPrenantes/developpementFourniture');
 const RisqueGeneral = require('../src/modeles/risqueGeneral');
 const RisqueSpecifique = require('../src/modeles/risqueSpecifique');
 const RisquesSpecifiques = require('../src/modeles/risquesSpecifiques');
@@ -336,84 +335,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .then(({ caracteristiquesComplementaires }) => {
         expect(caracteristiquesComplementaires.hebergeur).to.equal('Un hébergeur');
         expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
-        done();
-      })
-      .catch(done);
-  });
-
-  it("met à jour les parties prenantes avec l'entité développeur / fournisseur du service", (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-        caracteristiquesComplementaires: { structureDeveloppement: 'Une structure' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteDeveloppementFournitureAHomologation('123', 'Une structure')
-      .then(() => depot.homologation('123'))
-      .then(({ partiesPrenantes }) => {
-        expect(partiesPrenantes.partiesPrenantes.item(0).nom).to.equal('Une structure');
-        done();
-      })
-      .catch(done);
-  });
-
-  it('ne met pas à jour les parties prenantes avec avec une entité développeur / fournisseur du service vide', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteDeveloppementFournitureAHomologation('123', '')
-      .then(() => depot.homologation('123'))
-      .then(({ partiesPrenantes }) => {
-        expect(partiesPrenantes.partiesPrenantes.nombre()).to.equal(0);
-        done();
-      })
-      .catch(done);
-  });
-
-  it("conserve les anciennes parties prenantes lors de la mise à jour avec l'entité développeur / fournisseur du service", (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-        caracteristiquesComplementaires: { structureDeveloppement: 'Une structure' },
-        partiesPrenantes: { partiesPrenantes: [{ type: 'Hebergement', nom: 'hébergeur' }] },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteDeveloppementFournitureAHomologation('123', 'Une structure')
-      .then(() => depot.homologation('123'))
-      .then(({ partiesPrenantes }) => {
-        expect(partiesPrenantes.partiesPrenantes.tous()).to.have.length(2);
-        expect(partiesPrenantes.partiesPrenantes.tous().find((item) => item instanceof DeveloppementFourniture).nom).to.equal('Une structure');
-        done();
-      })
-      .catch(done);
-  });
-
-  it("écrase l'ancien développeur / fournisseur lors de la mise à jour de celui-ci dans les parties prenantes", (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-        caracteristiquesComplementaires: { structureDeveloppement: 'Une ancienne structure' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteDeveloppementFournitureAHomologation('123', 'Une structure')
-      .then(() => depot.homologation('123'))
-      .then(({ partiesPrenantes }) => {
-        expect(partiesPrenantes.partiesPrenantes.tous()).to.have.length(1);
-        expect(partiesPrenantes.partiesPrenantes.item(0).nom).to.equal('Une structure');
         done();
       })
       .catch(done);

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -475,6 +475,24 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
+  it('met à jour les caractéristiques complémentaires avec la structure du service', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+      }],
+    });
+    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
+
+    depot.ajouteStructureDeveloppementAHomologation('123', 'Une structure')
+      .then(() => depot.homologation('123'))
+      .then(({ caracteristiquesComplementaires }) => {
+        expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
+        done();
+      })
+      .catch(done);
+  });
+
   describe('concernant les risques généraux', () => {
     let valideRisque;
 

--- a/test/modeles/caracteristiquesComplementaires.spec.js
+++ b/test/modeles/caracteristiquesComplementaires.spec.js
@@ -49,16 +49,14 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
   describe('sur demande du statut de saisie', () => {
     describe("quand aucune entité externe n'a été saisie", () => {
       it('détermine le statut de saisie de manière standard', () => {
-        const caracteristiques = new CaracteristiquesComplementaires({ structureDeveloppement: 'Une structure' });
-        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
+        const caracteristiques = new CaracteristiquesComplementaires({});
+        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.A_SAISIR);
       });
     });
 
     describe("quand au moins une entité externe n'a été que partiellement saisie", () => {
       it('a pour statut de saisie A_COMPLETER', () => {
         const caracteristiques = new CaracteristiquesComplementaires({
-          structureDeveloppement: 'Une structure',
-          hebergeur: 'Un hébergeur',
           entitesExternes: [{ nom: 'Un nom, mais pas de contact' }],
         });
 
@@ -77,12 +75,12 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
         expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
       });
 
-      it("a pour statut A_COMPLETER si un des autres champs n'est pas saisi", () => {
+      it('a pour statut COMPLETES même si les autres champs ne sont pas saisis', () => {
         const caracteristiques = new CaracteristiquesComplementaires({
           entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
         });
 
-        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.A_COMPLETER);
+        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
       });
     });
   });

--- a/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
@@ -20,4 +20,12 @@ describe('Les parties prenantes', () => {
 
     expect(partiesPrenantes.hebergement()).to.eql({ type: 'Hebergement', nom: 'hébergeur' });
   });
+
+  elles('savent transmettre les informations du développement et fourniture du service', () => {
+    const partiesPrenantes = new PartiesPrenantes(
+      { partiesPrenantes: [{ type: 'DeveloppementFourniture', nom: 'structure' }] }
+    );
+
+    expect(partiesPrenantes.developpementFourniture()).to.eql({ type: 'DeveloppementFourniture', nom: 'structure' });
+  });
 });

--- a/test/modeles/partiesPrenantes/typePartiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/typePartiePrenante.spec.js
@@ -1,6 +1,7 @@
 const expect = require('expect.js');
 
-const { estHebergement } = require('../../../src/modeles/partiesPrenantes/typePartiePrenante');
+const { estHebergement, estDeveloppementFourniture } = require('../../../src/modeles/partiesPrenantes/typePartiePrenante');
+const DeveloppementFourniture = require('../../../src/modeles/partiesPrenantes/developpementFourniture');
 const Hebergement = require('../../../src/modeles/partiesPrenantes/hebergement');
 const PartiePrenante = require('../../../src/modeles/partiesPrenantes/partiePrenante');
 
@@ -13,5 +14,15 @@ describe('Le type de partie prenante', () => {
   it("renseigne si une partie prenante n'est pas un hébergement", () => {
     const partiePrenante = new PartiePrenante({ nom: 'nom' });
     expect(estHebergement(partiePrenante)).to.be(false);
+  });
+
+  it('renseigne si une partie prenante est de type développement fourniture', () => {
+    const partiePrenante = new DeveloppementFourniture({ nom: 'structure' });
+    expect(estDeveloppementFourniture(partiePrenante)).to.be(true);
+  });
+
+  it("renseigne si une partie prenante n'est pas de type développement fourniture", () => {
+    const partiePrenante = new PartiePrenante({ nom: 'nom' });
+    expect(estDeveloppementFourniture(partiePrenante)).to.be(false);
   });
 });

--- a/test/routes/routesApiHomologation.spec.js
+++ b/test/routes/routesApiHomologation.spec.js
@@ -386,6 +386,7 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
     beforeEach(() => {
       testeur.depotDonnees().ajoutePartiesPrenantesAHomologation = () => Promise.resolve();
       testeur.depotDonnees().ajouteHebergementAHomologation = () => Promise.resolve();
+      testeur.depotDonnees().ajouteStructureDeveloppementAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -443,6 +444,30 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       })
         .then((reponse) => {
           expect(hebergeurAjoute).to.be(true);
+          expect(reponse.status).to.equal(200);
+          expect(reponse.data).to.eql({ idHomologation: '456' });
+          done();
+        })
+        .catch(done);
+    });
+
+    it("demande au dépôt d'ajouter le développement du service dans les caractéristiques complémentaires", (done) => {
+      let structureDeveloppementAjoutee = false;
+
+      testeur.depotDonnees().ajouteStructureDeveloppementAHomologation = (
+        (idHomologation, nomStructureDeveloppement) => new Promise((resolve) => {
+          expect(idHomologation).to.equal('456');
+          expect(nomStructureDeveloppement).to.equal('Une structure');
+          structureDeveloppementAjoutee = true;
+          resolve();
+        })
+      );
+
+      axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {
+        partiesPrenantes: [{ type: 'DeveloppementFourniture', nom: 'Une structure' }],
+      })
+        .then((reponse) => {
+          expect(structureDeveloppementAjoutee).to.be(true);
           expect(reponse.status).to.equal(200);
           expect(reponse.data).to.eql({ idHomologation: '456' });
           done();

--- a/test/routes/routesApiHomologation.spec.js
+++ b/test/routes/routesApiHomologation.spec.js
@@ -194,7 +194,6 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
     beforeEach(() => {
       testeur.depotDonnees().ajouteCaracteristiquesAHomologation = () => Promise.resolve();
       testeur.depotDonnees().ajouteHebergementAHomologation = () => Promise.resolve();
-      testeur.depotDonnees().ajouteDeveloppementFournitureAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -232,30 +231,6 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       })
         .then((reponse) => {
           expect(caracteristiquesAjoutees).to.be(true);
-          expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.eql({ idHomologation: '456' });
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt d'ajouter la structure ayant développé dans les parties prenantes", (done) => {
-      let structureDeveloppementAjoutee = false;
-
-      testeur.depotDonnees().ajouteDeveloppementFournitureAHomologation = (
-        (idHomologation, structureDeveloppement) => new Promise((resolve) => {
-          expect(idHomologation).to.equal('456');
-          expect(structureDeveloppement).to.equal('Une structure');
-          structureDeveloppementAjoutee = true;
-          resolve();
-        })
-      );
-
-      axios.post('http://localhost:1234/api/homologation/456/caracteristiquesComplementaires', {
-        structureDeveloppement: 'Une structure',
-      })
-        .then((reponse) => {
-          expect(structureDeveloppementAjoutee).to.be(true);
           expect(reponse.status).to.equal(200);
           expect(reponse.data).to.eql({ idHomologation: '456' });
           done();


### PR DESCRIPTION
La « saisie du développement / fourniture de service » anciennement appelée « structure ayant développé le service » se fait dans la page parties prenantes et plus dans caractéristiques complémentaires

note : les noms des structures ayant développé sont toujours persistés avec les caractéristiques complémentaires