### PR TITLE
Onglets pour les rôles et responsabilités

### DIFF
--- a/public/assets/styles/homologation/partiesPrenantes.css
+++ b/public/assets/styles/homologation/partiesPrenantes.css
@@ -1,13 +1,41 @@
 .saisie-role-responsabilite {
-    border: 1px solid var(--liseres);
-    border-radius: 3px;
-    padding: 1em;
-    margin-top: 1em;
+  border: 1px solid var(--liseres);
+  border-radius: 3px;
+  padding: 1em;
+  margin-top: 1em;
 }
 
 .saisie-role-responsabilite label {
-    display: inline-block;
-    margin: 0;
-    margin-left: 0.1em;
-    font-weight: normal;
+  display: inline-block;
+  margin: 0;
+  margin-left: 0.1em;
+  font-weight: normal;
+}
+
+#onglets-liens {
+  display: flex;
+  column-gap: 1em;
+
+  margin-bottom: 2em;
+  padding: 0.5em 1em;
+
+  border: solid 1px var(--liseres);
+  border-radius: 5px;
+}
+  
+#onglets-liens > a {
+  padding: 0.5em 1.3em;
+  width: 100%;
+  text-align: center;
+}
+
+#onglets-liens > a.actif {
+  background: var(--bleu-mise-en-avant-20-pc);
+  border-radius: 3px;
+
+  font-weight: bold;
+}
+
+#onglets-liens ~ .onglet.invisible {
+  display: none;
 }

--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -1,28 +1,31 @@
 import parametres, { modifieParametresAvecItemsExtraits, modifieParametresGroupementElements } from '../modules/parametres.mjs';
 import brancheElementsAjoutables from '../modules/brancheElementsAjoutables.js';
