### PR TITLE
Création placeholder dans le champs E-mail

### DIFF
--- a/src/vues/connexion.pug
+++ b/src/vues/connexion.pug
@@ -11,7 +11,7 @@ block main
     section
       label E-mail
         br
-        input(id='login', type='email')
+        input(id='login', type='email', placeholder='ex: jean.dupont@domaine.fr')
       label Mot de passe
         br
         input(id='mot-de-passe', type='password')


### PR DESCRIPTION
<img width="390" alt="Screenshot 2022-05-29 at 19 18 32" src="https://user-images.githubusercontent.com/105624/170883106-de22e703-e771-4f8c-9ae6-bcb7ac458bea.png">

Ajout du placeholder " ex: jean.dupont@domaine.fr" dans le champs de saisie "Email".

