### PR TITLE
[NETTOYAGE] Séparation du dépot de données en plusieurs sous-dépôts

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -1,21 +1,10 @@
-const bcrypt = require('bcrypt');
-
-const {
-  ErreurAutorisationExisteDeja,
-  ErreurEmailManquant,
-  ErreurHomologationInexistante,
-  ErreurNomServiceDejaExistant,
-  ErreurNomServiceManquant,
-  ErreurUtilisateurExistant,
-  ErreurUtilisateurInexistant,
-} = require('./erreurs');
-const Referentiel = require('./referentiel');
 const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
-const FabriqueAutorisation = require('./modeles/autorisations/fabriqueAutorisation');
-const Homologation = require('./modeles/homologation');
-const Utilisateur = require('./modeles/utilisateur');
+const Referentiel = require('./referentiel');
+const depotDonneesAutorisations = require('./depots/depotDonneesAutorisations');
+const depotDonneesHomologations = require('./depots/depotDonneesHomologations');
+const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 
 const creeDepot = (config = {}) => {
   const {
@@ -25,277 +14,57 @@ const creeDepot = (config = {}) => {
     referentiel = Referentiel.creeReferentiel(),
   } = config;
 
-  const homologation = (idHomologation) => adaptateurPersistance.homologation(idHomologation)
-    .then((h) => (h ? new Homologation(h, referentiel) : undefined));
-
-  const ajouteAItemsDansHomologation = (nomListeItems, idHomologation, item) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((h) => {
-        h[nomListeItems] ||= [];
-
-        const donneesItem = item.toJSON();
-        const itemDejaDansDepot = h[nomListeItems].find((i) => i.id === donneesItem.id);
-        if (itemDejaDansDepot) {
-          Object.assign(itemDejaDansDepot, donneesItem);
-        } else {
-          h[nomListeItems].push(donneesItem);
-        }
-
-        const { id, ...donnees } = h;
-        return adaptateurPersistance.metsAJourHomologation(id, donnees);
-      })
-  );
-
-  const metsAJourProprieteHomologation = (nomPropriete, idOuHomologation, propriete) => {
-    const metsAJour = (h) => {
-      h[nomPropriete] ||= {};
-
-      const donneesPropriete = propriete.toJSON();
-      Object.assign(h[nomPropriete], donneesPropriete);
-
-      const { id, ...donnees } = h;
-      return adaptateurPersistance.metsAJourHomologation(id, donnees);
-    };
-
-    const trouveDonneesHomologation = (param) => (
-      typeof param === 'object'
-        ? Promise.resolve(param)
-        : adaptateurPersistance.homologation(param)
-    );
-
-    return trouveDonneesHomologation(idOuHomologation).then(metsAJour);
-  };
-
-  const metsAJourDescriptionServiceHomologation = (homologationCible, informations) => (
-    metsAJourProprieteHomologation('descriptionService', homologationCible, informations)
-  );
-
-  const remplaceProprieteHomologation = (nomPropriete, idHomologation, propriete) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((h) => {
-        const donneesPropriete = propriete.toJSON();
-        h[nomPropriete] = donneesPropriete;
-
-        const { id, ...donnees } = h;
-        return adaptateurPersistance.metsAJourHomologation(id, donnees);
-      })
-  );
-
-  const ajouteMesureGeneraleAHomologation = (...params) => (
-    ajouteAItemsDansHomologation('mesuresGenerales', ...params)
-  );
-
-  const ajouteRisqueGeneralAHomologation = (...params) => (
-    ajouteAItemsDansHomologation('risquesGeneraux', ...params)
-  );
-
-  const homologationExiste = (...params) => (
-    adaptateurPersistance.homologationAvecNomService(...params)
-      .then((h) => !!h)
-  );
-
-  const valideDescriptionService = (idUtilisateur, { nomService }, idHomologationMiseAJour) => {
-    if (typeof nomService !== 'string' || !nomService) {
-      return Promise.reject(new ErreurNomServiceManquant('Le nom du service ne peut pas être vide'));
-    }
-
-    return homologationExiste(idUtilisateur, nomService, idHomologationMiseAJour)
-      .then((homologationExistante) => (
-        homologationExistante
-          ? Promise.reject(new ErreurNomServiceDejaExistant(
-            `Le nom du service "${nomService}" existe déjà pour une autre homologation`
-          ))
-          : Promise.resolve()
-      ));
-  };
-
-  const ajouteDescriptionServiceAHomologation = (idUtilisateur, idHomologation, infos) => (
-    adaptateurPersistance.homologation(idHomologation)
-      .then((h) => (
-        valideDescriptionService(idUtilisateur, infos, h.id)
-          .then(() => metsAJourDescriptionServiceHomologation(h, infos))
-      ))
-  );
-
-  const ajouteRolesResponsabilitesAHomologation = (...params) => (
-    metsAJourProprieteHomologation('rolesResponsabilites', ...params)
-  );
-
-  const ajouteAvisExpertCyberAHomologation = (...params) => (
-    metsAJourProprieteHomologation('avisExpertCyber', ...params)
-  );
-
-  const homologations = (idUtilisateur) => adaptateurPersistance.homologations(idUtilisateur)
-    .then((hs) => hs.map((h) => new Homologation(h, referentiel)));
-
-  const nouvelleHomologation = (idUtilisateur, donneesDescriptionService) => {
-    const idHomologation = adaptateurUUID.genereUUID();
-    const idAutorisation = adaptateurUUID.genereUUID();
-    const donnees = {
-      idUtilisateur,
-      descriptionService: donneesDescriptionService,
-    };
-
-    return valideDescriptionService(idUtilisateur, donneesDescriptionService)
-      .then(() => adaptateurPersistance.ajouteHomologation(idHomologation, donnees))
-      .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
-        idUtilisateur, idHomologation, type: 'createur',
-      }))
-      .then(() => idHomologation);
-  };
-
-  const remplaceMesuresSpecifiquesPourHomologation = (...params) => (
-    remplaceProprieteHomologation('mesuresSpecifiques', ...params)
-  );
-
-  const remplaceRisquesSpecifiquesPourHomologation = (...params) => (
-    remplaceProprieteHomologation('risquesSpecifiques', ...params)
-  );
-
-  const utilisateur = (identifiant) => adaptateurPersistance.utilisateur(identifiant)
-    .then((u) => (u ? new Utilisateur(u, adaptateurJWT) : undefined));
-
-  const nouvelUtilisateur = (donneesUtilisateur) => new Promise((resolve, reject) => {
-    const { email } = donneesUtilisateur;
-    if (!email) throw new ErreurEmailManquant('Le champ email doit être renseigné');
-
-    adaptateurPersistance.utilisateurAvecEmail(email)
-      .then((u) => {
-        if (u) {
-          return reject(new ErreurUtilisateurExistant(
-            'Utilisateur déjà existant pour cette adresse email'
-          ));
-        }
-
-        const id = adaptateurUUID.genereUUID();
-        donneesUtilisateur.idResetMotDePasse = adaptateurUUID.genereUUID();
-        return bcrypt.hash(adaptateurUUID.genereUUID(), 10)
-          .then((hash) => {
-            donneesUtilisateur.motDePasse = hash;
-
-            adaptateurPersistance.ajouteUtilisateur(id, donneesUtilisateur)
-              .then(() => resolve(utilisateur(id)));
-          });
-      });
+  const depotHomologations = depotDonneesHomologations.creeDepot({
+    adaptateurPersistance, adaptateurUUID, referentiel,
   });
 
-  const utilisateurAFinaliser = (idReset) => adaptateurPersistance.utilisateurAvecIdReset(idReset)
-    .then((u) => (u ? new Utilisateur(u, adaptateurJWT) : undefined));
+  const depotUtilisateurs = depotDonneesUtilisateurs.creeDepot({
+    adaptateurJWT, adaptateurPersistance, adaptateurUUID, depotHomologations,
+  });
 
-  const utilisateurAuthentifie = (login, motDePasse) => (
-    adaptateurPersistance.utilisateurAvecEmail(login)
-      .then((u) => {
-        const motDePasseStocke = u && u.motDePasse;
-        const echecAuthentification = undefined;
+  const depotAutorisations = depotDonneesAutorisations.creeDepot({
+    adaptateurPersistance, adaptateurUUID, depotHomologations, depotUtilisateurs,
+  });
 
-        if (!motDePasseStocke) return new Promise((resolve) => resolve(echecAuthentification));
+  const {
+    ajouteAvisExpertCyberAHomologation,
+    ajouteDescriptionServiceAHomologation,
+    ajouteMesureGeneraleAHomologation,
+    ajouteRisqueGeneralAHomologation,
+    ajouteRolesResponsabilitesAHomologation,
+    homologation,
+    homologationExiste,
+    homologations,
+    nouvelleHomologation,
+    remplaceMesuresSpecifiquesPourHomologation,
+    remplaceRisquesSpecifiquesPourHomologation,
+    supprimeHomologation,
+  } = depotHomologations;
 
-        return bcrypt.compare(motDePasse, motDePasseStocke)
-          .then((authentificationReussie) => (authentificationReussie
-            ? new Utilisateur(u, adaptateurJWT)
-            : echecAuthentification
-          ));
-      })
-  );
+  const {
+    metsAJourMotDePasse,
+    metsAJourUtilisateur,
+    nouvelUtilisateur,
+    reinitialiseMotDePasse,
+    supprimeIdResetMotDePassePourUtilisateur,
+    supprimeUtilisateur,
+    utilisateur,
+    utilisateurAFinaliser,
+    utilisateurAuthentifie,
+    utilisateurExiste,
+    utilisateurAvecEmail,
+    valideAcceptationCGUPourUtilisateur,
+  } = depotUtilisateurs;
 
-  const utilisateurExiste = (id) => utilisateur(id).then((u) => !!u);
-
-  const { utilisateurAvecEmail } = adaptateurPersistance;
-
-  const metsAJourMotDePasse = (idUtilisateur, motDePasse) => (
-    bcrypt.hash(motDePasse, 10)
-      .then((hash) => adaptateurPersistance.metsAJourUtilisateur(
-        idUtilisateur, { motDePasse: hash }
-      ))
-      .then(() => utilisateur(idUtilisateur))
-  );
-
-  const metsAJourUtilisateur = (id, donnees) => {
-    delete donnees.motDePasse;
-    return adaptateurPersistance.metsAJourUtilisateur(id, donnees)
-      .then(() => utilisateur(id));
-  };
-
-  const reinitialiseMotDePasse = (email) => adaptateurPersistance.utilisateurAvecEmail(email)
-    .then((u) => {
-      if (!u) return undefined;
-
-      const idResetMotDePasse = adaptateurUUID.genereUUID();
-      return adaptateurPersistance.metsAJourUtilisateur(u.id, { idResetMotDePasse })
-        .then(() => utilisateur(u.id));
-    });
-
-  const { supprimeHomologation } = adaptateurPersistance;
-
-  const supprimeIdResetMotDePassePourUtilisateur = (utilisateurAModifier) => (
-    adaptateurPersistance.metsAJourUtilisateur(
-      utilisateurAModifier.id, { idResetMotDePasse: undefined }
-    )
-      .then(() => utilisateur(utilisateurAModifier.id))
-  );
-
-  const supprimeUtilisateur = (id) => homologations(id)
-    .then((hs) => hs.map((h) => adaptateurPersistance.supprimeHomologation(h.id)))
-    .then((suppressions) => Promise.all(suppressions))
-    .then(() => adaptateurPersistance.supprimeUtilisateur(id));
-
-  const valideAcceptationCGUPourUtilisateur = (utilisateurAModifier) => (
-    adaptateurPersistance.metsAJourUtilisateur(utilisateurAModifier.id, { cguAcceptees: true })
-      .then(() => utilisateur(utilisateurAModifier.id))
-  );
-
-  const autorisation = (id) => adaptateurPersistance.autorisation(id)
-    .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
-
-  const autorisationPour = (...params) => adaptateurPersistance.autorisationPour(...params)
-    .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
-
-  const autorisationExiste = (...params) => autorisationPour(...params)
-    .then((a) => !!a);
-
-  const autorisations = (idUtilisateur) => adaptateurPersistance.autorisations(idUtilisateur)
-    .then((as) => as.map((a) => FabriqueAutorisation.fabrique(a)));
-
-  const accesAutorise = (idUtilisateur, idHomologation) => autorisations(idUtilisateur)
-    .then((as) => as.some((a) => a.idHomologation === idHomologation));
-
-  const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => {
-    const verifieUtilisateurExiste = (id) => utilisateurExiste(id)
-      .then((existe) => {
-        if (!existe) throw new ErreurUtilisateurInexistant(`L'utilisateur "${id}" n'existe pas`);
-      });
-
-    return verifieUtilisateurExiste(idUtilisateurSource)
-      .then(() => verifieUtilisateurExiste(idUtilisateurCible))
-      .then(() => adaptateurPersistance
-        .transfereAutorisations(idUtilisateurSource, idUtilisateurCible));
-  };
-
-  const ajouteContributeurAHomologation = (idContributeur, idHomologation) => {
-    const verifieUtilisateurExiste = (id) => utilisateurExiste(id)
-      .then((existe) => {
-        if (!existe) throw new ErreurUtilisateurInexistant(`Le contributeur "${id}" n'existe pas`);
-      });
-
-    const verifieHomologationExiste = (id) => homologation(idHomologation)
-      .then((h) => {
-        if (!h) throw new ErreurHomologationInexistante(`L'homologation "${id}" n'existe pas`);
-      });
-
-    const verifieAutorisationInexistante = (...params) => autorisationExiste(...params)
-      .then((existe) => {
-        if (existe) throw new ErreurAutorisationExisteDeja("L'autorisation existe déjà");
-      });
-
-    const idAutorisation = adaptateurUUID.genereUUID();
-
-    return verifieUtilisateurExiste(idContributeur)
-      .then(() => verifieHomologationExiste(idHomologation))
-      .then(() => verifieAutorisationInexistante(idContributeur, idHomologation))
-      .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
-        idUtilisateur: idContributeur, idHomologation, type: 'contributeur',
-      }));
-  };
+  const {
+    accesAutorise,
+    autorisation,
+    autorisationExiste,
+    autorisationPour,
+    autorisations,
+    transfereAutorisations,
+    ajouteContributeurAHomologation,
+  } = depotAutorisations;
 
   return {
     accesAutorise,

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -1,0 +1,82 @@
+const adaptateurUUIDParDefaut = require('../adaptateurs/adaptateurUUID');
+const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateurPersistance');
+const {
+  ErreurAutorisationExisteDeja,
+  ErreurHomologationInexistante,
+  ErreurUtilisateurInexistant,
+} = require('../erreurs');
+const FabriqueAutorisation = require('../modeles/autorisations/fabriqueAutorisation');
+
+const creeDepot = (config = {}) => {
+  const {
+    adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
+    adaptateurUUID = adaptateurUUIDParDefaut,
+    depotHomologations,
+    depotUtilisateurs,
+  } = config;
+
+  const autorisation = (id) => adaptateurPersistance.autorisation(id)
+    .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
+
+  const autorisationPour = (...params) => adaptateurPersistance.autorisationPour(...params)
+    .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
+
+  const autorisationExiste = (...params) => autorisationPour(...params)
+    .then((a) => !!a);
+
+  const autorisations = (idUtilisateur) => adaptateurPersistance.autorisations(idUtilisateur)
+    .then((as) => as.map((a) => FabriqueAutorisation.fabrique(a)));
+
+  const accesAutorise = (idUtilisateur, idHomologation) => autorisations(idUtilisateur)
+    .then((as) => as.some((a) => a.idHomologation === idHomologation));
+
+  const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => {
+    const verifieUtilisateurExiste = (id) => depotUtilisateurs.utilisateurExiste(id)
+      .then((existe) => {
+        if (!existe) throw new ErreurUtilisateurInexistant(`L'utilisateur "${id}" n'existe pas`);
+      });
+
+    return verifieUtilisateurExiste(idUtilisateurSource)
+      .then(() => verifieUtilisateurExiste(idUtilisateurCible))
+      .then(() => adaptateurPersistance
+        .transfereAutorisations(idUtilisateurSource, idUtilisateurCible));
+  };
+
+  const ajouteContributeurAHomologation = (idContributeur, idHomologation) => {
+    const verifieUtilisateurExiste = (id) => depotUtilisateurs.utilisateurExiste(id)
+      .then((existe) => {
+        if (!existe) throw new ErreurUtilisateurInexistant(`Le contributeur "${id}" n'existe pas`);
+      });
+
+    const verifieHomologationExiste = (id) => depotHomologations.homologation(idHomologation)
+      .then((h) => {
+        if (!h) throw new ErreurHomologationInexistante(`L'homologation "${id}" n'existe pas`);
+      });
+
+    const verifieAutorisationInexistante = (...params) => autorisationExiste(...params)
+      .then((existe) => {
+        if (existe) throw new ErreurAutorisationExisteDeja("L'autorisation existe déjà");
+      });
+
+    const idAutorisation = adaptateurUUID.genereUUID();
+
+    return verifieUtilisateurExiste(idContributeur)
+      .then(() => verifieHomologationExiste(idHomologation))
+      .then(() => verifieAutorisationInexistante(idContributeur, idHomologation))
+      .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
+        idUtilisateur: idContributeur, idHomologation, type: 'contributeur',
+      }));
+  };
+
+  return {
+    accesAutorise,
+    autorisation,
+    autorisationExiste,
+    autorisationPour,
+    autorisations,
+    transfereAutorisations,
+    ajouteContributeurAHomologation,
+  };
+};
+
+module.exports = { creeDepot };

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -1,0 +1,155 @@
+const {
+  ErreurNomServiceDejaExistant,
+  ErreurNomServiceManquant,
+} = require('../erreurs');
+const Homologation = require('../modeles/homologation');
+
+const creeDepot = (config = {}) => {
+  const { adaptateurPersistance, adaptateurUUID, referentiel } = config;
+
+  const homologation = (idHomologation) => adaptateurPersistance.homologation(idHomologation)
+    .then((h) => (h ? new Homologation(h, referentiel) : undefined));
+
+  const ajouteAItemsDansHomologation = (nomListeItems, idHomologation, item) => (
+    adaptateurPersistance.homologation(idHomologation)
+      .then((h) => {
+        h[nomListeItems] ||= [];
+
+        const donneesItem = item.toJSON();
+        const itemDejaDansDepot = h[nomListeItems].find((i) => i.id === donneesItem.id);
+        if (itemDejaDansDepot) {
+          Object.assign(itemDejaDansDepot, donneesItem);
+        } else {
+          h[nomListeItems].push(donneesItem);
+        }
+
+        const { id, ...donnees } = h;
+        return adaptateurPersistance.metsAJourHomologation(id, donnees);
+      })
+  );
+
+  const metsAJourProprieteHomologation = (nomPropriete, idOuHomologation, propriete) => {
+    const metsAJour = (h) => {
+      h[nomPropriete] ||= {};
+
+      const donneesPropriete = propriete.toJSON();
+      Object.assign(h[nomPropriete], donneesPropriete);
+
+      const { id, ...donnees } = h;
+      return adaptateurPersistance.metsAJourHomologation(id, donnees);
+    };
+
+    const trouveDonneesHomologation = (param) => (
+      typeof param === 'object'
+        ? Promise.resolve(param)
+        : adaptateurPersistance.homologation(param)
+    );
+
+    return trouveDonneesHomologation(idOuHomologation).then(metsAJour);
+  };
+
+  const metsAJourDescriptionServiceHomologation = (homologationCible, informations) => (
+    metsAJourProprieteHomologation('descriptionService', homologationCible, informations)
+  );
+
+  const remplaceProprieteHomologation = (nomPropriete, idHomologation, propriete) => (
+    adaptateurPersistance.homologation(idHomologation)
+      .then((h) => {
+        const donneesPropriete = propriete.toJSON();
+        h[nomPropriete] = donneesPropriete;
+
+        const { id, ...donnees } = h;
+        return adaptateurPersistance.metsAJourHomologation(id, donnees);
+      })
+  );
+
+  const ajouteMesureGeneraleAHomologation = (...params) => (
+    ajouteAItemsDansHomologation('mesuresGenerales', ...params)
+  );
+
+  const ajouteRisqueGeneralAHomologation = (...params) => (
+    ajouteAItemsDansHomologation('risquesGeneraux', ...params)
+  );
+
+  const homologationExiste = (...params) => (
+    adaptateurPersistance.homologationAvecNomService(...params)
+      .then((h) => !!h)
+  );
+
+  const valideDescriptionService = (idUtilisateur, { nomService }, idHomologationMiseAJour) => {
+    if (typeof nomService !== 'string' || !nomService) {
+      return Promise.reject(new ErreurNomServiceManquant('Le nom du service ne peut pas être vide'));
+    }
+
+    return homologationExiste(idUtilisateur, nomService, idHomologationMiseAJour)
+      .then((homologationExistante) => (
+        homologationExistante
+          ? Promise.reject(new ErreurNomServiceDejaExistant(
+            `Le nom du service "${nomService}" existe déjà pour une autre homologation`
+          ))
+          : Promise.resolve()
+      ));
+  };
+
+  const ajouteDescriptionServiceAHomologation = (idUtilisateur, idHomologation, infos) => (
+    adaptateurPersistance.homologation(idHomologation)
+      .then((h) => (
+        valideDescriptionService(idUtilisateur, infos, h.id)
+          .then(() => metsAJourDescriptionServiceHomologation(h, infos))
+      ))
+  );
+
+  const ajouteRolesResponsabilitesAHomologation = (...params) => (
+    metsAJourProprieteHomologation('rolesResponsabilites', ...params)
+  );
+
+  const ajouteAvisExpertCyberAHomologation = (...params) => (
+    metsAJourProprieteHomologation('avisExpertCyber', ...params)
+  );
+
+  const homologations = (idUtilisateur) => adaptateurPersistance.homologations(idUtilisateur)
+    .then((hs) => hs.map((h) => new Homologation(h, referentiel)));
+
+  const nouvelleHomologation = (idUtilisateur, donneesDescriptionService) => {
+    const idHomologation = adaptateurUUID.genereUUID();
+    const idAutorisation = adaptateurUUID.genereUUID();
+    const donnees = {
+      idUtilisateur,
+      descriptionService: donneesDescriptionService,
+    };
+
+    return valideDescriptionService(idUtilisateur, donneesDescriptionService)
+      .then(() => adaptateurPersistance.ajouteHomologation(idHomologation, donnees))
+      .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
+        idUtilisateur, idHomologation, type: 'createur',
+      }))
+      .then(() => idHomologation);
+  };
+
+  const remplaceMesuresSpecifiquesPourHomologation = (...params) => (
+    remplaceProprieteHomologation('mesuresSpecifiques', ...params)
+  );
+
+  const remplaceRisquesSpecifiquesPourHomologation = (...params) => (
+    remplaceProprieteHomologation('risquesSpecifiques', ...params)
+  );
+
+  const { supprimeHomologation } = adaptateurPersistance;
+
+  return {
+    ajouteAvisExpertCyberAHomologation,
+    ajouteDescriptionServiceAHomologation,
+    ajouteMesureGeneraleAHomologation,
+    ajouteRisqueGeneralAHomologation,
+    ajouteRolesResponsabilitesAHomologation,
+    homologation,
+    homologationExiste,
+    homologations,
+    nouvelleHomologation,
+    remplaceMesuresSpecifiquesPourHomologation,
+    remplaceRisquesSpecifiquesPourHomologation,
+    supprimeHomologation,
+  };
+};
+
+module.exports = { creeDepot };

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -1,0 +1,126 @@
+const bcrypt = require('bcrypt');
+
+const adaptateurJWTParDefaut = require('../adaptateurs/adaptateurJWT');
+const adaptateurUUIDParDefaut = require('../adaptateurs/adaptateurUUID');
+const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateurPersistance');
+const {
+  ErreurEmailManquant,
+  ErreurUtilisateurExistant,
+} = require('../erreurs');
+const Utilisateur = require('../modeles/utilisateur');
+
+const creeDepot = (config = {}) => {
+  const {
+    adaptateurJWT = adaptateurJWTParDefaut,
+    adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
+    adaptateurUUID = adaptateurUUIDParDefaut,
+    depotHomologations,
+  } = config;
+
+  const utilisateur = (identifiant) => adaptateurPersistance.utilisateur(identifiant)
+    .then((u) => (u ? new Utilisateur(u, adaptateurJWT) : undefined));
+
+  const nouvelUtilisateur = (donneesUtilisateur) => new Promise((resolve, reject) => {
+    const { email } = donneesUtilisateur;
+    if (!email) throw new ErreurEmailManquant('Le champ email doit être renseigné');
+
+    adaptateurPersistance.utilisateurAvecEmail(email)
+      .then((u) => {
+        if (u) {
+          return reject(new ErreurUtilisateurExistant(
+            'Utilisateur déjà existant pour cette adresse email'
+          ));
+        }
+
+        const id = adaptateurUUID.genereUUID();
+        donneesUtilisateur.idResetMotDePasse = adaptateurUUID.genereUUID();
+        return bcrypt.hash(adaptateurUUID.genereUUID(), 10)
+          .then((hash) => {
+            donneesUtilisateur.motDePasse = hash;
+
+            adaptateurPersistance.ajouteUtilisateur(id, donneesUtilisateur)
+              .then(() => resolve(utilisateur(id)));
+          });
+      });
+  });
+
+  const utilisateurAFinaliser = (idReset) => adaptateurPersistance.utilisateurAvecIdReset(idReset)
+    .then((u) => (u ? new Utilisateur(u, adaptateurJWT) : undefined));
+
+  const utilisateurAuthentifie = (login, motDePasse) => (
+    adaptateurPersistance.utilisateurAvecEmail(login)
+      .then((u) => {
+        const motDePasseStocke = u && u.motDePasse;
+        const echecAuthentification = undefined;
+
+        if (!motDePasseStocke) return new Promise((resolve) => resolve(echecAuthentification));
+
+        return bcrypt.compare(motDePasse, motDePasseStocke)
+          .then((authentificationReussie) => (authentificationReussie
+            ? new Utilisateur(u, adaptateurJWT)
+            : echecAuthentification
+          ));
+      })
+  );
+
+  const utilisateurExiste = (id) => utilisateur(id).then((u) => !!u);
+
+  const { utilisateurAvecEmail } = adaptateurPersistance;
+
+  const metsAJourMotDePasse = (idUtilisateur, motDePasse) => (
+    bcrypt.hash(motDePasse, 10)
+      .then((hash) => adaptateurPersistance.metsAJourUtilisateur(
+        idUtilisateur, { motDePasse: hash }
+      ))
+      .then(() => utilisateur(idUtilisateur))
+  );
+
+  const metsAJourUtilisateur = (id, donnees) => {
+    delete donnees.motDePasse;
+    return adaptateurPersistance.metsAJourUtilisateur(id, donnees)
+      .then(() => utilisateur(id));
+  };
+
+  const reinitialiseMotDePasse = (email) => adaptateurPersistance.utilisateurAvecEmail(email)
+    .then((u) => {
+      if (!u) return undefined;
+
+      const idResetMotDePasse = adaptateurUUID.genereUUID();
+      return adaptateurPersistance.metsAJourUtilisateur(u.id, { idResetMotDePasse })
+        .then(() => utilisateur(u.id));
+    });
+
+  const supprimeIdResetMotDePassePourUtilisateur = (utilisateurAModifier) => (
+    adaptateurPersistance.metsAJourUtilisateur(
+      utilisateurAModifier.id, { idResetMotDePasse: undefined }
+    )
+      .then(() => utilisateur(utilisateurAModifier.id))
+  );
+
+  const supprimeUtilisateur = (id) => depotHomologations.homologations(id)
+    .then((hs) => hs.map((h) => adaptateurPersistance.supprimeHomologation(h.id)))
+    .then((suppressions) => Promise.all(suppressions))
+    .then(() => adaptateurPersistance.supprimeUtilisateur(id));
+
+  const valideAcceptationCGUPourUtilisateur = (utilisateurAModifier) => (
+    adaptateurPersistance.metsAJourUtilisateur(utilisateurAModifier.id, { cguAcceptees: true })
+      .then(() => utilisateur(utilisateurAModifier.id))
+  );
+
+  return {
+    metsAJourMotDePasse,
+    metsAJourUtilisateur,
+    nouvelUtilisateur,
+    reinitialiseMotDePasse,
+    supprimeIdResetMotDePassePourUtilisateur,
+    supprimeUtilisateur,
+    utilisateur,
+    utilisateurAFinaliser,
+    utilisateurAuthentifie,
+    utilisateurExiste,
+    utilisateurAvecEmail,
+    valideAcceptationCGUPourUtilisateur,
+  };
+};
+
+module.exports = { creeDepot };


### PR DESCRIPTION
Le fichier était devenu très gros, difficile à lire… et ne mettait pas en évidence les dépendances entre les différentes tables. Cette PR répond à ce problème.

PR à venir :
- Séparation des tests de `depotDonnees.spec.js` en plusieurs modules correspondants
- Voir si ça peut être pertinent de ne plus accéder à l'API des dépôts par `DepotDonnees.XXX()`, mais peut-être par quelque chose comme `DepotDonnees.utilisateurs.XXX()`