### PR TITLE
Page synthèse de sécurité - Bloc Résumé

### DIFF
--- a/public/assets/images/vignette_drapeau_france.svg
+++ b/public/assets/images/vignette_drapeau_france.svg
@@ -1,0 +1,12 @@
+<svg width="68" height="40" viewBox="0 0 68 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4074_3530)">
+<rect width="22.6667" height="40" fill="#0052B4"/>
+<rect x="22.6641" width="22.6667" height="40" fill="#F0F0F0"/>
+<rect x="45.3359" width="22.6667" height="40" fill="#D80027"/>
+</g>
+<defs>
+<clipPath id="clip0_4074_3530">
+<rect width="68" height="40" rx="10" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/assets/styles/palette.css
+++ b/public/assets/styles/palette.css
@@ -13,8 +13,10 @@
   --texte-moyen: #929292;
   --texte-clair: #abb6bf;
 
+  --bordure-foncee: var(--texte-clair);
   --liseres: #ebedf0;
   --fond-pale: #fafbfc;
+  --fond-gris-clair: var(--liseres);
 
   --vert-anssi: #4cb963;
   --jaune-anssi: #fcdf41;

--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -75,6 +75,7 @@ header {
 }
 
 h1 {
+  margin: 2em 0 0;
   text-transform: uppercase;
   font-size: 1.5em;
 }

--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -84,3 +84,57 @@ h1 {
   font-size: 2em;
   color: var(--bleu-anssi);
 }
+
+section {
+  position: relative;
+  border: 1px solid var(--bordure-foncee);
+  border-radius: 10px;
+  margin: 3.5em 0;
+  padding: 2.4em 1.7em 1.7em;
+}
+
+section:first-of-type {
+  margin-top: 5em;
+}
+
+section > h2 {
+  position: absolute;
+  top: -1.8em;
+  background-color: var(--fond-gris-clair);
+  border-radius: 33% / 100%;
+  padding: 0.17em 0.83em 0.33em;
+  color: var(--bleu-anssi);
+}
+
+.description dl {
+  margin: 0.5em 0;
+}
+
+.description dl.presentation {
+  margin-top: 1em;
+}
+
+.description :is(dt, dd) {
+  display: inline;
+}
+
+.description dt {
+  color: var(--texte-moyen);
+}
+
+.description dd {
+  margin-left: 0.25em;
+}
+
+.description .localisation-donnees.france::before {
+  content: '';
+  display: inline-block;
+  width: 24px;
+  height: 16px;
+  background-image: url(../images/vignette_drapeau_france.svg);
+  background-repeat: no-repeat;
+  background-size: contain;
+  border-radius: 5px;
+  margin-right: 3px;
+  transform: translateY(4px);
+}

--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -81,6 +81,5 @@ h1 {
 
 .nom-service {
   font-size: 2em;
-  font-weight: bold;
   color: var(--bleu-anssi);
 }

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -19,4 +19,20 @@ block append page
       h1 Synthèse de la sécurité du service
       .nom-service!= homologation.nomService()
 
+      section.description
+        h2 Résumé
+        dl
+          dt Type :
+          dd= homologation.descriptionTypeService()
+        dl
+          dt Données stockées :
+          dd( class = `localisation-donnees ${homologation.localisationDonnees()}`)= homologation.descriptionLocalisationDonnees()
+        dl
+          dt Statut :
+          dd= homologation.descriptionStatutDeploiement()
+
+        dl.presentation
+          dt Présentation :
+          dd= homologation.presentation()
+
   script(type = 'module', src = '/statique/homologation/syntheseSecurite.js')


### PR DESCRIPTION
Dans la page de synthèse de sécurité nous ajoutons le bloc de résumé du service
<img width="1020" alt="Capture d’écran 2022-10-06 à 12 16 33" src="https://user-images.githubusercontent.com/39462397/194288247-9079d983-7bb8-4590-8c67-8dce5af8a04c.png">
