### PR TITLE
Suppression des entités externes dans les données

### DIFF
--- a/migrations/20220316133022_supprimeColonneEntitesExternes.js
+++ b/migrations/20220316133022_supprimeColonneEntitesExternes.js
@@ -1,0 +1,43 @@
+const miseAJour = (contientDonneesCiblees, actionMiseAJour) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(contientDonneesCiblees)
+      .map(({ id, donnees }) => {
+        const donneesModifiees = actionMiseAJour(donnees);
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: donneesModifiees });
+      });
+    return Promise.all(misesAJour);
+  });
+
+const contientCaracteristiquesComplementaires = ({ donnees }) => (
+  donnees?.caracteristiquesComplementaires
+);
+
+const supprimeEntitesExternes = (donnees) => {
+  delete donnees.caracteristiquesComplementaires.entitesExternes;
+
+  return donnees;
+};
+
+const contientRolesResponsabilites = ({ donnees }) => donnees?.rolesResponsabilites;
+
+const copieEntitesExternes = (donnees) => {
+  donnees.caracteristiquesComplementaires ||= {};
+  donnees.caracteristiquesComplementaires.entitesExternes = donnees
+    .rolesResponsabilites
+    ?.partiesPrenantes
+    ?.filter((partiePrenante) => partiePrenante.type === 'PartiePrenanteSpecifique')
+    ?.map((partiePrenanteSpecifique) => ({
+      nom: partiePrenanteSpecifique.nom,
+      acces: partiePrenanteSpecifique.natureAcces,
+      contact: partiePrenanteSpecifique.pointContact,
+    }));
+
+  return donnees;
+};
+
+exports.up = miseAJour(contientCaracteristiquesComplementaires, supprimeEntitesExternes);
+
+exports.down = miseAJour(contientRolesResponsabilites, copieEntitesExternes);


### PR DESCRIPTION
Après le déplacement des entités externes dans les parties prenantes et la suppression dans le modèle,
nous pouvons supprimer les entités externes des données