### PR TITLE
Un espace supplémentaire entre l'icône et le message d'erreur

### DIFF
--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -24,10 +24,9 @@
 
 .message-erreur {
   display: none;
-  position: relative;
-  left: 1.1em;
 
   margin-top: 1em;
+  padding-left: 1.5em;
 
   color: var(--rose-anssi);
   font-weight: normal;
@@ -37,14 +36,13 @@
   content: '';
 
   position: absolute;
-  left: -1.1em;
+  left: 0;
 
   background-image: url(../../images/icone_attention_rose.svg);
   background-repeat: no-repeat;
   background-size: contain;
   width: 1em;
   height: 1em;
-
   transform: translateY(0.35em);
 }
 


### PR DESCRIPTION
Dans la pages Inscription et Édition de profil,
L'icône danger et le texte des messages d'erreurs étaient trop collés


<img width="474" alt="Capture d’écran 2022-09-09 à 09 34 36" src="https://user-images.githubusercontent.com/39462397/189298003-6dd9ed2a-63b1-41a2-992c-8eb6257ecfd5.png">
