### PR TITLE
[CORRECTION] Utilisation systématique du nom « MonServiceSécurisé »

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Mon Service Sécurisé",
+  "name": "MonServiceSécurisé",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "Mon Service Sécurisé",
+      "name": "MonServiceSécurisé",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Mon Service Sécurisé",
+  "name": "MonServiceSécurisé",
   "version": "1.0.0",
   "description": "",
   "engines": {

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const serveur = MSS.creeServeur(
 serveur.ecoute(port, () => {
   /* eslint-disable no-console */
 
-  console.log(`Mon Service Sécurisé est démarré et écoute le port ${port} !…`);
+  console.log(`MonServiceSécurisé est démarré et écoute le port ${port} !…`);
 
   /* eslint-enable no-console */
 });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -7,7 +7,7 @@ const middleware = (configuration = {}) => {
 
   const authentificationBasique = basicAuth({
     challenge: true,
-    realm: 'Administration Mon Service Sécurisé',
+    realm: 'Administration MonServiceSécurisé',
     users: { [login]: motDePasse },
     unauthorizedResponse: () => pug.renderFile('src/vues/accesRefuse.pug'),
   });

--- a/src/vues/aPropos.pug
+++ b/src/vues/aPropos.pug
@@ -9,7 +9,7 @@ block main
       h1 À propos
 
       p.
-        Mon Service Sécurisé est un service numérique développé par l'incubateur
+        MonServiceSécurisé est un service numérique développé par l'incubateur
         de services numériques du <a href="https://www.ssi.gouv.fr/agence/missions/rapport-dactivite-2020/">laboratoire d'innovation de l'ANSSI</a>,
         avec le soutien de l'incubateur <a href="https://beta.gouv.fr/startups/">Beta.gouv</a>
         (<a href="https://beta.gouv.fr/startups/homologation.html">plus d'informations</a>).

--- a/src/vues/cgu.pug
+++ b/src/vues/cgu.pug
@@ -6,12 +6,12 @@ block append styles
 block main
   .marges-fixes
     .documentation
-      h1 Conditions générales d'utilisation de Mon Service Sécurisé
+      h1 Conditions générales d'utilisation de MonServiceSécurisé
 
       p.
         Nous vous invitons à lire avec attention le présent document (ci-après,
         les « Conditions Générales d'Utilisation »). En accédant au présent
-        portail Mon Service Sécurisé (ci-après le «&nbsp;Site&nbsp;»), l'utilisateur du
+        portail MonServiceSécurisé (ci-après le «&nbsp;Site&nbsp;»), l'utilisateur du
         Site (ci-après « l'Utilisateur » ou « Vous ») s'engage à respecter les
         présentes Conditions Générales d'Utilisation. L'Utilisateur est
         nécessairement un membre du personnel d'une entité soumise au
@@ -32,7 +32,7 @@ block main
         conditions selon lesquelles l'Utilisateur peut accéder au Site et l'utiliser.
 
 
-      h2 2. Le portail Mon Service Sécurisé
+      h2 2. Le portail MonServiceSécurisé
 
       p Le Site a pour objet :
 
@@ -54,10 +54,10 @@ block main
         l'Utilisateur des Conditions Générales d'Utilisation. Par conséquent,
         pour créer un compte utilisateur, l'Utilisateur doit être un membre du
         personnel d'une entité soumise au RGS et avoir expressément accepté les
-        présentes Conditions Générales d'Utilisation en cochant la case «
-        J'accepte les conditions générales d'utilisation de Mon Service
-        Sécurisé » lors de la création de son compte. Ainsi, il confirme
-        accepter sans restriction ni réserve les Conditions Générales
+        présentes Conditions Générales d'Utilisation en cochant la case
+        « J'accepte les conditions générales d'utilisation de
+        MonServiceSécurisé » lors de la création de son compte. Ainsi, il
+        confirme accepter sans restriction ni réserve les Conditions Générales
         d'Utilisation ainsi que le traitement de ses données à caractère
         personnel, conformément à la <a href='/confidentialite'>Politique de
         confidentialité</a>. Si l'Utilisateur est en désaccord avec l'un de ces
@@ -205,7 +205,7 @@ block main
 
       h2 6. Responsabilités, garanties et accessibilité au Site
 
-      h3 A. Le portail Mon Service Sécurisé
+      h3 A. Le portail MonServiceSécurisé
 
       p.
         Le Site met en place les moyens nécessaires à son bon fonctionnement et

--- a/src/vues/confidentialite.pug
+++ b/src/vues/confidentialite.pug
@@ -6,10 +6,10 @@ block append styles
 block main
   .marges-fixes
     .documentation
-      h1 Politique de confidentialité de Mon Service Sécurisé
+      h1 Politique de confidentialité de MonServiceSécurisé
 
       p.
-        Dans le cadre de l'utilisation du portail Mon Service Securisé
+        Dans le cadre de l'utilisation du portail MonServiceSécurisé
         (ci-après le « Site »), l'utilisateur (ci-après l'« Utilisateur ») peut
         être amené à transmettre à l'Agence nationale de la sécurité des
         systèmes d'information (ci-après l'« ANSSI ») des données à caractère

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -63,7 +63,7 @@ block page
   .page
     header
       .mss
-        h1 Mon Service <b>Sécurisé</b>
+        h1 MonService<b>Sécurisé</b>
         p Sécuriser les service publics numériques
       .anssi Agence nationale de la sécurité des systèmes d'information (ANSSI)
 

--- a/src/vues/index.pug
+++ b/src/vues/index.pug
@@ -7,7 +7,7 @@ block main
   .introduction.marges-fixes
     .presentation
       h1.
-        Mon Service Sécurisé,<br>
+        MonServiceSécurisé,<br>
         l'homologation de sécurité 100% en ligne<br>
         des services publics numériques
       p.
@@ -47,7 +47,7 @@ block main
       h1 Une approche simplifiée pour les services numériques les plus courants
 
       p.
-        Mon Service Sécurisé vise à accroître le niveau de sécurité des téléservices publics
+        MonServiceSécurisé vise à accroître le niveau de sécurité des téléservices publics
         et autres sites web, applications mobiles et API publics les plus courants aux besoins
         de besoins de sécurité modérés (niveaux pianissimo
         du <a href="https://www.ssi.gouv.fr/actualite/lhomologation-en-9-etapes-simples-nouvelle-publication-de-lanssi/">guide de l'homologation en 9 étapes</a>).
@@ -69,8 +69,8 @@ block main
   .bandeau
     .illustration.marges-fixes
       h2.
-        Exemples de services numériques pouvant être homologués à l'aide de Mon
-        Service Sécurisé
+        Exemples de services numériques pouvant être homologués à l'aide de
+        MonServiceSécurisé
 
       .exemples
         .exemple.site-internet

--- a/src/vues/inscription.pug
+++ b/src/vues/inscription.pug
@@ -5,5 +5,5 @@ append champs-formulaire
     .case-a-cocher
       input(id = 'cguAcceptees', name = 'cguAcceptees', type = 'checkbox')
       label(for = 'cguAcceptees').
-        J'accepte les <a href="/cgu">conditions générales d'utilisation de Mon Service Sécurisé</a>
+        J'accepte les <a href="/cgu">conditions générales d'utilisation de MonServiceSécurisé</a>
     .message-erreur Ce champ est obligatoire. Veuillez le cocher.

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -12,7 +12,7 @@ block page
     link(href='/statique/assets/styles/entete.css', rel='stylesheet')
     link(href='/statique/assets/styles/piedPage.css', rel='stylesheet')
 
-  title Mon Service Sécurisé
+  title MonServiceSécurisé
 
   header.marges-fixes
     .bloc-marque
@@ -20,7 +20,7 @@ block page
       .republique-francaise RÉPUBLIQUE<br>FRANÇAISE
       .devise
     a.logo-anssi(href='https://www.ssi.gouv.fr')
-    a.logo-mss(href='/') Mon Service <b>Sécurisé</b>
+    a.logo-mss(href='/') MonService<b>Sécurisé</b>
     nav
       block navigation
 
@@ -28,7 +28,7 @@ block page
     block main
 
   footer.marges-fixes
-    span Mon Service Sécurisé par l'ANSSI
+    span MonServiceSécurisé par l'ANSSI
     nav
       a(href = '/aPropos') À propos
       a(href = '/confidentialite') Politique de confidentialité

--- a/src/vues/questionsFrequentes.pug
+++ b/src/vues/questionsFrequentes.pug
@@ -35,7 +35,7 @@ block main
               homologuer leurs services numériques ?
           li
             a(href = '#adapte').
-              Mon Service Sécurisé est-il adapté à l'homologation de tous les
+              MonServiceSécurisé est-il adapté à l'homologation de tous les
               services numériques ?
           li
             a(href = '#prestas').
@@ -171,7 +171,7 @@ block main
           et d'applications mobiles aux besoins de sécurité modérés.
 
         p.
-          Pour cela, MonServiceSecurisé propose une démarche en ligne basée sur :
+          Pour cela, MonServiceSécurisé propose une démarche en ligne basée sur :
         ul
           li.
             l'identification du niveau de gravité des risques les plus courants

--- a/src/vues/utilisateur/edition.pug
+++ b/src/vues/utilisateur/edition.pug
@@ -24,8 +24,8 @@ block formulaire
       if !utilisateur.accepteCGU()
         input(id = 'cguAcceptees', name = 'cguAcceptees', type = 'checkbox')
         label(for = 'cguAcceptees').
-          J'accepte les <a href="/cgu">conditions générales d'utilisation de Mon
-          Service Sécurisé</a>
+          J'accepte les <a href="/cgu">conditions générales d'utilisation de
+          MonServiceSécurisé</a>
 
     .bouton Mettre à jour &nbsp;&nbsp;›
 

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -134,7 +134,7 @@ describe('Le middleware MSS', () => {
 
       reponse.set = (nomHeader, valeurHeader) => {
         expect(nomHeader).to.equal('WWW-Authenticate');
-        expect(valeurHeader).to.equal('Basic realm="Administration Mon Service Sécurisé"');
+        expect(valeurHeader).to.equal('Basic realm="Administration MonServiceSécurisé"');
       };
 
       prepareVerificationReponse(reponse, 401, done);


### PR DESCRIPTION
Il restait encore à plusieurs endroits la mention historique « Mon Service Sécurisé ». Cette PR corrige ce problème

<img width="324" alt="Screenshot 2022-08-22 at 11 06 43" src="https://user-images.githubusercontent.com/105624/185884104-b5657c51-00b3-4cc2-b3e3-16c59c54b98e.png">
.