### PR TITLE
Nouvelle route pour la synthèse de sécurité

### DIFF
--- a/src/routes/routesHomologation.js
+++ b/src/routes/routesHomologation.js
@@ -31,6 +31,13 @@ const routesHomologation = (middleware, referentiel, moteurRegles) => {
       reponse.render('homologation/decision', { homologation, referentiel, nonce });
     });
 
+  routes.get('/:id/syntheseSecurite',
+    middleware.trouveHomologation,
+    (requete, reponse) => {
+      const { homologation } = requete;
+      reponse.render('homologation/syntheseSecurite', { homologation, referentiel });
+    });
+
   routes.get('/:id/descriptionService', middleware.trouveHomologation, (requete, reponse) => {
     const { homologation } = requete;
     reponse.render('homologation/descriptionService', { referentiel, homologation });

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -1,0 +1,7 @@
+extends ../base
+
+block page
+  .page
+    main
+      h1 Synthèse de la sécurité du service
+      .nom-service!= homologation.nomService()

--- a/test/routes/routesHomologation.spec.js
+++ b/test/routes/routesHomologation.spec.js
@@ -44,6 +44,15 @@ describe('Le serveur MSS des routes /homologation/*', () => {
     });
   });
 
+  describe('quand requête GET sur `/homologation/:id/syntheseSecurite`', () => {
+    it("recherche l'homologation correspondante", (done) => {
+      testeur.middleware().verifieRechercheHomologation(
+        'http://localhost:1234/homologation/456/syntheseSecurite',
+        done,
+      );
+    });
+  });
+
   describe('quand requête GET sur `/homologation/:id/mesures`', () => {
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation(


### PR DESCRIPTION
Dans la perspective de créer une synthèse de sécurité,
Une étape est de créer une nouvelle route `/syntheseSecurite`
