### PR TITLE
Détecte les paramètres de fonction déclarés et inutilisés

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,9 +17,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 12,
   },
-  plugins: [
-    'mocha',
-  ],
+  plugins: ['mocha'],
   rules: {
     'comma-dangle': ['error', {
       arrays: 'always-multiline',
@@ -31,6 +29,10 @@ module.exports = {
     'mocha/no-exclusive-tests': 'error',
     'no-param-reassign': ['error', { props: false }],
     'no-return-assign': ['error', 'except-parens'],
+    'no-unused-vars': ['error', {
+      args: 'all',
+      argsIgnorePattern: '^_',
+    }],
     'object-curly-newline': ['error', {
       ObjectExpression: { consistent: true },
       ObjectPattern: { consistent: true },

--- a/migrations/20211013203941_ajoutColonneRisquesGenerauxAHomologations.js
+++ b/migrations/20211013203941_ajoutColonneRisquesGenerauxAHomologations.js
@@ -13,7 +13,7 @@ exports.down = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees.risquesGeneraux)
-      .map(({ id, donnees: { risques, risquesGeneraux, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { risques: _, risquesGeneraux, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { risques: risquesGeneraux, ...autresDonnees } }));
 

--- a/migrations/20211021200444_supprimeColonneRisquesDeHomologations.js
+++ b/migrations/20211021200444_supprimeColonneRisquesDeHomologations.js
@@ -1,7 +1,7 @@
 exports.up = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
-      .map(({ id, donnees: { risques, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { risques: _, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { ...autresDonnees } }));
 

--- a/migrations/20211022131727_ajoutColonneMesuresGeneralesAHomologations.js.js
+++ b/migrations/20211022131727_ajoutColonneMesuresGeneralesAHomologations.js.js
@@ -13,7 +13,7 @@ exports.down = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees.mesuresGenerales)
-      .map(({ id, donnees: { mesures, mesuresGenerales, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { mesures: _, mesuresGenerales, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { mesures: mesuresGenerales, ...autresDonnees } }));
 

--- a/migrations/20211031201722_supprimeColonneMesuresDeHomologations.js
+++ b/migrations/20211031201722_supprimeColonneMesuresDeHomologations.js
@@ -1,7 +1,7 @@
 exports.up = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
-      .map(({ id, donnees: { mesures, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { mesures: _, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { ...autresDonnees } }));
 

--- a/migrations/20220110160004_dupliqueInformationsGeneralesDansDescriptionService.js
+++ b/migrations/20220110160004_dupliqueInformationsGeneralesDansDescriptionService.js
@@ -14,7 +14,7 @@ exports.down = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees.descriptionService)
-      .map(({ id, donnees: { descriptionService, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { descriptionService: _, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { ...autresDonnees } }));
     return Promise.all(misesAJour);

--- a/migrations/20220118162341_suppressionColonneHomologationsIdUtilisateur.js
+++ b/migrations/20220118162341_suppressionColonneHomologationsIdUtilisateur.js
@@ -1,7 +1,7 @@
 exports.up = (knex) => knex('homologations')
   .then((lignes) => {
     const suppressions = lignes
-      .map(({ id, donnees: { idUtilisateur, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { idUtilisateur: _, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { ...autresDonnees } }));
 

--- a/migrations/20220204145444_supprimeInformationsGenerales.js
+++ b/migrations/20220204145444_supprimeInformationsGenerales.js
@@ -2,7 +2,7 @@ exports.up = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees.informationsGenerales)
-      .map(({ id, donnees: { informationsGenerales, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { informationsGenerales: _, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { ...autresDonnees } }));
     return Promise.all(misesAJour);

--- a/migrations/20220216134942_dupliquePartiesPrenantesDansRolesResponsabilites.js
+++ b/migrations/20220216134942_dupliquePartiesPrenantesDansRolesResponsabilites.js
@@ -14,7 +14,7 @@ exports.down = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees.rolesResponsabilites)
-      .map(({ id, donnees: { rolesResponsabilites, ...autresDonnees } }) => knex('homologations')
+      .map(({ id, donnees: { rolesResponsabilites: _, ...autresDonnees } }) => knex('homologations')
         .where({ id })
         .update({ donnees: { ...autresDonnees } }));
     return Promise.all(misesAJour);

--- a/migrations/20220315083635_ecraseRolesResponsabilitesAvecPartiesPrenantes.js
+++ b/migrations/20220315083635_ecraseRolesResponsabilitesAvecPartiesPrenantes.js
@@ -2,7 +2,10 @@ exports.up = (knex) => knex('homologations')
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees.partiesPrenantes)
-      .map(({ id, donnees: { partiesPrenantes, rolesResponsabilites, ...autresDonnees } }) => knex('homologations')
+      .map(({
+        id,
+        donnees: { partiesPrenantes, rolesResponsabilites: _, ...autresDonnees },
+      }) => knex('homologations')
         .where({ id })
         .update({ donnees: {
           partiesPrenantes, rolesResponsabilites: partiesPrenantes, ...autresDonnees,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -39,12 +39,12 @@ const middleware = (configuration = {}) => {
     })
     .catch(suite);
 
-  const repousseExpirationCookie = (requete, reponse, suite) => {
+  const repousseExpirationCookie = (requete, _reponse, suite) => {
     requete.session.maintenant = Math.floor(Date.now() / 60_000);
     suite();
   };
 
-  const suppressionCookie = (requete, reponse, suite) => {
+  const suppressionCookie = (requete, _reponse, suite) => {
     requete.session = null;
     suite();
   };
@@ -94,7 +94,7 @@ const middleware = (configuration = {}) => {
       .catch(() => reponse.status(422).send("L'homologation n'a pas pu être récupérée")));
   };
 
-  const aseptise = (...nomsParametres) => ((requete, reponse, suite) => {
+  const aseptise = (...nomsParametres) => ((requete, _reponse, suite) => {
     const paramsTableauxVides = Object.keys(requete.body)
       .filter((p) => (Array.isArray(requete.body[p]) && requete.body[p].length === 0));
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -38,39 +38,39 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
   app.set('view engine', 'pug');
   app.set('views', './src/vues');
 
-  app.get('/', (requete, reponse) => {
+  app.get('/', (_requete, reponse) => {
     reponse.render('index');
   });
 
-  app.get('/aPropos', (requete, reponse) => {
+  app.get('/aPropos', (_requete, reponse) => {
     reponse.render('aPropos');
   });
 
-  app.get('/cgu', (requete, reponse) => {
+  app.get('/cgu', (_requete, reponse) => {
     reponse.render('cgu');
   });
 
-  app.get('/confidentialite', (requete, reponse) => {
+  app.get('/confidentialite', (_requete, reponse) => {
     reponse.render('confidentialite');
   });
 
-  app.get('/connexion', middleware.suppressionCookie, (requete, reponse) => {
+  app.get('/connexion', middleware.suppressionCookie, (_requete, reponse) => {
     reponse.render('connexion');
   });
 
-  app.get('/questionsFrequentes', (requete, reponse) => {
+  app.get('/questionsFrequentes', (_requete, reponse) => {
     reponse.render('questionsFrequentes');
   });
 
-  app.get('/mentionsLegales', (requete, reponse) => {
+  app.get('/mentionsLegales', (_requete, reponse) => {
     reponse.render('mentionsLegales');
   });
 
-  app.get('/reinitialisationMotDePasse', middleware.suppressionCookie, (requete, reponse) => {
+  app.get('/reinitialisationMotDePasse', middleware.suppressionCookie, (_requete, reponse) => {
     reponse.render('reinitialisationMotDePasse');
   });
 
-  app.get('/inscription', (requete, reponse) => {
+  app.get('/inscription', (_requete, reponse) => {
     reponse.render('inscription');
   });
 
@@ -91,11 +91,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, adaptateurMail,
         });
     });
 
-  app.get('/admin/inscription', middleware.authentificationBasique, (requete, reponse) => {
+  app.get('/admin/inscription', middleware.authentificationBasique, (_requete, reponse) => {
     reponse.render('admin/inscription');
   });
 
-  app.get('/espacePersonnel', middleware.verificationAcceptationCGU, (requete, reponse) => {
+  app.get('/espacePersonnel', middleware.verificationAcceptationCGU, (_requete, reponse) => {
     reponse.render('espacePersonnel');
   });
 

--- a/src/routes/routesHomologation.js
+++ b/src/routes/routesHomologation.js
@@ -7,7 +7,7 @@ const InformationsHomologation = require('../modeles/informationsHomologation');
 const routesHomologation = (middleware, referentiel) => {
   const routes = express.Router();
 
-  routes.get('/creation', middleware.verificationAcceptationCGU, (requete, reponse) => {
+  routes.get('/creation', middleware.verificationAcceptationCGU, (_requete, reponse) => {
     const homologation = new Homologation({});
     reponse.render('homologation/creation', { referentiel, homologation });
   });

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -32,7 +32,7 @@ const prepareVerificationReponse = (reponse, status, ...params) => {
 
 const prepareVerificationRedirection = (reponse, urlRedirection, done) => {
   reponse.redirect = (url) => {
-    expect(url).to.equal('/connexion');
+    expect(url).to.equal(urlRedirection);
     done();
   };
 };

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -50,60 +50,60 @@ const middlewareFantaisie = {
   },
 
   aseptise: (...nomsParametres) => (
-    (requete, reponse, suite) => {
+    (_requete, _reponse, suite) => {
       parametresAseptises = nomsParametres;
       suite();
     }
   ),
 
   aseptiseListes: (listes) => (
-    (requete, reponse, suite) => {
+    (_requete, _reponse, suite) => {
       listes.forEach(({ nom, proprietes }) => listesAseptisees.push({ nom, proprietes }));
       suite();
     }
   ),
 
-  authentificationBasique: (requete, reponse, suite) => {
+  authentificationBasique: (_requete, _reponse, suite) => {
     authentificationBasiqueMenee = true;
     suite();
   },
 
   idUtilisateurCourant: () => idUtilisateurCourant,
 
-  positionneHeaders: (requete, reponse, suite) => {
+  positionneHeaders: (_requete, _reponse, suite) => {
     headersPositionnes = true;
     suite();
   },
 
-  positionneHeadersAvecNonce: (requete, reponse, suite) => {
+  positionneHeadersAvecNonce: (_requete, _reponse, suite) => {
     headersAvecNoncePositionnes = true;
     suite();
   },
 
-  repousseExpirationCookie: (requete, reponse, suite) => {
+  repousseExpirationCookie: (_requete, _reponse, suite) => {
     expirationCookieRepoussee = true;
     suite();
   },
 
-  suppressionCookie: (requete, reponse, suite) => {
+  suppressionCookie: (_requete, _reponse, suite) => {
     suppressionCookieEffectuee = true;
     suite();
   },
 
-  trouveHomologation: (requete, reponse, suite) => {
+  trouveHomologation: (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
     requete.homologation = new Homologation({ id: '456' });
     rechercheHomologationEffectuee = true;
     suite();
   },
 
-  verificationJWT: (requete, reponse, suite) => {
+  verificationJWT: (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
     verificationJWTMenee = true;
     suite();
   },
 
-  verificationAcceptationCGU: (requete, reponse, suite) => {
+  verificationAcceptationCGU: (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
     verificationCGUMenee = true;
     suite();


### PR DESCRIPTION
L'intention de ce commit est de pouvoir détecter en amont ces paramètres inutilisés, plutôt que [pendant une relecture de PR](https://github.com/betagouv/mon-service-securise/pull/190#discussion_r827111096) 😉

Afin de permettre malgré tout l'utilisation de paramètres déclarés plus loin dans la liste des paramètres, on peut spécifier les paramètres nécessaires pour l'ordre d'appel, mais inutilisés dans la fonction, en les faisant précéder du caractère `_`.

Peut-être que c'est un peu plus lourd à utiliser, et que la déclaration explicite des paramètres inutilisés n'est pas vraiment dans l'esprit JavaScript. Malgré tout, cette vérification aura au moins permis de mettre en évidence une erreur ligne 35 dans le test `test/middleware.spec.js`.
