### PR TITLE
Mise à jour des statistiques

### DIFF
--- a/public/modules/statistiques/donnees.mjs
+++ b/public/modules/statistiques/donnees.mjs
@@ -21,7 +21,8 @@ const donnees = {
   '2022-05-30': { utilisateurs: 106, pourcentageUtilisateursEnPlus: 2, dossiers: 93 },
   '2022-06-07': { utilisateurs: 114, pourcentageUtilisateursEnPlus: 8, dossiers: 93 },
   '2022-06-13': { utilisateurs: 123, pourcentageUtilisateursEnPlus: 8, dossiers: 96 },
-  '2022-06-30': { utilisateurs: 127, pourcentageUtilisateursEnPlus: 3, dossiers: 98 },
+  '2022-06-20': { utilisateurs: 127, pourcentageUtilisateursEnPlus: 3, dossiers: 98 },
+  '2022-07-04': { utilisateurs: 139, pourcentageUtilisateursEnPlus: 9, dossiers: 105 },
 };
 
 export default donnees;


### PR DESCRIPTION
… On remarque tout de même qu'il y a un problème… quand on ne met pas à jour
une semaine donnée, les pourcentages depuis la précédente mesure sont
artificiellement gonflés. Peut-être qu'il faudra revoir ça.