### PR TITLE
Corrige la taille de l'image d'introduction

### DIFF
--- a/public/assets/styles/index.css
+++ b/public/assets/styles/index.css
@@ -9,7 +9,7 @@ h1 {
   display: flex;
   column-gap: 3em;
 
-  margin-top: 3em;
+  margin: 5em auto 3em auto;
 
   text-align: left;
 }
@@ -60,7 +60,7 @@ h1 {
 
 .bandeau-solution {
   background-color: #f6f6f6;
-  padding-bottom: 3em;
+  padding: 1em 0 4em 0;
 }
 
 .fonctionnalites ul {

--- a/public/assets/styles/index.css
+++ b/public/assets/styles/index.css
@@ -1,16 +1,8 @@
 h1 {
   margin-top: 0;
 
-  font-size: 2.8em;
+  font-size: 2.7em;
   line-height: 1.2em;
-}
-
-.intro-mss {
-  width: 67%;
-
-  background-image: url(../images/image_intro_mss.svg);
-  background-repeat: no-repeat;
-  background-size: contain;
 }
 
 .introduction {
@@ -22,12 +14,24 @@ h1 {
   text-align: left;
 }
 
+.presentation {
+  flex: 2;
+}
+
+.intro-mss {
+  flex: 1;
+
+  background-image: url(../images/image_intro_mss.svg);
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
 .introduction h1 {
   color: var(--bleu-anssi);
 }
 
 .introduction p {
-  font-size: 1.5em;
+  font-size: 1.4em;
 }
 
 .introduction .logos {


### PR DESCRIPTION
Dans la page d'accueil,
l'image d'introduction avait rétréci après un changement du texte d'introduction.
<img width="1331" alt="Capture d’écran 2022-06-02 à 10 38 28" src="https://user-images.githubusercontent.com/39462397/171590774-a3dd6f91-da27-4970-bd5e-2ed450a70d65.png">
