### PR TITLE
Suppression dans les mesures des statuts et modalités vides

### DIFF
--- a/migrations/20220509153038_nettoyageMesuresGeneralesVides.js
+++ b/migrations/20220509153038_nettoyageMesuresGeneralesVides.js
@@ -1,0 +1,16 @@
+exports.up = (knex) => knex('homologations')
+  .then((lines) => {
+    const misesAJour = lines
+      .filter(({ donnees }) => donnees?.mesuresGenerales)
+      .map(({ id, donnees: { mesuresGenerales, ...autresDonnees } }) => {
+        const mesuresNettoyees = mesuresGenerales.filter(
+          (mesure) => mesure.statut || mesure.modalites
+        );
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: { mesuresGenerales: mesuresNettoyees, ...autresDonnees } });
+      });
+    return Promise.all(misesAJour);
+  });
+
+exports.down = () => {};


### PR DESCRIPTION
Précédemment dans l'application (https://github.com/betagouv/mon-service-securise/pull/247) l'enregistrement des mesures enregistrait des mesures et de modalités vides.
Actuellement cela est visible dans le document d'homologation (dans le cas d'un enregistrement de la page mesures avant le correctif) où on a toutes les mesures qui s'affichent.

Ce code est une migration des données qui a pour but des supprimer les mesures générales qui ont un statut vide et des modalités vides.

Pour tester j'ai écrit dans node la commande qui suit avant et après la migration

```node
require('knex')(require('./knexfile').development).select('donnees').from('homologations').then((lines) => lines.map((line) => line.donnees).map((donnees) => donnees?.mesuresGenerales?.filter((mesure) => !mesure.statut && !mesure.modalites).reduce((acc, cur) => acc + 1, 0))).then(console.log);
```