### PR TITLE
[PREMANIEMENT] extraction composant carte

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -164,11 +164,62 @@ module.exports = {
   },
 
   niveauxGravite: {
-    nonConcerne: { position: 0, description: 'Non concerné', important: false },
-    minime: { position: 1, description: 'Minime', important: false },
-    significatif: { position: 2, description: 'Significatif', important: true },
-    grave: { position: 3, description: 'Grave', important: true },
-    critique: { position: 4, description: 'Critique', important: true },
+    nonConcerne: {
+      position: 0,
+      couleur: 'blanc',
+      description: 'Non concerné',
+      descriptionLongue: '',
+      important: false,
+    },
+    minime: {
+      position: 1,
+      couleur: 'vert',
+      description: 'Minime',
+      descriptionLongue: `
+        Aucun impact opérationnel ni sur les performances de l'activité ni sur
+        la sécurité des personnes et des biens. L'organisation surmontera la
+        situation sans trop de difficultés (consommation des marges)
+      `,
+      important: false,
+    },
+    significatif: {
+      position: 2,
+      couleur: 'jaune',
+      description: 'Significatif',
+      descriptionLongue: `
+        Dégradation des performances de l'activité sans impact sur la sécurité
+        des personnes et des biens. L'organisation surmontera la situation
+        malgré quelques difficultés (fonctionnement en mode dégradé)
+      `,
+      important: true,
+    },
+    grave: {
+      position: 3,
+      couleur: 'orange',
+      description: 'Grave',
+      descriptionLongue: `
+        Forte dégradation des performances de l'activité, avec d'éventuels
+        impacts significatifs sur la sécurité des personnes et des biens.
+        L'organisation surmontera la situation avec de sérieuses difficultés
+        (fonctionnement en mode très dégradé), sans impacts sectoriel ou
+        étatique
+      `,
+      important: true,
+    },
+    critique: {
+      position: 4,
+      couleur: 'rouge',
+      description: 'Critique',
+      descriptionLongue: `
+        Incapacité pour l'organisation d'assurer la totalité ou une partie de
+        son activité, avec d'éventuels impacts graves sur la sécurité des
+        personnes et des biens. L'organisation ne surmontera vraisemblablement
+        pas la situation (sa survie est menacée), les secteurs d'activité ou
+        étatiques dans lesquels elle opère seront susceptibles d'être
+        légèrement impactés, sans conséquences durables
+      `,
+      important: true,
+    },
   },
 
   risques: {
@@ -315,7 +366,7 @@ module.exports = {
       description: 'Mettre en place une politique de sécurité des mots de passe',
       categorie: 'protection',
       indispensable: true,
-      descriptionLongue: "Cette mesure permet d'éviter des mots de passe trop simples, trop courts ou anciens ne soient utilisés par un acteur malveillant pour accéder au service. Cette mesure peut être mise en œuvre en fixant des règles au moment de l'enregistrement d'un mot de passe (longueur, complexité, etc.) ; l'introduction d'un testeur de force de mot de passe ;  un délai d'expiration du mot de passe ; une politique de renouvellement automatique ; un accès sans mot de passe par la réception d'un code à usage unique à chaque connexion (hors SMS) ; l'impossibilité de réutiliser des mots de passe déjà employés par le passé ; la révocation immédiate de mots de passe  en cas de connexion suspecte, etc. Pour plus de détails, consultez le <a href=\"https://www.ssi.gouv.fr/administration/guide/recommandations-relatives-a-lauthentification-multifacteur-et-aux-mots-de-passe/\" target=\"_blank\" rel=\"noopener\">« Guide de l'ANSSI relatives à l'authentification multifacteur et aux mots de passe ».</a>",
+      descriptionLongue: "Cette mesure permet d'éviter des mots de passe trop simples, trop courts ou anciens ne soient utilisés par un acteur malveillant pour accéder au service. Cette mesure peut être mise en œuvre en fixant des règles au moment de l'enregistrement d'un mot de passe (longueur, complexité, etc.) ; l'introduction d'un testeur de force de mot de passe ; un délai d'expiration du mot de passe ; une politique de renouvellement automatique ; un accès sans mot de passe par la réception d'un code à usage unique à chaque connexion (hors SMS) ; l'impossibilité de réutiliser des mots de passe déjà employés par le passé ; la révocation immédiate de mots de passe en cas de connexion suspecte, etc. Pour plus de détails, consultez le <a href=\"https://www.ssi.gouv.fr/administration/guide/recommandations-relatives-a-lauthentification-multifacteur-et-aux-mots-de-passe/\" target=\"_blank\" rel=\"noopener\">« Guide de l'ANSSI relatives à l'authentification multifacteur et aux mots de passe ».</a>",
     },
     franceConnect: {
       description: 'Permettre la connexion des utilisateurs via FranceConnect',

--- a/public/assets/styles/carteInformations.css
+++ b/public/assets/styles/carteInformations.css
@@ -1,0 +1,69 @@
+.carte {
+  box-sizing: border-box;
+  width: 270px;
+  margin-bottom: 1.7em;
+  padding: 1.7em;
+
+  background-color: #fff;
+
+  text-align: left;
+}
+
+.carte h1 {
+  display: inline;
+
+  font-size: 1.2em;
+}
+
+.carte h2 {
+  margin-top: 0;
+
+  font-size: 1em;
+  font-weight: 600;
+  color: var(--texte-clair);
+}
+
+.carte h3 {
+  margin: 0;
+
+  color: var(--bleu-mise-en-avant);
+}
+
+.carte h3 + p {
+  margin-top: 0;
+}
+
+.carte .plus-details, .carte .moins-details {
+  text-align: right;
+  font-size: 0.85em;
+  cursor: pointer;
+}
+
+.carte .plus-details::after, .carte .moins-details::after {
+  content: '';
+  display: inline-block;
+  width: .6em;
+  height: .6em;
+  margin-left: 1em;
+
+  border: 2px var(--bleu-anssi) solid;
+  transform: rotate(0.12turn);
+}
+
+.carte .moins-details::after {
+  margin-bottom: -0.2em;
+
+  border-bottom: 0;
+  border-right: 0;
+}
+
+.carte .plus-details::after {
+  margin-bottom: 0.2em;
+
+  border-top: 0;
+  border-left: 0;
+}
+
+.carte .details, .carte .moins-details {
+  display: none;
+}

--- a/public/assets/styles/homologation/risques.css
+++ b/public/assets/styles/homologation/risques.css
@@ -80,79 +80,18 @@
   grid-gap: 1.7em;
 }
 
-.carte {
-  box-sizing: border-box;
-  width: 270px;
-  margin-bottom: 1.7em;
-  padding: 1.7em;
-
-  background-color: #fff;
-
-  text-align: left;
-}
-
-.carte .titre {
-  display: inline;
-
-  font-size: 1.2em;
-}
-
-.carte .sous-titre {
-  margin-top: 0;
-
-  font-size: 1em;
-  font-weight: 600;
-  color: var(--texte-clair);
-}
-
-.carte ul.niveaux-gravites {
+ul.niveaux-gravite {
   list-style: none;
 
   padding: 0;
 
   line-height: 1.8em;
 }
-.carte .niveaux-gravites .disque {
+
+.niveaux-gravite .disque {
   display: inline-block;
 
   margin: 0 0.8em -0.2em 0;
-}
-.carte .plus-details, .carte .moins-details {
-  text-align: right;
-  font-size: 0.85em;
-  cursor: pointer;
-}
-.carte .plus-details::after, .carte .moins-details::after {
-  content: '';
-  display: inline-block;
-  width: .6em;
-  height: .6em;
-  margin-left: 1em;
-
-  border: 2px var(--bleu-anssi) solid;
-  transform: rotate(0.12turn);
-}
-
-.carte .moins-details::after {
-  margin-bottom: -0.2em;
-
-  border-bottom: 0;
-  border-right: 0;
-}
-
-.carte .plus-details::after {
-  margin-bottom: 0.2em;
-
-  border-top: 0;
-  border-left: 0;
-}
-.carte h4 {
-  margin: 0;
-
-  color: var(--bleu-mise-en-avant);
-}
-.carte h4 + p {
-  margin-top: 0;
 }
 
 .rideau .modale {
@@ -162,8 +101,9 @@
   margin-top: 0.3em;
   margin-left: 1.5em;
 
-  color: var(--texte-fonce);            
+  color: var(--texte-fonce);
 }
+
 .rideau .modale li::before {
   content: '\25CF';
   display: block;

--- a/public/homologation/risques.js
+++ b/public/homologation/risques.js
@@ -14,6 +14,7 @@ $(() => {
   let indexMaxRisquesSpecifiques = 0;
 
   const NIVEAUX_GRAVITE = JSON.parse($('#donnees-referentiel-niveaux-gravite-risque').text());
+  const COULEURS = Object.values(NIVEAUX_GRAVITE).map((niveau) => niveau.couleur);
 
   const ajouteZoneSaisieCommentairePourRisque = ($r, nom) => {
     const $lien = $('a.informations-additionnelles', $r);
@@ -26,19 +27,20 @@ $(() => {
 
   const peupleRisquesGeneraux = (selecteurDonnees) => {
     const donneesRisques = JSON.parse($(selecteurDonnees).text());
+
     donneesRisques.forEach(({ id, commentaire, niveauGravite }) => {
       if (commentaire) $(`#commentaire-${id}`).show().val(texteHTML(commentaire));
 
       const $risque = $(`.risque#${id}`);
       if (niveauGravite) {
         const { position, description } = NIVEAUX_GRAVITE[niveauGravite];
-        metsAJourAffichageNiveauGravite($risque, niveauGravite, position, description);
+        metsAJourAffichageNiveauGravite($risque, niveauGravite, COULEURS, position, description);
       }
     });
   };
 
   const zoneSaisieRisqueSpecifique = (...params) => (
-    $saisieRisqueSpecifique(...params, NIVEAUX_GRAVITE)
+    $saisieRisqueSpecifique(...params, NIVEAUX_GRAVITE, COULEURS)
   );
 
   const brancheAjoutRisqueSpecifique = (...params) => brancheAjoutItem(
@@ -54,7 +56,7 @@ $(() => {
   ajouteModalesInformations();
 
   $('.risque').each((_, $r) => {
-    brancheComportementSaisieNiveauGravite($r, NIVEAUX_GRAVITE);
+    brancheComportementSaisieNiveauGravite($r, NIVEAUX_GRAVITE, COULEURS);
     ajouteZoneSaisieCommentairePourRisque($r, `commentaire-${$r.id}`);
   });
 

--- a/public/modules/elementsDom/saisieRisqueSpecifique.js
+++ b/public/modules/elementsDom/saisieRisqueSpecifique.js
@@ -20,7 +20,7 @@ const $curseur = (niveaux) => Object.keys(niveaux)
     $('<div class="curseur"></div>')
   );
 
-const $saisieNiveauGravite = (index, niveauGravite, niveaux) => {
+const $saisieNiveauGravite = (index, niveauGravite, niveaux, couleurs) => {
   const $conteneurSaisie = $(`
 <div class="niveau-gravite">
 <input id="niveauGravite-risque-specifique-${index}"
@@ -30,11 +30,17 @@ const $saisieNiveauGravite = (index, niveauGravite, niveaux) => {
 </div>
   `);
   $conteneurSaisie.append($curseur(niveaux), $('<div class="legende"></div>'));
-  brancheComportementSaisieNiveauGravite($conteneurSaisie, niveaux);
+  brancheComportementSaisieNiveauGravite($conteneurSaisie, niveaux, couleurs);
 
   if (niveauGravite) {
     const { position, description } = niveaux[niveauGravite];
-    metsAJourAffichageNiveauGravite($conteneurSaisie, niveauGravite, position, description);
+    metsAJourAffichageNiveauGravite(
+      $conteneurSaisie,
+      niveauGravite,
+      couleurs,
+      position,
+      description
+    );
   }
 
   return $conteneurSaisie;
@@ -48,14 +54,14 @@ const $textareaCommentaire = (index, commentaire) => (
   `)
 );
 
-const $saisieRisqueSpecifique = (index, donnees = {}, niveaux) => {
+const $saisieRisqueSpecifique = (index, donnees = {}, niveaux, couleurs) => {
   const { description = '', niveauGravite = '', commentaire = '' } = donnees;
 
   const $conteneur = $('<div class="saisie-risque-specifique"><div class="synthese"></div></div>');
 
   $('.synthese', $conteneur).append(
     $inputDescription(index, description),
-    $saisieNiveauGravite(index, niveauGravite, niveaux),
+    $saisieNiveauGravite(index, niveauGravite, niveaux, couleurs),
   );
 
   $conteneur.append(

--- a/public/modules/interactions/saisieNiveauGravite.js
+++ b/public/modules/interactions/saisieNiveauGravite.js
@@ -1,17 +1,21 @@
-const COULEURS_NIVEAUX_GRAVITE = ['blanc', 'vert', 'jaune', 'orange', 'rouge'];
-
-const metsAJourAffichageNiveauGravite = ($parent, niveauCourant, position, description) => {
+const metsAJourAffichageNiveauGravite = (
+  $parent,
+  niveauCourant,
+  couleurs,
+  position,
+  description
+) => {
   $('input', $parent).val(niveauCourant);
 
   const $disques = $('.disque', $parent);
   $disques.removeClass('eteint');
-  $disques.removeClass(COULEURS_NIVEAUX_GRAVITE.join(' '));
-  $disques.addClass((i) => (i <= position ? COULEURS_NIVEAUX_GRAVITE[position] : 'eteint'));
+  $disques.removeClass(couleurs.join(' '));
+  $disques.addClass((i) => (i <= position ? couleurs[position] : 'eteint'));
   $disques.first().toggleClass('cercle', position === 0);
   $('.legende', $parent).text(description);
 };
 
-const brancheComportementSaisieNiveauGravite = ($parent, niveaux) => {
+const brancheComportementSaisieNiveauGravite = ($parent, niveaux, couleurs) => {
   const $disques = $('.disque', $parent);
   $disques.click((e) => {
     e.preventDefault();
@@ -19,7 +23,7 @@ const brancheComportementSaisieNiveauGravite = ($parent, niveaux) => {
     const niveau = $disque.data('niveau');
 
     const { position, description } = niveaux[niveau];
-    metsAJourAffichageNiveauGravite($parent, niveau, position, description);
+    metsAJourAffichageNiveauGravite($parent, niveau, couleurs, position, description);
   });
 };
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -59,6 +59,11 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     return Object.keys(actionsSaisie()).find((a) => positionActionSaisie(a) === position + 1);
   };
 
+  const infosNiveauxGravite = (ordreInverse = false) => {
+    const niveaux = Object.values(niveauxGravite());
+    return ordreInverse ? niveaux.reverse() : niveaux;
+  };
+
   const descriptionExpiration = (identifiant) => {
     if (!identifiant) return 'Information non renseignée';
 
@@ -160,7 +165,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     identifiantsMesures,
     identifiantsNiveauxGravite,
     identifiantsRisques,
-    statutDeploiementValide,
+    infosNiveauxGravite,
     localisationDonnees,
     localisationsDonnees,
     mesure,
@@ -176,6 +181,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     seuilCriticiteMin,
     seuilsCriticites,
     statutsDeploiement,
+    statutDeploiementValide,
     statutsMesures,
     typeService,
     typesService,

--- a/src/vues/carteInformations.pug
+++ b/src/vues/carteInformations.pug
@@ -1,0 +1,14 @@
+block append styles
+  link(href = '/statique/assets/styles/carteInformations.css', rel = 'stylesheet')
+
+mixin carteInformations({ titre, sousTitre, details })
+  .carte
+    h1= titre
+    h2= sousTitre
+
+    block
+
+    .plus-details Plus de détails
+    .moins-details Moins de détails
+    .details
+      +#{details}

--- a/src/vues/homologation/risques.pug
+++ b/src/vues/homologation/risques.pug
@@ -1,4 +1,5 @@
 extends ./formulaire
+include ../carteInformations
 
 block append styles
   link(href = '/statique/assets/styles/homologation/risques.css', rel = 'stylesheet')
@@ -53,10 +54,39 @@ block formulaire
   script(type = 'module', src = '/statique/homologation/risques.js')
 
 block cartes-informations
-  .carte
-    h2.titre Niveaux de gravité
-    h3.sous-titre Découvrez les 5 niveaux définis par l'ANSSI.
-    ul.niveaux-gravites
+  mixin detailsRisques
+    h3 Critique
+    p.
+      Incapacité pour l’organisation d’assurer la totalité ou une partie de son activité,
+      avec d’éventuels impacts graves sur la sécurité des personnes et des biens.
+      L’organisation ne surmontera vraisemblablement pas la situation (sa survie est menacée),
+      les secteurs d’activité ou étatiques dans lesquels elle opère seront susceptibles d’être légèrement impactés,
+      sans conséquences durables
+
+    h3 Grave
+    p.
+      Forte dégradation des performances de l’activité, avec d’éventuels impacts significatifs
+      sur la sécurité des personnes et des biens. L’organisation surmontera la situation avec
+      de sérieuses difficultés (fonctionnement en mode très dégradé), sans impacts sectoriel ou étatique
+
+    h3 Significatif
+    p.
+      Dégradation des performances de l’activité sans impact sur la sécurité des personnes et des biens.
+      L’organisation surmontera la situation malgré quelques difficultés (fonctionnement en mode dégradé)
+
+    h3 Minime
+    p.
+      Aucun impact opérationnel ni sur les performances de l’activité ni sur la sécurité des personnes et des biens.
+      L’organisation surmontera la situation sans trop de difficultés (consommation des marges)
+
+    h3 Non concerné
+
+  +carteInformations({
+    titre: 'Niveaux de gravité',
+    sousTitre: "Découvrez les 5 niveaux définis par l'ANSSI.",
+    details: 'detailsRisques',
+  })
+    ul.niveaux-gravite
       li
         .disque.rouge
         .
@@ -77,31 +107,3 @@ block cartes-informations
         .disque.cercle.blanc
         .
           Non concerné
-    .plus-details Plus de détails
-    .moins-details Moins de détails
-    .details
-      h4 Critique
-      p.
-        Incapacité pour l’organisation d’assurer la totalité ou une partie de son activité,
-        avec d’éventuels impacts graves sur la sécurité des personnes et des biens.
-        L’organisation ne surmontera vraisemblablement pas la situation (sa survie est menacée),
-        les secteurs d’activité ou étatiques dans lesquels elle opère seront susceptibles d’être légèrement impactés,
-        sans conséquences durables
-
-      h4 Grave
-      p.
-        Forte dégradation des performances de l’activité, avec d’éventuels impacts significatifs
-        sur la sécurité des personnes et des biens. L’organisation surmontera la situation avec
-        de sérieuses difficultés (fonctionnement en mode très dégradé), sans impacts sectoriel ou étatique
-
-      h4 Significatif
-      p.
-        Dégradation des performances de l’activité sans impact sur la sécurité des personnes et des biens.
-        L’organisation surmontera la situation malgré quelques difficultés (fonctionnement en mode dégradé)
-
-      h4 Minime
-      p.
-        Aucun impact opérationnel ni sur les performances de l’activité ni sur la sécurité des personnes et des biens.
-        L’organisation surmontera la situation sans trop de difficultés (consommation des marges)
-
-      h4 Non concerné

--- a/src/vues/homologation/risques.pug
+++ b/src/vues/homologation/risques.pug
@@ -55,31 +55,10 @@ block formulaire
 
 block cartes-informations
   mixin detailsRisques
-    h3 Critique
-    p.
-      Incapacité pour l’organisation d’assurer la totalité ou une partie de son activité,
-      avec d’éventuels impacts graves sur la sécurité des personnes et des biens.
-      L’organisation ne surmontera vraisemblablement pas la situation (sa survie est menacée),
-      les secteurs d’activité ou étatiques dans lesquels elle opère seront susceptibles d’être légèrement impactés,
-      sans conséquences durables
-
-    h3 Grave
-    p.
-      Forte dégradation des performances de l’activité, avec d’éventuels impacts significatifs
-      sur la sécurité des personnes et des biens. L’organisation surmontera la situation avec
-      de sérieuses difficultés (fonctionnement en mode très dégradé), sans impacts sectoriel ou étatique
-
-    h3 Significatif
-    p.
-      Dégradation des performances de l’activité sans impact sur la sécurité des personnes et des biens.
-      L’organisation surmontera la situation malgré quelques difficultés (fonctionnement en mode dégradé)
-
-    h3 Minime
-    p.
-      Aucun impact opérationnel ni sur les performances de l’activité ni sur la sécurité des personnes et des biens.
-      L’organisation surmontera la situation sans trop de difficultés (consommation des marges)
-
-    h3 Non concerné
+    each niveau in referentiel.infosNiveauxGravite(ordreInverse = true)
+      - const { description, descriptionLongue } = niveau
+      h3= description
+      p= descriptionLongue
 
   +carteInformations({
     titre: 'Niveaux de gravité',
@@ -87,23 +66,8 @@ block cartes-informations
     details: 'detailsRisques',
   })
     ul.niveaux-gravite
-      li
-        .disque.rouge
-        .
-          Critique
-      li
-        .disque.orange
-        .
-          Grave
-      li
-        .disque.jaune
-        .
-          Significatif
-      li
-        .disque.vert
-        .
-          Minime
-      li
-        .disque.cercle.blanc
-        .
-          Non concerné
+      each niveau in referentiel.infosNiveauxGravite(ordreInverse = true)
+        - const { couleur, description } = niveau
+        li
+          .disque(class = `${ couleur === 'blanc' ? 'cercle blanc' : couleur }`)
+          = description

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -314,6 +314,27 @@ describe('Le référentiel', () => {
     expect(referentiel.identifiantsNiveauxGravite()).to.eql(['unNiveau', 'unAutreNiveau']);
   });
 
+  describe('sur demande des infos sur les niveaux de gravité des risques', () => {
+    it('retourne les informations', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        niveauxGravite: { niveauUn: { position: 0 }, niveauDeux: { position: 1 } },
+      });
+
+      expect(referentiel.infosNiveauxGravite()).to.eql([{ position: 0 }, { position: 1 }]);
+    });
+
+    it("sait retourner les informations dans l'ordre inverse", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        niveauxGravite: { niveauUn: { position: 0 }, niveauDeux: { position: 1 } },
+      });
+
+      expect(referentiel.infosNiveauxGravite(true)).to.eql([
+        { position: 1 },
+        { position: 0 },
+      ]);
+    });
+  });
+
   it("connaît l'action de saisie suivante d'une action de saisie donnée", () => {
     const referentiel = Referentiel.creeReferentiel({
       actionsSaisie: { uneAction: { position: 0 }, actionSuivante: { position: 1 } },


### PR DESCRIPTION
Cette PR vient en préparation de l'affichage du score dans un composant « carte ». On commence par extraire ce composant de la page risques, là où il était utilisé uniquement jusqu'à présent.

(Note : on profite de cette PR pour supprimer la duplication concernant la gestion des couleurs pour les risques.)