### PR TITLE
Retrait des mentions alpha et béta

### DIFF
--- a/src/vues/inscription.pug
+++ b/src/vues/inscription.pug
@@ -4,10 +4,10 @@ block formulaire
   form.acces-refuse
     h1 Créez votre compte
     p
-      span.
-        Pendant la phase alpha de l'exploitation de Mon Service Sécurisé, la
-        création de compte est restreinte. Merci de bien vouloir&nbsp;
+      span La création de compte est réservée exclusivement aux agents publics.
+      br
+      span Merci de bien vouloir&nbsp;
       a(href = 'mailto:contact@monservicesecurise.beta.gouv.fr?subject=Cr%C3%A9ation%20de%20compte').
         nous contacter
       span.
-        &nbsp;pour créer votre compte.
+        &nbsp;pour obtenir un accès.

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -28,7 +28,7 @@ block page
     block main
 
   footer.marges-fixes
-    span Mon Service Sécurisé par l'ANSSI – Version béta
+    span Mon Service Sécurisé par l'ANSSI
     nav
       a(href = '/aPropos') À propos
       a(href = '/confidentialite') Politique de confidentialité


### PR DESCRIPTION
Dans le footer de toutes les pages il y avait **Version béta** ce n'est plus le cas
Le texte de la page inscription à été changé pour ne plus faire apparaitre **phase alpha**
<img width="741" alt="Capture d’écran 2022-05-16 à 16 12 46" src="https://user-images.githubusercontent.com/39462397/168612831-1a6222e0-4f3a-4459-9a0a-b06a9d94b5db.png">
