### PR TITLE
Message d'erreur d'échec d'envoi d'e-mail de finalisation

### DIFF
--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -22,7 +22,7 @@
   position: relative;
 }
 
-.message-erreur {
+.message-erreur, .message-erreur-personnalise {
   display: none;
 
   margin-top: 1em;
@@ -32,7 +32,7 @@
   font-weight: normal;
 }
 
-.message-erreur::before {
+:is(.message-erreur, .message-erreur-personnalise)::before {
   content: '';
 
   position: absolute;
@@ -72,4 +72,12 @@ input[type="radio"]:not(.intouche):invalid {
 
 :is(input, select):not(.intouche):invalid ~ .message-erreur {
   display: block;
+}
+
+:is(input, select):invalid ~ .message-erreur-personnalise:not(:empty) {
+  display: block;
+}
+
+:is(input, select):invalid ~ .message-erreur-personnalise:not(:empty) ~ .message-erreur {
+  display: none;
 }

--- a/public/inscription.js
+++ b/public/inscription.js
@@ -1,9 +1,21 @@
 import brancheSoumissionFormulaireUtilisateur from './modules/interactions/brancheSoumissionFormulaireUtilisateur.js';
+import { brancheValidationPersonnalisee, declencheErreurPersonnalisee } from './modules/interactions/validation.js';
+
+const TYPE_ERREUR_ENVOI_EMAIL = 'ERREUR_ENVOI_EMAIL';
+const MESSAGE_ERREUR_ENVOI_EMAIL = "Cet e-mail n'existe pas ou est introuvable. Veuillez en saisir un autre ou nous contacter.";
 
 $(() => {
   const selecteurFormulaire = 'form#inscription';
-  const action = (donnees) => axios.post('/api/utilisateur', donnees)
-    .then(() => (window.location = '/activation'));
+  const selecteurChampEmail = '#email';
 
+  const action = (donnees) => axios.post('/api/utilisateur', donnees)
+    .then(() => (window.location = '/activation'))
+    .catch(({ response }) => {
+      if (response.status === 424 && response.data.type === TYPE_ERREUR_ENVOI_EMAIL) {
+        declencheErreurPersonnalisee(selecteurChampEmail, MESSAGE_ERREUR_ENVOI_EMAIL);
+      }
+    });
+
+  brancheValidationPersonnalisee(selecteurChampEmail);
   brancheSoumissionFormulaireUtilisateur(selecteurFormulaire, action);
 });

--- a/public/modules/interactions/validation.js
+++ b/public/modules/interactions/validation.js
@@ -25,4 +25,33 @@ const declencheValidation = (selecteurFormulaire) => {
   $(selecteurFormulaire).trigger(EVENEMENT_AFFICHE_ERREURS_SI_NECESSAIRE);
 };
 
-export { brancheValidation, declencheValidation };
+const brancheValidationPersonnalisee = (selecteurChampCible) => {
+  $(selecteurChampCible).on('invalid', (evenement) => {
+    evenement.preventDefault();
+    const champSaisie = evenement.target;
+    if (champSaisie.validity.customError) {
+      const $champSaisieEnErreur = $(champSaisie);
+      $champSaisieEnErreur.nextAll('.message-erreur-personnalise')
+        .text(champSaisie.validationMessage);
+      $champSaisieEnErreur.on('input', () => {
+        $champSaisieEnErreur.nextAll('.message-erreur-personnalise')
+          .text('');
+        champSaisie.setCustomValidity('');
+        champSaisie.reportValidity();
+      });
+    }
+  });
+};
+
+const declencheErreurPersonnalisee = (selecteurChampCible, messageErreur) => {
+  const htmlElement = $(selecteurChampCible)[0];
+  htmlElement.setCustomValidity(messageErreur);
+  htmlElement.reportValidity();
+};
+
+export {
+  brancheValidation,
+  brancheValidationPersonnalisee,
+  declencheValidation,
+  declencheErreurPersonnalisee,
+};

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -115,7 +115,7 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
           .then((u) => reponse.json({ idUtilisateur: u.id }))
           .catch((e) => {
             if (e instanceof EchecEnvoiMessage) {
-              reponse.status(424).send("L'envoi de l'email de finalisation d'inscription a échoué");
+              reponse.status(424).send({ type: 'ERREUR_ENVOI_EMAIL', message: "L'envoi de l'email de finalisation d'inscription a échoué" });
             } else if (e instanceof ErreurModele) {
               reponse.status(422).send(e.message);
             } else suite(e);

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -62,6 +62,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
               required,
               title = ''
             )
+            .message-erreur-personnalise
             .message-erreur L'e-mail est obligatoire. Veuillez respecter le format jean.dupont@domaine.fr.
 
       label Téléphone

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -230,7 +230,7 @@ describe('Le serveur MSS des routes /api/*', () => {
 
       it('retourne une erreur HTTP 424', (done) => {
         testeur.verifieRequeteGenereErreurHTTP(
-          424, "L'envoi de l'email de finalisation d'inscription a échoué",
+          424, { type: 'ERREUR_ENVOI_EMAIL', message: "L'envoi de l'email de finalisation d'inscription a échoué" },
           { method: 'post', url: 'http://localhost:1234/api/utilisateur', data: donneesRequete }, done
         );
       });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -27,7 +27,7 @@ const testeurMss = () => {
       .then(() => suite('Réponse OK inattendue'))
       .catch((erreur) => {
         expect(erreur.response.status).to.equal(status);
-        expect(erreur.response.data).to.equal(messageErreur);
+        expect(erreur.response.data).to.eql(messageErreur);
         suite();
       })
       .catch(suite);


### PR DESCRIPTION
Dans la page d'inscription,
quand un utilisateur utilise un e-mail avec un domaine inexistant ou si le système d'envoi est en erreur,
un message d'erreur apparait pour le notifier de cela.

Comportement : 

- après validation un encadré rouge et un message apparaissent autour du champ e-mail
- si on modifie le champ e-mail le message + encadré disparaissent
- les règles de validation doivent rester actives

<img width="473" alt="Capture d’écran 2022-09-19 à 09 34 47" src="https://user-images.githubusercontent.com/39462397/190969944-e262a331-58e7-47a0-bb7c-7a5536d9ea5e.png">


