### PR TITLE
Introduis la notion de mesures recommandées par l'ANSSI

### DIFF
--- a/src/modeles/mesure.js
+++ b/src/modeles/mesure.js
@@ -1,4 +1,7 @@
-/* eslint class-methods-use-this: ["error", { "exceptMethods": ["estIndispensable"] }] */
+/*
+   eslint class-methods-use-this:
+     ["error", { "exceptMethods": ["estIndispensable", "estRecommandee"] }]
+*/
 
 const InformationsHomologation = require('./informationsHomologation');
 const { ErreurStatutMesureInvalide } = require('../erreurs');
@@ -12,6 +15,10 @@ const STATUTS = {
 
 class Mesure extends InformationsHomologation {
   estIndispensable() {
+    return false;
+  }
+
+  estRecommandee() {
     return false;
   }
 

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -26,6 +26,10 @@ class MesureGenerale extends Mesure {
     return !!this.donneesReferentiel().indispensable;
   }
 
+  estRecommandee() {
+    return !this.estIndispensable();
+  }
+
   nonRetenue() {
     return this.statut === Mesure.STATUT_NON_RETENU;
   }

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -154,45 +154,14 @@ describe('Une homologation', () => {
     expect(homologation.descriptionExpiration()).to.equal('Dans un an');
   });
 
-  describe('sur demande de statistiques sur les mesures associées', () => {
-    const referentiel = Referentiel.creeReferentiel({
-      categoriesMesures: { une: 'catégorie 1', deux: 'catégorie 2' },
-      mesures: { id1: { categorie: 'une' }, id2: { categorie: 'une' }, id3: { categorie: 'deux' } },
-    });
+  it('délègue aux mesures le calcul des statistiques', () => {
+    let calculDelegueAuxMesures = false;
 
-    const moteur = { mesures: () => referentiel.mesures() };
+    const homologation = new Homologation({ id: '123', mesuresGenerales: [] });
+    homologation.mesures.statistiques = () => (calculDelegueAuxMesures = true);
 
-    it('fait la somme des mesures mises en oeuvre pour une catégorie donnée', () => {
-      const homologation = new Homologation({
-        id: '123', mesuresGenerales: [{ id: 'id1', statut: 'fait' }, { id: 'id2', statut: 'fait' }],
-      }, referentiel, moteur);
-      const stats = homologation.statistiquesMesures().toJSON();
-      expect(stats).to.eql({ une: { retenues: 2, misesEnOeuvre: 2 } });
-    });
-
-    it('ajoute les mesures planifiées à la somme des mesures retenues', () => {
-      const homologation = new Homologation({
-        id: '123', mesuresGenerales: [{ id: 'id1', statut: 'fait' }, { id: 'id2', statut: 'planifie' }],
-      }, referentiel, moteur);
-      const stats = homologation.statistiquesMesures().toJSON();
-      expect(stats).to.eql({ une: { retenues: 2, misesEnOeuvre: 1 } });
-    });
-
-    it('ne tient pas compte des mesures non retenues', () => {
-      const homologation = new Homologation({
-        id: '123', mesuresGenerales: [{ id: 'id1', statut: 'planifie' }, { id: 'id2', statut: 'nonRetenu' }],
-      }, referentiel, moteur);
-      const stats = homologation.statistiquesMesures().toJSON();
-      expect(stats).to.eql({ une: { retenues: 1, misesEnOeuvre: 0 } });
-    });
-
-    it('classe les statistiques par catégorie de mesure', () => {
-      const homologation = new Homologation({
-        id: '123', mesuresGenerales: [{ id: 'id1', statut: 'nonRetenu' }, { id: 'id3', statut: 'fait' }],
-      }, referentiel, moteur);
-      const stats = homologation.statistiquesMesures().toJSON();
-      expect(stats).to.eql({ deux: { retenues: 1, misesEnOeuvre: 1 } });
-    });
+    homologation.statistiquesMesures();
+    expect(calculDelegueAuxMesures).to.be(true);
   });
 
   describe('sur évaluation du statut de saisie des mesures', () => {

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -76,6 +76,6 @@ describe('Une mesure de sécurité', () => {
     expect(referentiel.mesures().identifiantMesure.indispensable).to.not.be.ok();
 
     const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait' }, referentiel);
-    expect(mesure.estIndispensable()).to.be(false);
+    expect(mesure.estRecommandee()).to.be(true);
   });
 });

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -66,4 +66,9 @@ describe('Une mesure spécifique', () => {
       done("La création de la mesure sans catégorie n'aurait pas dû lever d'exception.");
     }
   });
+
+  elle("n'est pas indispensable selon l'ANSSI", () => {
+    const mesure = new MesureSpecifique();
+    expect(mesure.estIndispensable()).to.be(false);
+  });
 });

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -71,4 +71,9 @@ describe('Une mesure spécifique', () => {
     const mesure = new MesureSpecifique();
     expect(mesure.estIndispensable()).to.be(false);
   });
+
+  elle("n'est pas recommandée par l'ANSSI", () => {
+    const mesure = new MesureSpecifique();
+    expect(mesure.estRecommandee()).to.be(false);
+  });
 });

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -5,7 +5,13 @@ const MesuresGenerales = require('../../src/modeles/mesuresGenerales');
 const { A_SAISIR, COMPLETES, A_COMPLETER } = MesuresGenerales;
 
 describe('La liste des mesures générales', () => {
-  const referentiel = { identifiantsMesures: () => ['mesure'] };
+  let referentiel;
+
+  beforeEach(() => (referentiel = {
+    identifiantsCategoriesMesures: () => [],
+    identifiantsMesures: () => [],
+    mesures: () => ({}),
+  }));
 
   it("est à saisir quand rien n'est saisi", () => {
     const donnees = { mesuresGenerales: [] };
@@ -14,17 +20,73 @@ describe('La liste des mesures générales', () => {
     expect(mesuresGenerales.statutSaisie()).to.equal(A_SAISIR);
   });
 
-  it('est complete quand les mesures sont completes', () => {
+  it('est complète quand les mesures sont complètes', () => {
+    referentiel.identifiantsMesures = () => ['mesure'];
+
     const donnees = { mesuresGenerales: [{ id: 'mesure', statut: 'fait' }] };
     const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
 
     expect(mesuresGenerales.statutSaisie()).to.equal(COMPLETES);
   });
 
-  it('est à completer quand toutes les mesures ne sont pas completes', () => {
+  it('est à compléter quand toutes les mesures ne sont pas complètes', () => {
+    referentiel.identifiantsMesures = () => ['mesure'];
+
     const donnees = { mesuresGenerales: [{ id: 'mesure' }] };
     const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
 
     expect(mesuresGenerales.statutSaisie()).to.equal(A_COMPLETER);
+  });
+
+  describe('sur demande de statistiques sur les mesures', () => {
+    beforeEach(() => {
+      referentiel.identifiantsCategoriesMesures = () => ['une', 'deux'];
+      referentiel.mesures = () => ({
+        id1: { categorie: 'une' },
+        id2: { categorie: 'une' },
+        id3: { categorie: 'deux' },
+      });
+      referentiel.identifiantsMesures = () => Object.keys(referentiel.mesures());
+    });
+
+    it('fait la somme des mesures mises en oeuvre pour une catégorie donnée', () => {
+      const donnees = {
+        mesuresGenerales: [{ id: 'id1', statut: 'fait' }, { id: 'id2', statut: 'fait' }],
+      };
+      const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
+
+      const stats = mesuresGenerales.statistiques().toJSON();
+      expect(stats).to.eql({ une: { retenues: 2, misesEnOeuvre: 2 } });
+    });
+
+    it('ajoute les mesures planifiées à la somme des mesures retenues', () => {
+      const donnees = {
+        mesuresGenerales: [{ id: 'id1', statut: 'fait' }, { id: 'id2', statut: 'planifie' }],
+      };
+      const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
+
+      const stats = mesuresGenerales.statistiques().toJSON();
+      expect(stats).to.eql({ une: { retenues: 2, misesEnOeuvre: 1 } });
+    });
+
+    it('ne tient pas compte des mesures non retenues', () => {
+      const donnees = {
+        mesuresGenerales: [{ id: 'id1', statut: 'planifie' }, { id: 'id2', statut: 'nonRetenu' }],
+      };
+      const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
+
+      const stats = mesuresGenerales.statistiques().toJSON();
+      expect(stats).to.eql({ une: { retenues: 1, misesEnOeuvre: 0 } });
+    });
+
+    it('classe les statistiques par catégorie de mesure', () => {
+      const donnees = {
+        mesuresGenerales: [{ id: 'id1', statut: 'nonRetenu' }, { id: 'id3', statut: 'fait' }],
+      };
+      const mesuresGenerales = new MesuresGenerales(donnees, referentiel);
+
+      const stats = mesuresGenerales.statistiques().toJSON();
+      expect(stats).to.eql({ deux: { retenues: 1, misesEnOeuvre: 1 } });
+    });
   });
 });


### PR DESCRIPTION
En préparation au calcul du cyberscore, on introduit la notion de mesures recommandées par l'ANSSI (notion qui varie suivant que la mesure est spécifique ou générique).

… Et on en profite pour nettoyer quelques tests.