### PR TITLE
[CORRECTION] Affiche correctement les descriptions de mesure dans le document d'homologation

### DIFF
--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -36,7 +36,7 @@ mixin mesuresPaginees({ titreAnnexe, titreSection, donnees })
 
               each mesure in mesures
                 li
-                  .description= mesure.descriptionMesure()
+                  .description!= mesure.descriptionMesure()
                   .statut(class = mesure.statut)
                   if mesure.estIndispensable()
                     .indispensable


### PR DESCRIPTION
Ces informations étant aseptisées, les apostrophes étaient affichées sous forme de code d'échappement.
Ce commit règle le problème.

<img width="640" alt="Screenshot 2022-05-23 at 15 52 21" src="https://user-images.githubusercontent.com/105624/169834807-5581d171-1517-49f8-8b9a-d3949ead4849.png">