### PR TITLE
Nouvelle partie prenante : maintenance du service

### DIFF
--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -13,7 +13,7 @@ $(() => {
     modifieParametresAvecItemsExtraits(
       params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
     );
-    ['hebergement', 'developpementFourniture'].forEach(
+    ['developpementFourniture', 'hebergement', 'maintenanceService'].forEach(
       (identifiant) => modifieParametresGroupementElements(params, 'partiesPrenantes', identifiant)
     );
     return params;

--- a/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
+++ b/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
@@ -1,5 +1,6 @@
 const DeveloppementFourniture = require('./developpementFourniture');
 const Hebergement = require('./hebergement');
+const MaintenanceService = require('./maintenanceService');
 const PartiePrenanteSpecifique = require('./partiePrenanteSpecifique');
 const { ErreurTypeInconnu } = require('../../erreurs');
 
@@ -9,6 +10,7 @@ const fabriquePartiePrenante = {
     switch (type) {
       case Hebergement.name: return new Hebergement(donnees);
       case DeveloppementFourniture.name: return new DeveloppementFourniture(donnees);
+      case MaintenanceService.name: return new MaintenanceService(donnees);
       case PartiePrenanteSpecifique.name: return new PartiePrenanteSpecifique(donnees);
       default: throw new ErreurTypeInconnu(`Le type "${type}" est inconnu`);
     }

--- a/src/modeles/partiesPrenantes/maintenanceService.js
+++ b/src/modeles/partiesPrenantes/maintenanceService.js
@@ -1,0 +1,5 @@
+const PartiePrenante = require('./partiePrenante');
+
+class MaintenanceService extends PartiePrenante {}
+
+module.exports = MaintenanceService;

--- a/src/modeles/partiesPrenantes/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes/partiesPrenantes.js
@@ -1,7 +1,8 @@
 const DeveloppementFourniture = require('./developpementFourniture');
-const Hebergement = require('./hebergement');
-const PartiePrenanteSpecifique = require('./partiePrenanteSpecifique');
 const ElementsFabricables = require('../elementsFabricables');
+const Hebergement = require('./hebergement');
+const MaintenanceService = require('./maintenanceService');
+const PartiePrenanteSpecifique = require('./partiePrenanteSpecifique');
 const fabriquePartiePrenante = require('./fabriquePartiePrenante');
 
 class PartiesPrenantes extends ElementsFabricables {
@@ -20,6 +21,10 @@ class PartiesPrenantes extends ElementsFabricables {
 
   developpementFourniture() {
     return this.type(DeveloppementFourniture);
+  }
+
+  maintenanceService() {
+    return this.type(MaintenanceService);
   }
 
   specifiques() {

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -52,6 +52,12 @@ block formulaire
         donnees: homologation.partiesPrenantes.partiesPrenantes.developpementFourniture(),
       })
 
+      +inputPartiePrenante({
+        categorie: 'Maintenance du service',
+        nomParametre: 'maintenanceService',
+        donnees: homologation.partiesPrenantes.partiesPrenantes.maintenanceService(),
+      })
+
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›
 
   script(type = 'module', src = '/statique/homologation/partiesPrenantes.js')

--- a/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
@@ -4,6 +4,7 @@ const { ErreurTypeInconnu } = require('../../../src/erreurs');
 const fabriquePartiePrenante = require('../../../src/modeles/partiesPrenantes/fabriquePartiePrenante');
 const DeveloppementFourniture = require('../../../src/modeles/partiesPrenantes/developpementFourniture');
 const Hebergement = require('../../../src/modeles/partiesPrenantes/hebergement');
+const MaintenanceService = require('../../../src/modeles/partiesPrenantes/maintenanceService');
 const PartiePrenanteSpecifique = require('../../../src/modeles/partiesPrenantes/partiePrenanteSpecifique');
 
 describe('La fabrique de partie prenante', () => {
@@ -15,6 +16,11 @@ describe('La fabrique de partie prenante', () => {
   it('fabrique des développements / fournitures de service', () => {
     const developpementFourniture = fabriquePartiePrenante.cree({ type: 'DeveloppementFourniture', nom: 'Mss' });
     expect(developpementFourniture).to.be.a(DeveloppementFourniture);
+  });
+
+  it('fabrique des maintenances du service', () => {
+    const maintenanceService = fabriquePartiePrenante.cree({ type: 'MaintenanceService', nom: 'Mss' });
+    expect(maintenanceService).to.be.a(MaintenanceService);
   });
 
   it('fabrique des parties prenantes spécifiques', () => {

--- a/test/modeles/partiesPrenantes/maintenanceService.spec.js
+++ b/test/modeles/partiesPrenantes/maintenanceService.spec.js
@@ -1,0 +1,10 @@
+const expect = require('expect.js');
+
+const MaintenanceService = require('../../../src/modeles/partiesPrenantes/maintenanceService');
+
+describe('Une maintenance du service', () => {
+  it('sait se décrire en JSON', () => {
+    const maintenanceService = new MaintenanceService({ nom: 'mainteneur' });
+    expect(maintenanceService.toJSON()).to.eql({ type: 'MaintenanceService', nom: 'mainteneur' });
+  });
+});

--- a/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
@@ -29,6 +29,14 @@ describe('Les parties prenantes', () => {
     expect(partiesPrenantes.developpementFourniture()).to.eql({ type: 'DeveloppementFourniture', nom: 'structure' });
   });
 
+  elles('savent transmettre la maintenance du service', () => {
+    const partiesPrenantes = new PartiesPrenantes(
+      { partiesPrenantes: [{ type: 'MaintenanceService', nom: 'mainteneur' }] }
+    );
+
+    expect(partiesPrenantes.maintenanceService()).to.eql({ type: 'MaintenanceService', nom: 'mainteneur' });
+  });
+
   elles('savent transmettre les parties prenantes spécifiques', () => {
     const partiesPrenantes = new PartiesPrenantes(
       { partiesPrenantes: [


### PR DESCRIPTION
Dans la page partie prenante nous pouvons renseigner une nouvelle partie prenante **Maintenance du service**
qui correspond au maintien en conditions opérationnelles
<img width="795" alt="Capture d’écran 2022-03-01 à 11 25 47" src="https://user-images.githubusercontent.com/39462397/156152054-3b7564fa-7f0f-4480-918b-23e74986e675.png">
