### PR TITLE
Mise à jour du titre et de la légende de la page mesures de sécurité

### DIFF
--- a/src/vues/homologation/mesures.pug
+++ b/src/vues/homologation/mesures.pug
@@ -15,12 +15,12 @@ block append styles
 
 block formulaire
   form.homologation#mesures
-    h1.action Mesures de sécurité
+    h1.action Sécuriser
     p.
       Sélectionnez le statut de mise en œuvre de chaque mesure de sécurité
       et apportez des précisions, si nécessaire.<br>
-      Ces informations permettent d'évaluer le niveau de sécurité du service
-      au regard des mesures indispensables et recommandées par l'ANSSI.
+      Ces informations permettent de suivre la mise en œuvre des mesures de
+      sécurité adaptées au service et d'évaluer son niveau de sécurité.
 
     section
       nav


### PR DESCRIPTION
- Titre « mesures de sécurité » devient « Sécuriser »
- MAJ de la légende.