### PR TITLE
Comportement en cas de réinscription

### DIFF
--- a/src/adaptateurs/adaptateurMail.js
+++ b/src/adaptateurs/adaptateurMail.js
@@ -110,9 +110,35 @@ L'équipe MonServiceSécurisé`,
   });
 };
 
+const envoieNotificationTentativeReinscription = (destinataire) => {
+  const transport = creeTransport();
+
+  return transport.sendMail({
+    from: process.env.ADRESSE_MAIL_CONTACT,
+    to: destinataire,
+    subject: 'MonServiceSécurisé - Tentative de réinscription',
+    text: `Bonjour,
+
+Lors de la création de votre compte utilisateur sur MonServiceSécurisé, l'e-mail que vous avez renseigné est déjà associé à un compte existant.
+
+Si vous souhaitez en créer un nouveau, cliquez sur ce lien :  
+${process.env.URL_BASE_MSS}/inscription
+
+Si vous souhaitez réinitialiser votre mot de passe, cliquez sur ce lien :  
+${process.env.URL_BASE_MSS}/reinitialisationMotDePasse
+
+Si vous n'êtes pas l'origine de cette demande, votre compte est sécurisé et vous pouvez ignorer cet e-mail.
+
+N'hésitez pas à nous contacter pour toutes précisions.
+
+L'équipe MonServiceSécurisé`,
+  });
+};
+
 module.exports = {
   envoieMessageFinalisationInscription,
   envoieMessageInvitationContribution,
   envoieMessageInvitationInscription,
   envoieMessageReinitialisationMotDePasse,
+  envoieNotificationTentativeReinscription,
 };

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -27,9 +27,9 @@ const creeDepot = (config = {}) => {
     adaptateurPersistance.utilisateurAvecEmail(email)
       .then((u) => {
         if (u) {
-          return reject(new ErreurUtilisateurExistant(
-            'Utilisateur déjà existant pour cette adresse email'
-          ));
+          return reject(
+            new ErreurUtilisateurExistant('Utilisateur déjà existant pour cette adresse email', u.id)
+          );
         }
 
         const id = adaptateurUUID.genereUUID();

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -24,9 +24,15 @@ class ErreurRisqueInconnu extends ErreurModele {}
 class ErreurStatutDeploiementInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
 class ErreurTentativeSuppressionCreateur extends ErreurModele {}
-class ErreurUtilisateurExistant extends ErreurModele {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
+
+class ErreurUtilisateurExistant extends ErreurModele {
+  constructor(message = '', idUtilisateur) {
+    super(message);
+    this.idUtilisateur = idUtilisateur;
+  }
+}
 
 module.exports = {
   EchecAutorisation,

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -316,7 +316,10 @@ describe('Le dépôt de données des utilisateurs', () => {
 
         depot.nouvelUtilisateur({ email: 'jean.dupont@mail.fr' })
           .then(() => done('Une exception aurait dû être levée.'))
-          .catch((e) => expect(e).to.be.a(ErreurUtilisateurExistant))
+          .catch((e) => {
+            expect(e).to.be.a(ErreurUtilisateurExistant);
+            expect(e.idUtilisateur).to.equal('123');
+          })
           .then(() => done())
           .catch(done);
       });


### PR DESCRIPTION
Dans la page d'inscription,
Quand un utilisateur utilise une adresse e-mail déjà lié à un compte
L'inscription n'apparait plus en erreur et un e-mail de notification de tentative de réinscription est envoyé à l'adresse renseignée

L'e-mail envoyé a pour objet **Tentative de réinscription** et le contenu :

```text
Bonjour,

Lors de la création de votre compte utilisateur sur MonServiceSécurisé, l'e-mail que vous avez renseigné est déjà associé à un compte existant.

Si vous souhaitez en créer un nouveau, cliquez sur ce lien :  
http://www.monservicesecurise.beta.gouv.fr/inscription

Si vous souhaitez réinitialiser votre mot de passe, cliquez sur ce lien :  
http://www.monservicesecurise.beta.gouv.fr/reinitialisationMotDePasse

Si vous n'êtes pas l'origine de cette demande, votre compte est sécurisé et vous pouvez ignorer cet e-mail.

N'hésitez pas à nous contacter pour toutes précisions.

L'équipe MonServiceSécurisé
```