### PR TITLE
Correction Affichage sans échappement des risques dans la décision

### DIFF
--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -88,7 +88,7 @@ block page
         ul
           each risque in homologation.risquesPrincipaux()
             li.
-              #{risque.descriptionRisque()} <br>
+              !{risque.descriptionRisque()} <br>
               (niveau de gravité : #{risque.descriptionNiveauGravite()})
 
       section.mesures


### PR DESCRIPTION
Dans la page de décision de l'homologation + PDF, dans le bloc _Principaux risques de sécurité identifiés_
les risques spécifiques qui comportent dans leurs descriptions des caractères spéciaux sont affiché avec des codes

<img width="561" alt="Capture d’écran 2022-07-19 à 14 30 33" src="https://user-images.githubusercontent.com/39462397/179750637-6d65f87f-3723-48b8-a43f-162d9cfbaac0.png">
