### PR TITLE
Suppression des entités externes dans le modèle

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -17,7 +17,6 @@ const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisati
 const Homologation = require('./modeles/homologation');
 const RolesResponsabilites = require('./modeles/rolesResponsabilites');
 const Utilisateur = require('./modeles/utilisateur');
-const CaracteristiquesComplementaires = require('./modeles/caracteristiquesComplementaires');
 
 const creeDepot = (config = {}) => {
   const {
@@ -121,19 +120,6 @@ const creeDepot = (config = {}) => {
 
   const ajouteCaracteristiquesAHomologation = (...params) => (
     metsAJourProprieteHomologation('caracteristiquesComplementaires', ...params)
-  );
-
-  const ajouteEntitesExternesAHomologation = (idHomologation, donnees) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((homologationTrouvee) => {
-        const { caracteristiquesComplementaires = {} } = homologationTrouvee;
-        caracteristiquesComplementaires.entitesExternes = donnees;
-        return metsAJourProprieteHomologation(
-          'caracteristiquesComplementaires',
-          homologationTrouvee,
-          new CaracteristiquesComplementaires(caracteristiquesComplementaires, referentiel)
-        );
-      })
   );
 
   const ajoutePartiesPrenantesAHomologation = (...params) => {
@@ -325,7 +311,6 @@ const creeDepot = (config = {}) => {
     ajouteCaracteristiquesAHomologation,
     ajouteContributeurAHomologation,
     ajouteDescriptionServiceAHomologation,
-    ajouteEntitesExternesAHomologation,
     ajouteMesureGeneraleAHomologation,
     ajoutePartiesPrenantesAHomologation,
     ajouteRisqueGeneralAHomologation,

--- a/src/modeles/caracteristiquesComplementaires.js
+++ b/src/modeles/caracteristiquesComplementaires.js
@@ -1,17 +1,17 @@
-const EntitesExternes = require('./entitesExternes');
 const InformationsHomologation = require('./informationsHomologation');
 const Referentiel = require('../referentiel');
 
 class CaracteristiquesComplementaires extends InformationsHomologation {
   constructor(donneesCaracteristiques = {}, referentiel = Referentiel.creeReferentielVide()) {
-    super({ listesAgregats: { entitesExternes: EntitesExternes } });
+    super();
     this.renseigneProprietes(donneesCaracteristiques);
 
     this.referentiel = referentiel;
   }
 
-  nombreEntitesExternes() {
-    return this.entitesExternes.nombre();
+  /* eslint-disable class-methods-use-this */
+  statutSaisie() {
+    return InformationsHomologation.COMPLETES;
   }
 }
 

--- a/src/modeles/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes.js
@@ -67,14 +67,6 @@ class PartiesPrenantes extends InformationsHomologation {
   descriptionStructureDeveloppement() {
     return this.partiesPrenantes.developpementFourniture()?.nom || '';
   }
-
-  entitesExternes() {
-    return this.partiesPrenantes.specifiques().map((specifique) => ({
-      nom: specifique.nom,
-      acces: specifique.natureAcces,
-      contact: specifique.pointContact,
-    }));
-  }
 }
 
 module.exports = PartiesPrenantes;

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -147,13 +147,9 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
     (requete, reponse) => {
       const partiesPrenantes = new PartiesPrenantes(requete.body);
       const idHomologation = requete.homologation.id;
-      depotDonnees.ajouteEntitesExternesAHomologation(
-        idHomologation, partiesPrenantes.entitesExternes()
-      )
-        .then(() => depotDonnees.ajoutePartiesPrenantesAHomologation(
-          idHomologation, partiesPrenantes
-        ))
-        .then(() => reponse.send({ idHomologation }));
+      depotDonnees.ajoutePartiesPrenantesAHomologation(
+        idHomologation, partiesPrenantes
+      ).then(() => reponse.send({ idHomologation }));
     });
 
   routes.post('/:id/risques', middleware.trouveHomologation, middleware.aseptise(

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -313,37 +313,12 @@ describe('Le dépôt de données persistées en mémoire', () => {
     });
     const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
 
-    const caracteristiques = new CaracteristiquesComplementaires({
-      entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
-    });
+    const caracteristiques = new CaracteristiquesComplementaires({});
 
     depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
       .then(() => depot.homologation('123'))
       .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.entitesExternes.item(0).nom).to.equal('Un nom');
-        done();
-      })
-      .catch(done);
-  });
-
-  it("met à jour les caractéristiques si elles existent déjà pour l'homologation", (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-        caracteristiquesComplementaires: { entitesExternes: [] },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    const caracteristiques = new CaracteristiquesComplementaires({
-      entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
-    });
-    depot.ajouteCaracteristiquesAHomologation('123', caracteristiques)
-      .then(() => depot.homologation('123'))
-      .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.entitesExternes.item(0).nom).to.equal('Un nom');
-        expect(caracteristiquesComplementaires.entitesExternes.item(0).contact).to.equal('Une adresse');
+        expect(caracteristiquesComplementaires).to.be.ok();
         done();
       })
       .catch(done);
