### PR TITLE
Utilisation explicite de la v1.0.0 d'Axios

### DIFF
--- a/src/routes/routesBibliotheques.js
+++ b/src/routes/routesBibliotheques.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const express = require('express');
 
 const CHEMINS_BIBLIOTHEQUES = {
-  'axios.min.js': 'https://unpkg.com/axios/dist/axios.min.js',
+  'axios-1.0.0.min.js': 'https://unpkg.com/axios@1.0.0/dist/axios.min.js',
   'chart.js': 'https://cdn.jsdelivr.net/npm/chart.js@^3',
   'chartjs-adapter-moment': 'https://cdn.jsdelivr.net/npm/chartjs-adapter-moment@^1',
   'html2canvas.min.js': 'https://unpkg.com/html2canvas/dist/html2canvas.min.js',

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -1,7 +1,7 @@
 extends ./base
 
 block page
-  script(src='/bibliotheques/axios.min.js')
+  script(src='/bibliotheques/axios-1.0.0.min.js')
   script(src='/bibliotheques/jquery-3.6.0.min.js')
 
   block styles


### PR DESCRIPTION
Axios a introduit une régression en livrant la version v1.1.0. Comme on chargeait toujours la version la plus récente, on s'est retrouvé avec une version qui ne marche pas.

(cf. https://github.com/axios/axios/issues/5038, et le patch proposé https://github.com/axios/axios/issues/5038#issuecomment-1270717223)