### PR TITLE
Versionnage des actions de saisie

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -11,11 +11,13 @@ module.exports = {
   },
 
   actionsSaisie: {
-    descriptionService: { position: 0, description: 'Description du service' },
-    rolesResponsabilites: { position: 1, description: 'Rôles et responsabilités' },
-    risques: { position: 2, description: 'Risques de sécurité' },
-    mesures: { position: 3, description: 'Mesures de sécurité' },
-    avisExpertCyber: { position: 4, description: 'Avis sur le dossier' },
+    v1: {
+      descriptionService: { position: 0, description: 'Description du service' },
+      rolesResponsabilites: { position: 1, description: 'Rôles et responsabilités' },
+      risques: { position: 2, description: 'Risques de sécurité' },
+      mesures: { position: 3, description: 'Mesures de sécurité' },
+      avisExpertCyber: { position: 4, description: 'Avis sur le dossier' },
+    },
   },
 
   seuilsCriticites: ['critique', 'eleve', 'moyen', 'faible'],

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -26,6 +26,7 @@ class ErreurStatutMesureInvalide extends ErreurModele {}
 class ErreurTentativeSuppressionCreateur extends ErreurModele {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
+class ErreurVersionActionSaisieManquante extends ErreurModele { }
 
 class ErreurUtilisateurExistant extends ErreurModele {
   constructor(message = '', idUtilisateur) {
@@ -64,4 +65,5 @@ module.exports = {
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,
   ErreurUtilisateurInexistant,
+  ErreurVersionActionSaisieManquante,
 };

--- a/src/modeles/actionSaisie.js
+++ b/src/modeles/actionSaisie.js
@@ -4,6 +4,7 @@ const Homologation = require('./homologation');
 const {
   ErreurIdentifiantActionSaisieInvalide,
   ErreurIdentifiantActionSaisieManquant,
+  ErreurVersionActionSaisieManquante,
 } = require('../erreurs');
 const Referentiel = require('../referentiel');
 
@@ -13,7 +14,7 @@ class ActionSaisie extends Base {
     referentiel = Referentiel.creeReferentielVide(),
     homologation = new Homologation({})
   ) {
-    super({ proprietesAtomiquesRequises: ['id'] });
+    super({ proprietesAtomiquesRequises: ['id', 'version'] });
     ActionSaisie.valide(donnees, referentiel);
     this.renseigneProprietes(donnees);
 
@@ -38,10 +39,16 @@ class ActionSaisie extends Base {
   }
 
   static valide(donnees, referentiel) {
-    const { id } = donnees;
+    const { id, version } = donnees;
     if (!id) {
       throw new ErreurIdentifiantActionSaisieManquant(
         "L'identifiant d'action de saisie doit être renseigné"
+      );
+    }
+
+    if (!version) {
+      throw new ErreurVersionActionSaisieManquante(
+        "La version d'action de saisie doit être renseignée"
       );
     }
 

--- a/src/modeles/actionSaisie.js
+++ b/src/modeles/actionSaisie.js
@@ -23,11 +23,11 @@ class ActionSaisie extends Base {
   }
 
   description() {
-    return this.referentiel.descriptionActionSaisie(this.id);
+    return this.referentiel.descriptionActionSaisie(this.version, this.id);
   }
 
   suivante() {
-    return this.referentiel.actionSuivante(this.id);
+    return this.referentiel.actionSuivante(this.version, this.id);
   }
 
   toJSON() {
@@ -52,7 +52,7 @@ class ActionSaisie extends Base {
       );
     }
 
-    const identifiants = referentiel.identifiantsActionsSaisie();
+    const identifiants = referentiel.identifiantsActionsSaisie(version);
     if (!identifiants.includes(id)) {
       throw new ErreurIdentifiantActionSaisieInvalide(
         `L'action de saisie "${id}" est invalide`

--- a/src/modeles/actionsSaisie.js
+++ b/src/modeles/actionsSaisie.js
@@ -13,7 +13,15 @@ class ActionsSaisie {
 
     return Object.keys(this.referentiel.actionsSaisie())
       .sort((a1, a2) => position(a1) - position(a2))
-      .map((a) => new ActionSaisie({ id: a }, this.referentiel, this.homologation).toJSON());
+      .map((a) => new ActionSaisie(
+        { id: a, version: ActionsSaisie.versionParDefaut() },
+        this.referentiel,
+        this.homologation
+      ).toJSON());
+  }
+
+  static versionParDefaut() {
+    return 'v1';
   }
 }
 

--- a/src/modeles/actionsSaisie.js
+++ b/src/modeles/actionsSaisie.js
@@ -3,7 +3,12 @@ const Homologation = require('./homologation');
 const Referentiel = require('../referentiel');
 
 class ActionsSaisie {
-  constructor(referentiel = Referentiel.creeReferentielVide, homologation = new Homologation({})) {
+  constructor(
+    version,
+    referentiel = Referentiel.creeReferentielVide,
+    homologation = new Homologation({})
+  ) {
+    this.version = version;
     this.referentiel = referentiel;
     this.homologation = homologation;
   }
@@ -11,17 +16,13 @@ class ActionsSaisie {
   toJSON() {
     const position = this.referentiel.positionActionSaisie;
 
-    return Object.keys(this.referentiel.actionsSaisie())
-      .sort((a1, a2) => position(a1) - position(a2))
+    return Object.keys(this.referentiel.actionsSaisie(this.version))
+      .sort((a1, a2) => position(this.version, a1) - position(this.version, a2))
       .map((a) => new ActionSaisie(
-        { id: a, version: ActionsSaisie.versionParDefaut() },
+        { id: a, version: this.version },
         this.referentiel,
         this.homologation
       ).toJSON());
-  }
-
-  static versionParDefaut() {
-    return 'v1';
   }
 }
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -4,14 +4,14 @@ const donneesParDefaut = require('../donneesReferentiel');
 const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   let donnees = donneesReferentiel;
 
-  const actionsSaisie = () => donnees.actionsSaisie;
-  const identifiantsActionsSaisie = () => Object.keys(actionsSaisie());
-  const actionSaisie = (id) => actionsSaisie()[id] || {};
-  const positionActionSaisie = (id) => actionSaisie(id).position;
+  const actionsSaisie = (version) => donnees.actionsSaisie[version] || {};
+  const identifiantsActionsSaisie = (version) => Object.keys(actionsSaisie(version));
+  const actionSaisie = (version, id) => actionsSaisie(version)[id] || {};
+  const positionActionSaisie = (version, id) => actionSaisie(version, id).position;
   const categoriesMesures = () => donnees.categoriesMesures;
   const descriptionCategorie = (idCategorie) => categoriesMesures()[idCategorie];
   const identifiantsCategoriesMesures = () => Object.keys(categoriesMesures());
-  const descriptionActionSaisie = (id) => actionSaisie(id).description;
+  const descriptionActionSaisie = (version, id) => actionSaisie(version, id).description;
   const delaisAvantImpactCritique = () => donnees.delaisAvantImpactCritique;
   const donneesCaracterePersonnel = () => donnees.donneesCaracterePersonnel;
   const echeancesRenouvellement = () => donnees.echeancesRenouvellement;
@@ -55,9 +55,10 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
 
   const indiceCyberMax = () => donnees.indiceCyber?.noteMax || 10;
 
-  const actionSuivante = (id) => {
-    const position = positionActionSaisie(id);
-    return Object.keys(actionsSaisie()).find((a) => positionActionSaisie(a) === position + 1);
+  const actionSuivante = (version, id) => {
+    const position = positionActionSaisie(version, id);
+    return Object.keys(actionsSaisie(version))
+      .find((a) => positionActionSaisie(version, a) === position + 1);
   };
 
   const infosNiveauxGravite = (ordreInverse = false) => {

--- a/src/routes/routesHomologation.js
+++ b/src/routes/routesHomologation.js
@@ -14,7 +14,7 @@ const routesHomologation = (middleware, referentiel, moteurRegles) => {
 
   routes.get('/:id', middleware.trouveHomologation, (requete, reponse) => {
     const { homologation } = requete;
-    const actionsSaisie = new ActionsSaisie(referentiel, homologation)
+    const actionsSaisie = new ActionsSaisie('v1', referentiel, homologation)
       .toJSON()
       .map(({ id, ...autresDonnees }) => (
         { url: `/homologation/${homologation.id}/${id}`, ...autresDonnees }

--- a/test/modeles/actionSaisie.spec.js
+++ b/test/modeles/actionSaisie.spec.js
@@ -7,6 +7,7 @@ const InformationsHomologation = require('../../src/modeles/informationsHomologa
 const {
   ErreurIdentifiantActionSaisieInvalide,
   ErreurIdentifiantActionSaisieManquant,
+  ErreurVersionActionSaisieManquante,
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 
@@ -14,7 +15,7 @@ describe('Une action de saisie', () => {
   it('connaît son identifiant', () => {
     const referentiel = Referentiel.creeReferentiel({ actionsSaisie: { uneAction: {} } });
 
-    const action = new ActionSaisie({ id: 'uneAction' }, referentiel);
+    const action = new ActionSaisie({ id: 'uneAction', version: 'v1' }, referentiel);
     expect(action.id).to.equal('uneAction');
   });
 
@@ -23,7 +24,7 @@ describe('Une action de saisie', () => {
       actionsSaisie: { uneAction: { description: 'Une description' } },
     });
 
-    const action = new ActionSaisie({ id: 'uneAction' }, referentiel);
+    const action = new ActionSaisie({ id: 'uneAction', version: 'v1' }, referentiel);
     expect(action.description()).to.equal('Une description');
   });
 
@@ -32,8 +33,17 @@ describe('Une action de saisie', () => {
       actionsSaisie: { uneAction: { position: 0 }, actionSuivante: { position: 1 } },
     });
 
-    const action = new ActionSaisie({ id: 'uneAction' }, referentiel);
+    const action = new ActionSaisie({ id: 'uneAction', version: 'v1' }, referentiel);
     expect(action.suivante()).to.equal('actionSuivante');
+  });
+
+  it('connaît sa version', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      actionsSaisie: { uneAction: { } },
+    });
+
+    const action = new ActionSaisie({ version: 'v1', id: 'uneAction' }, referentiel);
+    expect(action.version).to.equal('v1');
   });
 
   it('sait se décrire comme un objet JSON', () => {
@@ -44,7 +54,7 @@ describe('Une action de saisie', () => {
     const homologation = new Homologation({});
     homologation.statutSaisie = () => InformationsHomologation.A_SAISIR;
 
-    const action = new ActionSaisie({ id: 'uneAction' }, referentiel, homologation);
+    const action = new ActionSaisie({ id: 'uneAction', version: 'v1' }, referentiel, homologation);
     expect(action.toJSON()).to.eql({
       id: 'uneAction',
       description: 'Une description',
@@ -65,11 +75,22 @@ describe('Une action de saisie', () => {
 
   it("vérifie la validité de l'identifiant", (done) => {
     try {
-      new ActionSaisie({ id: 'actionInvalide' });
+      new ActionSaisie({ id: 'actionInvalide', version: 'v1' });
       done("La création de l'action de saisie aurait dû lever une erreur");
     } catch (e) {
       expect(e).to.be.a(ErreurIdentifiantActionSaisieInvalide);
       expect(e.message).to.equal("L'action de saisie \"actionInvalide\" est invalide");
+      done();
+    }
+  });
+
+  it('exige la présence de la version', (done) => {
+    try {
+      new ActionSaisie({ id: 'uneAction' });
+      done("La création de l'action de saisie aurait dû lever une erreur");
+    } catch (e) {
+      expect(e).to.be.a(ErreurVersionActionSaisieManquante);
+      expect(e.message).to.equal("La version d'action de saisie doit être renseignée");
       done();
     }
   });

--- a/test/modeles/actionSaisie.spec.js
+++ b/test/modeles/actionSaisie.spec.js
@@ -88,6 +88,23 @@ describe('Une action de saisie', () => {
     }
   });
 
+  it("exige que l'identifiant soit connu dans la version demandée", (done) => {
+    try {
+      const referentiel = Referentiel.creeReferentiel({
+        actionsSaisie: {
+          v1: { uneActionV1: {} },
+          v2: { uneActionV2: {} },
+        },
+      });
+      new ActionSaisie({ id: 'uneActionV2', version: 'v1' }, referentiel);
+      done("La création de l'action de saisie aurait dû lever une erreur");
+    } catch (e) {
+      expect(e).to.be.a(ErreurIdentifiantActionSaisieInvalide);
+      expect(e.message).to.equal("L'action de saisie \"uneActionV2\" est invalide");
+      done();
+    }
+  });
+
   it('exige la présence de la version', (done) => {
     try {
       new ActionSaisie({ id: 'uneAction' });

--- a/test/modeles/actionSaisie.spec.js
+++ b/test/modeles/actionSaisie.spec.js
@@ -13,7 +13,7 @@ const Referentiel = require('../../src/referentiel');
 
 describe('Une action de saisie', () => {
   it('connaît son identifiant', () => {
-    const referentiel = Referentiel.creeReferentiel({ actionsSaisie: { uneAction: {} } });
+    const referentiel = Referentiel.creeReferentiel({ actionsSaisie: { v1: { uneAction: {} } } });
 
     const action = new ActionSaisie({ id: 'uneAction', version: 'v1' }, referentiel);
     expect(action.id).to.equal('uneAction');
@@ -21,7 +21,9 @@ describe('Une action de saisie', () => {
 
   it('connaît sa description', () => {
     const referentiel = Referentiel.creeReferentiel({
-      actionsSaisie: { uneAction: { description: 'Une description' } },
+      actionsSaisie: {
+        v1: { uneAction: { description: 'Une description' } },
+      },
     });
 
     const action = new ActionSaisie({ id: 'uneAction', version: 'v1' }, referentiel);
@@ -30,7 +32,9 @@ describe('Une action de saisie', () => {
 
   it("connaît l'identifiant de l'action suivante", () => {
     const referentiel = Referentiel.creeReferentiel({
-      actionsSaisie: { uneAction: { position: 0 }, actionSuivante: { position: 1 } },
+      actionsSaisie: {
+        v1: { uneAction: { position: 0 }, actionSuivante: { position: 1 } },
+      },
     });
 
     const action = new ActionSaisie({ id: 'uneAction', version: 'v1' }, referentiel);
@@ -38,9 +42,7 @@ describe('Une action de saisie', () => {
   });
 
   it('connaît sa version', () => {
-    const referentiel = Referentiel.creeReferentiel({
-      actionsSaisie: { uneAction: { } },
-    });
+    const referentiel = Referentiel.creeReferentiel({ actionsSaisie: { v1: { uneAction: {} } } });
 
     const action = new ActionSaisie({ version: 'v1', id: 'uneAction' }, referentiel);
     expect(action.version).to.equal('v1');
@@ -48,7 +50,9 @@ describe('Une action de saisie', () => {
 
   it('sait se décrire comme un objet JSON', () => {
     const referentiel = Referentiel.creeReferentiel({
-      actionsSaisie: { uneAction: { position: 0, description: 'Une description' } },
+      actionsSaisie: {
+        v1: { uneAction: { position: 0, description: 'Une description' } },
+      },
     });
 
     const homologation = new Homologation({});

--- a/test/modeles/actionsSaisie.spec.js
+++ b/test/modeles/actionsSaisie.spec.js
@@ -11,15 +11,17 @@ describe("Les actions de saisie d'une homologation", () => {
   elles('retournent les infos de chaque action triée par position', () => {
     const referentiel = Referentiel.creeReferentiel({
       actionsSaisie: {
-        actionSuivante: { position: 1, description: "Description de l'action suivante" },
-        uneAction: { position: 0, description: 'Une description' },
+        v1: {
+          actionSuivante: { position: 1, description: "Description de l'action suivante" },
+          uneAction: { position: 0, description: 'Une description' },
+        },
       },
     });
 
     const homologation = new Homologation({});
     homologation.statutSaisie = () => InformationsHomologation.A_SAISIR;
 
-    const actions = new ActionsSaisie(referentiel, homologation);
+    const actions = new ActionsSaisie('v1', referentiel, homologation);
     expect(actions.toJSON()).to.eql([
       {
         id: 'uneAction',
@@ -32,5 +34,23 @@ describe("Les actions de saisie d'une homologation", () => {
         statut: InformationsHomologation.A_SAISIR,
       },
     ]);
+  });
+
+  elles('peuvent être choisies par leur version', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      actionsSaisie: {
+        v1: { uneAction: { position: 0, description: 'Une action V1' } },
+        v2: { uneAction: { position: 0, description: 'Une action V2' } },
+      },
+    });
+
+    const homologation = new Homologation({});
+    homologation.statutSaisie = () => InformationsHomologation.A_SAISIR;
+
+    const actions = new ActionsSaisie('v2', referentiel, homologation);
+
+    const [action] = actions.toJSON();
+    expect(action.id).to.equal('uneAction');
+    expect(action.description).to.equal('Une action V2');
   });
 });

--- a/test/modeles/actionsSaisie.spec.js
+++ b/test/modeles/actionsSaisie.spec.js
@@ -7,6 +7,12 @@ const InformationsHomologation = require('../../src/modeles/informationsHomologa
 
 const elles = it;
 
+function uneHomologation() {
+  const homologation = new Homologation({});
+  homologation.statutSaisie = () => InformationsHomologation.A_SAISIR;
+  return homologation;
+}
+
 describe("Les actions de saisie d'une homologation", () => {
   elles('retournent les infos de chaque action triée par position', () => {
     const referentiel = Referentiel.creeReferentiel({
@@ -18,10 +24,8 @@ describe("Les actions de saisie d'une homologation", () => {
       },
     });
 
-    const homologation = new Homologation({});
-    homologation.statutSaisie = () => InformationsHomologation.A_SAISIR;
+    const actions = new ActionsSaisie('v1', referentiel, uneHomologation());
 
-    const actions = new ActionsSaisie('v1', referentiel, homologation);
     expect(actions.toJSON()).to.eql([
       {
         id: 'uneAction',
@@ -44,10 +48,7 @@ describe("Les actions de saisie d'une homologation", () => {
       },
     });
 
-    const homologation = new Homologation({});
-    homologation.statutSaisie = () => InformationsHomologation.A_SAISIR;
-
-    const actions = new ActionsSaisie('v2', referentiel, homologation);
+    const actions = new ActionsSaisie('v2', referentiel, uneHomologation());
 
     const [action] = actions.toJSON();
     expect(action.id).to.equal('uneAction');

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -345,12 +345,22 @@ describe('Le référentiel', () => {
     });
   });
 
-  it("connaît l'action de saisie suivante d'une action de saisie donnée", () => {
+  it("retourne des actions de saisie vides si la version demandée n'existe pas", () => {
     const referentiel = Referentiel.creeReferentiel({
-      actionsSaisie: { uneAction: { position: 0 }, actionSuivante: { position: 1 } },
+      actionsSaisie: { v1: { uneAction: { position: 0 } } },
     });
 
-    expect(referentiel.actionSuivante('uneAction')).to.equal('actionSuivante');
+    expect(referentiel.actionsSaisie('vAutre')).to.eql({});
+  });
+
+  it("connaît l'action de saisie suivante d'une action de saisie donnée", () => {
+    const referentiel = Referentiel.creeReferentiel({
+      actionsSaisie: {
+        v1: { uneAction: { position: 0 }, actionSuivante: { position: 1 } },
+      },
+    });
+
+    expect(referentiel.actionSuivante('v1', 'uneAction')).to.equal('actionSuivante');
   });
 
   it("retourne `undefined` s'il n'y a pas d'action de saisie suivante", () => {


### PR DESCRIPTION
### Contexte 
 - La page « Synthèse » fait peau neuve.
 - On souhaite garder en PROD la page « Synthèse » actuelle tout en déployant la nouvelle.
 - La page actuelle sera remplacée seulement lorsque la nouvelle sera finalisée.
 - Tant qu'il n'y a pas de remplacement, les 2 pages doivent fonctionner en parallèle.

☝️ C'est ce dernier point qui motive cette PR.

### Résumé
Pour permettre la coexistence des 2 versions de « Synthèse », l'abstraction `ActionsSaisie` se voit enrichie d'une notion de `version`. 
Les `Actions` actuelles deviennent des actions `"v1"`.  
Les `Actions` de la nouvelle « Synthèse » seront des `"v2"`.

Cette PR n'apporte aucune fonctionnalité apparente. Elle ajoute simplement l'abstraction de `version` à l'existant.


### Architecture
La page actuelle utilise les `ActionsSaisie` (au pluriel) pour nourrir les liens affichés.   
L'idée est de continuer à utiliser cette abstraction d'`ActionsSaisie` sur la nouvelle mouture.  
Les actions de la nouvelle page diffèrent quelque peu : un sous-titre supplémentaire, et une possibilité d'être `indisponible` pour l'action _Homologuer_ 👇 

![image](https://user-images.githubusercontent.com/24898521/193910526-d4e32c08-a778-4330-97fe-420853f10c7e.png)

On va vouloir dans `donneesReferentiel` quelque chose qui ressemble à :

```js
actionsSaisie: {
  v1: {
    descriptionService: { position: 0, description: 'Description du service' },
    // ...les autres de la page actuelle
  },
  v2 : {
    descriptionService: { position: 0, description: 'Décrire', sousTitre: 'Présentez les ...' },
    // ...les 2 autres de la nouvelle page
 }
},
```

### Choix
`version` devient aussi important qu'`id` pour une `ActionSaisie`.  
Ça pousse à pas mal de changements de signatures du type :
```diff
-const f = (id) => ... 
+const f = (version, id) => ...
```

J'ai hésité avec un changement vers un objet `({version, id})`.

