### PR TITLE
Affiche en gris les contributeurs qui n'ont pas encore finalisé leur inscription

### DIFF
--- a/public/assets/images/pastille_grise.svg
+++ b/public/assets/images/pastille_grise.svg
@@ -1,0 +1,4 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12.5" cy="12.5" r="12" fill="#CECECE"/>
+<circle cx="12.5" cy="12.5" r="12" stroke="#CECECE"/>
+</svg>

--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -74,10 +74,16 @@
   margin-left: 0.3em;
   box-sizing: border-box;
 
-  background-image: url(../images/pastille_bleu_anssi.svg);
   background-repeat: no-repeat;
   background-size: contain;
+}
 
+.pastille-contributeur.valide {
+  background-image: url(../images/pastille_bleu_anssi.svg);
+}
+
+.pastille-contributeur.en-attente {
+  background-image: url(../images/pastille_grise.svg);
 }
 
 .pastille-contributeur .initiales {

--- a/public/modules/elementsDom/homologations.js
+++ b/public/modules/elementsDom/homologations.js
@@ -18,8 +18,12 @@ const $homologationExistante = (donneesHomologation, idUtilisateur) => {
   `);
 
   donneesHomologation.contributeurs.forEach((donneesContributeur) => {
+    const classePastilleContributeur = (
+      `pastille-contributeur ${donneesContributeur.cguAcceptees ? 'valide' : 'en-attente'}`
+    );
+
     $(`.${classePastillesContributeurs}`, $element).append($(`
-<div class="pastille-contributeur" title="${descriptionContributeur(donneesContributeur)}">
+<div class="${classePastilleContributeur}" title="${descriptionContributeur(donneesContributeur)}">
   <div class="initiales">${donneesContributeur.initiales}</div>
 </div>
     `));


### PR DESCRIPTION
Dans l'optique où on veut pouvoir inviter des contributeurs encore non inscrits dans MSS, on affiche en gris les pastilles des contributeurs invités qui n'ont pas encore finalisé leur inscription.