### PR TITLE
Correction du statut de saisie des mesures générales

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -43,7 +43,7 @@ class Homologation {
 
     const idMesures = Object.keys(moteurRegles.mesures(this.descriptionService));
     mesuresGenerales = mesuresGenerales.filter((m) => idMesures.includes(m.id));
-    this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel);
+    this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel, idMesures);
 
     this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);
     this.risques = new Risques(

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -4,7 +4,7 @@ const MesuresSpecifiques = require('./mesuresSpecifiques');
 const Referentiel = require('../referentiel');
 
 class Mesures extends InformationsHomologation {
-  constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide()) {
+  constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide(), identifiantsMesures) {
     super({
       listesAgregats: {
         mesuresGenerales: MesuresGenerales,
@@ -13,6 +13,7 @@ class Mesures extends InformationsHomologation {
     });
     this.renseigneProprietes(donnees, referentiel);
     this.referentiel = referentiel;
+    this.identifiantsMesures = identifiantsMesures || this.referentiel.identifiantsMesures();
   }
 
   nonSaisies() {
@@ -25,6 +26,16 @@ class Mesures extends InformationsHomologation {
 
   statistiques() {
     return this.mesuresGenerales.statistiques();
+  }
+
+  statutSaisie() {
+    const statutSaisieMesures = super.statutSaisie();
+    if (statutSaisieMesures === Mesures.COMPLETES
+      && this.identifiantsMesures.length !== this.mesuresGenerales.nombre()) {
+      return Mesures.A_COMPLETER;
+    }
+
+    return statutSaisieMesures;
   }
 }
 

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -50,7 +50,7 @@ class MesuresGenerales extends ElementsConstructibles {
 
   statutSaisie() {
     if (this.nonSaisies()) return MesuresGenerales.A_SAISIR;
-    if (this.items.length === this.referentiel.identifiantsMesures().length) {
+    if (this.items.every((item) => item.statutSaisie() === MesuresGenerales.COMPLETES)) {
       return MesuresGenerales.COMPLETES;
     }
     return MesuresGenerales.A_COMPLETER;

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -1,8 +1,9 @@
 const expect = require('expect.js');
 
-const InformationsHomologation = require('../../src/modeles/informationsHomologation');
+const { A_COMPLETER } = require('../../src/modeles/informationsHomologation');
 const Mesures = require('../../src/modeles/mesures');
 const MesuresSpecifiques = require('../../src/modeles/mesuresSpecifiques');
+const Referentiel = require('../../src/referentiel');
 
 const elles = it;
 
@@ -21,6 +22,18 @@ describe('Les mesures liées à une homologation', () => {
       mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
     });
 
-    expect(mesures.statutSaisie()).to.equal(InformationsHomologation.A_COMPLETER);
+    expect(mesures.statutSaisie()).to.equal(A_COMPLETER);
+  });
+
+  elles('sont à completer si toutes les mesures nécessaires ne sont pas complétées', () => {
+    const referentiel = Referentiel.creeReferentielVide();
+    referentiel.identifiantsMesures = () => ['mesure 1', 'mesure 2'];
+
+    const mesures = new Mesures({
+      mesuresGenerales: [{ id: 'mesure 1', statut: 'fait' }],
+      mesuresSpecifiques: [],
+    }, referentiel);
+
+    expect(mesures.statutSaisie()).to.equal(A_COMPLETER);
   });
 });

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -1,0 +1,30 @@
+const expect = require('expect.js');
+
+const MesuresGenerales = require('../../src/modeles/mesuresGenerales');
+
+const { A_SAISIR, COMPLETES, A_COMPLETER } = MesuresGenerales;
+
+describe('La liste des mesures générales', () => {
+  const referentiel = { identifiantsMesures: () => ['mesure'] };
+
+  it("est à saisir quand rien n'est saisi", () => {
+    const donnees = { mesuresGenerales: [] };
+    const mesuresGenerales = new MesuresGenerales(donnees);
+
+    expect(mesuresGenerales.statutSaisie()).to.equal(A_SAISIR);
+  });
+
+  it('est complete quand les mesures sont completes', () => {
+    const donnees = { mesuresGenerales: [{ id: 'mesure', statut: 'fait' }] };
+    const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
+
+    expect(mesuresGenerales.statutSaisie()).to.equal(COMPLETES);
+  });
+
+  it('est à completer quand toutes les mesures ne sont pas completes', () => {
+    const donnees = { mesuresGenerales: [{ id: 'mesure' }] };
+    const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
+
+    expect(mesuresGenerales.statutSaisie()).to.equal(A_COMPLETER);
+  });
+});


### PR DESCRIPTION
Dans la page de synthèse les mesures apparaissaient _à completer_
dû à la personnalisation et l'ajout d'une mesure spécifique application mobile.

Pour y remédier,

- j'ai modifié la condition de statut des mesures générales pour qu'elles regardent uniquement les statuts des mesures de la listes
- les mesures utilisent la listes des identifiants référentiel pour ajuster le statut des mesures générales
- l'homologation donne aux mesures les identifiants obtenu après le passage dans le moteur de règles

C'est un fix mais je trouve cela lourd