### PR TITLE
Renommage du label de la question des fonctionnalités

### DIFF
--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -65,7 +65,7 @@ mixin formulaireDescriptionService(idHomologation)
       +inputChoix({
         type: 'checkbox',
         nom: 'fonctionnalites',
-        titre: 'Principales fonctionnalités offertes par le service numérique',
+        titre: 'Fonctionnalité(s) offerte(s)',
         items: referentiel.fonctionnalites(),
         objetDonnees: homologation.descriptionService,
       })


### PR DESCRIPTION
Dans la page Description du service,
Le label de la question sur les fonctionnalités du service est renommé
<img width="443" alt="Capture d’écran 2022-05-18 à 10 16 32" src="https://user-images.githubusercontent.com/39462397/168991672-038d34f0-a686-4545-961b-408f9447570a.png">
