### PR TITLE
Chargement des bibliothèques tierces depuis MSS

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -18,7 +18,7 @@ const middleware = (configuration = {}) => {
     const politiqueSecuriteStyles = nonce
       ? `style-src 'self' 'nonce-${nonce}';`
       : '';
-    const politiqueSecuriteScripts = "script-src 'self' cdn.jsdelivr.net";
+    const politiqueSecuriteScripts = "script-src 'self'";
     reponse.set({
       'content-security-policy':
         `${politiqueCommuneSecuriteContenus} ${politiqueSecuriteStyles} ${politiqueSecuriteScripts}`,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -20,7 +20,7 @@ const middleware = (configuration = {}) => {
       : '';
     const politiqueSecuriteScripts = nonce
       ? `script-src 'self' 'nonce-${nonce}';`
-      : "script-src 'self' unpkg.com cdn.jsdelivr.net";
+      : "script-src 'self' cdn.jsdelivr.net";
     reponse.set({
       'content-security-policy':
         `${politiqueCommuneSecuriteContenus} ${politiqueSecuriteStyles} ${politiqueSecuriteScripts}`,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -18,9 +18,7 @@ const middleware = (configuration = {}) => {
     const politiqueSecuriteStyles = nonce
       ? `style-src 'self' 'nonce-${nonce}';`
       : '';
-    const politiqueSecuriteScripts = nonce
-      ? `script-src 'self' 'nonce-${nonce}';`
-      : "script-src 'self' cdn.jsdelivr.net";
+    const politiqueSecuriteScripts = "script-src 'self' cdn.jsdelivr.net";
     reponse.set({
       'content-security-policy':
         `${politiqueCommuneSecuriteContenus} ${politiqueSecuriteStyles} ${politiqueSecuriteScripts}`,

--- a/src/routes/routesBibliotheques.js
+++ b/src/routes/routesBibliotheques.js
@@ -3,7 +3,10 @@ const express = require('express');
 
 const CHEMINS_BIBLIOTHEQUES = {
   'axios.min.js': 'https://unpkg.com/axios/dist/axios.min.js',
+  'html2canvas.min.js': 'https://unpkg.com/html2canvas/dist/html2canvas.min.js',
   'jquery-3.6.0.min.js': 'https://code.jquery.com/jquery-3.6.0.min.js',
+  'jspdf.umd.min.js': 'https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js',
+  'purify.min.js': 'https://unpkg.com/dompurify/dist/purify.min.js',
 };
 
 const routesBibliotheques = () => {

--- a/src/routes/routesBibliotheques.js
+++ b/src/routes/routesBibliotheques.js
@@ -1,17 +1,24 @@
 const axios = require('axios');
 const express = require('express');
 
+const CHEMINS_BIBLIOTHEQUES = {
+  'axios.min.js': 'https://unpkg.com/axios/dist/axios.min.js',
+  'jquery-3.6.0.min.js': 'https://code.jquery.com/jquery-3.6.0.min.js',
+};
+
 const routesBibliotheques = () => {
   const routes = express.Router();
 
-  routes.get('/jquery-3.6.0.min.js', (_requete, reponse) => {
-    axios.get('https://code.jquery.com/jquery-3.6.0.min.js')
-      .then((reponseJquery) => reponse.type('text/javascript').send(reponseJquery.data));
-  });
+  routes.get('/:nomBibliotheque', (requete, reponse) => {
+    const { nomBibliotheque } = requete.params;
+    const chemin = CHEMINS_BIBLIOTHEQUES[nomBibliotheque];
 
-  routes.get('/axios.min.js', (_requete, reponse) => {
-    axios.get('https://unpkg.com/axios/dist/axios.min.js')
-      .then((reponseAxios) => reponse.type('text/javascript').send(reponseAxios.data));
+    if (chemin) {
+      axios.get(CHEMINS_BIBLIOTHEQUES[requete.params.nomBibliotheque])
+        .then((reponseDepot) => reponse.type('text/javascript').send(reponseDepot.data));
+    } else {
+      reponse.status(404).send(`Bibliothèque inconnue : ${nomBibliotheque}`);
+    }
   });
 
   return routes;

--- a/src/routes/routesBibliotheques.js
+++ b/src/routes/routesBibliotheques.js
@@ -3,9 +3,13 @@ const express = require('express');
 
 const CHEMINS_BIBLIOTHEQUES = {
   'axios.min.js': 'https://unpkg.com/axios/dist/axios.min.js',
+  'chart.js': 'https://cdn.jsdelivr.net/npm/chart.js@^3',
+  'chartjs-adapter-moment': 'https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@^1',
   'html2canvas.min.js': 'https://unpkg.com/html2canvas/dist/html2canvas.min.js',
   'jquery-3.6.0.min.js': 'https://code.jquery.com/jquery-3.6.0.min.js',
   'jspdf.umd.min.js': 'https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js',
+  moment: 'https://cdn.jsdelivr.net/npm/moment@^2',
+  'moment-locale-fr.js': 'https://cdn.jsdelivr.net/npm/moment/locale/fr.js',
   'purify.min.js': 'https://unpkg.com/dompurify/dist/purify.min.js',
 };
 

--- a/src/routes/routesBibliotheques.js
+++ b/src/routes/routesBibliotheques.js
@@ -9,6 +9,11 @@ const routesBibliotheques = () => {
       .then((reponseJquery) => reponse.type('text/javascript').send(reponseJquery.data));
   });
 
+  routes.get('/axios.min.js', (_requete, reponse) => {
+    axios.get('https://unpkg.com/axios/dist/axios.min.js')
+      .then((reponseAxios) => reponse.type('text/javascript').send(reponseAxios.data));
+  });
+
   return routes;
 };
 

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -44,9 +44,9 @@ mixin mesuresPaginees({ titreAnnexe, titreSection, donnees })
 
 block page
   script(src='/bibliotheques/jquery-3.6.0.min.js')
-  script(nonce = nonce, src='https://unpkg.com/dompurify/dist/purify.min.js')
-  script(nonce = nonce, src='https://unpkg.com/html2canvas/dist/html2canvas.min.js')
-  script(nonce = nonce, src='https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js')
+  script(src='/bibliotheques/purify.min.js')
+  script(src='/bibliotheques/html2canvas.min.js')
+  script(src='/bibliotheques/jspdf.umd.min.js')
 
   include ../fragments/diagnostics
 

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -1,7 +1,7 @@
 extends ./base
 
 block page
-  script(src='https://unpkg.com/axios/dist/axios.min.js')
+  script(src='/bibliotheques/axios.min.js')
   script(src='/bibliotheques/jquery-3.6.0.min.js')
 
   block styles

--- a/src/vues/statistiques.pug
+++ b/src/vues/statistiques.pug
@@ -4,10 +4,10 @@ block append styles
   link(href='/statique/assets/styles/statistiques.css', rel='stylesheet')
 
 block main
-  script(src='https://cdn.jsdelivr.net/npm/chart.js@^3')
-  script(src='https://cdn.jsdelivr.net/npm/moment@^2')
-  script(src='https://cdn.jsdelivr.net/npm/moment/locale/fr.js')
-  script(src='https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@^1')
+  script(src='/bibliotheques/chart.js')
+  script(src='/bibliotheques/moment')
+  script(src='/bibliotheques/moment-locale-fr.js')
+  script(src='/bibliotheques/chartjs-adapter-moment')
 
   .marges-fixes
     h1 Statistiques

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -324,12 +324,8 @@ describe('Le middleware MSS', () => {
       verifiePositionnementHeader('content-security-policy', "img-src 'self' data:;", done);
     });
 
-    it('autorise le chargement de tous les scripts extérieurs utilisés dans la vue', (done) => {
-      verifiePositionnementHeader(
-        'content-security-policy',
-        /script-src[^;]* cdn.jsdelivr.net/,
-        done
-      );
+    it('autorise le chargement de tous les scripts du domaine (et uniquement ceux-là)', (done) => {
+      verifiePositionnementHeader('content-security-policy', "script-src 'self'", done);
     });
 
     it('interdit le chargement de la page dans une iFrame', (done) => {

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -336,7 +336,7 @@ describe('Le middleware MSS', () => {
     it('autorise le chargement de tous les scripts extérieurs utilisés dans la vue', (done) => {
       verifiePositionnementHeader(
         'content-security-policy',
-        /script-src[^;]* unpkg.com cdn.jsdelivr.net/,
+        /script-src[^;]* cdn.jsdelivr.net/,
         done
       );
     });

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -303,15 +303,6 @@ describe('Le middleware MSS', () => {
         done,
       );
     });
-
-    it('autorise le chargement des scripts avec ce nonce', (done) => {
-      verifieHeaderAvecNonce(
-        '12345',
-        'content-security-policy',
-        "script-src 'self' 'nonce-12345';",
-        done,
-      );
-    });
   });
 
   describe('sur demande positionnement des headers', () => {

--- a/test/routes/routesBibliotheques.spec.js
+++ b/test/routes/routesBibliotheques.spec.js
@@ -1,0 +1,16 @@
+const testeurMSS = require('./testeurMSS');
+
+describe('Le serveur MSS des routes /bibliotheques/*', () => {
+  const testeur = testeurMSS();
+
+  beforeEach(testeur.initialise);
+
+  afterEach(testeur.arrete);
+
+  it('retourne une erreur HTTP 404 si la bibliothèque est inconnue', (done) => {
+    testeur.verifieRequeteGenereErreurHTTP(404, 'Bibliothèque inconnue : bibliothequeInconnue.js', {
+      method: 'get',
+      url: 'http://localhost:1234/bibliotheques/bibliothequeInconnue.js',
+    }, done);
+  });
+});


### PR DESCRIPTION
Cette PR fait suite à la #302 

Dorénavant, on ne fait plus d'appels directs à des URL en dehors du serveur MSS.