### PR TITLE
Affichage « prénom / nom » quand le prénom ou le nom n'ont pas été saisis

### DIFF
--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -36,11 +36,11 @@ class Utilisateur extends Base {
       typeof s === 'string' ? s.charAt(0).toUpperCase() : ''
     );
 
-    return `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(this.nom)}`;
+    return `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(this.nom)}` || '…';
   }
 
   prenomNom() {
-    return `${this.prenom} ${this.nom}`;
+    return [this.prenom, this.nom].join(' ').trim() || this.email;
   }
 
   toJSON() {

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -12,7 +12,24 @@ describe('Un utilisateur', () => {
 
     it('reste robuste en cas de prénom ou de nom absent', () => {
       const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
-      expect(utilisateur.initiales()).to.equal('');
+      expect(utilisateur.initiales()).to.equal('…');
+    });
+  });
+
+  describe('sur demande du « prénom / nom »', () => {
+    it('reste robuste si le nom est absent', () => {
+      const utilisateur = new Utilisateur({ prenom: 'Jean', email: 'jean.dupont@mail.fr' });
+      expect(utilisateur.prenomNom()).to.equal('Jean');
+    });
+
+    it('reste robuste si le prénom est absent', () => {
+      const utilisateur = new Utilisateur({ nom: 'Dupont', email: 'jean.dupont@mail.fr' });
+      expect(utilisateur.prenomNom()).to.equal('Dupont');
+    });
+
+    it("retourne l'email si le prénom et le nom sont absents", () => {
+      const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
+      expect(utilisateur.prenomNom()).to.equal('jean.dupont@mail.fr');
     });
   });
 


### PR DESCRIPTION
Dans l'optique où l'on va bientôt pouvoir inviter des contributeurs qui ne sont pas des utilisateurs existants en base, on doit gérer les cas où des utilisateurs seront créés uniquement avec leur email, et éviter que l'information « prénom / nom » de l'utilisateur dans l'entête, ou dans les pastilles contributeurs n'affiche pas de `undefined`.