### PR TITLE
Mise en avant des champs saisis

### DIFF
--- a/public/assets/styles/inscription.css
+++ b/public/assets/styles/inscription.css
@@ -1,4 +1,4 @@
-.departements select {
+select {
   box-sizing: border-box;
   width: 100%;
   margin-top: 0.3em;
@@ -87,4 +87,8 @@
 
 .requis[data-nom = 'cguAcceptees'] {
   margin-bottom: 2em;
+}
+
+.champ-saisi {
+  border-color: var(--bleu-mise-en-avant);
 }

--- a/public/inscription.js
+++ b/public/inscription.js
@@ -1,6 +1,9 @@
 import { controleChampsRequis, tousChampsRequisRemplis } from './modules/interactions/champsRequis.mjs';
 
 $(() => {
+  const brancheMiseEnAvantSaisie = () => $("input[type!='radio'][type!='checkbox'], select")
+    .on('change', (evenement) => $(evenement.target).toggleClass('champ-saisi', evenement.target.value !== ''));
+
   const reponseOuiNon = (nom) => {
     const valeur = $(`input[name="${nom}"]:checked`).val();
     switch (valeur) {
@@ -27,6 +30,7 @@ $(() => {
 
   const $formulaire = $('form#inscription');
 
+  brancheMiseEnAvantSaisie();
   $formulaire.on('submit', (evenement) => {
     evenement.preventDefault();
     controleChampsRequis(obtentionDonnees);


### PR DESCRIPTION
Dans la page d'inscription,
Quand un champ texte est rempli ou un champ à liste de choix est sélectionné,
Le conteneur du champ doit apparaitre en bleu comme dans l'UI kit
<img width="530" alt="Capture d’écran 2022-08-02 à 17 19 59" src="https://user-images.githubusercontent.com/39462397/182411055-ffab6db1-27c1-4fa8-bdf8-290ffae2a55d.png">
