### PR TITLE
Ajoute une route `/service/:id/homologations`

### DIFF
--- a/public/assets/styles/service/homologations.css
+++ b/public/assets/styles/service/homologations.css
@@ -1,0 +1,13 @@
+hr {
+  width: 100%;
+  border: solid 1px var(--liseres);
+}
+
+.consignes {
+  padding: 1em 0;
+}
+
+.bouton.blanc {
+  border: solid 1px var(--bleu-mise-en-avant);
+  background: #fff;
+}

--- a/src/mss.js
+++ b/src/mss.js
@@ -5,6 +5,7 @@ const { DUREE_SESSION } = require('./configurationServeur');
 const routesApi = require('./routes/routesApi');
 const routesBibliotheques = require('./routes/routesBibliotheques');
 const routesHomologation = require('./routes/routesHomologation');
+const routesService = require('./routes/routesService');
 
 require('dotenv').config();
 
@@ -126,6 +127,8 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
   app.use('/bibliotheques', routesBibliotheques());
 
   app.use('/homologation', routesHomologation(middleware, referentiel, moteurRegles));
+
+  app.use('/service', routesService(middleware));
 
   app.get('/utilisateur/edition', (requete, reponse) => {
     sersFormulaireEditionUtilisateur(requete, reponse);

--- a/src/routes/routesService.js
+++ b/src/routes/routesService.js
@@ -1,0 +1,14 @@
+const express = require('express');
+
+const routesService = (middleware) => {
+  const routes = express.Router();
+
+  routes.get('/:id/homologations', middleware.trouveHomologation, (requete, reponse) => {
+    const { homologation } = requete;
+    reponse.render('service/homologations', { homologation });
+  });
+
+  return routes;
+};
+
+module.exports = routesService;

--- a/src/vues/service/homologations.pug
+++ b/src/vues/service/homologations.pug
@@ -1,0 +1,18 @@
+extends ../homologation/formulaire
+
+block append styles
+  link(href='/statique/assets/styles/service/homologations.css', rel='stylesheet')
+
+block zone-principale
+  form.homologation
+    h1.action Homologuer
+    .consignes.
+      Complétez, téléchargez puis faites signer la
+      <i>Décision d'homologation de sécurité</i>
+      de votre service. Une fois ces étapes réalisées, renseignez la date de
+      signature pour connaître la date de la prochaine homologation.
+
+    hr
+
+    .bouton.blanc
+      a(href = `/homologation/${homologation.id}`) Revenir à la synthèse

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -1,0 +1,18 @@
+const testeurMSS = require('./testeurMSS');
+
+describe('Le serveur MSS des routes /service/*', () => {
+  const testeur = testeurMSS();
+
+  beforeEach(testeur.initialise);
+
+  afterEach(testeur.arrete);
+
+  describe('quand requête GET sur `/service/:id/homologations`', () => {
+    it("recherche la ressource correspondant à l'identifiant", (done) => {
+      testeur.middleware().verifieRechercheHomologation(
+        'http://localhost:1234/service/456/homologations',
+        done,
+      );
+    });
+  });
+});


### PR DESCRIPTION
<img width="679" alt="Screenshot 2022-09-11 at 19 20 01" src="https://user-images.githubusercontent.com/105624/189540725-c4d6385c-6013-4367-8024-1dc9db4a8304.png">

Première PR sur le parcours homologation.

Prochaines étapes :
- [ ] Migrer les données `homologations` en `services`
  - [ ] Dupliquer les données de la table `homologations` dans la table `services`
  - [ ] Reporter les requêtes d'ajout / modification d'homologation sur les services
  - [ ] Dupliquer les données de `autorisations.donnees->>'idHomologation'` dans `autorisations.donnees->>'idService'`
  - [ ] Reporter les requêtes d'ajout / modification des autorisations sur les services
  - [ ] Changer les routes concernant les homologations en routes concernant les services, et reporter les requêtes d'ajout / modification des services en ajout/modification des homologations
  - [ ] Supprimer les reports de requêtes
  - [ ] Supprimer la table `homologations`
- [ ] Différencier l'affichage dans `/service/:id/homologations` suivant qu'il y a ou pas une homologation rattachée au service
- [ ] Ajouter une route `POST /service/:id/homologation` et une route `GET /homologation/:id` (qui permet d'accéder au PDF)
- [ ] Changer la page de synthèse pour offrir les accès à décrire / sécuriser / homologuer.