### PR TITLE
Double enregistrement de la cartographie des acteurs

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -2,6 +2,7 @@ const {
   ErreurNomServiceDejaExistant,
   ErreurNomServiceManquant,
 } = require('../erreurs');
+const CartographieActeurs = require('../modeles/cartographieActeurs');
 const Homologation = require('../modeles/homologation');
 
 const creeDepot = (config = {}) => {
@@ -99,9 +100,12 @@ const creeDepot = (config = {}) => {
       ))
   );
 
-  const ajouteRolesResponsabilitesAHomologation = (...params) => (
-    metsAJourProprieteHomologation('rolesResponsabilites', ...params)
-  );
+  const ajouteRolesResponsabilitesAHomologation = (...params) => {
+    const [idHomologation, rolesResponsabilites] = params;
+
+    return metsAJourProprieteHomologation('rolesResponsabilites', ...params)
+      .then(() => metsAJourProprieteHomologation('cartographieActeurs', idHomologation, new CartographieActeurs(rolesResponsabilites.toJSON())));
+  };
 
   const ajouteAvisExpertCyberAHomologation = (...params) => (
     metsAJourProprieteHomologation('avisExpertCyber', ...params)

--- a/src/modeles/cartographieActeurs.js
+++ b/src/modeles/cartographieActeurs.js
@@ -1,0 +1,5 @@
+const RolesResponsabilites = require('./rolesResponsabilites');
+
+class CartographieActeurs extends RolesResponsabilites {}
+
+module.exports = CartographieActeurs;

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -2,6 +2,7 @@ const MoteurRegles = require('../moteurRegles');
 const Referentiel = require('../referentiel');
 
 const AvisExpertCyber = require('./avisExpertCyber');
+const CartographieActeurs = require('./cartographieActeurs');
 const DescriptionService = require('./descriptionService');
 const Mesure = require('./mesure');
 const Mesures = require('./mesures');
@@ -24,6 +25,7 @@ class Homologation {
   ) {
     const {
       id = '',
+      cartographieActeurs = {},
       contributeurs = [],
       createur = {},
       descriptionService = {},
@@ -46,6 +48,7 @@ class Homologation {
     this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel, idMesures);
 
     this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);
+    this.cartographieActeurs = new CartographieActeurs(cartographieActeurs);
     this.risques = new Risques(
       { risquesGeneraux, risquesSpecifiques },
       referentiel,

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -305,6 +305,26 @@ describe('Le dépot de données des homologations', () => {
       .catch(done);
   });
 
+  it('sait enregistrer les rôles et responsabilités en cartographie des acteurs', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [{
+        id: '123',
+        descriptionService: { nomService: 'nom' },
+      }],
+    });
+    const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
+
+    const rolesResponsabilites = new RolesResponsabilites({ autoriteHomologation: 'Jean Dupont' });
+    depot.ajouteRolesResponsabilitesAHomologation('123', rolesResponsabilites)
+      .then(() => depot.homologation('123'))
+      .then(({ cartographieActeurs }) => {
+        expect(cartographieActeurs).to.be.ok();
+        expect(cartographieActeurs.autoriteHomologation).to.equal('Jean Dupont');
+        done();
+      })
+      .catch(done);
+  });
+
   describe('concernant les risques généraux', () => {
     let valideRisque;
 


### PR DESCRIPTION
Etape 1 pour le changement de Roles et responsabilités en Cartographie des acteurs

Dans la page Roles et responsabilités,
Quand on enregistre les données,
les données sont persistées à la fois dans rolesResponsabilites et cartographieActeurs