### PR TITLE
Renommage des acteurs de l'homologation en gouvernance

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -55,8 +55,8 @@ class Homologation {
     this.referentiel = referentiel;
   }
 
-  acteursHomologation() {
-    return this.rolesResponsabilites.descriptionActeursHomologation();
+  gouvernance() {
+    return this.rolesResponsabilites.descriptionGouvernance();
   }
 
   autoriteHomologation() { return this.rolesResponsabilites.autoriteHomologation; }

--- a/src/modeles/rolesResponsabilites.js
+++ b/src/modeles/rolesResponsabilites.js
@@ -68,17 +68,17 @@ class RolesResponsabilites extends InformationsHomologation {
     return this.partiesPrenantes.developpementFourniture()?.nom || '';
   }
 
-  descriptionActeursHomologation() {
-    const acteurHomologationDecrit = (role, description) => ({ role, description });
+  descriptionGouvernance() {
+    const acteurDecrit = (role, description) => ({ role, description });
     const description = (acteur) => acteur.nom + (acteur.fonction ? ` (${acteur.fonction})` : '');
     const acteursSpecifiques = () => this.acteursHomologation.tous()
-      .map((acteur) => acteurHomologationDecrit(acteur.role, description(acteur)));
+      .map((acteur) => acteurDecrit(acteur.role, description(acteur)));
 
     const acteurs = [
-      acteurHomologationDecrit("Autorité d'homologation", this.descriptionAutoriteHomologation()),
-      acteurHomologationDecrit('Spécialiste cybersécurité', this.descriptionExpertCybersecurite()),
-      acteurHomologationDecrit('Délégué(e) à la protection des données à caractère personnel', this.descriptionDelegueProtectionDonnees()),
-      acteurHomologationDecrit('Responsable métier du projet', this.descriptionPiloteProjet()),
+      acteurDecrit("Autorité d'homologation", this.descriptionAutoriteHomologation()),
+      acteurDecrit('Spécialiste cybersécurité', this.descriptionExpertCybersecurite()),
+      acteurDecrit('Délégué(e) à la protection des données à caractère personnel', this.descriptionDelegueProtectionDonnees()),
+      acteurDecrit('Responsable métier du projet', this.descriptionPiloteProjet()),
       ...acteursSpecifiques(),
     ];
 

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -140,7 +140,7 @@ block page
         dl
           dt Décision d'homologation préparée par :
           dd= homologation.descriptionEquipePreparation()
-          each acteur in homologation.acteursHomologation()
+          each acteur in homologation.gouvernance()
             dt #{acteur.role} :
             dd= acteur.description
 

--- a/src/vues/homologation/rolesResponsabilites.pug
+++ b/src/vues/homologation/rolesResponsabilites.pug
@@ -17,10 +17,10 @@ block formulaire
 
     section
       nav#onglets-liens
-        a.actif#onglet-acteurs-homologations Acteurs de l'homologation
+        a.actif#onglet-gouvernance Gouvernance
         a#onglet-parties-prenantes Parties prenantes
 
-      .onglet#acteurs-homologations
+      .onglet#gouvernance
         +inputIdentite({
           role: "Autorité d'homologation",
           nomParametre: 'autoriteHomologation',

--- a/test/modeles/rolesResponsabilites.spec.js
+++ b/test/modeles/rolesResponsabilites.spec.js
@@ -169,14 +169,14 @@ describe("L'ensemble des rôles et responsabilités", () => {
     });
   });
 
-  describe("sur une demande de description des acteurs de l'homologation", () => {
+  describe('sur une demande de description de la gouvernance', () => {
     it("intègre l'autorité d'homologation", () => {
       const rolesResponsabilites = new RolesResponsabilites({
         autoriteHomologation: 'Jean Dupont', fonctionAutoriteHomologation: 'Maire',
       });
 
-      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
-      expect(acteursHomologations).to.eql([{ role: "Autorité d'homologation", description: 'Jean Dupont (Maire)' }]);
+      const gouvernance = rolesResponsabilites.descriptionGouvernance();
+      expect(gouvernance).to.eql([{ role: "Autorité d'homologation", description: 'Jean Dupont (Maire)' }]);
     });
 
     it('intègre le ou la spécialiste cybersécurité', () => {
@@ -184,8 +184,8 @@ describe("L'ensemble des rôles et responsabilités", () => {
         expertCybersecurite: 'John Dupond', fonctionExpertCybersecurite: 'Spécialiste',
       });
 
-      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
-      expect(acteursHomologations).to.eql([{ role: 'Spécialiste cybersécurité', description: 'John Dupond (Spécialiste)' }]);
+      const gouvernance = rolesResponsabilites.descriptionGouvernance();
+      expect(gouvernance).to.eql([{ role: 'Spécialiste cybersécurité', description: 'John Dupond (Spécialiste)' }]);
     });
 
     it('intègre le délégué ou la délégué à la protection des données à caractère personnel', () => {
@@ -193,8 +193,8 @@ describe("L'ensemble des rôles et responsabilités", () => {
         delegueProtectionDonnees: 'Marie Age', fonctionDelegueProtectionDonnees: 'Déléguée',
       });
 
-      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
-      expect(acteursHomologations).to.eql([{ role: 'Délégué(e) à la protection des données à caractère personnel', description: 'Marie Age (Déléguée)' }]);
+      const gouvernance = rolesResponsabilites.descriptionGouvernance();
+      expect(gouvernance).to.eql([{ role: 'Délégué(e) à la protection des données à caractère personnel', description: 'Marie Age (Déléguée)' }]);
     });
 
     it('intègre le ou la responsable métier du projet', () => {
@@ -202,8 +202,8 @@ describe("L'ensemble des rôles et responsabilités", () => {
         piloteProjet: 'Otto Graf', fonctionPiloteProjet: 'Pilote',
       });
 
-      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
-      expect(acteursHomologations).to.eql([{ role: 'Responsable métier du projet', description: 'Otto Graf (Pilote)' }]);
+      const gouvernance = rolesResponsabilites.descriptionGouvernance();
+      expect(gouvernance).to.eql([{ role: 'Responsable métier du projet', description: 'Otto Graf (Pilote)' }]);
     });
 
     it('intègre les acteurs spécifiques', () => {
@@ -213,8 +213,8 @@ describe("L'ensemble des rôles et responsabilités", () => {
         ],
       });
 
-      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
-      expect(acteursHomologations).to.eql([{ role: 'Rôle dans le projet', description: 'Sandra Nicouverture (Fonction)' }]);
+      const gouvernance = rolesResponsabilites.descriptionGouvernance();
+      expect(gouvernance).to.eql([{ role: 'Rôle dans le projet', description: 'Sandra Nicouverture (Fonction)' }]);
     });
 
     it('intègre les acteurs spécifiques sans les fonctions si elles ne sont pas présentes', () => {
@@ -224,14 +224,14 @@ describe("L'ensemble des rôles et responsabilités", () => {
         ],
       });
 
-      const acteursHomologations = rolesResponsabilites.descriptionActeursHomologation();
-      expect(acteursHomologations).to.eql([{ role: 'Rôle dans le projet', description: 'Yamamoto Kaderate' }]);
+      const gouvernance = rolesResponsabilites.descriptionGouvernance();
+      expect(gouvernance).to.eql([{ role: 'Rôle dans le projet', description: 'Yamamoto Kaderate' }]);
     });
 
     it("n'intègre pas les acteurs non renseignés", () => {
       const rolesResponsabilites = new RolesResponsabilites({});
 
-      expect(rolesResponsabilites.descriptionActeursHomologation()).to.have.length(0);
+      expect(rolesResponsabilites.descriptionGouvernance()).to.have.length(0);
     });
   });
 });

--- a/test_public/modules/interactions/brancheOnglets.spec.mjs
+++ b/test_public/modules/interactions/brancheOnglets.spec.mjs
@@ -8,10 +8,10 @@ describe('Le branchement des onglets', () => {
   beforeEach(() => {
     const sourcePage = `
       <nav id="onglets-liens">
-        <a class="actif" id="onglet-acteurs-homologations"></a>
+        <a class="actif" id="onglet-gouvernance"></a>
         <a id="onglet-parties-prenantes">Parties prenantes</a>
       </nav>
-      <div class="onglet" id="acteurs-homologations"></div>
+      <div class="onglet" id="gouvernance"></div>
       <div class="onglet" id="parties-prenantes"></div>
     `;
     const dom = new JSDOM(sourcePage);
@@ -21,7 +21,7 @@ describe('Le branchement des onglets', () => {
   it("rend visible l'onglet actif", () => {
     brancheOnglets('#onglets-liens > a');
 
-    expect($('#acteurs-homologations').hasClass('invisible')).to.be(false);
+    expect($('#gouvernance').hasClass('invisible')).to.be(false);
   });
 
   describe('sur une action de click sur un lien', () => {
@@ -38,7 +38,7 @@ describe('Le branchement des onglets', () => {
 
       $('#onglet-parties-prenantes').trigger('click');
 
-      expect($('#onglet-acteurs-homologations').hasClass('actif')).to.be(false);
+      expect($('#onglet-gouvernance').hasClass('actif')).to.be(false);
     });
 
     it("rend visible l'onglet ciblé", () => {
@@ -54,7 +54,7 @@ describe('Le branchement des onglets', () => {
 
       $('#onglet-parties-prenantes').trigger('click');
 
-      expect($('#acteurs-homologations').hasClass('invisible')).to.be(true);
+      expect($('#gouvernance').hasClass('invisible')).to.be(true);
     });
   });
 });


### PR DESCRIPTION
Dans la page rôles et responsabilités,
les acteurs de l'homologation deviennent la gouvernance
<img width="721" alt="Capture d’écran 2022-06-10 à 16 55 38" src="https://user-images.githubusercontent.com/39462397/173092928-da07d2b6-dbba-492a-a949-8d3c90025e6b.png">
