### PR TITLE
Correction de l'alignement des puces dans nouvelles fonctionnalités

### DIFF
--- a/public/assets/styles/nouvellesFonctionnalites.css
+++ b/public/assets/styles/nouvellesFonctionnalites.css
@@ -11,9 +11,10 @@ section.informations {
 .informations::before {
   content: '';
   display: block;
+
   width: 1.7em;
-  height: 1.2em;
   margin: 0.25em 0.5em 0 0;
+
   background-image: url(../images/icone_information_bleue.svg);
   background-size: contain;
   background-repeat: no-repeat;
@@ -25,19 +26,19 @@ section.informations {
 
 .evolutions {
   list-style: none;
+  position: relative;
   padding: 0;
 }
 
 .evolutions li {
  margin-bottom: 1em;
+ margin-left: 1.7em;
 }
 
 .evolutions li::before {
   content: '\2705';
-  display: inline-block;
-  width: 1.2em;
-  height: 1.2em;
-  margin-right: 0.5em;
+  position: absolute;
+  left: 0;
 }
 
 .evolutions img {


### PR DESCRIPTION
Dans la page http://localhost:1917/nouvellesFonctionnalites le texte se situe à droite des puces
<img width="325" alt="Capture d’écran 2022-04-06 à 17 44 39" src="https://user-images.githubusercontent.com/39462397/162014627-0a944a00-e08b-4879-80d7-82d9e9f6cab0.png">
