### PR TITLE
Suppression de l'hébergeur dans le modèle

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -125,11 +125,11 @@ const creeDepot = (config = {}) => {
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
   );
 
-  const ajouteAuxCaracteristiquesComplementaires = (propriete) => (idHomologation, nom) => (
+  const ajouteStructureDeveloppementAHomologation = (idHomologation, nom) => (
     adaptateurPersistance.homologation(idHomologation)
       .then((homologationTrouvee) => {
         const { caracteristiquesComplementaires = {} } = homologationTrouvee;
-        caracteristiquesComplementaires[propriete] = nom;
+        caracteristiquesComplementaires.structureDeveloppement = nom;
         return metsAJourProprieteHomologation(
           'caracteristiquesComplementaires',
           homologationTrouvee,
@@ -137,10 +137,6 @@ const creeDepot = (config = {}) => {
         );
       })
   );
-
-  const ajouteStructureDeveloppementAHomologation = ajouteAuxCaracteristiquesComplementaires('structureDeveloppement');
-
-  const ajouteHebergementAHomologation = ajouteAuxCaracteristiquesComplementaires('hebergeur');
 
   const ajoutePartiesPrenantesAHomologation = (...params) => {
     const [idHomologation, partiesPrenantes] = params;
@@ -342,7 +338,6 @@ const creeDepot = (config = {}) => {
     ajouteCaracteristiquesAHomologation,
     ajouteContributeurAHomologation,
     ajouteDescriptionServiceAHomologation,
-    ajouteHebergementAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajoutePartiesPrenantesSpecifiquesAHomologation,

--- a/src/modeles/caracteristiquesComplementaires.js
+++ b/src/modeles/caracteristiquesComplementaires.js
@@ -5,16 +5,12 @@ const Referentiel = require('../referentiel');
 class CaracteristiquesComplementaires extends InformationsHomologation {
   constructor(donneesCaracteristiques = {}, referentiel = Referentiel.creeReferentielVide()) {
     super({
-      proprietesAtomiquesFacultatives: ['hebergeur', 'structureDeveloppement'],
+      proprietesAtomiquesFacultatives: ['structureDeveloppement'],
       listesAgregats: { entitesExternes: EntitesExternes },
     });
     this.renseigneProprietes(donneesCaracteristiques);
 
     this.referentiel = referentiel;
-  }
-
-  descriptionHebergeur() {
-    return this.hebergeur || 'Hébergeur non renseigné';
   }
 
   nombreEntitesExternes() {

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -81,7 +81,7 @@ class Homologation {
 
   fonctionAutoriteHomologation() { return this.partiesPrenantes.fonctionAutoriteHomologation; }
 
-  hebergeur() { return this.caracteristiquesComplementaires.descriptionHebergeur(); }
+  hebergeur() { return this.partiesPrenantes.descriptionHebergeur(); }
 
   localisationDonnees() {
     return this.descriptionService.descriptionLocalisationDonnees();

--- a/src/modeles/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes.js
@@ -59,6 +59,10 @@ class PartiesPrenantes extends InformationsHomologation {
       this.delegueProtectionDonnees, this.fonctionDelegueProtectionDonnees
     );
   }
+
+  descriptionHebergeur() {
+    return this.partiesPrenantes.hebergement()?.nom || 'Hébergeur non renseigné';
+  }
 }
 
 module.exports = PartiesPrenantes;

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -153,14 +153,12 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
     ]),
     (requete, reponse) => {
       const partiesPrenantes = new PartiesPrenantes(requete.body);
-      const nomHebergement = partiesPrenantes.partiesPrenantes?.hebergement()?.nom;
       const nomStructureDeveloppement = partiesPrenantes
         .partiesPrenantes?.developpementFourniture()?.nom;
       const idHomologation = requete.homologation.id;
-      depotDonnees.ajouteHebergementAHomologation(requete.homologation.id, nomHebergement)
-        .then(() => depotDonnees.ajouteStructureDeveloppementAHomologation(
-          requete.homologation.id, nomStructureDeveloppement
-        ))
+      depotDonnees.ajouteStructureDeveloppementAHomologation(
+        requete.homologation.id, nomStructureDeveloppement
+      )
         .then(() => depotDonnees.ajoutePartiesPrenantesAHomologation(
           idHomologation, partiesPrenantes
         ))

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -325,7 +325,7 @@ describe('Le dépôt de données persistées en mémoire', () => {
       homologations: [{
         id: '123',
         descriptionService: { nomService: 'nom' },
-        caracteristiquesComplementaires: { hebergeur: 'Un hébergeur' },
+        caracteristiquesComplementaires: { entitesExternes: [] },
       }],
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
@@ -336,7 +336,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
     depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.hebergeur).to.equal('Un hébergeur');
         expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
         done();
       })
@@ -456,24 +455,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .then(({ rolesResponsabilites }) => {
         expect(rolesResponsabilites).to.be.ok();
         expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean Dupont');
-        done();
-      })
-      .catch(done);
-  });
-
-  it("met à jour les caractéristiques complémentaires avec l'hébergeur", (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteHebergementAHomologation('123', 'Un hébergeur')
-      .then(() => depot.homologation('123'))
-      .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.hebergeur).to.equal('Un hébergeur');
         done();
       })
       .catch(done);

--- a/test/modeles/caracteristiquesComplementaires.spec.js
+++ b/test/modeles/caracteristiquesComplementaires.spec.js
@@ -7,41 +7,32 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
   it('connaît ses constituants', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
       structureDeveloppement: 'Une structure',
-      hebergeur: 'Un hébergeur',
       entitesExternes: [{ nom: 'Un nom' }],
     });
 
     expect(caracteristiques.structureDeveloppement).to.equal('Une structure');
