### PR TITLE
Suppression des rôles responsabilités du modèle

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -101,7 +101,6 @@ const creeDepot = (config = {}) => {
 
   const ajouteCartographieActeursAHomologation = (...params) => (
     metsAJourProprieteHomologation('cartographieActeurs', ...params)
-      .then(() => metsAJourProprieteHomologation('rolesResponsabilites', ...params))
   );
 
   const ajouteAvisExpertCyberAHomologation = (...params) => (

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -7,7 +7,6 @@ const DescriptionService = require('./descriptionService');
 const Mesure = require('./mesure');
 const Mesures = require('./mesures');
 const Risques = require('./risques');
-const RolesResponsabilites = require('./rolesResponsabilites');
 const Utilisateur = require('./utilisateur');
 
 const NIVEAUX = {
@@ -32,7 +31,6 @@ class Homologation {
       mesuresSpecifiques = [],
       risquesGeneraux = [],
       risquesSpecifiques = [],
-      rolesResponsabilites = {},
       avisExpertCyber = {},
     } = donnees;
 
@@ -47,7 +45,6 @@ class Homologation {
     mesuresGenerales = mesuresGenerales.filter((m) => idMesures.includes(m.id));
     this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel, idMesures);
 
-    this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);
     this.cartographieActeurs = new CartographieActeurs(cartographieActeurs);
     this.risques = new Risques(
       { risquesGeneraux, risquesSpecifiques },

--- a/src/modeles/rolesResponsabilites.js
+++ b/src/modeles/rolesResponsabilites.js
@@ -1,5 +1,0 @@
-const CartographieActeurs = require('./cartographieActeurs');
-
-class RolesResponsabilites extends CartographieActeurs {}
-
-module.exports = RolesResponsabilites;

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -305,26 +305,6 @@ describe('Le dépot de données des homologations', () => {
       .catch(done);
   });
 
-  it('sait enregistrer la cartographie des acteurs en rôles et responsabilités', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      }],
-    });
-    const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
-
-    const cartographieActeurs = new CartographieActeurs({ autoriteHomologation: 'Jean Dupont' });
-    depot.ajouteCartographieActeursAHomologation('123', cartographieActeurs)
-      .then(() => depot.homologation('123'))
-      .then(({ rolesResponsabilites }) => {
-        expect(rolesResponsabilites).to.be.ok();
-        expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean Dupont');
-        done();
-      })
-      .catch(done);
-  });
-
   describe('concernant les risques généraux', () => {
     let valideRisque;
 


### PR DESCRIPTION
Etape 5 pour le changement de Roles et responsabilités en Cartographie des acteurs

Comme la cartographie des acteurs n'est plus persistée dans les rôles et responsabilités nous pouvons supprimer les rôles et responsabilités du modèle de données