### PR TITLE
Accessibilité de la description du statut de déploiement dans l'homologation

### DIFF
--- a/src/modeles/descriptionService.js
+++ b/src/modeles/descriptionService.js
@@ -37,6 +37,10 @@ class DescriptionService extends InformationsHomologation {
     return this.referentiel.localisationDonnees(this.localisationDonnees);
   }
 
+  descriptionStatutDeploiement() {
+    return this.referentiel.descriptionStatutDeploiement(this.statutDeploiement);
+  }
+
   descriptionTypeService() {
     return this.referentiel.typeService(this.typeService);
   }

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -77,6 +77,8 @@ class Homologation {
 
   descriptionTypeService() { return this.descriptionService.descriptionTypeService(); }
 
+  descriptionStatutDeploiement() { return this.descriptionService.descriptionStatutDeploiement(); }
+
   descriptionStatutsMesures() {
     return Mesure.statutsPossibles().reduce((acc, s) => {
       acc[s] = { description: this.referentiel.descriptionStatutMesure(s) };

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -35,6 +35,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const descriptionRisque = (idRisque) => risque(idRisque).description;
   const seuilsCriticites = () => donnees.seuilsCriticites;
   const statutsDeploiement = () => donnees.statutsDeploiement;
+  const descriptionStatutDeploiement = (idStatut) => statutsDeploiement()[idStatut]?.description;
   const statutDeploiementValide = (id) => Object.keys(statutsDeploiement()).includes(id);
   const statutsMesures = () => donnees.statutsMesures;
   const descriptionStatutMesure = (idStatut) => statutsMesures()[idStatut];
@@ -180,6 +181,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     risques,
     seuilCriticiteMin,
     seuilsCriticites,
+    descriptionStatutDeploiement,
     statutsDeploiement,
     statutDeploiementValide,
     statutsMesures,

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -72,6 +72,22 @@ describe('La description du service', () => {
     expect(descriptionService.descriptionLocalisationDonnees()).to.equal('Quelque part en France');
   });
 
+  elle('décrit le statut de déploiement', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      statutsDeploiement: {
+        enLigne: {
+          description: 'En ligne',
+        },
+      },
+    });
+
+    const descriptionService = new DescriptionService({
+      statutDeploiement: 'enLigne',
+    }, referentiel);
+
+    expect(descriptionService.descriptionStatutDeploiement()).to.equal('En ligne');
+  });
+
   elle("se comporte correctement si le type de service n'est pas présent", () => {
     const descriptionService = new DescriptionService();
     expect(descriptionService.descriptionTypeService()).to.equal('Type de service non renseignée');

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -228,4 +228,21 @@ describe('Une homologation', () => {
 
     expect(homologation.indiceSecurite()).to.equal(3.7);
   });
+
+  it('sait décrire le statut de déploiement', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      statutsDeploiement: {
+        enLigne: {
+          description: 'En ligne',
+        },
+      },
+    });
+    const homologation = new Homologation({
+      id: '123',
+      idUtilisateur: '456',
+      descriptionService: { nomService: 'nom', statutDeploiement: 'enLigne' },
+    }, referentiel);
+
+    expect(homologation.descriptionStatutDeploiement()).to.equal('En ligne');
+  });
 });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -85,6 +85,16 @@ describe('Le référentiel', () => {
     expect(referentiel.statutsDeploiement()).to.eql({ uneClef: 'une valeur' });
   });
 
+  it('sait décrire un statut de déploiement', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      statutsDeploiement: {
+        uneClef: { description: 'Une description' },
+      },
+    });
+
+    expect(referentiel.descriptionStatutDeploiement('uneClef')).to.equal('Une description');
+  });
+
   it('connaît la liste des fonctionnalités possibles', () => {
     const referentiel = Referentiel.creeReferentiel({
       fonctionnalites: { uneClef: 'une valeur' },


### PR DESCRIPTION
Afin de pouvoir produire le futur document de synthèse de sécurité,
Nous souhaitons avoir la possibilité d'afficher le statut de déploiement.