### PR TITLE
Affichage correct des descriptions des risques

### DIFF
--- a/public/assets/styles/decision.css
+++ b/public/assets/styles/decision.css
@@ -161,6 +161,7 @@ section.introduction h2 {
 section.risques ul {
   grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 1em 2em;
+  grid-auto-rows: 1fr;
 }
 
 section.risques li, section.detail-risques dt {
@@ -168,7 +169,7 @@ section.risques li, section.detail-risques dt {
   justify-content: flex-end;
   align-items: center;
 
-  height: 4em;
+  min-height: 4em;
   overflow: hidden;
 
   padding: 0.5em 0.5em 0.5em 3.5em;


### PR DESCRIPTION
Dans le document d'homologation,
Quand une description de risque avait plus de quatre lignes
la première ligne n'apparaissait pas.