### PR TITLE
Erreur dans la récupération des paramètres de la sécurité du service

### DIFF
--- a/public/homologation/partiesPrenantes.js
+++ b/public/homologation/partiesPrenantes.js
@@ -7,7 +7,7 @@ const tousLesParametres = (selecteurFormulaire) => {
   modifieParametresAvecItemsExtraits(
     params, 'acteursHomologation', '^(role|nom|fonction)-acteur-homologation-'
   );
-  ['developpementFourniture', 'hebergement', 'maintenanceService'].forEach(
+  ['developpementFourniture', 'hebergement', 'maintenanceService', 'securiteService'].forEach(
     (identifiant) => modifieParametresGroupementElements(params, 'partiesPrenantes', identifiant)
   );
   return params;


### PR DESCRIPTION
Dans la page parties prenantes onglet parties prenantes,
Quand on renseigne la sécurité du service
L'information n'est pas prise en compte

- les paramètres ne sont pas bien ajustés avant la requête
- surement causé par un rebase trop rapide