### PR TITLE
Correction filtre mesures specifiques

### DIFF
--- a/public/assets/styles/homologation/rolesResponsabilites.css
+++ b/public/assets/styles/homologation/rolesResponsabilites.css
@@ -22,7 +22,7 @@
   border: solid 1px var(--liseres);
   border-radius: 5px;
 }
-  
+
 #onglets-liens > a {
   padding: 0.5em 1.3em;
   width: 100%;
@@ -34,8 +34,4 @@
   border-radius: 3px;
 
   font-weight: bold;
-}
-
-#onglets-liens ~ .onglet.invisible {
-  display: none;
 }

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -47,3 +47,7 @@ section:last-of-type {
 
   text-align: left;
 }
+
+.invisible {
+  display: none;
+}

--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -1,4 +1,5 @@
 import arrangeParametresMesures from '../modules/arrangeParametresMesures.mjs';
+import brancheFiltresMesures from '../modules/interactions/brancheFiltresMesures.mjs';
 import parametres from '../modules/parametres.mjs';
 import { brancheAjoutItem, peupleListeItems } from '../modules/saisieListeItems.js';
 import texteHTML from '../modules/texteHTML.js';
@@ -7,31 +8,6 @@ import ajouteModalesInformations from '../modules/interactions/modalesInformatio
 
 $(() => {
   let indexMaxMesuresSpecifiques = 0;
-
-  const mesureSpecifiqueDeCategorie = (elementMesureSpecifique, categorieFiltre) => (
-    categorieFiltre
-      ? $(`option[value="${categorieFiltre}"]:selected, option[value=""]:selected`, elementMesureSpecifique).length === 1
-      : true
-  );
-
-  const filtreMesures = (categorieFiltre) => {
-    $('.mesure').each((_, item) => $(item).toggle($(item).hasClass(categorieFiltre)));
-    $('.item-ajoute').each((_, item) => $(item)
-      .toggle(mesureSpecifiqueDeCategorie(item, categorieFiltre)));
-  };
-
-  const brancheFiltres = (selecteurFiltres) => {
-    const $filtres = $(selecteurFiltres);
-    $filtres.each((_, f) => {
-      $(f).on('click', (e) => {
-        $('.actif').removeClass('actif');
-        $(e.target).addClass('actif');
-
-        const idCategorie = e.target.id;
-        filtreMesures(idCategorie);
-      });
-    });
-  };
 
   const $conteneurModalites = (nom) => {
     const $conteneur = $('<div class="informations-additionnelles"></div>');
@@ -114,7 +90,7 @@ ${statuts}
 
   ajouteModalesInformations();
 
-  brancheFiltres('form#mesures nav > a');
+  brancheFiltresMesures('actif', 'form#mesures nav > a', '.mesure', '.item-ajoute');
 
   ajouteConteneursModalites();
   peupleFormulaire();

--- a/public/modules/interactions/brancheFiltresMesures.mjs
+++ b/public/modules/interactions/brancheFiltresMesures.mjs
@@ -1,0 +1,35 @@
+const CLASSE_ELEMENT_INVISIBLE = 'invisible';
+
+const mesureSpecifiqueDeCategorie = (elementMesureSpecifique, categorieFiltre) => !categorieFiltre
+  || $(`option[value="${categorieFiltre}"]:selected, option[value=""]:selected`, elementMesureSpecifique).length === 1;
+
+const mesureGeneraleDeCategorie = (elementMesure, categorieFiltre) => !categorieFiltre
+  || $(elementMesure).hasClass(categorieFiltre);
+
+const filtreMesures = (categorie, selecteurMesureGenerale, selecteurMesureSpecifique) => {
+  $(selecteurMesureGenerale).each((_, item) => $(item)
+    .toggleClass(CLASSE_ELEMENT_INVISIBLE, !mesureGeneraleDeCategorie(item, categorie)));
+
+  $(selecteurMesureSpecifique).each((_, item) => $(item)
+    .toggleClass(CLASSE_ELEMENT_INVISIBLE, !mesureSpecifiqueDeCategorie(item, categorie)));
+};
+
+const brancheFiltresMesures = (
+  classeFiltreActif,
+  selecteurFiltres,
+  selecteurMesureGenerale,
+  selecteurMesureSpecifique
+) => {
+  const $filtres = $(selecteurFiltres);
+  $filtres.each((_, f) => {
+    $(f).on('click', (e) => {
+      $(`.${classeFiltreActif}`).removeClass(classeFiltreActif);
+      $(e.target).addClass(classeFiltreActif);
+
+      const idCategorie = e.target.id;
+      filtreMesures(idCategorie, selecteurMesureGenerale, selecteurMesureSpecifique);
+    });
+  });
+};
+
+export default brancheFiltresMesures;

--- a/src/vues/homologation/mesures.pug
+++ b/src/vues/homologation/mesures.pug
@@ -25,13 +25,13 @@ block formulaire
 
     section
       nav
-        a.actif#tout Tout
+        a.actif Tout
         each categorie, identifiant in referentiel.categoriesMesures()
           a(id = identifiant)= categorie
 
       .mesures
         each donnees, identifiant in mesures
-          .mesure.tout(class = donnees.categorie)
+          .mesure(class = donnees.categorie)
             +inputMesure({
               nom: identifiant,
               titre: donnees.description,

--- a/test_public/modules/interactions/brancheFiltresMesures.spec.mjs
+++ b/test_public/modules/interactions/brancheFiltresMesures.spec.mjs
@@ -1,0 +1,72 @@
+import expect from 'expect.js';
+import jquery from 'jquery';
+import { JSDOM } from 'jsdom';
+
+import brancheFiltresMesures from '../../../public/modules/interactions/brancheFiltresMesures.mjs';
+
+describe('Le branchement des filtres dans la page des mesures', () => {
+  beforeEach(() => {
+    const sourcePage = `
+      <nav>
+        <a class="actif">Aucun filtre</a>
+        <a id="A">Filtre A</a>
+        <a id="B">Filtre B</a>
+      </nav>
+
+      <div class="mesures-generales">
+        <div id="mesure-generale-A" class="mesure-generale A">Une mesure générale de catégorie A</div>
+        <div id="mesure-generale-B" class="mesure-generale B">Une mesure générale de catégorie B</div>
+      </div>
+
+      <div class="mesures-specifiques">
+        <div id= "mesure-specifique-defaut" class="mesure-specifique">
+          <select><option value="" selected>Catégorie non spécifiée</option></select>
+        </div>
+        <div id= "mesure-specifique-A" class="mesure-specifique">
+          <select><option value="A" selected>Catégorie A</option></select>
+        </div>
+        <div id= "mesure-specifique-B" class="mesure-specifique">
+          <select><option value="B" selected>Catégorie B</option></select>
+        </div>
+      </div>
+    `;
+    const dom = new JSDOM(sourcePage);
+    global.$ = jquery(dom.window);
+  });
+
+  it('change le filtre actif quand on clique dessus', () => {
+    brancheFiltresMesures('actif', 'nav > a', '.mesure-generale', '.mesure-specifique');
+
+    expect($('#A').hasClass('actif')).to.be(false);
+
+    $('#A').trigger('click');
+    expect($('a.actif').length).to.equal(1);
+    expect($('#A').hasClass('actif')).to.be(true);
+  });
+
+  it('filtre correctement les mesures générales', () => {
+    brancheFiltresMesures('actif', 'nav > a', '.mesure-generale', '.mesure-specifique');
+
+    expect($('.mesure-generale.invisible').length).to.equal(0);
+
+    $('#A').trigger('click');
+    expect($('.mesure-generale.invisible').length).to.equal(1);
+    expect($('#mesure-generale-B').hasClass('invisible')).to.be(true);
+
+    $('nav > a').first().trigger('click');
+    expect($('.mesure-generale.invisible').length).to.equal(0);
+  });
+
+  it('filtre correctement les mesures spécifiques', () => {
+    brancheFiltresMesures('actif', 'nav > a', '.mesure-generale', '.mesure-specifique');
+
+    expect($('.mesure-specifique.invisible').length).to.equal(0);
+
+    $('#A').trigger('click');
+    expect($('.mesure-specifique.invisible').length).to.equal(1);
+    expect($('#mesure-specifique-B').hasClass('invisible')).to.be(true);
+
+    $('nav > a').first().trigger('click');
+    expect($('.mesure-specifique.invisible').length).to.equal(0);
+  });
+});

--- a/test_public/modules/interactions/brancheOnglets.spec.mjs
+++ b/test_public/modules/interactions/brancheOnglets.spec.mjs
@@ -1,6 +1,7 @@
 import expect from 'expect.js';
 import jquery from 'jquery';
 import { JSDOM } from 'jsdom';
+
 import brancheOnglets from '../../../public/modules/interactions/brancheOnglets.mjs';
 
 describe('Le branchement des onglets', () => {


### PR DESCRIPTION
Lorsqu'on cliquait sur le filtre « Tout », les mesures spécifiques ne s'affichaient plus. Cette PR corrige l'anomalie.

Au passage, j'ai extrait le code des interactions de la barre de filtre dans un module à part et j'ai ajouté des tests pour valider le comportement attendu.