### PR TITLE
Les Intervenants dans le documents d'homologation

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -47,6 +47,10 @@ class Homologation {
     this.referentiel = referentiel;
   }
 
+  acteursHomologation() {
+    return this.rolesResponsabilites.descriptionActeursHomologation();
+  }
+
   autoriteHomologation() { return this.rolesResponsabilites.autoriteHomologation; }
 
   delegueProtectionDonnees() {

--- a/src/modeles/rolesResponsabilites.js
+++ b/src/modeles/rolesResponsabilites.js
@@ -67,6 +67,23 @@ class RolesResponsabilites extends InformationsHomologation {
   descriptionStructureDeveloppement() {
     return this.partiesPrenantes.developpementFourniture()?.nom || '';
   }
+
+  descriptionActeursHomologation() {
+    const acteurHomologationDecrit = (role, description) => ({ role, description });
+    const description = (acteur) => acteur.nom + (acteur.fonction ? ` (${acteur.fonction})` : '');
+    const acteursSpecifiques = () => this.acteursHomologation.tous()
+      .map((acteur) => acteurHomologationDecrit(acteur.role, description(acteur)));
+
+    const acteurs = [
+      acteurHomologationDecrit("Autorité d'homologation", this.descriptionAutoriteHomologation()),
+      acteurHomologationDecrit('Spécialiste cybersécurité', this.descriptionExpertCybersecurite()),
+      acteurHomologationDecrit('Délégué(e) à la protection des données à caractère personnel', this.descriptionDelegueProtectionDonnees()),
+      acteurHomologationDecrit('Responsable métier du projet', this.descriptionPiloteProjet()),
+      ...acteursSpecifiques(),
+    ];
+
+    return acteurs.filter((acteur) => acteur.description !== 'Information non renseignée');
+  }
 }
 
 module.exports = RolesResponsabilites;

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -139,6 +139,9 @@ nav.ne-pas-imprimer
       dl
         dt Décision d'homologation préparée par :
         dd= homologation.descriptionEquipePreparation()
+        each acteur in homologation.acteursHomologation()
+          dt #{acteur.role} :
+          dd= acteur.description
 
     section
       h2 Calendrier

--- a/test/modeles/rolesResponsabilites.spec.js
+++ b/test/modeles/rolesResponsabilites.spec.js
@@ -168,4 +168,70 @@ describe("L'ensemble des rôles et responsabilités", () => {
       expect(rolesResponsabilites.descriptionStructureDeveloppement()).to.equal('');
     });
   });
+
+  describe("sur une demande de description des acteurs de l'homologation", () => {
+    it("intègre l'autorité d'homologation", () => {
+      const rolesResponsabilites = new RolesResponsabilites({
+        autoriteHomologation: 'Jean Dupont', fonctionAutoriteHomologation: 'Maire',
+      });
+
+      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
+      expect(acteursHomologations).to.eql([{ role: "Autorité d'homologation", description: 'Jean Dupont (Maire)' }]);
+    });
+
+    it('intègre le ou la spécialiste cybersécurité', () => {
+      const rolesResponsabilites = new RolesResponsabilites({
+        expertCybersecurite: 'John Dupond', fonctionExpertCybersecurite: 'Spécialiste',
+      });
+
+      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
+      expect(acteursHomologations).to.eql([{ role: 'Spécialiste cybersécurité', description: 'John Dupond (Spécialiste)' }]);
+    });
+
+    it('intègre le délégué ou la délégué à la protection des données à caractère personnel', () => {
+      const rolesResponsabilites = new RolesResponsabilites({
+        delegueProtectionDonnees: 'Marie Age', fonctionDelegueProtectionDonnees: 'Déléguée',
+      });
+
+      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
+      expect(acteursHomologations).to.eql([{ role: 'Délégué(e) à la protection des données à caractère personnel', description: 'Marie Age (Déléguée)' }]);
+    });
+
+    it('intègre le ou la responsable métier du projet', () => {
+      const rolesResponsabilites = new RolesResponsabilites({
+        piloteProjet: 'Otto Graf', fonctionPiloteProjet: 'Pilote',
+      });
+
+      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
+      expect(acteursHomologations).to.eql([{ role: 'Responsable métier du projet', description: 'Otto Graf (Pilote)' }]);
+    });
+
+    it('intègre les acteurs spécifiques', () => {
+      const rolesResponsabilites = new RolesResponsabilites({
+        acteursHomologation: [
+          { role: 'Rôle dans le projet', nom: 'Sandra Nicouverture', fonction: 'Fonction' },
+        ],
+      });
+
+      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
+      expect(acteursHomologations).to.eql([{ role: 'Rôle dans le projet', description: 'Sandra Nicouverture (Fonction)' }]);
+    });
+
+    it('intègre les acteurs spécifiques sans les fonctions si elles ne sont pas présentes', () => {
+      const rolesResponsabilites = new RolesResponsabilites({
+        acteursHomologation: [
+          { role: 'Rôle dans le projet', nom: 'Yamamoto Kaderate' },
+        ],
+      });
+
+      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
+      expect(acteursHomologations).to.eql([{ role: 'Rôle dans le projet', description: 'Yamamoto Kaderate' }]);
+    });
+
+    it("n'intègre pas les acteurs non renseignés", () => {
+      const rolesResponsabilites = new RolesResponsabilites({});
+
+      expect(rolesResponsabilites.descriptionActeursHomologation()).to.have.length(0);
+    });
+  });
 });


### PR DESCRIPTION
Dans le document d'homologation,
nous souhaitons voir apparaitre les intervenants listés dans la page rôles et responsabilités.

Dans le bloc Equipe j'ai ajouté après _Décision d'homologation préparée par ..._ tous les acteurs de l'homologation
![Capture d’écran 2022-03-17 à 16 42 27](https://user-images.githubusercontent.com/39462397/158837712-7b7205a4-397e-4778-b45d-bf3a8ceafed4.png)

