### PR TITLE
Corrige alignement des indices avec les noms de catégories

### DIFF
--- a/public/assets/styles/carteInformations.css
+++ b/public/assets/styles/carteInformations.css
@@ -44,6 +44,8 @@
 
 .carte dd {
   font-family: 'Arial';
+
+  padding-top: 0.2em;
   text-align: right;
 }
 


### PR DESCRIPTION
<img width="408" alt="Screenshot 2022-08-30 at 09 56 34" src="https://user-images.githubusercontent.com/105624/187383075-14d461ec-0550-453c-a5ba-7ad95350ca93.png">

En changeant la police des scores pour Arial (pour aligner les scores entre eux) on a provoqué un désalignement avec les noms des catégories.

Ce commit résout le problème.