### PR TITLE
Utilisation modules Node.js installés à la création de l'image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-app:
     - .env
   volumes:
     - .:/usr/src/app
+    - node_modules:/usr/src/app/node_modules/
 
 services:
   db:
@@ -39,3 +40,6 @@ services:
 
 networks:
   postgres:
+
+volumes:
+  node_modules:


### PR DESCRIPTION
… plutôt que ceux de la machine hôte. Cela permet de pouvoir utiliser le code du projet depuis la machine hôte et depuis le conteneur, chaque contexte d'utilisation ayant ses propres dépendances de modules Node installées de manière cohérente.

En particulier : il devient possible d'exécuter les tests avec`./script/tests.sh` (dans le contexte du conteneur Docker sous Linux) _et_ depuis la machine hôte sous un OS différent, par exemple depuis l'IDE.

Il fallait faire deux modifications dans la configuration :
- d'une part ne pas copier les modules déjà installés sur la machine hôte lors de la construction de l'image
- d'autre part ne pas mapper les modules de la machine hôte lors de l'exécution de l'image

Cf. documentation :
- https://docs.docker.com/compose/compose-file/#volumes
- https://docs.docker.com/engine/reference/builder/#dockerignore-file