### PR TITLE
[CORRECTION] comparaison au type non défini

### DIFF
--- a/public/modules/interactions/champsRequis.mjs
+++ b/public/modules/interactions/champsRequis.mjs
@@ -1,5 +1,5 @@
 const obtentionValeur = (obtentionDonnees, element) => obtentionDonnees[$(element).data('nom')]();
-const champNonRempli = (valeur) => valeur === '' || valeur === undefined;
+const champNonRempli = (valeur) => valeur === '' || typeof valeur === 'undefined';
 const champRempli = (valeur) => !champNonRempli(valeur);
 
 const controleChampsRequis = (obtentionDonnees) => {


### PR DESCRIPTION
Dans le fichier `champsRequis.mjs` on utilise un `=== undefined` pour tester si la valeur est de type non défini,
C'est une meilleur pratique d'utiliser `typeof … === 'undefined'`