### PR TITLE
Correction de l'affichage des risques spécifiques échappés

### DIFF
--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -87,7 +87,7 @@ nav.ne-pas-imprimer
       ul
         each risque in homologation.risquesPrincipaux()
           li.
-            #{risque.descriptionRisque()} <br>
+            !{risque.descriptionRisque()} <br>
             (niveau de gravité : #{risque.descriptionNiveauGravite()})
 
     section.mesures


### PR DESCRIPTION
Dans le document d'homologation,
Dans la parties des risques principaux,
Le texte des risques spécifiques avec caractères spéciaux ne s'affichait pas correctement
<img width="311" alt="Capture d’écran 2022-04-08 à 15 05 58" src="https://user-images.githubusercontent.com/39462397/162441566-726d8670-ddcb-4a30-804d-973b2dfe67bc.png">
