### PR TITLE
Publie page statistiques d'usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,10 @@ module.exports = {
   ],
   globals: {
     axios: 'readonly',
+    Chart: 'readonly',
     html2canvas: 'readonly',
     jspdf: 'readonly',
+    moment: 'readonly',
   },
   parserOptions: {
     ecmaVersion: 12,

--- a/public/modules/statistiques/construis.mjs
+++ b/public/modules/statistiques/construis.mjs
@@ -1,0 +1,4 @@
+const construis = (clef, donnees) => Object.keys(donnees)
+  .map((date) => ({ x: date, y: donnees[date][clef] }));
+
+export default construis;

--- a/public/modules/statistiques/donnees.mjs
+++ b/public/modules/statistiques/donnees.mjs
@@ -1,0 +1,24 @@
+const donnees = {
+  '2022-01-10': { utilisateurs: 33, dossiers: 38 },
+  '2022-01-17': { utilisateurs: 39, dossiers: 46 },
+  '2022-01-24': { utilisateurs: 40, dossiers: 52 },
+  '2022-01-31': { utilisateurs: 40, dossiers: 53 },
+  '2022-02-08': { utilisateurs: 40, dossiers: 54 },
+  '2022-02-14': { utilisateurs: 40, dossiers: 54 },
+  '2022-02-21': { utilisateurs: 42, dossiers: 57 },
+  '2022-02-28': { utilisateurs: 60, dossiers: 66 },
+  '2022-03-07': { utilisateurs: 61, dossiers: 66 },
+  '2022-03-14': { utilisateurs: 61, dossiers: 68 },
+  '2022-03-21': { utilisateurs: 62, dossiers: 69 },
+  '2022-03-28': { utilisateurs: 62, dossiers: 69 },
+  '2022-04-05': { utilisateurs: 68, dossiers: 72 },
+  '2022-04-14': { utilisateurs: 73, dossiers: 77 },
+  '2022-04-25': { utilisateurs: 73, dossiers: 80 },
+  '2022-05-02': { utilisateurs: 79, dossiers: 82 },
+  '2022-05-09': { utilisateurs: 86, dossiers: 82 },
+  '2022-05-16': { utilisateurs: 88, dossiers: 83 },
+  '2022-05-23': { utilisateurs: 104, dossiers: 91 },
+  '2022-05-30': { utilisateurs: 106, dossiers: 93 },
+};
+
+export default donnees;

--- a/public/statistiques.js
+++ b/public/statistiques.js
@@ -1,0 +1,39 @@
+import donnees from './modules/statistiques/donnees.mjs';
+import construis from './modules/statistiques/construis.mjs';
+
+$(() => {
+  moment.locale('fr');
+
+  const data = {
+    datasets: [{
+      label: 'Utilisateurs inscrits',
+      backgroundColor: '#0f7ac7',
+      borderColor: '#0f7ac7',
+      data: construis('utilisateurs', donnees),
+    },
+    {
+      label: 'Dossiers créés',
+      backgroundColor: '#ff6584',
+      borderColor: '#ff6584',
+      data: construis('dossiers', donnees),
+    }],
+  };
+
+  const options = {
+    elements: {
+      point: { radius: 0 },
+    },
+    scales: {
+      x: {
+        type: 'time',
+        time: { unit: 'month' },
+      },
+    },
+  };
+
+  const config = { type: 'line', data, options };
+
+  /* eslint-disable no-new */
+  new Chart(document.getElementById('utilisateursEtDossiers'), config);
+  /* eslint-enable no-new */
+});

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -20,7 +20,7 @@ const middleware = (configuration = {}) => {
       : '';
     const politiqueSecuriteScripts = nonce
       ? `script-src 'self' 'nonce-${nonce}';`
-      : "script-src 'self' unpkg.com code.jquery.com";
+      : "script-src 'self' unpkg.com code.jquery.com cdn.jsdelivr.net";
     reponse.set({
       'content-security-policy':
         `${politiqueCommuneSecuriteContenus} ${politiqueSecuriteStyles} ${politiqueSecuriteScripts}`,

--- a/src/mss.js
+++ b/src/mss.js
@@ -72,6 +72,10 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles, adapta
     reponse.render('nouvellesFonctionnalites');
   });
 
+  app.get('/statistiques', (_requete, reponse) => {
+    reponse.render('statistiques');
+  });
+
   app.get('/reinitialisationMotDePasse', middleware.suppressionCookie, (_requete, reponse) => {
     reponse.render('reinitialisationMotDePasse');
   });

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -34,5 +34,6 @@ block page
       a(href = '/confidentialite') Politique de confidentialité
       a(href = '/mentionsLegales') Mentions légales
       a(href = '/cgu') Conditions générales d'utilisation
+      a(href = '/statistiques') Statistiques d'usage
 
   script(src='/statique/entete.js')

--- a/src/vues/statistiques.pug
+++ b/src/vues/statistiques.pug
@@ -1,0 +1,15 @@
+extends mssDeconnecte
+
+block main
+  script(src='https://cdn.jsdelivr.net/npm/chart.js@^3')
+  script(src='https://cdn.jsdelivr.net/npm/moment@^2')
+  script(src='https://cdn.jsdelivr.net/npm/moment/locale/fr.js')
+  script(src='https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@^1')
+
+  .marges-fixes
+    h1 Statistiques
+
+    div
+      canvas(id = 'utilisateursEtDossiers')
+
+  script(type = 'module', src = '/statique/statistiques.js')

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -336,7 +336,7 @@ describe('Le middleware MSS', () => {
     it('autorise le chargement de tous les scripts extérieurs utilisés dans la vue', (done) => {
       verifiePositionnementHeader(
         'content-security-policy',
-        /script-src[^;]* unpkg.com code.jquery.com/,
+        /script-src[^;]* unpkg.com code.jquery.com cdn.jsdelivr.net/,
         done
       );
     });

--- a/test_public/modules/statistiques/construis.spec.mjs
+++ b/test_public/modules/statistiques/construis.spec.mjs
@@ -1,0 +1,17 @@
+import expect from 'expect.js';
+
+import construis from '../../../public/modules/statistiques/construis.mjs';
+
+describe('La construction des données statistiques', () => {
+  it('prépare le jeu de données pour chart.js', () => {
+    const donnees = {
+      '2022-01-01': { stat1: 15, stat2: 26 },
+      '2022-12-31': { stat1: 209, stat2: 1789 },
+    };
+
+    expect(construis('stat2', donnees)).to.eql([
+      { x: '2022-01-01', y: 26 },
+      { x: '2022-12-31', y: 1789 },
+    ]);
+  });
+});


### PR DESCRIPTION
<img width="626" alt="Screenshot 2022-05-29 at 19 08 31" src="https://user-images.githubusercontent.com/105624/170882735-d5948b44-7ab9-4ff5-a176-ae6443395bb2.png">

Dans un premier temps, les données statistiques sont remplies à la main dans le fichier `public/modules/statistiques/donnees.mjs`. À terme, on utilisera plutôt une requête en base de données.