### PR TITLE
Cartes d'informations dans la page des risques

### DIFF
--- a/public/assets/styles/homologation/risques.css
+++ b/public/assets/styles/homologation/risques.css
@@ -27,7 +27,16 @@
   gap: 0.4em;
 }
 
-.niveau-gravite .disque {
+.niveau-gravite .disque:hover {
+  cursor: pointer;
+  border-color: var(--bleu-anssi);
+}
+
+.niveau-gravite .disque.eteint {
+  background: var(--liseres);
+}
+
+.disque {
   height: 1em;
   width: 1em;
 
@@ -37,36 +46,27 @@
   background: var(--liseres);
 }
 
-.niveau-gravite .disque:hover {
-  cursor: pointer;
-  border-color: var(--bleu-anssi);
-}
-
-.niveau-gravite .disque.cercle {
+.disque.cercle {
   border: solid .5px var(--bleu-anssi);
 }
 
-.niveau-gravite .disque.eteint {
-  background: var(--liseres);
-}
-
-.niveau-gravite .disque.blanc {
+.disque.blanc {
   background: #fff;
 }
 
-.niveau-gravite .disque.vert {
+.disque.vert {
   background: var(--vert-anssi);
 }
 
-.niveau-gravite .disque.jaune {
+.disque.jaune {
   background: var(--jaune-anssi);
 }
 
-.niveau-gravite .disque.orange {
+.disque.orange {
   background: var(--orange-anssi);
 }
 
-.niveau-gravite .disque.rouge {
+.disque.rouge {
   background: var(--rouge-anssi);
 }
 
@@ -74,4 +74,83 @@
   height: 1.4em;
   font-size: 0.7em;
   font-weight: normal;
+}
+
+.formulaire {
+  grid-gap: 1.7em;
+}
+
+.carte {
+  box-sizing: border-box;
+  width: 270px;
+  margin-bottom: 1.7em;
+  padding: 1.7em;
+
+  background-color: #fff;
+
+  text-align: left;
+}
+
+.carte .titre {
+  display: inline;
+
+  font-size: 1.2em;
+}
+
+.carte .sous-titre {
+  margin-top: 0;
+
+  font-size: 1em;
+  font-weight: 600;
+  color: var(--texte-clair);
+}
+
+.carte ul.niveaux-gravites {
+  list-style: none;
+
+  padding: 0;
+
+  line-height: 1.8em;
+}
+.carte .niveaux-gravites .disque {
+  display: inline-block;
+
+  margin: 0 0.8em -0.2em 0;
+}
+.carte .plus-details, .carte .moins-details {
+  text-align: right;
+  font-size: 0.85em;
+  cursor: pointer;
+}
+.carte .plus-details::after, .carte .moins-details::after {
+  content: '';
+  display: inline-block;
+  width: .6em;
+  height: .6em;
+  margin-left: 1em;
+
+  border: 2px var(--bleu-anssi) solid;
+  transform: rotate(0.12turn);
+}
+
+.carte .moins-details::after {
+  margin-bottom: -0.2em;
+
+  border-bottom: 0;
+  border-right: 0;
+}
+
+.carte .plus-details::after {
+  margin-bottom: 0.2em;
+
+  border-top: 0;
+  border-left: 0;
+}
+.carte h4 {
+  margin: 0;
+
+  color: var(--bleu-mise-en-avant);
+}
+.carte h4 + p {
+  margin-top: 0;
 }

--- a/public/homologation/risques.js
+++ b/public/homologation/risques.js
@@ -63,6 +63,13 @@ $(() => {
   indexMaxRisquesSpecifiques = peupleRisquesSpecifiques('#risques-specifiques', '#donnees-risques-specifiques');
   brancheAjoutRisqueSpecifique('.nouvel-item', '#risques-specifiques');
 
+  $('.carte .details').hide();
+  $('.carte .moins-details').hide();
+  $('.carte .plus-details, .carte .moins-details').on('click', () => {
+    $('.carte .details').toggle();
+    $('.carte .plus-details, .carte .moins-details').toggle();
+  });
+
   const $bouton = $('.bouton');
   const identifiantHomologation = $bouton.attr('identifiant');
 

--- a/src/vues/homologation/formulaire.pug
+++ b/src/vues/homologation/formulaire.pug
@@ -13,3 +13,5 @@ block main
 
   .formulaire.marges-fixes
     block formulaire
+    .cartes-informations
+      block cartes-informations

--- a/src/vues/homologation/risques.pug
+++ b/src/vues/homologation/risques.pug
@@ -52,3 +52,57 @@ block formulaire
   script(id = 'donnees-risques-specifiques', type = 'application/json').
     !{JSON.stringify(homologation.risques.toJSON().risquesSpecifiques || [])}
   script(type = 'module', src = '/statique/homologation/risques.js')
+
+block cartes-informations
+  .carte
+    h2.titre Niveaux de gravité
+    h3.sous-titre Découvrez les 5 niveaux définis par l'ANSSI.
+    ul.niveaux-gravites
+      li
+        .disque.rouge
+        .
+          Critique
+      li
+        .disque.orange
+        .
+          Grave
+      li
+        .disque.jaune
+        .
+          Significatif
+      li
+        .disque.vert
+        .
+          Minime
+      li
+        .disque.cercle.blanc
+        .
+          Non concerné
+    .plus-details Plus de détails
+    .moins-details Moins de détails
+    .details
+      h4 Critique
+      p.
+        Incapacité pour l’organisation d’assurer la totalité ou une partie de son activité,
+        avec d’éventuels impacts graves sur la sécurité des personnes et des biens.
+        L’organisation ne surmontera vraisemblablement pas la situation (sa survie est menacée),
+        les secteurs d’activité ou étatiques dans lesquels elle opère seront susceptibles d’être légèrement impactés,
+        sans conséquences durables
+
+      h4 Grave
+      p.
+        Forte dégradation des performances de l’activité, avec d’éventuels impacts significatifs
+        sur la sécurité des personnes et des biens. L’organisation surmontera la situation avec
+        de sérieuses difficultés (fonctionnement en mode très dégradé), sans impacts sectoriel ou étatique
+
+      h4 Significatif
+      p.
+        Dégradation des performances de l’activité sans impact sur la sécurité des personnes et des biens.
+        L’organisation surmontera la situation malgré quelques difficultés (fonctionnement en mode dégradé)
+
+      h4 Minime
+      p.
+        Aucun impact opérationnel ni sur les performances de l’activité ni sur la sécurité des personnes et des biens.
+        L’organisation surmontera la situation sans trop de difficultés (consommation des marges)
+
+      h4 Non concerné


### PR DESCRIPTION
Dans la page des risques,
nous souhaitons avoir des cartes d'informations pour aider l'utilisateur.
<img width="1146" alt="Capture d’écran 2022-04-27 à 17 23 05" src="https://user-images.githubusercontent.com/39462397/165553681-ca427ba3-ef06-4338-a7a2-f5d7984e7d7f.png">

Des maquettes sont disponibles dans Figma Version Cible

Note : 
- La largeur de la carte ainsi que les gouttières ne corespondent pas à la maquette Version Cible car cela entraine un dépassement des 1200px de largeur ou la réduction du formulaire.
- Pour les gouttières j'ai pris la valeur de 24px de la maquette UI kit
- Pour les cartes j'ai choisi la largeur de 270px qui est moins que les 282px prévu mais qui selon moi est un bon équilibre avec la taille diminué du formulaire