### PR TITLE
Duplication des homologations en services

### DIFF
--- a/migrations/20220911174845_creationTableServices.js
+++ b/migrations/20220911174845_creationTableServices.js
@@ -1,0 +1,8 @@
+exports.up = (knex) => knex.schema
+  .createTable('services', (table) => {
+    table.uuid('id');
+    table.primary('id');
+    table.json('donnees');
+  });
+
+exports.down = (knex) => knex.schema.dropTable('services');

--- a/migrations/20220911180114_duplicationHomologationsDansServices.js
+++ b/migrations/20220911180114_duplicationHomologationsDansServices.js
@@ -1,0 +1,5 @@
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => lignes.map((donnees) => knex('services').insert(donnees)))
+  .then((insertions) => Promise.all(insertions));
+
+exports.down = (knex) => knex('services').del();

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -3,6 +3,7 @@ const adaptateurHorlogeParDefaut = require('./adaptateurHorloge');
 const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogeParDefaut) => {
   donnees.utilisateurs ||= [];
   donnees.homologations ||= [];
+  donnees.services ||= [];
   donnees.autorisations ||= [];
 
   const metsAJourEnregistrement = (fonctionRecherche, id, donneesAMettreAJour) => (
@@ -13,6 +14,11 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
 
   const ajouteHomologation = (id, donneesHomologation) => {
     donnees.homologations.push(Object.assign(donneesHomologation, { id }));
+    return Promise.resolve();
+  };
+
+  const ajouteService = (id, donneesService) => {
+    donnees.services.push(Object.assign(donneesService, { id }));
     return Promise.resolve();
   };
 
@@ -139,6 +145,7 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
   return {
     ajouteAutorisation,
     ajouteHomologation,
+    ajouteService,
     ajouteUtilisateur,
     autorisation,
     autorisationPour,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -12,6 +12,11 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
       .then(() => {})
   );
 
+  const supprimeEnregistrement = (nomTable, id) => {
+    donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
+    return Promise.resolve();
+  };
+
   const ajouteHomologation = (id, donneesHomologation) => {
     donnees.homologations.push(Object.assign(donneesHomologation, { id }));
     return Promise.resolve();
@@ -76,20 +81,16 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
 
   const metsAJourService = (...params) => metsAJourEnregistrement(service, ...params);
 
-  const supprimeHomologation = (id) => {
-    donnees.homologations = donnees.homologations.filter((h) => h.id !== id);
-    return Promise.resolve();
-  };
+  const supprimeHomologation = (...params) => supprimeEnregistrement('homologations', ...params);
 
   const supprimeHomologations = () => {
     donnees.homologations = [];
     return Promise.resolve();
   };
 
-  const supprimeUtilisateur = (id) => {
-    donnees.utilisateurs = donnees.utilisateurs.filter((u) => u.id !== id);
-    return Promise.resolve();
-  };
+  const supprimeService = (...params) => supprimeEnregistrement('services', ...params);
+
+  const supprimeUtilisateur = (...params) => supprimeEnregistrement('utilisateurs', ...params);
 
   const supprimeUtilisateurs = () => {
     donnees.utilisateurs = [];
@@ -162,6 +163,7 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     supprimeAutorisationsHomologation,
     supprimeHomologation,
     supprimeHomologations,
+    supprimeService,
     supprimeUtilisateur,
     supprimeUtilisateurs,
     transfereAutorisations,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -38,6 +38,10 @@ const nouvelAdaptateur = (env) => {
     .then(convertisLigneEnObjet)
     .catch(() => undefined);
 
+  const supprimeEnregistrement = (nomTable, id) => knex(nomTable)
+    .where({ id })
+    .del();
+
   const ajouteHomologation = (...params) => ajouteLigneDansTable('homologations', ...params);
   const ajouteService = (...params) => ajouteLigneDansTable('services', ...params);
   const ajouteUtilisateur = (...params) => ajouteLigneDansTable('utilisateurs', ...params);
@@ -106,15 +110,11 @@ const nouvelAdaptateur = (env) => {
   const nbUtilisateurs = () => knex('utilisateurs').count()
     .then((rows) => rows[0]['count(*)']);
 
-  const supprimeHomologation = (id) => knex('homologations')
-    .where({ id })
-    .del();
+  const supprimeHomologation = (...params) => supprimeEnregistrement('homologations', ...params);
+  const supprimeService = (...params) => supprimeEnregistrement('services', ...params);
+  const supprimeUtilisateur = (...params) => supprimeEnregistrement('utilisaateurs', ...params);
 
   const supprimeHomologations = () => knex('homologations').del();
-
-  const supprimeUtilisateur = (id) => knex('utilisateurs')
-    .where({ id })
-    .del();
 
   const supprimeUtilisateurs = () => knex('utilisateurs').del();
 
@@ -182,6 +182,7 @@ const nouvelAdaptateur = (env) => {
     supprimeAutorisations,
     supprimeAutorisationsHomologation,
     supprimeHomologation,
+    supprimeService,
     supprimeHomologations,
     supprimeUtilisateur,
     supprimeUtilisateurs,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -39,6 +39,7 @@ const nouvelAdaptateur = (env) => {
     .catch(() => undefined);
 
   const ajouteHomologation = (...params) => ajouteLigneDansTable('homologations', ...params);
+  const ajouteService = (...params) => ajouteLigneDansTable('services', ...params);
   const ajouteUtilisateur = (...params) => ajouteLigneDansTable('utilisateurs', ...params);
 
   const arreteTout = () => knex.destroy();
@@ -163,6 +164,7 @@ const nouvelAdaptateur = (env) => {
   return {
     ajouteAutorisation,
     ajouteHomologation,
+    ajouteService,
     ajouteUtilisateur,
     arreteTout,
     autorisation,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -45,6 +45,8 @@ const nouvelAdaptateur = (env) => {
 
   const homologation = (id) => elementDeTable('homologations', id);
 
+  const service = (id) => elementDeTable('services', id);
+
   const homologationAvecNomService = (idUtilisateur, nomService, idHomologationMiseAJour = '') => (
     knex('homologations')
       .join('autorisations', knex.raw("(autorisations.donnees->>'idHomologation')::uuid"), 'homologations.id')
@@ -97,6 +99,7 @@ const nouvelAdaptateur = (env) => {
       }, []));
 
   const metsAJourHomologation = (...params) => metsAJourTable('homologations', ...params);
+  const metsAJourService = (...params) => metsAJourTable('services', ...params);
   const metsAJourUtilisateur = (...params) => metsAJourTable('utilisateurs', ...params);
 
   const nbUtilisateurs = () => knex('utilisateurs').count()
@@ -169,8 +172,10 @@ const nouvelAdaptateur = (env) => {
     homologationAvecNomService,
     homologations,
     metsAJourHomologation,
+    metsAJourService,
     metsAJourUtilisateur,
     nbUtilisateurs,
+    service,
     supprimeAutorisation,
     supprimeAutorisations,
     supprimeAutorisationsHomologation,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -130,7 +130,10 @@ const creeDepot = (config = {}) => {
     };
 
     return valideDescriptionService(idUtilisateur, donneesDescriptionService)
-      .then(() => adaptateurPersistance.ajouteHomologation(idHomologation, donnees))
+      .then(() => Promise.all([
+        adaptateurPersistance.ajouteHomologation(idHomologation, donnees),
+        adaptateurPersistance.ajouteService(idHomologation, donnees),
+      ]))
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
         idUtilisateur, idHomologation, type: 'createur',
       }))

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -65,7 +65,10 @@ const creeDepot = (config = {}) => {
         h[nomPropriete] = donneesPropriete;
 
         const { id, ...donnees } = h;
-        return adaptateurPersistance.metsAJourHomologation(id, donnees);
+        return Promise.all([
+          adaptateurPersistance.metsAJourHomologation(id, donnees),
+          adaptateurPersistance.metsAJourService(id, donnees),
+        ]);
       })
   );
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -150,7 +150,10 @@ const creeDepot = (config = {}) => {
 
   const supprimeHomologation = (idHomologation) => adaptateurPersistance
     .supprimeAutorisationsHomologation(idHomologation)
-    .then(() => adaptateurPersistance.supprimeHomologation(idHomologation));
+    .then(() => Promise.all([
+      adaptateurPersistance.supprimeHomologation(idHomologation),
+      adaptateurPersistance.supprimeService(idHomologation),
+    ]));
 
   return {
     ajouteAvisExpertCyberAHomologation,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -24,7 +24,10 @@ const creeDepot = (config = {}) => {
         }
 
         const { id, ...donnees } = h;
-        return adaptateurPersistance.metsAJourHomologation(id, donnees);
+        return Promise.all([
+          adaptateurPersistance.metsAJourHomologation(id, donnees),
+          adaptateurPersistance.metsAJourService(id, donnees),
+        ]);
       })
   );
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -39,7 +39,10 @@ const creeDepot = (config = {}) => {
       Object.assign(h[nomPropriete], donneesPropriete);
 
       const { id, ...donnees } = h;
-      return adaptateurPersistance.metsAJourHomologation(id, donnees);
+      return Promise.all([
+        adaptateurPersistance.metsAJourHomologation(id, donnees),
+        adaptateurPersistance.metsAJourService(id, donnees),
+      ]);
     };
 
     const trouveDonneesHomologation = (param) => (

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -1,0 +1,13 @@
+const Service = require('../modeles/service');
+
+const creeDepot = (config = {}) => {
+  const { adaptateurPersistance, referentiel } = config;
+  const service = (idService) => adaptateurPersistance.service(idService)
+    .then((s) => (s ? new Service(s, referentiel) : undefined));
+
+  return {
+    service,
+  };
+};
+
+module.exports = { creeDepot };

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -98,7 +98,10 @@ const creeDepot = (config = {}) => {
   );
 
   const supprimeUtilisateur = (id) => depotHomologations.homologations(id)
-    .then((hs) => hs.map((h) => adaptateurPersistance.supprimeHomologation(h.id)))
+    .then((hs) => hs.map((h) => Promise.all([
+      adaptateurPersistance.supprimeHomologation(h.id),
+      adaptateurPersistance.supprimeService(h.id),
+    ])))
     .then((suppressions) => Promise.all(suppressions))
     .then(() => adaptateurPersistance.supprimeUtilisateur(id));
 

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -1,0 +1,6 @@
+const Homologation = require('./homologation');
+
+class Service extends Homologation {
+}
+
+module.exports = Service;

--- a/src/utilitaires/copie.js
+++ b/src/utilitaires/copie.js
@@ -1,0 +1,3 @@
+const copie = (donnees) => JSON.parse(JSON.stringify(donnees));
+
+module.exports = copie;

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -256,12 +256,19 @@ describe('Le dépot de données des homologations', () => {
   });
 
   describe("sur demande de mise à jour de la description du service d'une homologation", () => {
-    it("met à jour la description du service d'une homologation", (done) => {
-      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+    let adaptateurPersistance;
+
+    beforeEach(() => {
+      const donneesHomologation = { id: '123', descriptionService: { nomService: 'Super Service', presentation: 'Une présentation' } };
+      adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
         utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
-        homologations: [{ id: '123', descriptionService: { nomService: 'Super Service' } }],
+        homologations: [copie(donneesHomologation)],
+        services: [copie(donneesHomologation)],
       });
+    });
+
+    it("met à jour la description du service d'une homologation", (done) => {
       const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 
       const description = new DescriptionService({ nomService: 'Nouveau Nom' });
@@ -274,12 +281,21 @@ describe('Le dépot de données des homologations', () => {
         .catch(done);
     });
 
+    it("met à jour la description de service dans l'objet métier service", (done) => {
+      const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
+      const depotServices = DepotDonneesServices.creeDepot({ adaptateurPersistance });
+
+      const description = new DescriptionService({ nomService: 'Nouveau Nom' });
+      depot.ajouteDescriptionServiceAHomologation('999', '123', description)
+        .then(() => depotServices.service('123'))
+        .then(({ descriptionService }) => {
+          expect(descriptionService.nomService).to.equal('Nouveau Nom');
+          done();
+        })
+        .catch(done);
+    });
+
     it('lève une exception si le nom du service est absent', (done) => {
-      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
-        utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
-        homologations: [{ id: '123', descriptionService: { nomService: 'Super Service' } }],
-      });
       const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 
       const description = new DescriptionService({ nomService: '' });
@@ -296,13 +312,6 @@ describe('Le dépot de données des homologations', () => {
     });
 
     it("ne détecte pas de doublon sur le nom de service pour l'homologation en cours de mise à jour", (done) => {
-      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        autorisations: [{ idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
-        utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
-        homologations: [
-          { id: '123', descriptionService: { nomService: 'Super Service', presentation: 'Une présentation' } },
-        ],
-      });
       const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 
       const description = new DescriptionService({ nomService: 'Super Service', presentation: 'Une autre présentation' });
@@ -317,10 +326,10 @@ describe('Le dépot de données des homologations', () => {
   });
 
   it('sait associer des rôles et responsabilités à une homologation', (done) => {
+    const donneesHomologation = { id: '123', descriptionService: { nomService: 'nom' } };
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        { id: '123', descriptionService: { nomService: 'nom' } },
-      ],
+      homologations: [copie(donneesHomologation)],
+      services: [copie(donneesHomologation)],
     });
     const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 
@@ -410,10 +419,10 @@ describe('Le dépot de données des homologations', () => {
   });
 
   it("sait associer un avis d'expert cyber à une homologation", (done) => {
+    const donneesHomologation = { id: '123', descriptionService: { nomService: 'nom' } };
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        { id: '123', descriptionService: { nomService: 'nom' } },
-      ],
+      homologations: [copie(donneesHomologation)],
+      services: [copie(donneesHomologation)],
     });
     const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -129,24 +129,47 @@ describe('Le dépot de données des homologations', () => {
       .catch(done);
   });
 
-  it('sait associer une mesure spécifique à une homologation', (done) => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        { id: '123', descriptionService: { nomService: 'nom' } },
-      ],
-    });
-    const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
+  describe("sur demande d'association de mesures spécifiques à un service", () => {
+    let adaptateurPersistance;
 
-    const mesures = new MesuresSpecifiques({ mesuresSpecifiques: [{ description: 'Une mesure spécifique' }] });
-    depot.remplaceMesuresSpecifiquesPourHomologation('123', mesures)
-      .then(() => depot.homologation('123'))
-      .then(({ mesures: { mesuresSpecifiques } }) => {
-        expect(mesuresSpecifiques.nombre()).to.equal(1);
-        expect(mesuresSpecifiques.item(0)).to.be.a(MesureSpecifique);
-        expect(mesuresSpecifiques.item(0).description).to.equal('Une mesure spécifique');
-        done();
-      })
-      .catch(done);
+    beforeEach(() => {
+      const donneesHomologation = { id: '123', descriptionService: { nomService: 'nom' } };
+      adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        homologations: [copie(donneesHomologation)],
+        services: [copie(donneesHomologation)],
+      });
+    });
+
+    it("associe les mesures spécifiques à l'homologation", (done) => {
+      const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
+
+      const mesures = new MesuresSpecifiques({ mesuresSpecifiques: [{ description: 'Une mesure spécifique' }] });
+      depot.remplaceMesuresSpecifiquesPourHomologation('123', mesures)
+        .then(() => depot.homologation('123'))
+        .then(({ mesures: { mesuresSpecifiques } }) => {
+          expect(mesuresSpecifiques.nombre()).to.equal(1);
+          expect(mesuresSpecifiques.item(0)).to.be.a(MesureSpecifique);
+          expect(mesuresSpecifiques.item(0).description).to.equal('Une mesure spécifique');
+          done();
+        })
+        .catch(done);
+    });
+
+    it('associe les mesures spécifiques au service', (done) => {
+      const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
+      const depotServices = DepotDonneesServices.creeDepot({ adaptateurPersistance });
+
+      const mesures = new MesuresSpecifiques({ mesuresSpecifiques: [{ description: 'Une mesure spécifique' }] });
+      depot.remplaceMesuresSpecifiquesPourHomologation('123', mesures)
+        .then(() => depotServices.service('123'))
+        .then(({ mesures: { mesuresSpecifiques } }) => {
+          expect(mesuresSpecifiques.nombre()).to.equal(1);
+          expect(mesuresSpecifiques.item(0)).to.be.a(MesureSpecifique);
+          expect(mesuresSpecifiques.item(0).description).to.equal('Une mesure spécifique');
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('concernant les mesures générales', () => {
@@ -377,10 +400,10 @@ describe('Le dépot de données des homologations', () => {
   });
 
   it('sait associer un risque spécifique à une homologation', (done) => {
+    const donneesHomologation = { id: '123', descriptionService: { nomService: 'nom' } };
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [
-        { id: '123', descriptionService: { nomService: 'nom' } },
-      ],
+      homologations: [copie(donneesHomologation)],
+      services: [copie(donneesHomologation)],
     });
     const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 
@@ -397,12 +420,14 @@ describe('Le dépot de données des homologations', () => {
   });
 
   it('supprime les risques spécifiques précédemment associés', (done) => {
+    const donneesHomologations = {
+      id: '123',
+      descriptionService: { nomService: 'nom' },
+      risquesSpecifiques: [{ description: 'Un ancien risque' }],
+    };
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-      homologations: [{
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-        risquesSpecifiques: [{ description: 'Un ancien risque' }],
-      }],
+      homologations: [copie(donneesHomologations)],
+      services: [copie(donneesHomologations)],
     });
     const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -616,23 +616,48 @@ describe('Le dépot de données des homologations', () => {
   });
 
   describe("sur demande de suppression d'une homologation", () => {
-    it("supprime l'homologation", (done) => {
-      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+    let adaptateurPersistance;
+
+    beforeEach(() => {
+      const donneesHomologation = { id: '123', descriptionService: { nomService: 'Un service' } };
+      adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
-        homologations: [{ id: '123', descriptionService: { nomService: 'Un service' } }],
+        homologations: [copie(donneesHomologation)],
+        services: [copie(donneesHomologation)],
         autorisations: [{ id: '456', idUtilisateur: '999', idHomologation: '123', type: 'createur' }],
       });
+    });
+
+    it("supprime l'homologation", (done) => {
       const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
 
-      depot.supprimeHomologation('123')
-        .then(depot.homologation('123'))
-        .then((h) => expect(h).to.be(undefined))
-        .then(() => done())
+      adaptateurPersistance.homologation('123')
+        .then((h) => expect(h).to.be.an(Object))
+        .then(() => depot.supprimeHomologation('123'))
+        .then(() => adaptateurPersistance.homologation('123'))
+        .then((h) => {
+          expect(h).to.be(undefined);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('supprime le service', (done) => {
+      const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
+
+      adaptateurPersistance.service('123')
+        .then((s) => expect(s).to.be.an(Object))
+        .then(() => depot.supprimeHomologation('123'))
+        .then(() => adaptateurPersistance.service('123'))
+        .then((s) => {
+          expect(s).to.be(undefined);
+          done();
+        })
         .catch(done);
     });
 
     it('supprime les autorisations associées', (done) => {
-      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [
           { id: '999', email: 'jean.dupont@mail.fr' },
           { id: '000', email: 'contributeur@mail.fr' },

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -87,7 +87,7 @@ describe('Le dépot de données des homologations', () => {
   it('peut retrouver une homologation à partir de son identifiant', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [
-        { id: '789', idUtilisateur: '999', descriptionService: { nomService: 'nom' } },
+        { id: '789', descriptionService: { nomService: 'nom' } },
       ],
     });
     const referentiel = Referentiel.creeReferentielVide();

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -470,6 +470,7 @@ describe('Le dépot de données des homologations', () => {
       adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
         homologations: [],
+        services: [],
         autorisations: [],
       });
       adaptateurUUID = { genereUUID: () => 'unUUID' };
@@ -483,7 +484,7 @@ describe('Le dépot de données des homologations', () => {
         .then(() => depot.homologations('123'))
         .then((homologations) => {
           expect(homologations.length).to.equal(1);
-          expect(homologations[0].descriptionService.nomService).to.equal('Super Service');
+          expect(homologations[0].nomService()).to.equal('Super Service');
           done();
         })
         .catch(done);
@@ -499,6 +500,18 @@ describe('Le dépot de données des homologations', () => {
         .then(() => depot.homologations('123'))
         .then((homologations) => {
           expect(homologations[0].id).to.equal('11111111-1111-1111-1111-111111111111');
+          done();
+        })
+        .catch(done);
+    });
+
+    it('ajoute en copie un nouveau service au dépôt', (done) => {
+      const depotDonneesServices = DepotDonneesServices.creeDepot({ adaptateurPersistance });
+
+      depot.nouvelleHomologation('123', { nomService: 'Super Service' })
+        .then((idHomologation) => depotDonneesServices.service(idHomologation))
+        .then((service) => {
+          expect(service.nomService()).to.equal('Super Service');
           done();
         })
         .catch(done);

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -24,9 +24,9 @@ const RisqueSpecifique = require('../../src/modeles/risqueSpecifique');
 const RisquesSpecifiques = require('../../src/modeles/risquesSpecifiques');
 const RolesResponsabilites = require('../../src/modeles/rolesResponsabilites');
 
-describe('Le dépot de données des homologations', () => {
-  const copie = (donnees) => JSON.parse(JSON.stringify(donnees));
+const copie = require('../../src/utilitaires/copie');
 
+describe('Le dépot de données des homologations', () => {
   it("connaît toutes les homologations d'un utilisateur donné", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1,0 +1,27 @@
+const expect = require('expect.js');
+
+const Referentiel = require('../../src/referentiel');
+const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
+const DepotDonneesServices = require('../../src/depots/depotDonneesServices');
+const Service = require('../../src/modeles/service');
+
+describe('Le dépôt de données des services', () => {
+  it('peut retrouver un service à partir de son identifiant', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      services: [
+        { id: '789', descriptionService: { nomService: 'nom' } },
+      ],
+    });
+    const referentiel = Referentiel.creeReferentielVide();
+    const depot = DepotDonneesServices.creeDepot({ adaptateurPersistance, referentiel });
+
+    depot.service('789')
+      .then((service) => {
+        expect(service).to.be.a(Service);
+        expect(service.id).to.equal('789');
+        expect(service.referentiel).to.equal(referentiel);
+        done();
+      })
+      .catch(done);
+  });
+});


### PR DESCRIPTION
Grosse PR – pas sûr de savoir comment la découper en plusieurs morceaux… Suggestions bienvenues.

Cette PR fait suite à #366 et s'inscrit de manière plus large dans l'ajout d'un parcours homologation.

Prochaines étapes :
- [ ] Migrer les données `homologations` en `services`
  - [x] Dupliquer les données de la table `homologations` dans la table `services`
  - [x] Reporter les requêtes d'ajout / modification d'homologation sur les services
  - [ ] Dupliquer les données de `autorisations.donnees->>'idHomologation'` dans `autorisations.donnees->>'idService'`
  - [ ] Reporter les requêtes d'ajout / modification des autorisations sur les services
  - [ ] Changer les routes concernant les homologations en routes concernant les services, et reporter les requêtes d'ajout / modification des services en ajout/modification des homologations
  - [ ] Supprimer les reports de requêtes
  - [ ] Supprimer la table `homologations`
- [ ] Différencier l'affichage dans `/service/:id/homologations` suivant qu'il y a ou pas une homologation rattachée au service
- [ ] Ajouter une route `POST /service/:id/homologation` et une route `GET /homologation/:id` (qui permet d'accéder au PDF)
- [ ] Changer la page de synthèse pour offrir les accès à décrire / sécuriser / homologuer.