### PR TITLE
[CORRECTION] Alignement du 'plus' dans la pastille bleue

### DIFF
--- a/public/assets/images/icone_plus_pastille_bleue.svg
+++ b/public/assets/images/icone_plus_pastille_bleue.svg
@@ -1,4 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="12" r="12" fill="#0F7AC7"/>
-<text fill="white" xml:space="preserve" style="white-space: pre" font-family="Marianne" font-size="18" font-weight="bold" letter-spacing="0em"><tspan x="6.60352" y="16.875">+</tspan></text>
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 25.5C6.09625 25.5 0.5 19.9038 0.5 13C0.5 6.09625 6.09625 0.5 13 0.5C19.9038 0.5 25.5 6.09625 25.5 13C25.5 19.9038 19.9038 25.5 13 25.5ZM11.75 11.75H6.75V14.25H11.75V19.25H14.25V14.25H19.25V11.75H14.25V6.75H11.75V11.75Z" fill="#0F7AC7"/>
 </svg>


### PR DESCRIPTION
Problème rencontré sur Firefox dans l'espace personnel :
<img width="215" alt="Capture d’écran 2022-04-07 à 15 58 57" src="https://user-images.githubusercontent.com/39462397/162216713-b74aa525-666b-4356-81e2-0d1a174c6098.png">
