### PR TITLE
Renmmage des statuts de déploiement

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -31,11 +31,11 @@ module.exports = {
     enProjet: {
       description: 'En projet',
     },
-    accessible: {
-      description: 'Le service est déjà accessible aux utilisateurs',
+    enCours: {
+      description: 'En cours de développement ou de déploiement',
     },
-    nonAccessible: {
-      description: "Le service n'est pas accessible aux utilisateurs",
+    enLigne: {
+      description: 'En ligne et accessible aux usagers et/ou agents',
     },
   },
 

--- a/migrations/20220517130637_modificationClesStatutDeploiement.js
+++ b/migrations/20220517130637_modificationClesStatutDeploiement.js
@@ -1,0 +1,34 @@
+const nouveauStatut = (statut) => {
+  switch (statut) {
+    case 'accessible': return 'enLigne';
+    case 'nonAccessible': return 'enCours';
+    default: return statut;
+  }
+};
+
+const ancienStatut = (statut) => {
+  switch (statut) {
+    case 'enLigne': return 'accessible';
+    case 'enCours': return 'nonAccessible';
+    default: return statut;
+  }
+};
+
+const modifieStatutDeploiement = (changementStatut) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees?.descriptionService)
+      .map(({ id, donnees: { descriptionService, ...autresDonnees } }) => {
+        descriptionService.statutDeploiement = changementStatut(
+          descriptionService.statutDeploiement
+        );
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: { descriptionService, ...autresDonnees } });
+      });
+    return Promise.all(misesAJour);
+  });
+
+exports.up = modifieStatutDeploiement(nouveauStatut);
+
+exports.down = modifieStatutDeploiement(ancienStatut);


### PR DESCRIPTION
Dans la page Description du service,
les statuts de déploiement accessible et non accessible sont renommés en en ligne et en cours
<img width="398" alt="Capture d’écran 2022-05-17 à 15 55 53" src="https://user-images.githubusercontent.com/39462397/168828047-be76f40b-60d3-4697-9478-fbc518d71309.png">

Note : ce dev comporte une migration de données