### PR TITLE
Correction enregistrement des mesures vides

### DIFF
--- a/public/modules/arrangeParametresMesures.mjs
+++ b/public/modules/arrangeParametresMesures.mjs
@@ -17,13 +17,15 @@ const arrangeParametresMesures = (parametres) => {
       nomParametre !== CLE_MESURES_SPECIFIQUES && nomParametre !== CLE_MESURES_GENERALES
     ))
     .reduce((acc, nomParametre) => {
-      const nomParametreModalites = nomParametre.match(/^modalites-(.*)$/)?.[1];
-      if (nomParametreModalites) {
-        acc[nomParametreModalites] = acc[nomParametreModalites] || {};
-        acc[nomParametreModalites].modalites = parametres[nomParametre];
-      } else {
-        acc[nomParametre] = acc[nomParametre] || {};
-        acc[nomParametre].statut = parametres[nomParametre];
+      if (parametres[nomParametre]) {
+        const nomParametreModalites = nomParametre.match(/^modalites-(.*)$/)?.[1];
+        if (nomParametreModalites) {
+          acc[nomParametreModalites] = acc[nomParametreModalites] || {};
+          acc[nomParametreModalites].modalites = parametres[nomParametre];
+        } else {
+          acc[nomParametre] = acc[nomParametre] || {};
+          acc[nomParametre].statut = parametres[nomParametre];
+        }
       }
       delete parametres[nomParametre];
       return acc;

--- a/test_public/modules/arrangeParametresMesures.spec.mjs
+++ b/test_public/modules/arrangeParametresMesures.spec.mjs
@@ -57,4 +57,13 @@ describe("Une demande d'arrangement des paramètres des mesures", () => {
     expect(mesuresGenerales).to.have.property('contactSecurite');
     expect(mesuresGenerales.contactSecurite.modalites).to.equal('Des modalités');
   });
+
+  it("n'ajoute pas de paramètres vides dans les mesures", () => {
+    const parametres = { contactSecurite: '', 'modalites-contactSecurite': '' };
+
+    arrangeParametresMesures(parametres);
+
+    const { mesuresGenerales } = parametres;
+    expect(mesuresGenerales).to.not.have.property('contactSecurite');
+  });
 });


### PR DESCRIPTION
Dans la page des mesures,
quand on enregistre les mesures générales,
actuellement toutes les mesures vide sont enregistrées ce qui donne le faux positif de page saisie