### PR TITLE
Suppression dans le modèle de la structure de développement

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -14,7 +14,6 @@ const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
 const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
-const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 const Homologation = require('./modeles/homologation');
 const RolesResponsabilites = require('./modeles/rolesResponsabilites');
 const Utilisateur = require('./modeles/utilisateur');
@@ -123,19 +122,6 @@ const creeDepot = (config = {}) => {
 
   const ajouteCaracteristiquesAHomologation = (...params) => (
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
-  );
-
-  const ajouteStructureDeveloppementAHomologation = (idHomologation, nom) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((homologationTrouvee) => {
-        const { caracteristiquesComplementaires = {} } = homologationTrouvee;
-        caracteristiquesComplementaires.structureDeveloppement = nom;
-        return metsAJourProprieteHomologation(
-          'caracteristiquesComplementaires',
-          homologationTrouvee,
-          new CaracteristiquesComplementaires(caracteristiquesComplementaires, referentiel)
-        );
-      })
   );
 
   const ajoutePartiesPrenantesAHomologation = (...params) => {
@@ -342,7 +328,6 @@ const creeDepot = (config = {}) => {
     ajoutePartiesPrenantesAHomologation,
     ajoutePartiesPrenantesSpecifiquesAHomologation,
     ajouteRisqueGeneralAHomologation,
-    ajouteStructureDeveloppementAHomologation,
     autorisation,
     autorisationExiste,
     autorisationPour,

--- a/src/modeles/caracteristiquesComplementaires.js
+++ b/src/modeles/caracteristiquesComplementaires.js
@@ -4,10 +4,7 @@ const Referentiel = require('../referentiel');
 
 class CaracteristiquesComplementaires extends InformationsHomologation {
   constructor(donneesCaracteristiques = {}, referentiel = Referentiel.creeReferentielVide()) {
-    super({
-      proprietesAtomiquesFacultatives: ['structureDeveloppement'],
-      listesAgregats: { entitesExternes: EntitesExternes },
-    });
+    super({ listesAgregats: { entitesExternes: EntitesExternes } });
     this.renseigneProprietes(donneesCaracteristiques);
 
     this.referentiel = referentiel;

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -111,7 +111,9 @@ class Homologation {
     return this[nomInformationsHomologation].statutSaisie();
   }
 
-  structureDeveloppement() { return this.caracteristiquesComplementaires.structureDeveloppement; }
+  structureDeveloppement() {
+    return this.partiesPrenantes.descriptionStructureDeveloppement();
+  }
 
   toJSON() {
     return {

--- a/src/modeles/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes.js
@@ -63,6 +63,10 @@ class PartiesPrenantes extends InformationsHomologation {
   descriptionHebergeur() {
     return this.partiesPrenantes.hebergement()?.nom || 'Hébergeur non renseigné';
   }
+
+  descriptionStructureDeveloppement() {
+    return this.partiesPrenantes.developpementFourniture()?.nom || '';
+  }
 }
 
 module.exports = PartiesPrenantes;

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -153,15 +153,8 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
     ]),
     (requete, reponse) => {
       const partiesPrenantes = new PartiesPrenantes(requete.body);
-      const nomStructureDeveloppement = partiesPrenantes
-        .partiesPrenantes?.developpementFourniture()?.nom;
       const idHomologation = requete.homologation.id;
-      depotDonnees.ajouteStructureDeveloppementAHomologation(
-        requete.homologation.id, nomStructureDeveloppement
-      )
-        .then(() => depotDonnees.ajoutePartiesPrenantesAHomologation(
-          idHomologation, partiesPrenantes
-        ))
+      depotDonnees.ajoutePartiesPrenantesAHomologation(idHomologation, partiesPrenantes)
         .then(() => reponse.send({ idHomologation }));
     });
 

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -308,13 +308,13 @@ describe('Le dépôt de données persistées en mémoire', () => {
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
     const caracteristiques = new CaracteristiquesComplementaires({
-      structureDeveloppement: 'Une structure',
+      entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
     });
 
     depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
+        expect(caracteristiquesComplementaires.entitesExternes.item(0).nom).to.equal('Un nom');
         done();
       })
       .catch(done);
@@ -331,12 +331,13 @@ describe('Le dépôt de données persistées en mémoire', () => {
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
     const caracteristiques = new CaracteristiquesComplementaires({
-      structureDeveloppement: 'Une structure',
+      entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
     });
     depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
+        expect(caracteristiquesComplementaires.entitesExternes.item(0).nom).to.equal('Un nom');
+        expect(caracteristiquesComplementaires.entitesExternes.item(0).contact).to.equal('Une adresse');
         done();
       })
       .catch(done);
@@ -455,24 +456,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .then(({ rolesResponsabilites }) => {
         expect(rolesResponsabilites).to.be.ok();
         expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean Dupont');
-        done();
-      })
-      .catch(done);
-  });
-
-  it('met à jour les caractéristiques complémentaires avec la structure du service', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteStructureDeveloppementAHomologation('123', 'Une structure')
-      .then(() => depot.homologation('123'))
-      .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.structureDeveloppement).to.equal('Une structure');
         done();
       })
       .catch(done);

