### PR TITLE
Correction de la sauvegarde des modalités des mesures

### DIFF
--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -1,5 +1,6 @@
+import arrangeParametresMesures from '../modules/arrangeParametresMesures.mjs';
+import parametres from '../modules/parametres.mjs';
 import { brancheAjoutItem, peupleListeItems } from '../modules/saisieListeItems.js';
-import { parametresAvecItemsExtraits } from '../modules/parametres.mjs';
 import texteHTML from '../modules/texteHTML.js';
 
 import ajouteModalesInformations from '../modules/interactions/modalesInformations.mjs';
@@ -135,11 +136,9 @@ ${statuts}
   const identifiantHomologation = $bouton.attr('identifiant');
 
   $bouton.click(() => {
-    const params = parametresAvecItemsExtraits(
-      'form#mesures',
-      'mesuresSpecifiques',
-      '^(description|categorie|statut|modalites)-mesure-specifique-',
-    );
+    const params = parametres('form#mesures');
+    arrangeParametresMesures(params);
+
     axios.post(`/api/homologation/${identifiantHomologation}/mesures`, params)
       .then((reponse) => (window.location = `/homologation/${reponse.data.idHomologation}`));
   });

--- a/public/modules/arrangeParametresMesures.mjs
+++ b/public/modules/arrangeParametresMesures.mjs
@@ -1,0 +1,11 @@
+import { modifieParametresAvecItemsExtraits } from './parametres.mjs';
+
+const arrangeParametresMesures = (parametres) => {
+  modifieParametresAvecItemsExtraits(
+    parametres,
+    'mesuresSpecifiques',
+    '^(description|categorie|statut|modalites)-mesure-specifique-',
+  );
+};
+
+export default arrangeParametresMesures;

