### PR TITLE
Affiche correctement les cartes homologation dans Espace Personnel

### DIFF
--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -12,14 +12,19 @@
 }
 
 .homologation {
-  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
 
+  min-width: 0;
   height: 12em;
   padding: 2em;
 
   border: solid 1px var(--liseres);
   border-radius: 5px;
   background: white;
+
+  color: var(--texte-fonce);
 }
 
 .homologation:hover {
@@ -38,18 +43,14 @@
   font-weight: bold;
 }
 
-.homologation.existante {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-
-  color: var(--texte-fonce);
-}
-
 .homologation p {
   margin: 0.5em;
 
   font-size: 0.8em;
+}
+
+.contributeurs {
+  display: none;
 }
 
 .pastilles-contributeurs {


### PR DESCRIPTION
- Pour l'instant on ne peut pas ajouter de contributeurs, donc on n'affiche pas le texte « contributeurs » (pour l'instant)
- On centre les éléments de la carte « nouvelle homologation »
<img width="480" alt="Screenshot 2022-02-24 at 17 13 33" src="https://user-images.githubusercontent.com/105624/155563171-d3af8763-f039-4d04-a5b0-804cc8175a8c.png">

