### PR TITLE
Style de la page de connexion

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -1,6 +1,36 @@
 form.etroit {
+  display: flex;
+  flex-direction: column;
+
   margin: 2em auto 0;
   width: 350px;
+}
+
+form.etroit h1 {
+  margin: 2em 0 0.2em 0;
+  padding: 0;
+
+  line-height: 1.1em;
+}
+
+form.etroit .sous-titre {
+  margin: 0;
+}
+
+form.etroit section {
+  padding-bottom: 0;
+  border: 0;
+}
+form.etroit label {
+  margin-bottom: 2em;
+}
+form.etroit a {
+  font-weight: normal;
+}
+
+form.etroit .bouton {
+  margin: 1em 0 2em auto;
+  padding: 1em 2em;
 }
 
 form {

--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -17,6 +17,12 @@ form.etroit .sous-titre {
   margin: 0;
 }
 
+form.etroit .description {
+  margin-top: 2em;
+
+  text-align: left;
+}
+
 form.etroit section {
   padding-bottom: 0;
   border: 0;

--- a/src/vues/admin/inscription.pug
+++ b/src/vues/admin/inscription.pug
@@ -6,7 +6,7 @@ block append styles
 block main
   form.etroit
     h1 Créez votre compte
-    p
+    p.sous-titre
       a(href = '/connexion') Connectez-vous
       span &nbsp;si vous avez déjà un compte
     section

--- a/src/vues/connexion.pug
+++ b/src/vues/connexion.pug
@@ -6,7 +6,7 @@ block append styles
 block main
   form.etroit
     h1 Connectez-vous
-    p ou&nbsp;
+    p.sous-titre ou&nbsp;
       a(href='/inscription') créez votre compte
     section
       label E-mail
@@ -15,7 +15,7 @@ block main
       label Mot de passe
         br
         input(id='mot-de-passe', type='password')
-        a(href='/reinitialisationMotDePasse') mot de passe oublié
-    .bouton Se connecter &nbsp;&nbsp;›
+        a(href='/reinitialisationMotDePasse' class='texte-normal') mot de passe oublié
+    .bouton Valider
 
   script(src='/statique/connexion.js')

--- a/src/vues/reinitialisationMotDePasse.pug
+++ b/src/vues/reinitialisationMotDePasse.pug
@@ -8,7 +8,7 @@ block main
     h1.
       Réinitialisez<br>
       votre mot de passe
-    p.
+    p.description.
       Vous avez oublié votre mot de passe ? Indiquez-nous l'email associé à
       votre compte et nous vous enverrons un lien de réinitialisation.
     section


### PR DESCRIPTION
Dans la page de connexion,
le style à changé : 
- plus de séparateurs
- bouton à droite
- _mot de passe oublié_ en non gras
- ajustement des espaces blancs
Le label du bouton a changé

Les pages Inscription et Réinitialisation du mot de passe ont aussi changé

<img width="579" alt="Capture d’écran 2022-06-01 à 14 28 47" src="https://user-images.githubusercontent.com/39462397/171404586-23e60fd1-de85-4959-bcc3-67747ed81d49.png">
<img width="573" alt="Capture d’écran 2022-06-01 à 14 28 59" src="https://user-images.githubusercontent.com/39462397/171404624-5d726241-f22d-4183-beed-3effcb6474b8.png">
<img width="567" alt="Capture d’écran 2022-06-01 à 14 29 09" src="https://user-images.githubusercontent.com/39462397/171404666-9994e783-3810-44c4-9f17-d7971f776a12.png">
