### PR TITLE
Bandeau nouveautés dans l'espace personnel

### DIFF
--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -166,3 +166,23 @@
 .confirmation .bouton {
   margin: 0;
 }
+
+.bandeau-nouveautes {
+  display: flex;
+  height: 2.7em;
+  align-items: center;
+  
+  background-color: var(--rose-anssi);
+}
+
+.bandeau-nouveautes:hover {
+  background-color: var(--rose-mise-en-avant);
+}
+
+.bandeau-nouveautes p {
+  color: #fff;
+  font-weight: bold;
+  font-size: .95em;
+  text-transform: uppercase;
+  text-align: left;
+}

--- a/public/assets/styles/palette.css
+++ b/public/assets/styles/palette.css
@@ -4,6 +4,8 @@
   --bleu-mise-en-avant: #0f7ac7;
   --bleu-mise-en-avant-03-pc: #0f7ac708;
   --bleu-mise-en-avant-20-pc: #0f7ac730;
+  --rose-anssi: #ff6584;
+  --rose-mise-en-avant: #f15172;
 
   --texte-fonce: #2f3a43;
   --texte-moyen: #929292;

--- a/src/vues/espacePersonnel.pug
+++ b/src/vues/espacePersonnel.pug
@@ -5,6 +5,9 @@ block append styles
   link(href='/statique/assets/styles/espacePersonnel.css', rel='stylesheet')
 
 block main
+  a(href= './nouvellesFonctionnalites').bandeau-nouveautes
+    p.marges-fixes.
+      Découvrez les nouvelles fonctionnalités  ›
   .suivi-homologations.marges-fixes
     h1 Mon espace personnel
     .homologations


### PR DESCRIPTION
Dans la page espace personnel,
nous souhaitons avoir un bandeau permettant d'accéder à la page présentant les nouveautés
<img width="452" alt="Capture d’écran 2022-03-23 à 15 57 57" src="https://user-images.githubusercontent.com/39462397/159729012-e57a8fa8-c591-4df9-8bed-b02b9e90334f.png">
