### PR TITLE
Nouvelle partie prenante : sécurité du service

### DIFF
--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -13,7 +13,7 @@ $(() => {
     modifieParametresAvecItemsExtraits(
       params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
     );
-    ['developpementFourniture', 'hebergement', 'maintenanceService'].forEach(
+    ['developpementFourniture', 'hebergement', 'maintenanceService', 'securiteService'].forEach(
       (identifiant) => modifieParametresGroupementElements(params, 'partiesPrenantes', identifiant)
     );
     return params;

--- a/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
+++ b/src/modeles/partiesPrenantes/fabriquePartiePrenante.js
@@ -2,18 +2,27 @@ const DeveloppementFourniture = require('./developpementFourniture');
 const Hebergement = require('./hebergement');
 const MaintenanceService = require('./maintenanceService');
 const PartiePrenanteSpecifique = require('./partiePrenanteSpecifique');
+const SecuriteService = require('./securiteService');
 const { ErreurTypeInconnu } = require('../../erreurs');
+
+const partiesPrenantesAutorises = [
+  DeveloppementFourniture,
+  Hebergement,
+  MaintenanceService,
+  PartiePrenanteSpecifique,
+  SecuriteService,
+];
 
 const fabriquePartiePrenante = {
   cree: (donnees) => {
     const { type } = donnees;
-    switch (type) {
-      case Hebergement.name: return new Hebergement(donnees);
-      case DeveloppementFourniture.name: return new DeveloppementFourniture(donnees);
-      case MaintenanceService.name: return new MaintenanceService(donnees);
-      case PartiePrenanteSpecifique.name: return new PartiePrenanteSpecifique(donnees);
-      default: throw new ErreurTypeInconnu(`Le type "${type}" est inconnu`);
+
+    if (!partiesPrenantesAutorises.some((classe) => classe.name === type)) {
+      throw new ErreurTypeInconnu(`Le type "${type}" est inconnu`);
     }
+
+    const ClassePartiePrenante = partiesPrenantesAutorises.find((classe) => classe.name === type);
+    return new ClassePartiePrenante(donnees);
   },
 };
 

--- a/src/modeles/partiesPrenantes/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes/partiesPrenantes.js
@@ -3,6 +3,7 @@ const ElementsFabricables = require('../elementsFabricables');
 const Hebergement = require('./hebergement');
 const MaintenanceService = require('./maintenanceService');
 const PartiePrenanteSpecifique = require('./partiePrenanteSpecifique');
+const SecuriteService = require('./securiteService');
 const fabriquePartiePrenante = require('./fabriquePartiePrenante');
 
 class PartiesPrenantes extends ElementsFabricables {
@@ -25,6 +26,10 @@ class PartiesPrenantes extends ElementsFabricables {
 
   maintenanceService() {
     return this.type(MaintenanceService);
+  }
+
+  securiteService() {
+    return this.type(SecuriteService);
   }
 
   specifiques() {

--- a/src/modeles/partiesPrenantes/securiteService.js
+++ b/src/modeles/partiesPrenantes/securiteService.js
@@ -1,0 +1,5 @@
+const PartiePrenante = require('./partiePrenante');
+
+class SecuriteService extends PartiePrenante {}
+
+module.exports = SecuriteService;

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -58,6 +58,12 @@ block formulaire
         donnees: homologation.partiesPrenantes.partiesPrenantes.maintenanceService(),
       })
 
+      +inputPartiePrenante({
+        categorie: 'Gestion de la sécurité du service',
+        nomParametre: 'securiteService',
+        donnees: homologation.partiesPrenantes.partiesPrenantes.securiteService(),
+      })
+
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›
 
   script(type = 'module', src = '/statique/homologation/partiesPrenantes.js')

--- a/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/fabriquePartiePrenante.spec.js
@@ -6,6 +6,7 @@ const DeveloppementFourniture = require('../../../src/modeles/partiesPrenantes/d
 const Hebergement = require('../../../src/modeles/partiesPrenantes/hebergement');
 const MaintenanceService = require('../../../src/modeles/partiesPrenantes/maintenanceService');
 const PartiePrenanteSpecifique = require('../../../src/modeles/partiesPrenantes/partiePrenanteSpecifique');
+const SecuriteService = require('../../../src/modeles/partiesPrenantes/securiteService');
 
 describe('La fabrique de partie prenante', () => {
   it('fabrique des hébergements', () => {
@@ -21,6 +22,11 @@ describe('La fabrique de partie prenante', () => {
   it('fabrique des maintenances du service', () => {
     const maintenanceService = fabriquePartiePrenante.cree({ type: 'MaintenanceService', nom: 'Mss' });
     expect(maintenanceService).to.be.a(MaintenanceService);
+  });
+
+  it('fabrique des sécurité du service', () => {
+    const securiteService = fabriquePartiePrenante.cree({ type: 'SecuriteService', nom: 'Structure supervision' });
+    expect(securiteService).to.be.a(SecuriteService);
   });
 
   it('fabrique des parties prenantes spécifiques', () => {

--- a/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes/partiesPrenantes.spec.js
@@ -37,6 +37,14 @@ describe('Les parties prenantes', () => {
     expect(partiesPrenantes.maintenanceService()).to.eql({ type: 'MaintenanceService', nom: 'mainteneur' });
   });
 
+  elles('savent transmettre la sécurité du service', () => {
+    const partiesPrenantes = new PartiesPrenantes(
+      { partiesPrenantes: [{ type: 'SecuriteService', nom: 'Structure supervision' }] }
+    );
+
+    expect(partiesPrenantes.securiteService()).to.eql({ type: 'SecuriteService', nom: 'Structure supervision' });
+  });
+
   elles('savent transmettre les parties prenantes spécifiques', () => {
     const partiesPrenantes = new PartiesPrenantes(
       { partiesPrenantes: [

--- a/test/modeles/partiesPrenantes/securiteService.spec.js
+++ b/test/modeles/partiesPrenantes/securiteService.spec.js
@@ -1,0 +1,10 @@
+const expect = require('expect.js');
+
+const SecuriteService = require('../../../src/modeles/partiesPrenantes/securiteService');
+
+describe('Une sécurité du service', () => {
+  it('sait se décrire en JSON', () => {
+    const securiteService = new SecuriteService({ nom: 'Structure supervision' });
+    expect(securiteService.toJSON()).to.eql({ type: 'SecuriteService', nom: 'Structure supervision' });
+  });
+});


### PR DESCRIPTION
Dans la page partie prenante nous pouvons renseigner une nouvelle partie prenante Sécurité du service
qui correspond au maintien en conditions de sécurité
<img width="759" alt="Capture d’écran 2022-03-01 à 12 08 21" src="https://user-images.githubusercontent.com/39462397/156158507-995ff6aa-34f1-41e2-b0c8-6d2e488f018d.png">