--- a/public/modules/arrangeParametresMesures.mjs
+++ b/public/modules/arrangeParametresMesures.mjs
@@ -1,11 +1,33 @@
 import { modifieParametresAvecItemsExtraits } from './parametres.mjs';
 
 const arrangeParametresMesures = (parametres) => {
+  const CLE_MESURES_SPECIFIQUES = 'mesuresSpecifiques';
+  const CLE_MESURES_GENERALES = 'mesuresGenerales';
+
   modifieParametresAvecItemsExtraits(
     parametres,
-    'mesuresSpecifiques',
+    CLE_MESURES_SPECIFIQUES,
     '^(description|categorie|statut|modalites)-mesure-specifique-',
   );
+
+  parametres[CLE_MESURES_GENERALES] = parametres[CLE_MESURES_GENERALES] || {};
+
+  parametres[CLE_MESURES_GENERALES] = Object.keys(parametres)
+    .filter((nomParametre) => (
+      nomParametre !== CLE_MESURES_SPECIFIQUES && nomParametre !== CLE_MESURES_GENERALES
+    ))
+    .reduce((acc, nomParametre) => {
+      const nomParametreModalites = nomParametre.match(/^modalites-(.*)$/)?.[1];
+      if (nomParametreModalites) {
+        acc[nomParametreModalites] = acc[nomParametreModalites] || {};
+        acc[nomParametreModalites].modalites = parametres[nomParametre];
+      } else {
+        acc[nomParametre] = acc[nomParametre] || {};
+        acc[nomParametre].statut = parametres[nomParametre];
+      }
+      delete parametres[nomParametre];
+      return acc;
+    }, parametres[CLE_MESURES_GENERALES]);
 };
 
 export default arrangeParametresMesures;

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -82,22 +82,23 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
   });
 
   routes.post('/:id/mesures', middleware.trouveHomologation, middleware.aseptise(
-    '*',
+    'mesuresGenerales.*.statut',
+    'mesuresGenerales.*.modalites',
     'mesuresSpecifiques.*.description',
     'mesuresSpecifiques.*.categorie',
     'mesuresSpecifiques.*.statut',
     'mesuresSpecifiques.*.modalites',
   ),
   (requete, reponse, suite) => {
-    const { mesuresSpecifiques = [], ...params } = requete.body;
-    const identifiantsMesures = Object.keys(params).filter((p) => !p.match(/^modalites-/));
+    const { mesuresSpecifiques = [], mesuresGenerales = {} } = requete.body;
+
     const idHomologation = requete.homologation.id;
     try {
-      const ajouts = identifiantsMesures.reduce((acc, im) => {
+      const ajouts = Object.keys(mesuresGenerales).reduce((acc, im) => {
         const mesure = new MesureGenerale({
           id: im,
-          statut: params[im],
-          modalites: params[`modalites-${im}`],
+          statut: mesuresGenerales[im].statut,
+          modalites: mesuresGenerales[im].modalites,
         }, referentiel);
 
         return acc.then(

--- a/test/routes/routesApiHomologation.spec.js
+++ b/test/routes/routesApiHomologation.spec.js
@@ -205,7 +205,8 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
     it('aseptise tous les paramètres de la requête', (done) => {
       testeur.middleware().verifieAseptisationParametres(
         [
-          '*',
+          'mesuresGenerales.*.statut',
+          'mesuresGenerales.*.modalites',
           'mesuresSpecifiques.*.description',
           'mesuresSpecifiques.*.categorie',
           'mesuresSpecifiques.*.statut',
@@ -230,8 +231,9 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       };
 
       axios.post('http://localhost:1234/api/homologation/456/mesures', {
-        identifiantMesure: 'fait',
-        'modalites-identifiantMesure': "Des modalités d'application",
+        mesuresGenerales: {
+          identifiantMesure: { statut: 'fait', modalites: "Des modalités d'application" },
+        },
       })
         .then((reponse) => {
           expect(mesureAjoutee).to.be(true);
@@ -284,7 +286,7 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
       testeur.verifieRequeteGenereErreurHTTP(422, 'Données invalides', {
         method: 'post',
         url: 'http://localhost:1234/api/homologation/456/mesures',
-        data: { identifiantInvalide: 'statutInvalide' },
+        data: { mesuresGenerales: { identifiantInvalide: { statut: 'statutInvalide' } } },
       }, done);
     });
   });

--- a/test_public/modules/arrangeParametresMesures.spec.mjs
+++ b/test_public/modules/arrangeParametresMesures.spec.mjs
@@ -1,0 +1,23 @@
+import expect from 'expect.js';
+
+import arrangeParametresMesures from '../../public/modules/arrangeParametresMesures.mjs';
+
+describe("Une demande d'arrangement des paramètres des mesures", () => {
+  it('met en forme les paramètres des mesures spécifiques', () => {
+    const parametres = {
+      'description-mesure-specifique-0': 'Une description',
+      'categorie-mesure-specifique-0': 'gouvernance',
+      'statut-mesure-specifique-0': 'fait',
+      'modalites-mesure-specifique-0': 'Des modalités',
+    };
+
+    arrangeParametresMesures(parametres);
+
+    const { mesuresSpecifiques } = parametres;
+    expect(mesuresSpecifiques.length).to.equal(1);
+    expect(mesuresSpecifiques[0].description).to.equal('Une description');
+    expect(mesuresSpecifiques[0].categorie).to.equal('gouvernance');
+    expect(mesuresSpecifiques[0].statut).to.equal('fait');
+    expect(mesuresSpecifiques[0].modalites).to.equal('Des modalités');
+  });
+});

--- a/test_public/modules/arrangeParametresMesures.spec.mjs
+++ b/test_public/modules/arrangeParametresMesures.spec.mjs
@@ -20,4 +20,41 @@ describe("Une demande d'arrangement des paramètres des mesures", () => {
     expect(mesuresSpecifiques[0].statut).to.equal('fait');
     expect(mesuresSpecifiques[0].modalites).to.equal('Des modalités');
   });
+
+  it("met en forme le statut d'une mesure", () => {
+    const parametres = { contactSecurite: 'fait' };
+
+    arrangeParametresMesures(parametres);
+
+    const { mesuresGenerales } = parametres;
+    expect(mesuresGenerales).to.have.property('contactSecurite');
+    expect(mesuresGenerales.contactSecurite.statut).to.equal('fait');
+  });
+
+  it('supprime la clé après la mise en forme', () => {
+    const parametres = { contactSecurite: 'fait' };
+
+    arrangeParametresMesures(parametres);
+
+    expect(parametres).to.not.have.property('contactSecurite');
+  });
+
+  it('doit contenir uniquement les mesures générales sous la clé `mesuresGenerales`', () => {
+    const parametres = { contactSecurite: 'fait' };
+
+    arrangeParametresMesures(parametres);
+
+    const { mesuresGenerales } = parametres;
+    expect(Object.keys(mesuresGenerales).length).to.equal(1);
+  });
+
+  it("met en forme la modalité d'une mesure", () => {
+    const parametres = { 'modalites-contactSecurite': 'Des modalités' };
+
+    arrangeParametresMesures(parametres);
+
+    const { mesuresGenerales } = parametres;
+    expect(mesuresGenerales).to.have.property('contactSecurite');
+    expect(mesuresGenerales.contactSecurite.modalites).to.equal('Des modalités');
+  });
 });


### PR DESCRIPTION
Dans la page des mesures,
Quand on renseigne des modalités sans cocher de statut,
Les modalités sont bien prises en compte