### PR TITLE
[CORRECTION] Typo dans les notes finales de la décision

### DIFF
--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -173,7 +173,7 @@ block page
           signée, la décision d'homologation pourra être publiée sur
           MonServiceSécurisé et sur « !{homologation.nomService()} ».
           MonServiceSécurisé et l'ANSSI ne peuvent en aucun cas être tenus
-          responsables d'incidents de sécurité susceptibles d'affeter le service
+          responsables d'incidents de sécurité susceptibles d'affecter le service
           numérique homologué et des conséquences qui pourraient en découler.
 
       .saut-page


### PR DESCRIPTION
Dans la page de la décision d'homologation,
il manquait un c à affecter