### PR TITLE
Correction affichage parasite d'une icône d'information

### DIFF
--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -8,12 +8,6 @@ import ajouteModalesInformations from '../modules/interactions/modalesInformatio
 $(() => {
   let indexMaxMesuresSpecifiques = 0;
 
-  const mesureGeneraleDeCategorie = (mesureGenerale, categorieFiltre) => (
-    categorieFiltre
-      ? categorieFiltre === mesureGenerale.categorie
-      : true
-  );
-
   const mesureSpecifiqueDeCategorie = (elementMesureSpecifique, categorieFiltre) => (
     categorieFiltre
       ? $(`option[value="${categorieFiltre}"]:selected, option[value=""]:selected`, elementMesureSpecifique).length === 1
@@ -21,11 +15,7 @@ $(() => {
   );
 
   const filtreMesures = (categorieFiltre) => {
-    const referentielMesures = JSON.parse($('#referentiel-mesures').text());
-
-    Object.keys(referentielMesures).forEach((id) => $(`fieldset#${id}`)
-      .toggle(mesureGeneraleDeCategorie(referentielMesures[id], categorieFiltre)));
-
+    $('.mesure').each((_, item) => $(item).toggle($(item).hasClass(categorieFiltre)));
     $('.item-ajoute').each((_, item) => $(item)
       .toggle(mesureSpecifiqueDeCategorie(item, categorieFiltre)));
   };
@@ -33,7 +23,7 @@ $(() => {
   const brancheFiltres = (selecteurFiltres) => {
     const $filtres = $(selecteurFiltres);
     $filtres.each((_, f) => {
-      $(f).click((e) => {
+      $(f).on('click', (e) => {
         $('.actif').removeClass('actif');
         $(e.target).addClass('actif');
 
@@ -49,7 +39,7 @@ $(() => {
     const $zoneSaisie = $(`<textarea id=${nom} name=${nom}></textarea>`);
     $zoneSaisie.hide();
 
-    $lien.click(() => {
+    $lien.on('click', () => {
       $zoneSaisie.toggle();
       if ($zoneSaisie.is(':visible')) $zoneSaisie.focus();
     });
@@ -135,7 +125,7 @@ ${statuts}
   const $bouton = $('.bouton');
   const identifiantHomologation = $bouton.attr('identifiant');
 
-  $bouton.click(() => {
+  $bouton.on('click', () => {
     const params = parametres('form#mesures');
     arrangeParametresMesures(params);
 

--- a/src/vues/homologation/mesures.pug
+++ b/src/vues/homologation/mesures.pug
@@ -25,13 +25,13 @@ block formulaire
 
     section
       nav
-        a.actif Tout
+        a.actif#tout Tout
         each categorie, identifiant in referentiel.categoriesMesures()
           a(id = identifiant)= categorie
 
       .mesures
         each donnees, identifiant in mesures
-          .mesure
+          .mesure.tout(class = donnees.categorie)
             +inputMesure({
               nom: identifiant,
               titre: donnees.description,
@@ -57,9 +57,6 @@ block formulaire
 
   script(id = 'donnees-mesures-specifiques', type = 'application/json').
     !{JSON.stringify(homologation.mesures.toJSON().mesuresSpecifiques || [])}
-
-  script(id = 'referentiel-mesures', type = 'application/json').
-    !{JSON.stringify(referentiel.mesures())}
 
   script(id = 'referentiel-categories-mesures', type = 'application/json').
     !{JSON.stringify(referentiel.categoriesMesures())}


### PR DESCRIPTION
Dans la page des mesures,
avec un service qui n'est pas une application mobile,
quand on filtre pour avoir uniquement les mesures de protections,
en bas de la page il y a un i qui vient s'ajouter et perturbe l'affichage

- la désactivation des affichages des mesures se faisaient sur les fieldset je l'ai déplacée sur les div.mesure parents
- j'ai changé le comportement d'identification des mesures en étant plus déclaratif dans le pug

boy-scout : j'ai transformer le .click() en .on('click', )