--- a/test/modeles/caracteristiquesComplementaires.spec.js
+++ b/test/modeles/caracteristiquesComplementaires.spec.js
@@ -6,34 +6,19 @@ const InformationsHomologation = require('../../src/modeles/informationsHomologa
 describe("L'ensemble des caractéristiques complémentaires", () => {
   it('connaît ses constituants', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
-      structureDeveloppement: 'Une structure',
       entitesExternes: [{ nom: 'Un nom' }],
     });
 
-    expect(caracteristiques.structureDeveloppement).to.equal('Une structure');
     expect(caracteristiques.nombreEntitesExternes()).to.equal(1);
   });
 
   it('sait se présenter au format JSON', () => {
     const caracteristiques = new CaracteristiquesComplementaires({
-      structureDeveloppement: 'Une structure',
       entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
     });
 
     expect(caracteristiques.toJSON()).to.eql({
-      structureDeveloppement: 'Une structure',
       entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
-    });
-  });
-
-  it('presente un JSON partiel si certaines caractéristiques ne sont pas définies', () => {
-    const caracteristiques = new CaracteristiquesComplementaires({
-      structureDeveloppement: 'Une structure',
-    });
-
-    expect(caracteristiques.toJSON()).to.eql({
-      structureDeveloppement: 'Une structure',
-      entitesExternes: [],
     });
   });
 
