### PR TITLE
Nouveaux texte dans la page d'activation de compte

### DIFF
--- a/src/vues/activation.pug
+++ b/src/vues/activation.pug
@@ -7,5 +7,11 @@ block append styles
 block main
   .etroit
     h1 Activer votre compte
-    p.description Un e-mail contenant un lien d’activation vous a été envoyé pour finaliser la création de votre compte.
-    a.bouton(href = '/') Aller sur la page d'accueil
+    .description
+      p.
+        Un e-mail contenant un lien d'activation vous a été envoyé pour finaliser la création de votre compte.
+      p.
+        La réception peut prendre quelques minutes.<br>
+        Si vous n'avez pas reçu cet e-mail, contactez-nous à
+        <a href="mailto:contact@monservicesecurise.beta.gouv.fr?subject=Non%20r%C3%A9ception%20du%20lien%20d%27activation">contact@monservicesecurise.beta.gouv.fr</a>.
+    a.bouton(href = '/') Aller à la page d'accueil


### PR DESCRIPTION
Dans la page d'activation qui apparait après l'inscription d'un nouvel utilisateur `/activation`,
Le texte se voit modifié.

NOTE : Je me suis permis d'écrire un objet au mailto : `Non réception du lien d'activation`

<img width="410" alt="Capture d’écran 2022-08-05 à 16 44 21" src="https://user-images.githubusercontent.com/39462397/183101439-d74c4f46-cc84-4298-8144-74ee2e267f2e.png">
