### PR TITLE
Suppression dans les données des parties prenantes

### DIFF
--- a/migrations/20220331122356_suppressionPartiesPrenantes.js
+++ b/migrations/20220331122356_suppressionPartiesPrenantes.js
@@ -1,0 +1,21 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.partiesPrenantes)
+      .map(({ id, donnees: { partiesPrenantes: _, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: { ...autresDonnees } }));
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.rolesResponsabilites)
+      .map(({ id, donnees: { rolesResponsabilites, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: {
+          rolesResponsabilites, partiesPrenantes: rolesResponsabilites, ...autresDonnees,
+        } }));
+    return Promise.all(misesAJour);
+  });


### PR DESCRIPTION
Dans les données en base,
l'objet `partiesPrenantes` n'est plus utilisé et peut être supprimé.
