### PR TITLE
Renommage sous-titre et phrase du mot de passe

### DIFF
--- a/src/vues/connexion.pug
+++ b/src/vues/connexion.pug
@@ -6,8 +6,8 @@ block append styles
 block main
   form.etroit
     h1 Connectez-vous
-    p Vous n'avez pas encore de compte ?&nbsp;
-      a(href='/inscription') Créez-en un !
+    p ou&nbsp;
+      a(href='/inscription') créez votre compte
     section
       label E-mail
         br
@@ -15,7 +15,7 @@ block main
       label Mot de passe
         br
         input(id='mot-de-passe', type='password')
-        a(href='/reinitialisationMotDePasse') J'ai oublié mon mot de passe
+        a(href='/reinitialisationMotDePasse') mot de passe oublié
     .bouton Se connecter &nbsp;&nbsp;›
 
   script(src='/statique/connexion.js')


### PR DESCRIPTION
<img width="406" alt="Screenshot 2022-05-29 at 19 27 31" src="https://user-images.githubusercontent.com/105624/170883515-d8e45171-5be1-4452-9af8-32c947231928.png">

Le sous-titre "Vous n'avez pas encore de compte ? Créez-en un !" est remplacé par "ou créez votre compte".
La phrase "J'ai oublié mon mot de passe" est remplacée par "mot de passe oublié".