### PR TITLE
Utilisation d'une image Docker plus proche de celle déployée par Scalingo

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,1 @@
+https://github.com/Scalingo/nodejs-buildpack.git

--- a/.profile
+++ b/.profile
@@ -1,0 +1,7 @@
+# Ajoute les variables d'environnement initialisées par les buildpacks, pour
+# pouvoir utiliser les applications associées depuis une session shell.
+
+for file in $(ls .profile.d/*); do
+  . $file;
+done
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM node:16
+FROM scalingo/scalingo-20:latest
 
-RUN npm install -g npm
+ENV NPM_CONFIG_PRODUCTION=false
+ENV NPM_NO_BUILD=true
 
-WORKDIR /usr/src/app
-COPY package.json package-lock.json /usr/src/app/
-RUN npm install
+RUN useradd -ms /bin/bash mss
+WORKDIR /home/mss
+COPY .buildpacks package.json package-lock.json ./
+COPY scripts/buildpack.sh scripts/
 
-COPY . /usr/src/app
+RUN mkdir -p /tmp/cache /tmp/env && \
+    scripts/buildpack.sh /home/mss /tmp/cache /tmp/env && \
+    rm .profile.d/WEB_CONCURRENCY.sh
+
+COPY --chown=mss:mss . .
+RUN chown -R mss:mss .profile.d .npm
+
+USER mss
 EXPOSE 3000
-CMD ["npm", "start"]
+ENTRYPOINT ["/home/mss/scripts/entrypoint.sh"]
+CMD ["npx", "nodemon", "server.js"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+postdeploy: npx knex migrate:latest && node creeUtilisateurDemo.js
 web: node server.js

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ entités publiques à sécuriser et à homologuer leurs services publics numéri
 ## Configuration de l'environnement de développement
 
 Il est nécessaire en prérequis d'avoir installé [Git](https://git-scm.com/),
-[Docker](https://www.docker.com/) et [Node.js v16](https://nodejs.org/en/).
+[Docker-Compose](https://docs.docker.com/compose/install/) et [Node.js
+v16](https://nodejs.org/en/).
 
 Commencer par récupérer les sources du projet et aller dans le répertoire créé.
 
@@ -20,29 +21,25 @@ $ git clone https://github.com/betagouv/mon-service-securise.git && cd mon-servi
 
 Créer un fichier `.env` à partir du fichier `.env.template` et renseigner les diverses variables d'environnement.
 
-Lancer le script `scripts/start.sh`
-
 Se connecter au conteneur de la base de données et créer une nouvelle base `mss` pour un utilisateur postgres.
 
 ```sh
-$ docker exec -t mon-service-securise_db_1 createdb -U postgres mss
+$ docker-compose run --rm db createdb -U postgres mss
 ```
 
 Exécuter les migrations depuis le conteneur du serveur web.
 
 ```sh
-$ docker exec -t mon-service-securise_web_1 npx knex migrate:latest
+$ docker-compose run --rm web npx knex migrate:latest
 ```
 
-Le serveur est configuré et prêt à être redémarré.
+Le serveur est configuré et prêt à être démarré.
 
 ## Lancement du serveur
 
 ```sh
-$ docker-compose restart web
+$ script/start.sh
 ```
-
-(Ou arret et ré-exécution de `./script/start.sh`)
 
 Le serveur devrait être accessible depuis un navigateur à l'URL
 `http://localhost:[PORT_MSS]` (avec comme valeur pour `PORT_MSS` celle indiquée
@@ -56,3 +53,18 @@ Il est alors possible de créer un compte utilisateur à l'url `http://localhost
 Les tests peuvent être lancés depuis un conteneur Docker en exécutant le script
 `scripts/tests.sh`. Les tests sont alors rejoués à chaque modification de
 fichier du projet sur la machine hôte.
+
+## Note concernant les variables des binaires installés par buildpack
+
+L'installation de Node.js dans l'image se fait selon [le processus standard de
+Scalingo basé sur le mécanisme de
+buildpacks](https://doc.scalingo.com/platform/deployment/buildpacks/intro). Par ce mécanisme, les variables d'environnement liées à l'exécution des binaires installés sont consignées dans des fichiers du répertoire `.profile.d`. _Ces variables doivent être chargées avant de pouvoir utiliser les binaires._ Ainsi, si on lance une commande _via_ `docker-compose exec`, il conviendra d'exécuter soit le fichier `scripts/entrypoint.sh` suivi de la commande, soit de lancer la commande dans un bash avec login :
+```bash
+$ docker-compose exec web scripts/entrypoint.sh which npm
+$ docker-compose exec web bash -lc "which npm"
+```
+
+L'exécution de `scripts/entrypoint.sh` étant déclarée dans le `Dockerfile`, il n'y a pas besoin de recharger les variables quand on passe par la commande `docker-compose run` :
+```bash
+$ docker-compose run --rm web which npm
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,11 @@ x-app:
   env_file:
     - .env
   volumes:
-    - .:/usr/src/app
-    - node_modules:/usr/src/app/node_modules/
+    - .:/home/mss
+    - node_modules:/home/mss/node_modules/
+    - /home/mss/.npm/
+    - /home/mss/.profile.d/
+    - /home/mss/.scalingo/
 
 services:
   db:
@@ -28,7 +31,6 @@ services:
 
   web:
     <<: *configuration-base
-    command: "npx nodemon server.js"
     environment:
       - NODE_ENV=development
     networks:

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "npm": "8"
   },
   "scripts": {
-    "build": "knex migrate:latest && npm test && npm run cree-utilisateur-demo",
-    "cree-utilisateur-demo": "node creeUtilisateurDemo.js",
+    "build": "npm test",
     "test": "eslint . && mocha",
     "test:mocha": "mocha",
     "test:watch": "nodemon --exec mocha",

--- a/scripts/buildpack.sh
+++ b/scripts/buildpack.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Inspiré de : https://github.com/Scalingo/multi-buildpack/blob/master/bin/compile
+
+set -e
+unset GIT_DIR
+
+dir=$(mktemp -t buildpackXXXXX)
+rm -rf $dir
+
+url="https://github.com/Scalingo/multi-buildpack.git"
+echo "=====> Downloading Buildpack: $url"
+
+git clone $url $dir >/dev/null 2>&1
+cd $dir
+chmod -f +x $dir/bin/{detect,compile,release} || true
+$dir/bin/compile $1 $2 $3
+
+if [ $? != 0 ]; then
+  exit 1
+fi
+
+if [ -e $dir/export ]; then
+  source $dir/export
+fi
+
+if [ -x $dir/bin/release ]; then
+  $dir/bin/release $1 > $1/last_pack_release.out
+fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. .profile
+
+exec "$@"


### PR DESCRIPTION
… Cela pour préparer l'installation de TeX dans l'image par le système de buildpack et pouvoir tester que ça fonctionne avant le déploiement.