### PR TITLE
Affichage correct du texte échappé dans le document d'homologation

### DIFF
--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -77,9 +77,9 @@ nav.ne-pas-imprimer
         dt Objet :
         dd= homologation.presentation()
         dt Développé par :
-        dd= homologation.structureDeveloppement()
+        dd!= homologation.structureDeveloppement()
         dt Hébergement et localisation des données :
-        dd= `${homologation.hebergeur()}, ${homologation.localisationDonnees()}`
+        dd!= `${homologation.hebergeur()}, ${homologation.localisationDonnees()}`
 
     section.risques
       h2 Principaux risques de sécurité identifiés


### PR DESCRIPTION
Dans le document d'homologation,
dans la première partie,
les caractères spéciaux étaient affichés en code html