### PR TITLE
Changement des statuts de mesure

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -225,7 +225,7 @@ module.exports = {
 
   statutsMesures: {
     fait: 'Fait',
-    planifie: 'Planifié',
+    enCours: 'En cours',
     nonFait: 'Non fait',
     nonRetenu: 'Non concerné',
   },

--- a/migrations/20220614074541_changementStatutsMesuresPlanifies.js
+++ b/migrations/20220614074541_changementStatutsMesuresPlanifies.js
@@ -1,0 +1,22 @@
+const metsAJourStatutMesure = (changeStatut) => (mesure) => {
+  mesure.statut = changeStatut(mesure.statut);
+  return mesure;
+};
+
+const changementMesures = (changeStatut) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees?.mesuresGenerales || donnees?.mesuresSpecifiques)
+      .map(({ id, donnees: { mesuresGenerales, mesuresSpecifiques, ...autresDonnees } }) => knex('homologations')
+        .where({ id })
+        .update({ donnees: {
+          mesuresGenerales: mesuresGenerales?.map(metsAJourStatutMesure(changeStatut)),
+          mesuresSpecifiques: mesuresSpecifiques?.map(metsAJourStatutMesure(changeStatut)),
+          ...autresDonnees,
+        } }));
+    return Promise.all(misesAJour);
+  });
+
+exports.up = changementMesures((statut) => (statut === 'planifie' ? 'enCours' : statut));
+
+exports.down = changementMesures((statut) => (statut === 'enCours' ? 'planifie' : statut));

--- a/public/assets/styles/decision.css
+++ b/public/assets/styles/decision.css
@@ -362,7 +362,7 @@ section.detail-mesures .statut.fait, .legende .fait:before {
   background: var(--bleu-mise-en-avant);
 }
 
-section.detail-mesures .statut.planifie, .legende .planifie:before {
+section.detail-mesures .statut.enCours, .legende .enCours:before {
   background: var(--bleu-ciel);
 }
 

--- a/src/modeles/mesure.js
+++ b/src/modeles/mesure.js
@@ -8,7 +8,7 @@ const { ErreurStatutMesureInvalide } = require('../erreurs');
 
 const STATUTS = {
   STATUT_FAIT: 'fait',
-  STATUT_PLANIFIE: 'planifie',
+  STATUT_EN_COURS: 'enCours',
   STATUT_NON_FAIT: 'nonFait',
   STATUT_NON_RETENU: 'nonRetenu',
 };

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -46,7 +46,7 @@ class MesuresGenerales extends ElementsConstructibles {
       const { id, statut } = mesure;
       const { categorie } = this.referentiel.mesure(id);
 
-      if (statut === MesureGenerale.STATUT_FAIT || statut === MesureGenerale.STATUT_PLANIFIE) {
+      if (statut === MesureGenerale.STATUT_FAIT || statut === MesureGenerale.STATUT_EN_COURS) {
         stats[categorie].retenues += 1;
 
         if (statut === MesureGenerale.STATUT_FAIT) {

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -96,7 +96,7 @@ block page
         p Recommandées par l'ANSSI, détails en annexe
 
         .legende
-          .planifie Planifié
+          .enCours En cours
           .fait Fait
 
         - const statistiquesMesures = homologation.statistiquesMesures()

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -208,7 +208,7 @@ describe('Le dépot de données des homologations', () => {
           {
             id: '123',
             descriptionService: { nomService: 'nom' },
-            mesures: [{ id: 'identifiantMesure', statut: MesureGenerale.STATUT_PLANIFIE }],
+            mesures: [{ id: 'identifiantMesure', statut: MesureGenerale.STATUT_EN_COURS }],
           },
         ],
       });

--- a/test/modeles/mesure.spec.js
+++ b/test/modeles/mesure.spec.js
@@ -6,7 +6,7 @@ const elle = it;
 
 describe('Une mesure', () => {
   elle('connaît ses statuts possibles', () => {
-    expect(Mesure.statutsPossibles()).to.eql(['fait', 'planifie', 'nonFait', 'nonRetenu']);
+    expect(Mesure.statutsPossibles()).to.eql(['fait', 'enCours', 'nonFait', 'nonRetenu']);
   });
 
   elle("ne tient pas compte du statut s'il n'est pas renseigné", (done) => {

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -74,10 +74,10 @@ describe('La liste des mesures générales', () => {
       expect(stats.deux.misesEnOeuvre).to.equal(0);
     });
 
-    it('ajoute les mesures planifiées à la somme des mesures retenues', () => {
+    it('ajoute les mesures en cours à la somme des mesures retenues', () => {
       const mesuresGenerales = creeMesuresGenerales([
         { id: 'id1', statut: 'fait' },
-        { id: 'id2', statut: 'planifie' },
+        { id: 'id2', statut: 'enCours' },
       ]);
 
       const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
@@ -87,7 +87,7 @@ describe('La liste des mesures générales', () => {
 
     it('ne tient pas compte des mesures non retenues', () => {
       const mesuresGenerales = creeMesuresGenerales([
-        { id: 'id1', statut: 'planifie' },
+        { id: 'id1', statut: 'enCours' },
         { id: 'id2', statut: 'nonRetenu' },
       ]);
 


### PR DESCRIPTION
Dans la page des mesures,
Il était possible d'avoir en statut Fait Planifié Non fait ou Non concerné
maintenant le statut Planifié est retiré et le statut En cours prend sa place

Les mesures avec un statut Planifié auront un statut Non fait

Notes : 
- ce dev contient une migration de données
- la page Décision et le document d'homologation sont impactés

<img width="784" alt="Capture d’écran 2022-06-15 à 16 26 50" src="https://user-images.githubusercontent.com/39462397/173852310-09471f29-4a7f-4c50-ad42-63ecde306043.png">
<img width="982" alt="Capture d’écran 2022-06-15 à 16 27 36" src="https://user-images.githubusercontent.com/39462397/173852347-b8a173f3-4494-4b3c-a1df-0c01ccfcc201.png">
<img width="1020" alt="Capture d’écran 2022-06-15 à 16 27 51" src="https://user-images.githubusercontent.com/39462397/173852396-24fe2adc-96c6-4daf-9a83-021713d9fdb4.png">
