### PR TITLE
Copie des parties prenantes en roles et responsabilités

### DIFF
--- a/migrations/20220315083635_ecraseRolesResponsabilitesAvecPartiesPrenantes.js
+++ b/migrations/20220315083635_ecraseRolesResponsabilitesAvecPartiesPrenantes.js
@@ -1,0 +1,13 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.partiesPrenantes)
+      .map(({ id, donnees: { partiesPrenantes, rolesResponsabilites, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: {
+          partiesPrenantes, rolesResponsabilites: partiesPrenantes, ...autresDonnees,
+        } }));
+    return Promise.all(misesAJour);
+  });
+
+exports.down = () => {};


### PR DESCRIPTION
Les parties prenantes spécifiques n'ont pas été copiées lors de la première migration et n'étaient pas écrites dans les rôles et responsabilités du temps des caractéristiques complémentaires.
Une nouvelle copie remettra tout à jour