### PR TITLE
Modale de déconnexion multi fenêtres

### DIFF
--- a/public/modules/deconnexion.js
+++ b/public/modules/deconnexion.js
@@ -1,7 +1,18 @@
 import afficheModaleDeconnexion from './interactions/afficheModaleDeconnexion.mjs';
 
+const HEURE_DECONNEXION = 'heureDeconnexion';
+
+const lanceDecompteAffichage = () => {
+  if (Date.now() >= localStorage.getItem(HEURE_DECONNEXION)) {
+    afficheModaleDeconnexion('.rideau#deconnexion', '.rideau');
+  } else {
+    setTimeout(lanceDecompteAffichage, localStorage.getItem(HEURE_DECONNEXION) - Date.now());
+  }
+};
+
 const lanceDecompteDeconnexion = (dureeSession) => {
-  setTimeout(afficheModaleDeconnexion, dureeSession, '.rideau#deconnexion', '.rideau');
+  localStorage.setItem(HEURE_DECONNEXION, new Date(Date.now() + dureeSession).valueOf());
+  setTimeout(lanceDecompteAffichage, dureeSession);
 };
 
 export default lanceDecompteDeconnexion;


### PR DESCRIPTION
Quand un utilisateur est connecté sur plusieurs onglets / fenêtres,
les modales notifiant la déconnexions doivent être synchronisées

NOTE : utilisation d'une variable dans le localStorage coté client