### PR TITLE
Utilisation d'un adaptateur chiffrement

### DIFF
--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,7 +1,10 @@
 const bcrypt = require('bcrypt');
 
-const chaineChiffree = (chaineEnClair) => bcrypt.hash(chaineEnClair, 10);
-const nonce = () => chaineChiffree(`${Math.random()}`)
+const NOMBRE_DE_PASSES = 10;
+
+const chiffre = (chaineEnClair) => bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
+const { compare } = bcrypt;
+const nonce = () => chiffre(`${Math.random()}`)
   .then((s) => s.replace(/[/$.]/g, ''));
 
-module.exports = { nonce };
+module.exports = { chiffre, compare, nonce };

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -103,12 +103,4 @@ const creeDepot = (config = {}) => {
   };
 };
 
-const creeDepotVide = () => {
-  const adaptateurPersistance = fabriqueAdaptateurPersistance();
-  return adaptateurPersistance.supprimeUtilisateurs()
-    .then(() => adaptateurPersistance.supprimeHomologations())
-    .then(() => adaptateurPersistance.supprimeAutorisations())
-    .then(() => creeDepot({ adaptateurPersistance }));
-};
-
-module.exports = { creeDepot, creeDepotVide };
+module.exports = { creeDepot };

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -1,5 +1,4 @@
-const bcrypt = require('bcrypt');
-
+const adaptateurChiffrementParDefaut = require('../adaptateurs/adaptateurChiffrement');
 const adaptateurJWTParDefaut = require('../adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('../adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateurPersistance');
@@ -11,6 +10,7 @@ const Utilisateur = require('../modeles/utilisateur');
 
 const creeDepot = (config = {}) => {
   const {
+    adaptateurChiffrement = adaptateurChiffrementParDefaut,
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
     adaptateurUUID = adaptateurUUIDParDefaut,
@@ -34,7 +34,7 @@ const creeDepot = (config = {}) => {
 
         const id = adaptateurUUID.genereUUID();
         donneesUtilisateur.idResetMotDePasse = adaptateurUUID.genereUUID();
-        return bcrypt.hash(adaptateurUUID.genereUUID(), 10)
+        return adaptateurChiffrement.chiffre(adaptateurUUID.genereUUID())
           .then((hash) => {
             donneesUtilisateur.motDePasse = hash;
 
@@ -55,7 +55,7 @@ const creeDepot = (config = {}) => {
 
         if (!motDePasseStocke) return new Promise((resolve) => resolve(echecAuthentification));
 
-        return bcrypt.compare(motDePasse, motDePasseStocke)
+        return adaptateurChiffrement.compare(motDePasse, motDePasseStocke)
           .then((authentificationReussie) => (authentificationReussie
             ? new Utilisateur(u, adaptateurJWT)
             : echecAuthentification
@@ -68,7 +68,7 @@ const creeDepot = (config = {}) => {
   const { utilisateurAvecEmail } = adaptateurPersistance;
 
   const metsAJourMotDePasse = (idUtilisateur, motDePasse) => (
-    bcrypt.hash(motDePasse, 10)
+    adaptateurChiffrement.chiffre(motDePasse)
       .then((hash) => adaptateurPersistance.metsAJourUtilisateur(
         idUtilisateur, { motDePasse: hash }
       ))

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -1,10 +1,10 @@
 const expect = require('expect.js');
 
-const DepotDonnees = require('../src/depotDonnees');
+const { depotVide } = require('./depots/depotVide');
 
 describe('Le dépôt de données vide', () => {
   it('ne retourne aucune homologation pour un utilisateur donné', (done) => {
-    DepotDonnees.creeDepotVide()
+    depotVide()
       .then((depot) => depot.homologations('456'))
       .then((hs) => expect(hs).to.eql([]))
       .then(() => done())
@@ -12,7 +12,7 @@ describe('Le dépôt de données vide', () => {
   });
 
   it('ne retourne rien si on cherche une homologation à partir de son identifiant', (done) => {
-    DepotDonnees.creeDepotVide()
+    depotVide()
       .then((depot) => depot.homologation('123'))
       .then((h) => expect(h).to.be(undefined))
       .then(() => done())
@@ -20,7 +20,7 @@ describe('Le dépôt de données vide', () => {
   });
 
   it('ne retourne rien si on cherche un utilisateur à partir de son identifiant', (done) => {
-    DepotDonnees.creeDepotVide()
+    depotVide()
       .then((depot) => depot.utilisateur('456'))
       .then((u) => expect(u).to.be(undefined))
       .then(() => done())
@@ -28,7 +28,7 @@ describe('Le dépôt de données vide', () => {
   });
 
   it("n'authentifie pas l'utilisateur", (done) => {
-    DepotDonnees.creeDepotVide()
+    depotVide()
       .then((depot) => depot.utilisateurAuthentifie('jean.dupont@mail.fr', 'mdp_12345'))
       .then((utilisateur) => expect(utilisateur).to.be(undefined))
       .then(() => done())

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -1,7 +1,8 @@
 const expect = require('expect.js');
 
+const { depotVide } = require('./depotVide');
+
 const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
-const DepotDonnees = require('../../src/depotDonnees');
 const DepotDonneesAutorisations = require('../../src/depots/depotDonneesAutorisations');
 const DepotDonneesHomologations = require('../../src/depots/depotDonneesHomologations');
 const DepotDonneesUtilisateurs = require('../../src/depots/depotDonneesUtilisateurs');
@@ -118,7 +119,7 @@ describe('Le dépôt de données des autorisations', () => {
     });
 
     it("retourne `undefined` si l'autorisation est inexistante", (done) => {
-      DepotDonnees.creeDepotVide()
+      depotVide()
         .then((depot) => depot.autorisation('123'))
         .then((autorisation) => expect(autorisation).to.be(undefined))
         .then(() => done())

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -1,5 +1,7 @@
 const expect = require('expect.js');
 
+const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
+
 const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
 const DepotDonneesHomologations = require('../../src/depots/depotDonneesHomologations');
 const DepotDonneesUtilisateurs = require('../../src/depots/depotDonneesUtilisateurs');
@@ -15,10 +17,7 @@ describe('Le dépôt de données des utilisateurs', () => {
 
   beforeEach(() => {
     adaptateurJWT = 'Un adaptateur';
-    adaptateurChiffrement = {
-      chiffre: () => Promise.resolve('chaîne chiffrée'),
-      compare: () => Promise.resolve(true),
-    };
+    adaptateurChiffrement = fauxAdaptateurChiffrement;
   });
 
   it("retourne l'utilisateur authentifié", (done) => {
@@ -56,14 +55,6 @@ describe('Le dépôt de données des utilisateurs', () => {
   });
 
   it("met à jour le mot de passe d'un utilisateur", (done) => {
-    adaptateurChiffrement.chiffre = (chaineEnClair) => Promise.resolve(
-      chaineEnClair === 'mdp_12345' ? 'mdp_12345-chiffré' : 'un_autre_mdp-chiffré'
-    );
-    adaptateurChiffrement.compare = (chaineEnClair, chaineChiffree) => (
-      adaptateurChiffrement.chiffre(chaineEnClair)
-        .then((resultatChiffre) => resultatChiffre === chaineChiffree)
-    );
-
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       utilisateurs: [{
         id: '123', prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr', motDePasse: 'mdp_origine-chiffré',

--- a/test/depots/depotVide.js
+++ b/test/depots/depotVide.js
@@ -1,0 +1,21 @@
+const fabriqueAdaptateurPersistance = require('../../src/adaptateurs/fabriqueAdaptateurPersistance');
+const DepotDonnees = require('../../src/depotDonnees');
+
+const fauxAdaptateurChiffrement = {
+  chiffre: (chaine) => Promise.resolve(`${chaine}-chiffré`),
+  compare: (enClair, chiffreeReference) => fauxAdaptateurChiffrement.chiffre(enClair)
+    .then((chaineChiffree) => chaineChiffree === chiffreeReference),
+};
+
+const depotVide = (config = {
+  adaptateurChiffrement: fauxAdaptateurChiffrement,
+  adaptateurPersistance: fabriqueAdaptateurPersistance(),
+}) => {
+  const { adaptateurPersistance } = config;
+  return adaptateurPersistance.supprimeUtilisateurs()
+    .then(() => adaptateurPersistance.supprimeHomologations())
+    .then(() => adaptateurPersistance.supprimeAutorisations())
+    .then(() => DepotDonnees.creeDepot(config));
+};
+
+module.exports = { depotVide };

--- a/test/depots/depotVide.js
+++ b/test/depots/depotVide.js
@@ -1,11 +1,7 @@
+const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
+
 const fabriqueAdaptateurPersistance = require('../../src/adaptateurs/fabriqueAdaptateurPersistance');
 const DepotDonnees = require('../../src/depotDonnees');
-
-const fauxAdaptateurChiffrement = {
-  chiffre: (chaine) => Promise.resolve(`${chaine}-chiffré`),
-  compare: (enClair, chiffreeReference) => fauxAdaptateurChiffrement.chiffre(enClair)
-    .then((chaineChiffree) => chaineChiffree === chiffreeReference),
-};
 
 const depotVide = (config = {
   adaptateurChiffrement: fauxAdaptateurChiffrement,

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -1,0 +1,7 @@
+const fauxAdaptateurChiffrement = {
+  chiffre: (chaine) => Promise.resolve(`${chaine}-chiffré`),
+  compare: (enClair, chiffreeReference) => fauxAdaptateurChiffrement.chiffre(enClair)
+    .then((chaineChiffree) => chaineChiffree === chiffreeReference),
+};
+
+module.exports = fauxAdaptateurChiffrement;

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const expect = require('expect.js');
 
-const DepotDonnees = require('../../src/depotDonnees');
+const { depotVide } = require('../depots/depotVide');
 const MoteurRegles = require('../../src/moteurRegles');
 const MSS = require('../../src/mss');
 const Referentiel = require('../../src/referentiel');
@@ -37,7 +37,7 @@ const testeurMss = () => {
     middleware.reinitialise();
     referentiel = Referentiel.creeReferentielVide();
     moteurRegles = new MoteurRegles(referentiel);
-    DepotDonnees.creeDepotVide()
+    depotVide()
       .then((depot) => {
         depotDonnees = depot;
         serveur = MSS.creeServeur(


### PR DESCRIPTION
Pour ne plus dépendre de bcrypt dans les tests,
Nous mettons en place un adaptateur de chiffrement.

NOTE : il reste une dépendance à bcrypt dans les tests du fichier depotDonnees.spec.js qui utilisent `DepotDonnees.creeDepotVide()` qui 🤷🏻‍♂️ utilise bcrypt