### PR TITLE
Le pied de page en bas de la page

### DIFF
--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -1,10 +1,18 @@
+html {
+  height: 100%;
+}
+
 body {
+  height: 100%;
   margin: 0;
   padding: 0;
 
   min-width: 1200px;
 
   font-family: "Marianne";
+
+  display: flex;
+  flex-direction: column;
 }
 
 .marges-fixes {
@@ -14,6 +22,7 @@ body {
 }
 
 main {
+  flex-grow: 1;
   padding-bottom: 5em;
   border-top: solid 1px var(--liseres);
   border-bottom: solid 1px var(--liseres);


### PR DESCRIPTION
Dans certaines pages (exemple : /reinitialisationMotDePasse) le footer apparait légèrement surélevé

NOTE : j'ai essayé pleins de choses : position absolute fixe flexbox et cette solution fonctionne sans trop chambouler le site