+import brancheOnglets from '../modules/interactions/brancheOnglets.mjs';
+
+const tousLesParametres = (selecteurFormulaire) => {
+  const params = parametres(selecteurFormulaire);
+  modifieParametresAvecItemsExtraits(
+    params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
+  );
+  ['developpementFourniture', 'hebergement', 'maintenanceService'].forEach(
+    (identifiant) => modifieParametresGroupementElements(params, 'partiesPrenantes', identifiant)
+  );
+  return params;
+};
 
 $(() => {
+  brancheOnglets('#onglets-liens > a');
+
   brancheElementsAjoutables('acteurs-homologation', 'acteur-homologation', {
     role: { label: 'Rôle au regard du projet' },
     nom: { label: 'Nom / Prénom' },
     fonction: { label: 'Fonction' },
   });
 
-  const tousLesParametres = (selecteurFormulaire) => {
-    const params = parametres(selecteurFormulaire);
-    modifieParametresAvecItemsExtraits(
-      params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
-    );
-    ['developpementFourniture', 'hebergement', 'maintenanceService', 'securiteService'].forEach(
-      (identifiant) => modifieParametresGroupementElements(params, 'partiesPrenantes', identifiant)
-    );
-    return params;
-  };
-
   const $bouton = $('.bouton');
   const identifiantHomologation = $bouton.attr('identifiant');
 
-  $bouton.click(() => {
+  $bouton.on('click', () => {
     const params = tousLesParametres('form#parties-prenantes');
 
     axios.post(`/api/homologation/${identifiantHomologation}/partiesPrenantes`, params)

--- a/public/modules/interactions/brancheOnglets.mjs
+++ b/public/modules/interactions/brancheOnglets.mjs
@@ -1,0 +1,23 @@
+const SELECTEUR_ONGLETS = '.onglet';
+const PREFIX_IDENTIFIANT_ONGLETS = 'onglet-';
+const CLASSE_LIEN_ACTIF = 'actif';
+const CLASSE_ONGLET_INVISIBLE = 'invisible';
+
+const identifiantOngletActif = (selecteurLienActif) => $(selecteurLienActif).prop('id').slice(PREFIX_IDENTIFIANT_ONGLETS.length);
+
+const brancheOnglets = (selecteurLiens) => {
+  $(SELECTEUR_ONGLETS).addClass(CLASSE_ONGLET_INVISIBLE);
+  
+  const selecteurLienActif = `${selecteurLiens}.${CLASSE_LIEN_ACTIF}`;
+  $(`#${identifiantOngletActif(selecteurLienActif)}`).removeClass(CLASSE_ONGLET_INVISIBLE);
+
+  $(selecteurLiens).on('click', (event) => {
+    $(selecteurLiens).removeClass(CLASSE_LIEN_ACTIF);
+    $(event.target).addClass(CLASSE_LIEN_ACTIF);
+
+    $(SELECTEUR_ONGLETS).addClass(CLASSE_ONGLET_INVISIBLE);
+    $(`#${identifiantOngletActif(event.target)}`).removeClass(CLASSE_ONGLET_INVISIBLE);
+  });
+};
+
+export default brancheOnglets;

--- a/src/vues/homologation/partiesPrenantes.pug
+++ b/src/vues/homologation/partiesPrenantes.pug
@@ -11,58 +11,59 @@ block formulaire
     h1.action Parties prenantes
 
     section
-      h3 Acteurs de l'homologation
+      nav#onglets-liens
+        a.actif#onglet-acteurs-homologations Acteurs de l'homologation
+        a#onglet-les-parties-prenantes Parties prenantes
 
-      +inputIdentite({
-        role: "Autorité d'homologation",
-        nomParametre: 'autoriteHomologation',
-      })
+      .onglet#acteurs-homologations
+        +inputIdentite({
+          role: "Autorité d'homologation",
+          nomParametre: 'autoriteHomologation',
+        })
 
-      +inputIdentite({
-        role: 'Spécialiste cybersécurité',
-        nomParametre: 'expertCybersecurite',
-      })
+        +inputIdentite({
+          role: 'Spécialiste cybersécurité',
+          nomParametre: 'expertCybersecurite',
+        })
 
-      +inputIdentite({
-        role: 'Délégué(e) à la protection des données à caractère personnel',
-        nomParametre: 'delegueProtectionDonnees',
-      })
+        +inputIdentite({
+          role: 'Délégué(e) à la protection des données à caractère personnel',
+          nomParametre: 'delegueProtectionDonnees',
+        })
 
-      +inputIdentite({
-        role: 'Responsable métier du projet',
-        nomParametre: 'piloteProjet',
-      })
+        +inputIdentite({
+          role: 'Responsable métier du projet',
+          nomParametre: 'piloteProjet',
+        })
 
-      +elementsAjoutablesActeurHomologation({
-        donnees: homologation.partiesPrenantes.acteursHomologation.toJSON(),
-      })
+        +elementsAjoutablesActeurHomologation({
+          donnees: homologation.partiesPrenantes.acteursHomologation.toJSON(),
+        })
 
-    section
-      h3 Parties prenantes
+      .onglet#les-parties-prenantes
+        +inputPartiePrenante({
+          categorie: 'Hébergement du service',
+          nomParametre: 'hebergement',
+          donnees: homologation.partiesPrenantes.partiesPrenantes.hebergement(),
+        })
 
-      +inputPartiePrenante({
-        categorie: 'Hébergement du service',
-        nomParametre: 'hebergement',
-        donnees: homologation.partiesPrenantes.partiesPrenantes.hebergement(),
-      })
+        +inputPartiePrenante({
+          categorie: 'Développement / fourniture du service',
+          nomParametre: 'developpementFourniture',
+          donnees: homologation.partiesPrenantes.partiesPrenantes.developpementFourniture(),
+        })
 
-      +inputPartiePrenante({
-        categorie: 'Développement / fourniture du service',
-        nomParametre: 'developpementFourniture',
-        donnees: homologation.partiesPrenantes.partiesPrenantes.developpementFourniture(),
-      })
+        +inputPartiePrenante({
+          categorie: 'Maintenance du service',
+          nomParametre: 'maintenanceService',
+          donnees: homologation.partiesPrenantes.partiesPrenantes.maintenanceService(),
+        })
 
-      +inputPartiePrenante({
-        categorie: 'Maintenance du service',
-        nomParametre: 'maintenanceService',
-        donnees: homologation.partiesPrenantes.partiesPrenantes.maintenanceService(),
-      })
-
-      +inputPartiePrenante({
-        categorie: 'Gestion de la sécurité du service',
-        nomParametre: 'securiteService',
-        donnees: homologation.partiesPrenantes.partiesPrenantes.securiteService(),
-      })
+        +inputPartiePrenante({
+          categorie: 'Gestion de la sécurité du service',
+          nomParametre: 'securiteService',
+          donnees: homologation.partiesPrenantes.partiesPrenantes.securiteService(),
+        })
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›
 

--- a/test_public/modules/interactions/brancheOnglets.spec.mjs
+++ b/test_public/modules/interactions/brancheOnglets.spec.mjs
@@ -1,0 +1,59 @@
+import expect from 'expect.js';
+import brancheOnglets from '../../../public/modules/interactions/brancheOnglets.mjs';
+import jquery from 'jquery';
+import { JSDOM } from 'jsdom';
+
+describe('Le branchement des onglets', () => {
+  beforeEach(() => {
+    const sourcePage = `
+      <nav id="onglets-liens">
+        <a class="actif" id="onglet-acteurs-homologations"></a>
+        <a id="onglet-parties-prenantes">Parties prenantes</a>
+      </nav>
+      <div class="onglet" id="acteurs-homologations"></div>
+      <div class="onglet" id="parties-prenantes"></div>
+    `;
+    const dom = new JSDOM(sourcePage);
+    global.$ = jquery(dom.window);
+  });
+
+  it("rend visible l'onglet actif", () => {
+    brancheOnglets('#onglets-liens > a');
+
+    expect($('#acteurs-homologations').hasClass('invisible')).to.be(false);
+  });
+
+  describe('sur une action de click sur un lien', () => {
+    it('rend actif le lien cliqué', () => {
+      brancheOnglets('#onglets-liens > a');
+      
+      $('#onglet-parties-prenantes').trigger('click');
+
+      expect($('#onglet-parties-prenantes').hasClass('actif')).to.be(true);
+    });
+
+    it('rend inactif les liens non cliqués', () => {
+      brancheOnglets('#onglets-liens > a');
+      
+      $('#onglet-parties-prenantes').trigger('click');
+
+      expect($('#onglet-acteurs-homologations').hasClass('actif')).to.be(false);
+    });
+
+    it("rend visible l'onglet ciblé", () => {
+      brancheOnglets('#onglets-liens > a');
+      
+      $('#onglet-parties-prenantes').trigger('click');
+
+      expect($('#parties-prenantes').hasClass('invisible')).to.be(false);
+    });
+
+    it("rend non visible les onglets non ciblés", () => {
+      brancheOnglets('#onglets-liens > a');
+      
+      $('#onglet-parties-prenantes').trigger('click');
+
+      expect($('#acteurs-homologations').hasClass('invisible')).to.be(true);
+    });
+  });
+});


### PR DESCRIPTION
Dans la page parties prenantes,
Nous utilisons des onglets pour afficher soit les _acteurs de l'homologation_ soit les _parties prenantes_

NOTE : j'ai retiré les titres de section **Acteurs de l'homologations** et **Parties prenantes** car je trouvais que cela faisait doublon
<img width="865" alt="Capture d’écran 2022-03-03 à 10 23 41" src="https://user-images.githubusercontent.com/39462397/156535327-88764f97-366b-44f7-9205-7efc4ad516be.png">
