### PR TITLE
Duplication des rôles et responsabilités dans la cartographie des acteurs

### DIFF
--- a/migrations/20220518154731_dupliqueRolesResponsabilitesDansCartographieActeurs.js
+++ b/migrations/20220518154731_dupliqueRolesResponsabilitesDansCartographieActeurs.js
@@ -1,0 +1,21 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.rolesResponsabilites)
+      .map(({ id, donnees: { rolesResponsabilites, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: {
+          rolesResponsabilites, cartographieActeurs: rolesResponsabilites, ...autresDonnees,
+        } }));
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.cartographieActeurs)
+      .map(({ id, donnees: { cartographieActeurs: _, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: { ...autresDonnees } }));
+    return Promise.all(misesAJour);
+  });


### PR DESCRIPTION
Etape 2 pour le changement de Roles et responsabilités en Cartographie des acteurs

Migration ayant pour but de copier les données des rôles et responsabilités dans les cartographies des acteurs