-    expect(caracteristiques.hebergeur).to.equal('Un hébergeur');
     expect(caracteristiques.nombreEntitesExternes()).to.equal(1);
-  });
-
-  it("retourne une valeur d'hébergeur par défaut", () => {
-    const caracteristiques = new CaracteristiquesComplementaires();
-    expect(caracteristiques.descriptionHebergeur()).to.equal('Hébergeur non renseigné');
   });
 
   it('sait se présenter au format JSON', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
       structureDeveloppement: 'Une structure',
-      hebergeur: 'Un hébergeur',
       entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
     });
 
     expect(caracteristiques.toJSON()).to.eql({
       structureDeveloppement: 'Une structure',
-      hebergeur: 'Un hébergeur',
       entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
     });
   });
 
   it('presente un JSON partiel si certaines caractéristiques ne sont pas définies', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
-      hebergeur: 'ovh',
+      structureDeveloppement: 'Une structure',
     });
 
     expect(caracteristiques.toJSON()).to.eql({
-      hebergeur: 'ovh',
+      structureDeveloppement: 'Une structure',
       entitesExternes: [],
     });
   });
@@ -68,7 +59,6 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
       it('a pour statut COMPLETES si tous les autres champs sont remplis', () => {
         const caracteristiques = new CaracteristiquesComplementaires({
           structureDeveloppement: 'Une structure',
-          hebergeur: 'Un hébergeur',
           entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
         });
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -73,7 +73,6 @@ describe('Une homologation', () => {
       id: '123',
       caracteristiquesComplementaires: {
         structureDeveloppement: 'Une structure',
-        hebergeur: 'Un hébergeur',
       },
       descriptionService: {
         localisationDonnees: 'france',
@@ -83,7 +82,6 @@ describe('Une homologation', () => {
 
     expect(homologation.presentation()).to.equal('Une présentation');
     expect(homologation.structureDeveloppement()).to.equal('Une structure');
-    expect(homologation.hebergeur()).to.equal('Un hébergeur');
     expect(homologation.localisationDonnees()).to.equal('Quelque part en France');
   });
 
@@ -96,6 +94,9 @@ describe('Une homologation', () => {
         delegueProtectionDonnees: 'Rémi Fassol',
         piloteProjet: 'Sylvie Martin',
         expertCybersecurite: 'Anna Dubreuil',
+        partiesPrenantes: [
+          { type: 'Hebergement', nom: 'Hébergeur' },
+        ],
       },
     });
 
@@ -104,6 +105,7 @@ describe('Une homologation', () => {
     expect(homologation.delegueProtectionDonnees()).to.equal('Rémi Fassol');
     expect(homologation.piloteProjet()).to.equal('Sylvie Martin');
     expect(homologation.expertCybersecurite()).to.equal('Anna Dubreuil');
+    expect(homologation.hebergeur()).to.equal('Hébergeur');
   });
 
   it('connaît ses risques spécifiques', () => {

--- a/test/modeles/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes.spec.js
@@ -136,6 +136,20 @@ describe("L'ensemble des parties prenantes", () => {
     expect(partiesPrenantes.descriptionDelegueProtectionDonnees()).to.equal('Jean Dupont (DSI)');
   });
 
+  describe("sur une demande de description de l'hébergeur", () => {
+    it("présente le nom de l'hébergement", () => {
+      const partiesPrenantes = new PartiesPrenantes({ partiesPrenantes: [{ type: 'Hebergement', nom: 'Un hébergeur' }] });
+
+      expect(partiesPrenantes.descriptionHebergeur()).to.equal('Un hébergeur');
+    });
+
+    it("retourne une valeur par défaut lorsque l'hébergement n'est pas présent", () => {
+      const partiesPrenantes = new PartiesPrenantes();
+
+      expect(partiesPrenantes.descriptionHebergeur()).to.equal('Hébergeur non renseigné');
+    });
+  });
+
   it('détermine le statut de saisie', () => {
     const partiesPrenantes = new PartiesPrenantes();
     expect(partiesPrenantes.statutSaisie()).to.equal(InformationsHomologation.A_SAISIR);

--- a/test/routes/routesApiHomologation.spec.js
+++ b/test/routes/routesApiHomologation.spec.js
@@ -221,14 +221,14 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       testeur.depotDonnees().ajouteCaracteristiquesAHomologation = (
         (idHomologation, caracteristiques) => new Promise((resolve) => {
           expect(idHomologation).to.equal('456');
-          expect(caracteristiques.hebergeur).to.equal('Un hébergeur');
+          expect(caracteristiques.structureDeveloppement).to.equal('Une structure');
           caracteristiquesAjoutees = true;
           resolve();
         })
       );
 
       axios.post('http://localhost:1234/api/homologation/456/caracteristiquesComplementaires', {
-        hebergeur: 'Un hébergeur',
+        structureDeveloppement: 'Une structure',
       })
         .then((reponse) => {
           expect(caracteristiquesAjoutees).to.be(true);
@@ -390,7 +390,6 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
   describe('quand requête POST sur `/api/homologation/:id/partiesPrenantes`', () => {
     beforeEach(() => {
       testeur.depotDonnees().ajoutePartiesPrenantesAHomologation = () => Promise.resolve();
-      testeur.depotDonnees().ajouteHebergementAHomologation = () => Promise.resolve();
       testeur.depotDonnees().ajouteStructureDeveloppementAHomologation = () => Promise.resolve();
     });
 
@@ -427,30 +426,6 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {})
         .then(() => {
           testeur.middleware().verifieAseptisationListe('acteursHomologation', ['role', 'nom', 'fonction']);
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt d'ajouter l'hébergement dans les caractéristiques complémentaires", (done) => {
-      let hebergeurAjoute = false;
-
-      testeur.depotDonnees().ajouteHebergementAHomologation = (
-        (idHomologation, nomHebergeur) => new Promise((resolve) => {
-          expect(idHomologation).to.equal('456');
-          expect(nomHebergeur).to.equal('Un hébergeur');
-          hebergeurAjoute = true;
-          resolve();
-        })
-      );
-
-      axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {
-        partiesPrenantes: [{ type: 'Hebergement', nom: 'Un hébergeur' }],
-      })
-        .then((reponse) => {
-          expect(hebergeurAjoute).to.be(true);
-          expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.eql({ idHomologation: '456' });
           done();
         })
         .catch(done);


### PR DESCRIPTION
Comme l'hébergeur n'est plus affiché dans la page caractéristiques complémentaires,
il peut être supprimé dans le modèle

- changement de l'appel pour l'affichage dans le document de synthèse