### PR TITLE
Changement cible pour le bouton S'inscrire 

### DIFF
--- a/src/vues/index.pug
+++ b/src/vues/index.pug
@@ -20,7 +20,7 @@ block main
         .logo-rgs
         .logo-rgpd
       nav
-        a.bouton(href = 'mailto:contact@monservicesecurise.beta.gouv.fr?subject=Cr%C3%A9ation%20de%20compte').
+        a.bouton(href = '/inscription').
           S'inscrire
     .intro-mss
 


### PR DESCRIPTION
Dans la page d'accueil,
le bouton `S'inscrire` invite à envoyer un e-mail,
nous souhaitons qu'il nous emmène directement vers la page inscription.