### PR TITLE
Remplaces texte des e-mails page MentionsLegales

### DIFF
--- a/src/vues/mentionsLegales.pug
+++ b/src/vues/mentionsLegales.pug
@@ -18,7 +18,7 @@ block main
         51 boulevard de la Tour-Maubourg<br>
         75700 Paris 07 SP<br>
         France<br>
-        Mél : lab-inno [at] ssi.gouv.fr
+        <a href="mailto:lab-inno@ssi.gouv.fr">lab-inno@ssi.gouv.fr</a>.
 
       h2 Directeur de la publication
 
@@ -39,5 +39,5 @@ block main
       p.
         Toute correspondance à leur attention doit être adressée à l'adresse
         suivante :<br>
-        support [at] scalingo.com.
+        <a href="mailto:support@scalingo.com">support@scalingo.com</a>.
 


### PR DESCRIPTION
Remplace les deux lignes concernant les adresses e-mails (lab ANSSI et Scalingo). 