### PR TITLE
Entête de la page de synthèse de sécurité

### DIFF
--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -5,6 +5,75 @@
   color: #000;
 }
 
+header {
+  display: flex;
+}
+
+.bloc-marque {
+  margin-right: auto;
+}
+
+.bloc-marque :is(.marianne, .devise) {
+  width: 45%;
+
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.bloc-marque .marianne {
+  height: 10px;
+
+  background-image: url(../images/marianne.svg);
+}
+
+.bloc-marque .devise {
+  height: 20px;
+
+  background-image: url(../images/devise.svg);
+}
+
+.bloc-marque .republique-francaise {
+  padding: 2px 0 4px;
+
+  line-height: 100%;
+  font-size: 10px;
+  color: #000;
+  font-weight: bold;
+}
+
+.logo-mss {
+  color: var(--bleu-anssi);
+}
+
+.logo-mss::before {
+  content: '';
+  display: block;
+  position: absolute;
+  margin: 11px 0 0 -30px;
+
+  width: 25px;
+  height: 30px;
+
+  background-image: url(../images/logo_mss.svg);
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.logo-mss .logo {
+  font-size: 2em;
+}
+
+.logo-anssi {
+  width: 60px;
+  height: 60px;
+
+  margin-left: 15px;
+
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-image: url(../images/logo_anssi.png);
+}
+
 h1 {
   text-transform: uppercase;
   font-size: 1.5em;

--- a/src/vues/homologation/decision.pug
+++ b/src/vues/homologation/decision.pug
@@ -42,13 +42,12 @@ mixin mesuresPaginees({ titreAnnexe, titreSection, donnees })
                     .indispensable
       .saut-page
 
-block append page
+include ../fragments/diagnostics
 
-  include ../fragments/diagnostics
-
-  block append styles
+block append styles
     link(href='/statique/assets/styles/decision.css', rel='stylesheet')
 
+block append page
   .page
     header
       .mss

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -1,10 +1,9 @@
 extends ../documentImprimable
 
+block append styles
+  link(href='/statique/assets/styles/syntheseSecurite.css', rel='stylesheet')
+
 block append page
-
-  block append styles
-    link(href='/statique/assets/styles/syntheseSecurite.css', rel='stylesheet')
-
   .page
     header
       .bloc-marque

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -6,6 +6,16 @@ block append page
     link(href='/statique/assets/styles/syntheseSecurite.css', rel='stylesheet')
 
   .page
+    header
+      .bloc-marque
+        .marianne
+        .republique-francaise RÉPUBLIQUE<br>FRANÇAISE
+        .devise
+      .logo-mss
+        .logo MonService<b>Sécurisé</b>
+        .devise Protégeons les services publics en ligne
+      .logo-anssi
+
     main
       h1 Synthèse de la sécurité du service
       .nom-service!= homologation.nomService()


### PR DESCRIPTION
Dans la quête du PDF de synthèse de sécurité,
La page doit avoir un header avec les logos

La page est à l'adresse `/homologation/[id]/syntheseSecurite`

<img width="1034" alt="Capture d’écran 2022-10-04 à 09 58 47" src="https://user-images.githubusercontent.com/39462397/193766070-22757192-04bb-4df1-a3ee-bb8a64cf2fb5.png">

NOTE : sur ma machine avec google chrome quand je télécharge le document le logo de l'ANSSI est flou 😢