### PR TITLE
Arrêt double persistance des parties prenantes

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -118,8 +118,7 @@ const creeDepot = (config = {}) => {
   );
 
   const ajouteRolesResponsabilitesAHomologation = (...params) => (
-    metsAJourProprieteHomologation('partiesPrenantes', ...params)
-      .then(() => metsAJourProprieteHomologation('rolesResponsabilites', ...params))
+    metsAJourProprieteHomologation('rolesResponsabilites', ...params)
   );
 
   const ajouteAvisExpertCyberAHomologation = (...params) => (

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -3,7 +3,6 @@ const AvisExpertCyber = require('./avisExpertCyber');
 const DescriptionService = require('./descriptionService');
 const Mesure = require('./mesure');
 const Mesures = require('./mesures');
-const PartiesPrenantes = require('./partiesPrenantes');
 const Risques = require('./risques');
 const RolesResponsabilites = require('./rolesResponsabilites');
 const Utilisateur = require('./utilisateur');
@@ -24,7 +23,6 @@ class Homologation {
       descriptionService = {},
       mesuresGenerales = [],
       mesuresSpecifiques = [],
-      partiesPrenantes = {},
       risquesGeneraux = [],
       risquesSpecifiques = [],
       rolesResponsabilites = {},
@@ -36,7 +34,6 @@ class Homologation {
     this.contributeurs = contributeurs.map((c) => new Utilisateur(c));
     this.descriptionService = new DescriptionService(descriptionService, referentiel);
     this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel);
-    this.partiesPrenantes = new PartiesPrenantes(partiesPrenantes);
     this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);
     this.risques = new Risques(
       { risquesGeneraux, risquesSpecifiques },

--- a/src/modeles/partiesPrenantes.js
+++ b/src/modeles/partiesPrenantes.js
@@ -1,3 +1,0 @@
-const RolesResponsabilites = require('./rolesResponsabilites');
-
-module.exports = class PartiesPrenantes extends RolesResponsabilites {};

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -322,26 +322,6 @@ describe('Le dépôt de données persistées en mémoire', () => {
       .catch(done);
   });
 
-  it('sait enregistrer les rôles et responsabilités en parties prenantes', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      }],
-    });
-    const depot = DepotDonnees.creeDepot({ adaptateurPersistance });
-
-    const roles = new RolesResponsabilites({ autoriteHomologation: 'Jean Dupont' });
-    depot.ajouteRolesResponsabilitesAHomologation('123', roles)
-      .then(() => depot.homologation('123'))
-      .then(({ partiesPrenantes }) => {
-        expect(partiesPrenantes).to.be.ok();
-        expect(partiesPrenantes.autoriteHomologation).to.equal('Jean Dupont');
-        done();
-      })
-      .catch(done);
-  });
-
   describe('concernant les risques généraux', () => {
     let valideRisque;
 


### PR DESCRIPTION
Après le changement des parties prenantes en rôles et responsabilités,
nous pouvons arrêter la double persistance.

note : la classe PartiesPrenantes n'ayant plus d'utilité peut être supprimé