@@ -382,26 +357,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .then(({ rolesResponsabilites }) => {
         expect(rolesResponsabilites).to.be.ok();
         expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean Dupont');
-        done();
-      })
-      .catch(done);
-  });
-
-  it('met à jour les caractéristiques complémentaires avec les entités externes', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    depot.ajouteEntitesExternesAHomologation('123', [{ nom: 'Un nom', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }])
-      .then(() => depot.homologation('123'))
-      .then(({ caracteristiquesComplementaires }) => {
-        expect(caracteristiquesComplementaires.entitesExternes.item(0).nom).to.equal('Un nom');
-        expect(caracteristiquesComplementaires.entitesExternes.item(0).contact).to.equal('jean.dupont@mail.fr');
-        expect(caracteristiquesComplementaires.entitesExternes.item(0).acces).to.equal('Accès administrateur');
         done();
       })
       .catch(done);

--- a/test/modeles/caracteristiquesComplementaires.spec.js
+++ b/test/modeles/caracteristiquesComplementaires.spec.js
@@ -4,58 +4,11 @@ const CaracteristiquesComplementaires = require('../../src/modeles/caracteristiq
 const InformationsHomologation = require('../../src/modeles/informationsHomologation');
 
 describe("L'ensemble des caractéristiques complémentaires", () => {
-  it('connaît ses constituants', () => {
-    const caracteristiques = new CaracteristiquesComplementaires({
-      entitesExternes: [{ nom: 'Un nom' }],
-    });
-
-    expect(caracteristiques.nombreEntitesExternes()).to.equal(1);
-  });
-
-  it('sait se présenter au format JSON', () => {
-    const caracteristiques = new CaracteristiquesComplementaires({
-      entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
-    });
-
-    expect(caracteristiques.toJSON()).to.eql({
-      entitesExternes: [{ nom: 'Une entité', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }],
-    });
-  });
-
   describe('sur demande du statut de saisie', () => {
-    describe("quand aucune entité externe n'a été saisie", () => {
-      it('détermine le statut de saisie de manière standard', () => {
-        const caracteristiques = new CaracteristiquesComplementaires({});
-        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.A_SAISIR);
-      });
-    });
+    it('a pour statut COMPLETES', () => {
+      const caracteristiques = new CaracteristiquesComplementaires({});
 
-    describe("quand au moins une entité externe n'a été que partiellement saisie", () => {
-      it('a pour statut de saisie A_COMPLETER', () => {
-        const caracteristiques = new CaracteristiquesComplementaires({
-          entitesExternes: [{ nom: 'Un nom, mais pas de contact' }],
-        });
-
-        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.A_COMPLETER);
-      });
-    });
-
-    describe('quand toutes les entités externes sont complètement saisies', () => {
-      it('a pour statut COMPLETES si tous les autres champs sont remplis', () => {
-        const caracteristiques = new CaracteristiquesComplementaires({
-          entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
-        });
-
-        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
-      });
-
-      it('a pour statut COMPLETES même si les autres champs ne sont pas saisis', () => {
-        const caracteristiques = new CaracteristiquesComplementaires({
-          entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
-        });
-
-        expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
-      });
+      expect(caracteristiques.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
     });
   });
 });

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -82,9 +82,7 @@ describe('Une homologation', () => {
     });
     const homologation = new Homologation({
       id: '123',
-      caracteristiquesComplementaires: {
-        entitesExternes: [{ nom: 'Un nom', contact: 'Une adresse' }],
-      },
+      caracteristiquesComplementaires: {},
       descriptionService: {
         localisationDonnees: 'france',
         presentation: 'Une présentation',
@@ -92,7 +90,7 @@ describe('Une homologation', () => {
     }, referentiel);
 
     expect(homologation.presentation()).to.equal('Une présentation');
-    expect(homologation.caracteristiquesComplementaires.entitesExternes.item(0).nom).to.equal('Un nom');
+    expect(homologation.caracteristiquesComplementaires).to.be.ok();
     expect(homologation.localisationDonnees()).to.equal('Quelque part en France');
   });
 

--- a/test/modeles/partiesPrenantes.spec.js
+++ b/test/modeles/partiesPrenantes.spec.js
@@ -150,16 +150,6 @@ describe("L'ensemble des parties prenantes", () => {
     });
   });
 
-  it('présente les entités externes', () => {
-    const partiesPrenantes = new PartiesPrenantes({
-      partiesPrenantes: [
-        { type: 'PartiePrenanteSpecifique', nom: 'Un nom', natureAcces: 'un accès', pointContact: 'un contact' },
-      ],
-    });
-
-    expect(partiesPrenantes.entitesExternes()).to.eql([{ nom: 'Un nom', acces: 'un accès', contact: 'un contact' }]);
-  });
-
   it('détermine le statut de saisie', () => {
     const partiesPrenantes = new PartiesPrenantes();
     expect(partiesPrenantes.statutSaisie()).to.equal(InformationsHomologation.A_SAISIR);

--- a/test/routes/routesApiHomologation.spec.js
+++ b/test/routes/routesApiHomologation.spec.js
@@ -208,17 +208,13 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       testeur.depotDonnees().ajouteCaracteristiquesAHomologation = (
         (idHomologation, caracteristiques) => new Promise((resolve) => {
           expect(idHomologation).to.equal('456');
-          expect(caracteristiques.entitesExternes.item(0).nom).to.equal('nom');
-          expect(caracteristiques.entitesExternes.item(0).acces).to.equal('acces');
-          expect(caracteristiques.entitesExternes.item(0).contact).to.equal('contact');
+          expect(caracteristiques).to.be.ok();
           caracteristiquesAjoutees = true;
           resolve();
         })
       );
 
-      axios.post('http://localhost:1234/api/homologation/456/caracteristiquesComplementaires', {
-        entitesExternes: [{ nom: 'nom', acces: 'acces', contact: 'contact' }],
-      })
+      axios.post('http://localhost:1234/api/homologation/456/caracteristiquesComplementaires', {})
         .then((reponse) => {
           expect(caracteristiquesAjoutees).to.be(true);
           expect(reponse.status).to.equal(200);
@@ -376,30 +372,6 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {})
         .then(() => {
           testeur.middleware().verifieAseptisationListe('partiesPrenantes', ['nom', 'natureAcces', 'pointContact']);
-          done();
-        })
-        .catch(done);
-    });
-
-    it("demande au dépôt d'ajouter les entités externes dans les caractéristiques complémentaires", (done) => {
-      let entitesExternesAjoutee = false;
-
-      testeur.depotDonnees().ajouteEntitesExternesAHomologation = (
-        (idHomologation, entitesExternes) => new Promise((resolve) => {
-          expect(idHomologation).to.equal('456');
-          expect(entitesExternes).to.eql([{ nom: 'Un nom', contact: 'jean.dupont@mail.fr', acces: 'Accès administrateur' }]);
-          entitesExternesAjoutee = true;
-          resolve();
-        })
-      );
-
-      axios.post('http://localhost:1234/api/homologation/456/partiesPrenantes', {
-        partiesPrenantes: [{ type: 'PartiePrenanteSpecifique', nom: 'Un nom', pointContact: 'jean.dupont@mail.fr', natureAcces: 'Accès administrateur' }],
-      })
-        .then((reponse) => {
-          expect(entitesExternesAjoutee).to.be(true);
-          expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.eql({ idHomologation: '456' });
           done();
         })
         .catch(done);


### PR DESCRIPTION
Comme les entités externes on été déplacé en parties prenantes spécifiques dans la page rôles et responsabilités, nous pouvons les supprimer du modèle