### PR TITLE
Changement de textes dans la page inscription

### DIFF
--- a/src/vues/mssInscription.pug
+++ b/src/vues/mssInscription.pug
@@ -49,14 +49,14 @@ block main
           })
         label Poste
           br
-          input(id = 'poste', type = 'text', placeholder = "ex : Chargé des systèmes d'informations")
+          input(id = 'poste', type = 'text', placeholder = "ex : Cheffe/Chef de projet maîtrise d'ouvrage")
         .requis(data-nom = 'nomEntitePublique')
           label Nom de votre entité publique
             br
             input(id = 'nomEntitePublique', type = 'text', placeholder = "ex : Agglomération de Mansart")
             .message-erreur Ce champs est obligatoire. Veuillez le renseigner.
         .requis(data-nom = 'departementEntitePublique')
-          label Département de votre entité publique
+          label Département où est localisée cette entité
             br
             .departements
               select(id = 'departementEntitePublique')


### PR DESCRIPTION
Dans la page inscription le titre du département et l'exemple du poste ne convenaient pas.
<img width="473" alt="Capture d’écran 2022-08-01 à 14 53 24" src="https://user-images.githubusercontent.com/39462397/182152261-3b6eea82-d6f3-42c6-80ae-a0851f4a944f.png">
