### PR TITLE
Personnalisation des mesures achat sur étagère

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -552,7 +552,7 @@ module.exports = {
   },
 
   reglesPersonnalisation: {
-    clefsDescriptionServiceAConsiderer: ['typeService', 'fonctionnalites'],
+    clefsDescriptionServiceAConsiderer: ['typeService', 'fonctionnalites', 'provenanceService'],
     mesuresBase: [
       'limitationInterconnexions',
       'listeEquipements',
@@ -619,6 +619,13 @@ module.exports = {
         'testIntrusion',
         'supervision',
         'sauvegardeDonnees',
+      ],
+    },
+    mesuresARetirer: {
+      achat: [
+        'listeEquipements',
+        'testIntrusion',
+        'notificationConnexionsSuspectes',
       ],
     },
   },

--- a/src/moteurRegles.js
+++ b/src/moteurRegles.js
@@ -6,25 +6,34 @@ class MoteurRegles {
     this.referentiel = referentiel;
   }
 
-  mesuresAAjouter(descriptionService) {
-    const {
-      clefsDescriptionServiceAConsiderer = [],
-      mesuresAAjouter = {},
-    } = this.reglesPersonnalisation;
+  regle(identifiantRegle, descriptionService) {
+    const { clefsDescriptionServiceAConsiderer = [] } = this.reglesPersonnalisation;
+    const regle = this.reglesPersonnalisation[identifiantRegle] || {};
 
     const valeursDescriptionService = clefsDescriptionServiceAConsiderer.flatMap(
       (clef) => descriptionService[clef]
     );
 
-    return Object.keys(mesuresAAjouter)
+    return Object.keys(regle)
       .filter((clef) => valeursDescriptionService.includes(clef))
-      .flatMap((clef) => mesuresAAjouter[clef]);
+      .flatMap((clef) => regle[clef]);
+  }
+
+  mesuresAAjouter(descriptionService) {
+    return this.regle('mesuresAAjouter', descriptionService);
+  }
+
+  mesuresARetirer(descriptionService) {
+    return this.regle('mesuresARetirer', descriptionService);
   }
 
   mesures(...params) {
     const { mesuresBase = [] } = this.reglesPersonnalisation;
     const mesuresAAjouter = this.mesuresAAjouter(...params);
-    const idMesures = mesuresBase.concat(mesuresAAjouter);
+    const mesuresARetirer = this.mesuresARetirer(...params);
+    const idMesures = mesuresBase
+      .concat(mesuresAAjouter)
+      .filter((mesure) => !mesuresARetirer.includes(mesure));
 
     return idMesures.reduce(
       (resultat, id) => Object.assign(resultat, { [id]: this.referentiel.mesure(id) }),

--- a/test/moteurRegles.spec.js
+++ b/test/moteurRegles.spec.js
@@ -61,4 +61,48 @@ describe('Le moteur de règles', () => {
     const description = new DescriptionService();
     expect(moteur.mesures(description)).to.eql({});
   });
+
+  describe('quand il est faut retirer des mesures', () => {
+    it('détermine quelles mesures sont à retirer en fonction de la description du service', () => {
+      const referentiel = Referentiel.creeReferentiel({ reglesPersonnalisation: {
+        clefsDescriptionServiceAConsiderer: ['provenanceService'],
+        mesuresARetirer: { achat: ['uneMesure', 'uneAutreMesure'] },
+      } });
+      const moteur = new MoteurRegles(referentiel);
+
+      const achat = new DescriptionService({ provenanceService: ['achat'] });
+      expect(moteur.mesuresARetirer(achat)).to.eql(['uneMesure', 'uneAutreMesure']);
+    });
+
+    it('ne retire aucune mesure si aucune règle ne correspond à la description du service', () => {
+      const referentiel = Referentiel.creeReferentiel({ reglesPersonnalisation: {
+        clefsDescriptionServiceAConsiderer: ['provenanceService'],
+        mesuresARetirer: { achat: ['uneMesure', 'uneAutreMesure'] },
+      } });
+      const moteur = new MoteurRegles(referentiel);
+
+      const developpement = new DescriptionService({ provenanceService: ['developpement'] });
+      expect(moteur.mesuresARetirer(developpement)).to.eql([]);
+    });
+
+    it('retire les mesures à retirer aux mesures de base', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        mesures: {
+          mesureBase: {},
+          mesureASupprimer: {},
+        },
+        reglesPersonnalisation: {
+          clefsDescriptionServiceAConsiderer: ['provenanceService'],
+          mesuresBase: ['mesureBase', 'mesureASupprimer'],
+          mesuresARetirer: { achat: ['mesureASupprimer'] },
+        },
+      });
+      const moteur = new MoteurRegles(referentiel);
+
+      const achat = new DescriptionService({ provenanceService: ['achat'] });
+      expect(moteur.mesures(achat)).to.eql({
+        mesureBase: {},
+      });
+    });
+  });
 });


### PR DESCRIPTION
Quand l'utilisateur achète l'application,
les mesures à retirer sont
- Disposer d'une liste à jour des équipements et des logiciels contribuant au fonctionnement du service numérique
- Effectuer un test d'intrusion et/ou réaliser un bug bounty
~- Réaliser un audit de configuration et de code source du service~
- Envoyer aux administrateurs et aux utilisateurs une notification en cas de connexion suspecte

Ce dev est l'occasion d'écrire la règle de retrait de mesures
~La mesure **Réaliser un audit de configuration et de code source du service** est nouvelle, elle n'a pas été pour le moment ajoutée aux mesures de base~