### PR TITLE
Clé de localisation des données disponible dans l'homologation

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -75,6 +75,10 @@ class Homologation {
     return this.avisExpertCyber.descriptionExpiration();
   }
 
+  descriptionLocalisationDonnees() {
+    return this.descriptionService.descriptionLocalisationDonnees();
+  }
+
   descriptionTypeService() { return this.descriptionService.descriptionTypeService(); }
 
   descriptionStatutDeploiement() { return this.descriptionService.descriptionStatutDeploiement(); }
@@ -97,7 +101,7 @@ class Homologation {
   hebergeur() { return this.rolesResponsabilites.descriptionHebergeur(); }
 
   localisationDonnees() {
-    return this.descriptionService.descriptionLocalisationDonnees();
+    return this.descriptionService.localisationDonnees;
   }
 
   mesuresSpecifiques() { return this.mesures.mesuresSpecifiques; }

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -80,7 +80,7 @@ block page
           dt Développé par :
           dd!= homologation.structureDeveloppement()
           dt Hébergement et localisation des données :
-          dd!= `${homologation.hebergeur()}, ${homologation.localisationDonnees()}`
+          dd!= `${homologation.hebergeur()}, ${homologation.descriptionLocalisationDonnees()}`
 
       section.risques
         h2 Principaux risques de sécurité identifiés

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -237,6 +237,7 @@ describe('Une homologation', () => {
         },
       },
     });
+
     const homologation = new Homologation({
       id: '123',
       idUtilisateur: '456',
@@ -244,5 +245,41 @@ describe('Une homologation', () => {
     }, referentiel);
 
     expect(homologation.descriptionStatutDeploiement()).to.equal('En ligne');
+  });
+
+  it('connaît la localisation des données', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      localisationsDonnees: {
+        france: {
+          description: 'France',
+        },
+      },
+    });
+
+    const homologation = new Homologation({
+      id: '123',
+      idUtilisateur: '456',
+      descriptionService: { nomService: 'nom', localisationDonnees: 'france' },
+    }, referentiel);
+
+    expect(homologation.localisationDonnees()).to.equal('france');
+  });
+
+  it('sait décrire la localisation des données', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      localisationsDonnees: {
+        france: {
+          description: 'France',
+        },
+      },
+    });
+
+    const homologation = new Homologation({
+      id: '123',
+      idUtilisateur: '456',
+      descriptionService: { nomService: 'nom', localisationDonnees: 'france' },
+    }, referentiel);
+
+    expect(homologation.descriptionLocalisationDonnees()).to.equal('France');
   });
 });


### PR DESCRIPTION
Afin de pouvoir produire le futur document de synthèse de sécurité,
Nous souhaitons avoir la possibilité d'utiliser la clé de localisation des données.