### PR TITLE
Renommage en cartographie des acteurs

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -4,7 +4,7 @@ const expiration = (duree) => `${duree.charAt(0).toUpperCase()}${duree.slice(1)}
 module.exports = {
   actionsSaisie: {
     descriptionService: { position: 0, description: 'Description du service' },
-    rolesResponsabilites: { position: 1, description: 'Rôles et responsabilités' },
+    cartographieActeurs: { position: 1, description: 'Rôles et responsabilités' },
     risques: { position: 2, description: 'Risques de sécurité' },
     mesures: { position: 3, description: 'Mesures de sécurité' },
     avisExpertCyber: { position: 4, description: 'Avis sur le dossier' },

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -4,7 +4,7 @@ const expiration = (duree) => `${duree.charAt(0).toUpperCase()}${duree.slice(1)}
 module.exports = {
   actionsSaisie: {
     descriptionService: { position: 0, description: 'Description du service' },
-    cartographieActeurs: { position: 1, description: 'Rôles et responsabilités' },
+    cartographieActeurs: { position: 1, description: 'Cartographie des acteurs' },
     risques: { position: 2, description: 'Risques de sécurité' },
     mesures: { position: 3, description: 'Mesures de sécurité' },
     avisExpertCyber: { position: 4, description: 'Avis sur le dossier' },

--- a/public/assets/styles/homologation/cartographieActeurs.css
+++ b/public/assets/styles/homologation/cartographieActeurs.css
@@ -1,11 +1,11 @@
-.saisie-role-responsabilite {
+.saisie-acteur {
   border: 1px solid var(--liseres);
   border-radius: 3px;
   padding: 1em;
   margin-top: 1em;
 }
 
-.saisie-role-responsabilite label {
+.saisie-acteur label {
   display: inline-block;
   margin: 0;
   margin-left: 0.1em;

--- a/public/homologation/cartographieActeurs.js
+++ b/public/homologation/cartographieActeurs.js
@@ -30,9 +30,9 @@ $(() => {
   const identifiantHomologation = $bouton.attr('identifiant');
 
   $bouton.on('click', () => {
-    const params = tousLesParametres('form#roles-responsabilites');
+    const params = tousLesParametres('form#cartographie-acteurs');
 
-    axios.post(`/api/homologation/${identifiantHomologation}/rolesResponsabilites`, params)
+    axios.post(`/api/homologation/${identifiantHomologation}/cartographieActeurs`, params)
       .then((reponse) => (window.location = `/homologation/${reponse.data.idHomologation}`));
   });
 });

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -125,7 +125,7 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
     }
   });
 
-  routes.post('/:id/rolesResponsabilites',
+  routes.post('/:id/cartographieActeurs',
     middleware.trouveHomologation,
     middleware.aseptiseListes([
       { nom: 'acteursHomologation', proprietes: ActeursHomologation.proprietesItem() },

--- a/src/routes/routesHomologation.js
+++ b/src/routes/routesHomologation.js
@@ -42,9 +42,9 @@ const routesHomologation = (middleware, referentiel, moteurRegles) => {
     reponse.render('homologation/mesures', { referentiel, homologation, mesures });
   });
 
-  routes.get('/:id/rolesResponsabilites', middleware.trouveHomologation, (requete, reponse) => {
+  routes.get('/:id/cartographieActeurs', middleware.trouveHomologation, (requete, reponse) => {
     const { homologation } = requete;
-    reponse.render('homologation/rolesResponsabilites', { homologation });
+    reponse.render('homologation/cartographieActeurs', { homologation });
   });
 
   routes.get('/:id/risques', middleware.trouveHomologation, (requete, reponse) => {

--- a/src/vues/fragments/inputIdentite.pug
+++ b/src/vues/fragments/inputIdentite.pug
@@ -1,6 +1,6 @@
 mixin inputIdentite({ role, nomParametre })
   label(for='aucuneAction')= role
-    .saisie-role-responsabilite
+    .saisie-acteur
       label(for = nomParametre) Prénom / Nom
       input(
         id = nomParametre, name = nomParametre, type = 'text',

--- a/src/vues/fragments/inputPartiePrenante.pug
+++ b/src/vues/fragments/inputPartiePrenante.pug
@@ -1,6 +1,6 @@
 mixin inputPartiePrenante({ categorie, nomParametre, donnees })
   label= categorie
-    .saisie-role-responsabilite
+    .saisie-acteur
       -
         const proprietes = [
           {

--- a/src/vues/homologation/cartographieActeurs.pug
+++ b/src/vues/homologation/cartographieActeurs.pug
@@ -5,10 +5,10 @@ include ../fragments/elementsAjoutables/elementsAjoutablesActeurHomologation
 include ../fragments/elementsAjoutables/elementsAjoutablesPartiePrenante
 
 block append styles
-  link(href = '/statique/assets/styles/homologation/rolesResponsabilites.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/homologation/cartographieActeurs.css', rel = 'stylesheet')
 
 block formulaire
-  form.homologation#roles-responsabilites
+  form.homologation#cartographie-acteurs
     h1.action Rôles et responsabilités
     p.
       Renseignez les informations concernant les responsables et les contributeurs
@@ -76,4 +76,4 @@ block formulaire
 
     .bouton(identifiant = homologation.id) Enregistrer &nbsp;&nbsp;›
 
-  script(type = 'module', src = '/statique/homologation/rolesResponsabilites.js')
+  script(type = 'module', src = '/statique/homologation/cartographieActeurs.js')

--- a/src/vues/homologation/cartographieActeurs.pug
+++ b/src/vues/homologation/cartographieActeurs.pug
@@ -9,7 +9,7 @@ block append styles
 
 block formulaire
   form.homologation#cartographie-acteurs
-    h1.action Rôles et responsabilités
+    h1.action Cartographie des acteurs
     p.
       Renseignez les informations concernant les responsables et les contributeurs
       au fonctionnement du service. Cette cartographie permet de connaître l'ensemble

--- a/test/routes/routesApiHomologation.spec.js
+++ b/test/routes/routesApiHomologation.spec.js
@@ -292,7 +292,7 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
     });
   });
 
-  describe('quand requête POST sur `/api/homologation/:id/rolesResponsabilites`', () => {
+  describe('quand requête POST sur `/api/homologation/:id/cartographieActeurs`', () => {
     beforeEach(() => {
       testeur.depotDonnees().ajouteCartographieActeursAHomologation = () => Promise.resolve();
       testeur.depotDonnees().ajouteEntitesExternesAHomologation = () => Promise.resolve();
@@ -301,7 +301,7 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation({
         method: 'post',
-        url: 'http://localhost:1234/api/homologation/456/rolesResponsabilites',
+        url: 'http://localhost:1234/api/homologation/456/cartographieActeurs',
       }, done);
     });
 
@@ -315,7 +315,7 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
         return Promise.resolve();
       };
 
-      axios.post('http://localhost:1234/api/homologation/456/rolesResponsabilites', {
+      axios.post('http://localhost:1234/api/homologation/456/cartographieActeurs', {
         autoriteHomologation: 'Jean Dupont',
       })
         .then((reponse) => {
@@ -328,7 +328,7 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
     });
 
     it("aseptise la liste des acteurs de l'homologation ainsi que son contenu", (done) => {
-      axios.post('http://localhost:1234/api/homologation/456/rolesResponsabilites', {})
+      axios.post('http://localhost:1234/api/homologation/456/cartographieActeurs', {})
         .then(() => {
           testeur.middleware().verifieAseptisationListe('acteursHomologation', ['role', 'nom', 'fonction']);
           done();
@@ -337,7 +337,7 @@ describe('Le serveur MSS des routes /api/homologation/*', () => {
     });
 
     it('aseptise la liste des parties prenantes ainsi que son contenu', (done) => {
-      axios.post('http://localhost:1234/api/homologation/456/rolesResponsabilites', {})
+      axios.post('http://localhost:1234/api/homologation/456/cartographieActeurs', {})
         .then(() => {
           testeur.middleware().verifieAseptisationListe('partiesPrenantes', ['nom', 'natureAcces', 'pointContact']);
           done();

--- a/test/routes/routesHomologation.spec.js
+++ b/test/routes/routesHomologation.spec.js
@@ -74,10 +74,10 @@ describe('Le serveur MSS des routes /homologation/*', () => {
     });
   });
 
-  describe('quand requete GET sur `/homologation/:id/rolesResponsabilites`', () => {
+  describe('quand requête GET sur `/homologation/:id/cartographieActeurs`', () => {
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/rolesResponsabilites',
+        'http://localhost:1234/homologation/456/cartographieActeurs',
         done,
       );
     });


### PR DESCRIPTION
Etape 4 pour le changement de Roles et responsabilités en Cartographie des acteurs

- Renommage des fichiers
- Renommage des routes
- Changement du titre dans l'ancienne page Rôle et responsabilités
<img width="807" alt="Capture d’écran 2022-05-19 à 15 22 27" src="https://user-images.githubusercontent.com/39462397/169303540-566d2806-3eae-4764-afcd-972493c307e9.png">

- Changement du label du lien dans la page de synthèse
<img width="703" alt="Capture d’écran 2022-05-19 à 15 22 07" src="https://user-images.githubusercontent.com/39462397/169303509-534817a4-06ee-4fb2-a1c8-002c179f675a.png">
<img width="807" alt="Capture d’écran 2022-05-19 à 15 22 27" src="https://user-images.githubusercontent.com/39462397/169303540-566d2806-3eae-4764-afcd-972493c307e9.png">