@@ -58,7 +43,6 @@ describe("L'ensemble des caractéristiques complémentaires", () => {
     describe('quand toutes les entités externes sont complètement saisies', () => {
       it('a pour statut COMPLETES si tous les autres champs sont remplis', () => {
         const caracteristiques = new CaracteristiquesComplementaires({
-          structureDeveloppement: 'Une structure',
           entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
         });
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -72,7 +72,7 @@ describe('Une homologation', () => {
     const homologation = new Homologation({
       id: '123',
       caracteristiquesComplementaires: {
-        structureDeveloppement: 'Une structure',
+        entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
       },
       descriptionService: {
         localisationDonnees: 'france',
@@ -81,7 +81,7 @@ describe('Une homologation', () => {
     }, referentiel);
 
     expect(homologation.presentation()).to.equal('Une présentation');
-    expect(homologation.structureDeveloppement()).to.equal('Une structure');
+    expect(homologation.caracteristiquesComplementaires.entitesExternes.item(0).nom).to.equal('Un nom');
     expect(homologation.localisationDonnees()).to.equal('Quelque part en France');
   });
 
@@ -96,6 +96,7 @@ describe('Une homologation', () => {
         expertCybersecurite: 'Anna Dubreuil',
         partiesPrenantes: [
           { type: 'Hebergement', nom: 'Hébergeur' },
+          { type: 'DeveloppementFourniture', nom: 'Une structure' },
         ],
       },
     });
@@ -106,6 +107,7 @@ describe('Une homologation', () => {
     expect(homologation.piloteProjet()).to.equal('Sylvie Martin');
     expect(homologation.expertCybersecurite()).to.equal('Anna Dubreuil');
     expect(homologation.hebergeur()).to.equal('Hébergeur');
+    expect(homologation.structureDeveloppement()).to.equal('Une structure');
   });
 
   it('connaît ses risques spécifiques', () => {

--- a/test/modeles/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes.spec.js
@@ -154,4 +154,18 @@ describe("L'ensemble des parties prenantes", () => {
     const partiesPrenantes = new PartiesPrenantes();
     expect(partiesPrenantes.statutSaisie()).to.equal(InformationsHomologation.A_SAISIR);
   });
+
+  describe('sur une demande de description de la structure ayant réalisé le développement', () => {
+    it('présente le nom de la structure', () => {
+      const partiesPrenantes = new PartiesPrenantes({ partiesPrenantes: [{ type: 'DeveloppementFourniture', nom: 'Une structure' }] });
+
+      expect(partiesPrenantes.descriptionStructureDeveloppement()).to.equal('Une structure');
+    });
+
+    it("reste robuste lorsque la structure n'est pas présent", () => {
+      const partiesPrenantes = new PartiesPrenantes();
+
+      expect(partiesPrenantes.descriptionStructureDeveloppement()).to.equal('');
+    });
+  });
 });

--- a/test/routes/routesApiHomologation.spec.js
+++ b/test/routes/routesApiHomologation.spec.js
@@ -221,14 +221,16 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       testeur.depotDonnees().ajouteCaracteristiquesAHomologation = (
         (idHomologation, caracteristiques) => new Promise((resolve) => {
           expect(idHomologation).to.equal('456');
-          expect(caracteristiques.structureDeveloppement).to.equal('Une structure');
+          expect(caracteristiques.entitesExternes.item(0).nom).to.equal('nom');
+          expect(caracteristiques.entitesExternes.item(0).acces).to.equal('acces');
+          expect(caracteristiques.entitesExternes.item(0).contact).to.equal('contact');
           caracteristiquesAjoutees = true;
           resolve();
         })
       );
 
       axios.post('http://localhost:1234/api/homologation/456/caracteristiquesComplementaires', {
-        structureDeveloppement: 'Une structure',
+        entitesExternes: [{ nom: 'nom', acces: 'acces', contact: 'contact' }],
       })
         .then((reponse) => {
           expect(caracteristiquesAjoutees).to.be(true);
@@ -390,7 +392,6 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
   describe('quand requête POST sur `/api/homologation/:id/partiesPrenantes`', () => {
     beforeEach(() => {
       testeur.depotDonnees().ajoutePartiesPrenantesAHomologation = () => Promise.resolve();
-      testeur.depotDonnees().ajouteStructureDeveloppementAHomologation = () => Promise.resolve();
     });
 
     it("recherche l'homologation correspondante", (done) => {
@@ -426,30 +427,6 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {})
         .then(() => {
           testeur.middleware().verifieAseptisationListe('acteursHomologation', ['role', 'nom', 'fonction']);
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt d'ajouter le développement du service dans les caractéristiques complémentaires", (done) => {
-      let structureDeveloppementAjoutee = false;
-
-      testeur.depotDonnees().ajouteStructureDeveloppementAHomologation = (
-        (idHomologation, nomStructureDeveloppement) => new Promise((resolve) => {
-          expect(idHomologation).to.equal('456');
-          expect(nomStructureDeveloppement).to.equal('Une structure');
-          structureDeveloppementAjoutee = true;
-          resolve();
-        })
-      );
-
-      axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {
-        partiesPrenantes: [{ type: 'DeveloppementFourniture', nom: 'Une structure' }],
-      })
-        .then((reponse) => {
-          expect(structureDeveloppementAjoutee).to.be(true);
-          expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.eql({ idHomologation: '456' });
           done();
         })
         .catch(done);


### PR DESCRIPTION
La structure du développement qui se trouvait dans les caractéristiques complémentaires est maintenant disponible dans la partie prenante développement / fourniture
Donc le code dans les caractéristiques complémentaires est devenu inutile