### PR TITLE
Ajout nouvelle page synthèse

### DIFF
--- a/public/assets/styles/cartes/indiceCyber.css
+++ b/public/assets/styles/cartes/indiceCyber.css
@@ -1,0 +1,13 @@
+.carte .score-mss {
+  margin-bottom: 1em;
+  font-size: 1.3em;
+}
+
+.carte :is(.score, .score-max) {
+  font-weight: bold;
+  color: var(--rose-anssi);
+}
+
+.carte .score {
+  font-size: 1.6em;
+}

--- a/public/assets/styles/homologation.css
+++ b/public/assets/styles/homologation.css
@@ -92,17 +92,3 @@ a.action.a-completer {
 a.action.a-faire {
   background-image: url(../images/icone_vide_pastille_blanche.svg);
 }
-
-.carte .score-mss {
-  margin-bottom: 1em;
-  font-size: 1.3em;
-}
-
-.carte :is(.score, .score-max) {
-  font-weight: bold;
-  color: var(--rose-anssi);
-}
-
-.carte .score {
-  font-size: 1.6em;
-}

--- a/public/assets/styles/homologation/synthese.css
+++ b/public/assets/styles/homologation/synthese.css
@@ -1,0 +1,10 @@
+.tableau-bord {
+  display: flex;
+  display-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.outils-complementaires {
+  text-align: left;
+}

--- a/src/routes/routesHomologation.js
+++ b/src/routes/routesHomologation.js
@@ -23,6 +23,13 @@ const routesHomologation = (middleware, referentiel, moteurRegles) => {
     reponse.render('homologation', { referentiel, homologation, actionsSaisie, InformationsHomologation });
   });
 
+  routes.get('/:id/synthese/', middleware.trouveHomologation, (requete, reponse) => {
+    const { homologation } = requete;
+    const actionsSaisie = [];
+
+    reponse.render('homologation/synthese', { referentiel, service: homologation, actionsSaisie, InformationsHomologation });
+  });
+
   routes.get('/:id/decision',
     middleware.trouveHomologation,
     middleware.positionneHeadersAvecNonce,

--- a/src/vues/cartes/indiceCyber.pug
+++ b/src/vues/cartes/indiceCyber.pug
@@ -1,0 +1,39 @@
+include ../carteInformations
+
+block append styles
+  link(href = '/statique/assets/styles/cartes/indiceCyber.css', rel = 'stylesheet')
+
+mixin indiceCyber({ referentiel, indiceSecurite })
+  - const indiceSecuriteMax = referentiel.indiceSecuriteMax()
+  - const formatte = Intl.NumberFormat('fr', { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format
+
+  mixin detailsIndiceSecurite
+    h3 Par catégorie de mesure
+    dl
+      each id in referentiel.identifiantsCategoriesMesures()
+          dt= referentiel.descriptionCategorie(id)
+          dd= (typeof indiceSecurite[id] === 'number' ? `${formatte(indiceSecurite[id])} / ${indiceSecuriteMax}` : '–')
+
+    h3 À quoi sert l'indice de sécurité ?
+    p.
+        L'indice de sécurité fournit une indication du niveau de sécurité du
+        service basée sur une évaluation de la conformité de ce dernier à un
+        socle de mesures de sécurité personnalisé.
+    p.
+        Cette note ne constitue pas une preuve effective de la sécurité du
+        service. MonServiceSécurisé et l'ANSSI ne peuvent en aucun cas être tenus
+        responsables d'incidents de sécurité susceptibles d'affecter le service
+        numérique, quelle que soit la note attribuée à ce dernier.
+
+    p: a(href = '/questionsFrequentes#indice-securite', target = '_blank', rel = 'noopener').nouvel-onglet En savoir plus
+
+
+  - const { total } = indiceSecurite
+  +carteInformations({
+    titre: 'Indice de sécurité',
+    sousTitre: "Évalué par l'ANSSI",
+    details: 'detailsIndiceSecurite'
+  })
+    .score-mss
+      span.score= formatte(total)
+      span.score-max= ` / ${indiceSecuriteMax}`

--- a/src/vues/homologation.pug
+++ b/src/vues/homologation.pug
@@ -1,5 +1,5 @@
 extends deuxColonnes
-include carteInformations
+include cartes/indiceCyber
 
 mixin action({ description, url, statut })
   - let classeStyleStatut
@@ -36,33 +36,5 @@ block zone-principale
 
 block cartes-informations
   - const indiceSecurite = homologation.indiceSecurite()
-  - const indiceSecuriteMax = referentiel.indiceSecuriteMax()
-  - const formatte = Intl.NumberFormat('fr', { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format
-
-  mixin detailsIndiceSecurite
-    h3 Par catégorie de mesure
-    dl
-      each id in referentiel.identifiantsCategoriesMesures()
-        dt= referentiel.descriptionCategorie(id)
-        dd= (typeof indiceSecurite[id] === 'number' ? `${formatte(indiceSecurite[id])} / ${indiceSecuriteMax}` : '–')
-
-    h3 À quoi sert l'indice de sécurité ?
-    p.
-      L'indice de sécurité fournit une indication du niveau de sécurité du
-      service basée sur une évaluation de la conformité de ce dernier à un
-      socle de mesures de sécurité personnalisé.
-    p.
-      Cette note ne constitue pas une preuve effective de la sécurité du
-      service. MonServiceSécurisé et l'ANSSI ne peuvent en aucun cas être tenus
-      responsables d'incidents de sécurité susceptibles d'affecter le service
-      numérique, quelle que soit la note attribuée à ce dernier.
-
-    p: a(href = '/questionsFrequentes#indice-securite', target = '_blank', rel = 'noopener').nouvel-onglet En savoir plus
-
-
-  - const { total } = indiceSecurite
-  if process.env.AVEC_INDICE_SECURITE && total > 0
-    +carteInformations({ titre: 'Indice de sécurité', sousTitre: "Évalué par l'ANSSI", details: 'detailsIndiceSecurite' })
-      .score-mss
-        span.score= formatte(total)
-        span.score-max= ` / ${indiceSecuriteMax}`
+  if process.env.AVEC_INDICE_SECURITE
+    +indiceCyber({ referentiel, indiceSecurite })

--- a/src/vues/homologation/synthese.pug
+++ b/src/vues/homologation/synthese.pug
@@ -1,0 +1,71 @@
+extends ../deuxColonnes
+include ../carteInformations
+
+mixin action({ description, url, statut })
+  - let classeStyleStatut
+  -
+    switch(statut) {
+      case InformationsHomologation.A_SAISIR: classeStyleStatut = 'a-faire'; break;
+      case InformationsHomologation.A_COMPLETER: classeStyleStatut = 'a-completer'; break;
+      case InformationsHomologation.COMPLETES: classeStyleStatut = 'faite'; break;
+      default: '';
+    }
+
+  a.action(class = classeStyleStatut, href = url)= description
+
+
+block append styles
+  link(href = '/statique/assets/styles/homologation/synthese.css', rel = 'stylesheet')
+
+block retour
+  a(href = '/espacePersonnel') ‹&nbsp;&nbsp;Mon espace personnel
+
+block zone-principale
+  .details-service
+    .tableau-bord
+      .titre-service
+        h1!= service.nomService()
+      a.bouton(href = `/homologation/${service.id}/decision`) Télécharger la synthèse
+
+    .actions
+      ul
+        each actionSaisie in actionsSaisie
+          li
+            +action(actionSaisie)
+
+    .outils-complementaires
+      h3 Outils complémentaires
+      // vide pour l'instant
+
+block cartes-informations
+  - const indiceSecurite = service.indiceSecurite()
+  - const indiceSecuriteMax = referentiel.indiceSecuriteMax()
+  - const formatte = Intl.NumberFormat('fr', { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format
+
+  mixin detailsIndiceSecurite
+    h3 Par catégorie de mesure
+    dl
+      each id in referentiel.identifiantsCategoriesMesures()
+        dt= referentiel.descriptionCategorie(id)
+        dd= (typeof indiceSecurite[id] === 'number' ? `${formatte(indiceSecurite[id])} / ${indiceSecuriteMax}` : '–')
+
+    h3 À quoi sert l'indice de sécurité ?
+    p.
+      L'indice de sécurité fournit une indication du niveau de sécurité du
+      service basée sur une évaluation de la conformité de ce dernier à un
+      socle de mesures de sécurité personnalisé.
+    p.
+      Cette note ne constitue pas une preuve effective de la sécurité du
+      service. MonServiceSécurisé et l'ANSSI ne peuvent en aucun cas être tenus
+      responsables d'incidents de sécurité susceptibles d'affecter le service
+      numérique, quelle que soit la note attribuée à ce dernier.
+
+    p: a(href = '/questionsFrequentes#indice-securite', target = '_blank', rel = 'noopener').nouvel-onglet En savoir plus
+
+
+  - const { total } = indiceSecurite
+  if process.env.AVEC_INDICE_SECURITE && total > 0
+    +carteInformations({ titre: 'Indice de sécurité', sousTitre: "Évalué par l'ANSSI", details: 'detailsIndiceSecurite' })
+      .score-mss
+        span.score= formatte(total)
+        span.score-max= ` / ${indiceSecuriteMax}`

--- a/src/vues/homologation/synthese.pug
+++ b/src/vues/homologation/synthese.pug
@@ -1,5 +1,5 @@
 extends ../deuxColonnes
-include ../carteInformations
+include ../cartes/indiceCyber
 
 mixin action({ description, url, statut })
   - let classeStyleStatut
@@ -39,33 +39,5 @@ block zone-principale
 
 block cartes-informations
   - const indiceSecurite = service.indiceSecurite()
-  - const indiceSecuriteMax = referentiel.indiceSecuriteMax()
-  - const formatte = Intl.NumberFormat('fr', { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format
-
-  mixin detailsIndiceSecurite
-    h3 Par catégorie de mesure
-    dl
-      each id in referentiel.identifiantsCategoriesMesures()
-        dt= referentiel.descriptionCategorie(id)
-        dd= (typeof indiceSecurite[id] === 'number' ? `${formatte(indiceSecurite[id])} / ${indiceSecuriteMax}` : '–')
-
-    h3 À quoi sert l'indice de sécurité ?
-    p.
-      L'indice de sécurité fournit une indication du niveau de sécurité du
-      service basée sur une évaluation de la conformité de ce dernier à un
-      socle de mesures de sécurité personnalisé.
-    p.
-      Cette note ne constitue pas une preuve effective de la sécurité du
-      service. MonServiceSécurisé et l'ANSSI ne peuvent en aucun cas être tenus
-      responsables d'incidents de sécurité susceptibles d'affecter le service
-      numérique, quelle que soit la note attribuée à ce dernier.
-
-    p: a(href = '/questionsFrequentes#indice-securite', target = '_blank', rel = 'noopener').nouvel-onglet En savoir plus
-
-
-  - const { total } = indiceSecurite
-  if process.env.AVEC_INDICE_SECURITE && total > 0
-    +carteInformations({ titre: 'Indice de sécurité', sousTitre: "Évalué par l'ANSSI", details: 'detailsIndiceSecurite' })
-      .score-mss
-        span.score= formatte(total)
-        span.score-max= ` / ${indiceSecuriteMax}`
+  if process.env.AVEC_INDICE_SECURITE
+    +indiceCyber({ referentiel, indiceSecurite })

--- a/test/routes/routesHomologation.spec.js
+++ b/test/routes/routesHomologation.spec.js
@@ -19,6 +19,15 @@ describe('Le serveur MSS des routes /homologation/*', () => {
     });
   });
 
+  describe('quand requête GET sur `/homologation/:id/synthese`', () => {
+    it('recherche la ressource correspondante', (done) => {
+      testeur.middleware().verifieRechercheHomologation(
+        'http://localhost:1234/homologation/456/synthese',
+        done,
+      );
+    });
+  });
+
   describe('quand requête GET sur `/homologation/:id/descriptionService`', () => {
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24898521/193789226-d1fab155-3691-43fb-ad0b-7ab02b9708ce.png)

Prochaines étapes :
 - [ ] afficher véritablement les actions de saisie,
 - [ ] introduire un attribut `indisponible` pour l'action de saisie du _parcours homologation_,
 - [ ] mise en forme.

Cette page est accessible par l'URL orpheline `/homologation/:id/synthese`. On choisit de dupliquer la page `/homologation/:id` tant que la page de synthèse « nouvelle UX » n'est pas utilisable. 

Au passage, on en a profité pour extraire une carte `indiceCyber` qui permet de résoudre une duplication entre les 2 vues touchées par cette PR.

On a inséré une `div` de classe `outils-complementaires` qui permettra de travailler en parallèle sur l'intégration des outils complémentaires.

