### PR TITLE
Affichage du nom du service en haut des formulaires

### DIFF
--- a/public/assets/styles/activation.css
+++ b/public/assets/styles/activation.css
@@ -1,10 +1,4 @@
-.etroit {
-  width: 400px;
-  padding: 0 5.25em 2em;
-  border-radius: 5px;
-  background: #fff;
-}
-
-.etroit .bouton {
-  margin-top: 2em;
+.info {
+  display: flex;
+  flex-direction: column;
 }

--- a/public/assets/styles/bouton.css
+++ b/public/assets/styles/bouton.css
@@ -1,7 +1,7 @@
 .bouton {
   display: inline-block;
 
-  margin: 2em;
+  margin: 2em auto;
   padding: 1em 3em;
   border-radius: 3px;
   background: var(--bleu-mise-en-avant);

--- a/public/assets/styles/carteInformations.css
+++ b/public/assets/styles/carteInformations.css
@@ -2,6 +2,7 @@
   box-sizing: border-box;
   width: 270px;
   padding: 1.7em;
+  border-radius: 5px;
 
   background-color: #fff;
 

--- a/public/assets/styles/deuxColonnes.css
+++ b/public/assets/styles/deuxColonnes.css
@@ -1,0 +1,6 @@
+.corps {
+  display: grid;
+  grid-template-columns: 4fr 1fr;
+  grid-gap: 2em;
+  margin-top: 3em;
+}

--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -1,48 +1,6 @@
-.etroit {
+form {
   display: flex;
   flex-direction: column;
-
-  margin: 2em auto 0;
-  width: 350px;
-}
-
-.etroit h1 {
-  margin: 2em 0 0.2em 0;
-  padding: 0;
-
-  line-height: 1.1em;
-}
-
-.etroit .sous-titre {
-  margin: 0;
-}
-
-.etroit .description {
-  margin-top: 2em;
-
-  text-align: left;
-}
-
-.etroit section {
-  padding-bottom: 0;
-  border: 0;
-}
-.etroit label {
-  margin-bottom: 2em;
-}
-.etroit a {
-  font-weight: normal;
-}
-
-.etroit .bouton {
-  margin: 1em 0 2em auto;
-  padding: 1em 2em;
-}
-
-form {
-  padding: 0 7em 2em;
-  border-radius: 5px;
-  background: #fff;
 }
 
 form h1 {
@@ -195,11 +153,4 @@ textarea {
 select {
   display: block;
   margin: 1em 0;
-}
-
-.formulaire {
-  display: grid;
-  grid-template-columns: 4fr 1fr;
-  grid-gap: 3em;
-  margin-top: 3em;
 }

--- a/public/assets/styles/homologation/formulaire.css
+++ b/public/assets/styles/homologation/formulaire.css
@@ -1,3 +1,11 @@
+.nom-service h1 {
+  margin: 0;
+
+  text-align: left;
+  font-size: 1em;
+  font-variant-caps: small-caps;
+}
+
 form.homologation * {
   text-align: left;
 }
@@ -12,7 +20,6 @@ form.homologation h1 {
 }
 
 form.homologation h1.action {
-  margin-top: 2em;
   padding-top: 0;
 
   font-weight: normal;

--- a/public/assets/styles/homologation/risques.css
+++ b/public/assets/styles/homologation/risques.css
@@ -76,10 +76,6 @@
   font-weight: normal;
 }
 
-.formulaire {
-  grid-gap: 1.7em;
-}
-
 ul.niveaux-gravite {
   list-style: none;
 

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -60,3 +60,49 @@ section:last-of-type {
 .invisible {
   display: none;
 }
+
+.zone-principale, .etroit {
+  padding: 4em 7em 2em;
+  border-radius: 5px;
+  background: #fff;
+}
+
+.etroit {
+  width: 400px;
+  margin: 2em auto 0;
+}
+
+.etroit h1 {
+  margin: 0 0 0.2em 0;
+  padding: 0;
+
+  line-height: 1.1em;
+}
+
+.etroit .sous-titre {
+  margin: 0;
+}
+
+.etroit .description {
+  margin-top: 2em;
+
+  text-align: left;
+}
+
+.etroit section {
+  padding-bottom: 0;
+  border: 0;
+}
+
+.etroit label {
+  margin-bottom: 2em;
+}
+
+.etroit a {
+  font-weight: normal;
+}
+
+.etroit .bouton {
+  margin: 2em 0 2em auto;
+  padding: 1em 2em;
+}

--- a/src/vues/accesRefuse.pug
+++ b/src/vues/accesRefuse.pug
@@ -1,6 +1,6 @@
-extends ./homologation/formulaire
+extends deuxColonnes
 
-block formulaire
-  form.acces-refuse
+block zone-principale
+  .acces-refuse
     h1 Accès refusé
     p Désolé, vous n'avez pas accès aux fonctionnalités d'administration.

--- a/src/vues/activation.pug
+++ b/src/vues/activation.pug
@@ -1,11 +1,10 @@
 extends ./mssDeconnecte
 
 block append styles
-  link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/activation.css', rel = 'stylesheet')
 
 block main
-  .etroit
+  .info.etroit
     h1 Activer votre compte
     .description
       p.

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -1,0 +1,19 @@
+extends mssConnecte
+
+block append styles
+  link(href = '/statique/assets/styles/deuxColonnes.css', rel = 'stylesheet')
+
+block retour
+  - let lienRetour = '/';
+  - if (homologation) lienRetour = '/espacePersonnel';
+  - if (homologation && homologation.id) lienRetour = `/homologation/${homologation.id}`;
+  a(href = lienRetour) ‹&nbsp;&nbsp;Retour
+
+block main
+  .corps.marges-fixes
+    .zone-principale
+      block nom-service
+      block zone-principale
+
+    .cartes-informations
+      block cartes-informations

--- a/src/vues/homologation.pug
+++ b/src/vues/homologation.pug
@@ -1,4 +1,4 @@
-extends homologation/formulaire
+extends deuxColonnes
 include carteInformations
 
 mixin action({ description, url, statut })
@@ -20,7 +20,7 @@ block append styles
 block retour
   a(href = '/espacePersonnel') ‹&nbsp;&nbsp;Mon espace personnel
 
-block formulaire
+block zone-principale
   .details-homologation
     .tableau-bord
       .description-dossier

--- a/src/vues/homologation/formulaire.pug
+++ b/src/vues/homologation/formulaire.pug
@@ -1,17 +1,14 @@
-extends ../mssConnecte
+extends ../deuxColonnes
 
 block append styles
   link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/homologation/formulaire.css', rel = 'stylesheet')
 
-block retour
-  - let lienRetour = '/';
-  - if (homologation) lienRetour = '/espacePersonnel';
-  - if (homologation && homologation.id) lienRetour = `/homologation/${homologation.id}`;
-  a(href = lienRetour) ‹&nbsp;&nbsp;Retour
+block nom-service
+  if (homologation)
+    .nom-service
+      h1!= homologation.nomService()
 
-block main
-  .formulaire.marges-fixes
+block zone-principale
+  .formulaire
     block formulaire
-    .cartes-informations
-      block cartes-informations


### PR DESCRIPTION
<img width="384" alt="Screenshot 2022-09-09 at 18 04 16" src="https://user-images.githubusercontent.com/105624/189393401-7e6a4f97-d32b-410a-8fcc-2bd683f9cfb6.png">

Cette PR introduit le template `deuxColonnes.pug` utilisé par la page de synthèse (et dans le futur par la page listant les homologations pour un service donné) et spécialisé par le template `homologation/formulaire.pug`. Ce template sur deux colonnes offre un place holder dans lequel on peut injecter le nom du service depuis les pages filles.

Elle met en évidence le besoin d'homogénéiser la structure de la « zone principale » des divers templates, et de ce fait résout quelques duplications dans les feuilles de style.

Cette PR embarque enfin une homogénéisation de présentation des cartes d'information.
