### PR TITLE
Changement erreur nom et prénom

### DIFF
--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -10,7 +10,13 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
 
   section
     block champs-formulaire
-      - const patternNomPrenom = "^[a-zàâäéèêëïîôöùûüÿçæœA-ZÀÂÄÉÈÊËÏÎÔÖÙÛÜŸÇÆŒ]+([ .'\\-]?[a-zàâäéèêëïîôöùûüÿçæœA-ZÀÂÄÉÈÊËÏÎÔÖÙÛÜŸÇÆŒ]+)*$"
+      -
+        const patternNomPrenom = "^[a-zàâäéèêëïîôöùûüÿçæœA-ZÀÂÄÉÈÊËÏÎÔÖÙÛÜŸÇÆŒ]+([ .'\\-]?[a-zàâäéèêëïîôöùûüÿçæœA-ZÀÂÄÉÈÊËÏÎÔÖÙÛÜŸÇÆŒ]+)*$";
+        const messageErreurNomPrenom = (label) => `
+          Le ${label} est obligatoire. Veuillez renseigner des lettres avec ou sans signes diacritiques.
+          Les chiffres ne sont pas autorisés.
+        `;
+
       if emailLectureSeule
         p.affichage-simple
           strong E-mail&nbsp
@@ -28,7 +34,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
             pattern = patternNomPrenom,
             title = ''
           )
-          .message-erreur Le prénom est obligatoire. Veuillez le renseigner.
+          .message-erreur= messageErreurNomPrenom('prénom') 
 
       .requis(data-nom = 'nom')
         label Nom
@@ -42,7 +48,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
             pattern = patternNomPrenom,
             title = ''
           )
-          .message-erreur Le nom est obligatoire. Veuillez le renseigner.
+          .message-erreur= messageErreurNomPrenom('nom') 
 
       if !emailLectureSeule
         .requis(data-nom = 'email')

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -11,7 +11,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
   section
     block champs-formulaire
       -
-        const patternNomPrenom = "^[a-zàâäéèêëïîôöùûüÿçæœA-ZÀÂÄÉÈÊËÏÎÔÖÙÛÜŸÇÆŒ]+([ .'\\-]?[a-zàâäéèêëïîôöùûüÿçæœA-ZÀÂÄÉÈÊËÏÎÔÖÙÛÜŸÇÆŒ]+)*$";
+        const patternNomPrenom = '^\\D+$';
         const messageErreurNomPrenom = (label) => `
           Le ${label} est obligatoire. Veuillez renseigner des lettres avec ou sans signes diacritiques.
           Les chiffres ne sont pas autorisés.


### PR DESCRIPTION
Dans les formulaire d'inscription et d'édition,
le nom et le prénom acceptent tout les caractères non chiffre,
et un nouveau message renseigne cela
<img width="637" alt="Capture d’écran 2022-09-02 à 15 25 52" src="https://user-images.githubusercontent.com/39462397/188157071-8dabb8da-3334-4c99-bd22-396a62595792.png">
