### PR TITLE
Correction de l'affichage tronqué de nom de service long

### DIFF
--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -67,6 +67,10 @@ section:last-of-type {
   background: #fff;
 }
 
+.zone-principale {
+  min-width: 0;
+}
+
 .etroit {
   width: 400px;
   margin: 2em auto 0;


### PR DESCRIPTION
Dans la page de synthèse,
Quand le nom du service est trop long,
L'affichage du nom doit être tronqué pour tenir dans le bloc
<img width="977" alt="Capture d’écran 2022-09-23 à 11 46 52" src="https://user-images.githubusercontent.com/39462397/191934901-20b034cd-dec0-4da3-a8a7-7c90274a8318.png">
