### PR TITLE
Nouveau statut de déploiement en projet

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -28,6 +28,9 @@ module.exports = {
   },
 
   statutsDeploiement: {
+    enProjet: {
+      description: 'En projet',
+    },
     accessible: {
       description: 'Le service est déjà accessible aux utilisateurs',
     },


### PR DESCRIPTION
Dans la description du service,
quand l'utilisateur renseigne le statut de déploiement du service numérique,
il souhaite avoir la possibilité de choisir En projet