### PR TITLE
Message de prévention dans inscription

### DIFF
--- a/public/assets/styles/inscription.css
+++ b/public/assets/styles/inscription.css
@@ -27,9 +27,39 @@
   transform: rotate(45deg);
 }
 
+.avertissement {
+  display: flex;
+  margin-top: 2em;
+  text-align: left;
+}
+
+.avertissement::before {
+  content: '⚠';
+  background-color: var(--bleu-mise-en-avant);
+  border-radius: 5px 0 0 5px;
+  border: 1px var(--bleu-mise-en-avant) solid;
+  border-right: 0;
+
+  padding-top: 0.9em;
+  width: 6em;
+
+  text-align: center;
+  color: #fff;
+  font-size: 1.2em;
+}
+
+.avertissement p {
+  border: 1px var(--bleu-mise-en-avant) solid;
+  border-left: 0;
+  border-radius: 0 5px 5px 0;
+
+  margin: 0;
+  padding: 1em;
+}
+
 .mention {
   align-self: end;
-  margin-top: 3em;
+  margin-top: 2em;
   margin-bottom: -1em;
 }
 

--- a/src/vues/mssInscription.pug
+++ b/src/vues/mssInscription.pug
@@ -12,6 +12,8 @@ block main
     p.sous-titre
       span ou&nbsp;
       a(href = '/connexion') connectez-vous
+    .avertissement
+      p La création de compte sur MonServiceSécurisé est exclusivement réservée aux agents publics.
     .mention champ obligatoire
     section
       block champs-formulaire

--- a/src/vues/mssInscription.pug
+++ b/src/vues/mssInscription.pug
@@ -49,14 +49,14 @@ block main
           })
         label Poste
           br
-          input(id = 'poste', type = 'text', placeholder = "ex : Chargé des systèmes d'informations")
+          input(id = 'poste', type = 'text', placeholder = "ex : Cheffe/Chef de projet maîtrise d'ouvrage")
         .requis(data-nom = 'nomEntitePublique')
           label Nom de votre entité publique
             br
             input(id = 'nomEntitePublique', type = 'text', placeholder = "ex : Agglomération de Mansart")
             .message-erreur Ce champs est obligatoire. Veuillez le renseigner.
         .requis(data-nom = 'departementEntitePublique')
-          label Département de votre entité publique
+          label Département où est localisée cette entité
             br
             .departements
               select(id = 'departementEntitePublique')


### PR DESCRIPTION
Dans la page d'inscription,
nous souhaitons voir un message de prévention pour l'utilisateur
<img width="591" alt="Capture d’écran 2022-08-01 à 14 55 55" src="https://user-images.githubusercontent.com/39462397/182152665-d3eb37a1-5a2d-49ae-8e75-05f1f9ddc416.png">

Nouvelle proposition
<img width="609" alt="Capture d’écran 2022-08-02 à 15 30 57" src="https://user-images.githubusercontent.com/39462397/182389107-e078053f-88d0-4f6d-85ab-8290138eaa76.png">
