### PR TITLE
Pdf synthèse - graphique mesures recommandées

### DIFF
--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -162,19 +162,28 @@ section > h2 {
 .graphique {
   background-color: var(--fond-gris-clair);
   padding: 1.7em;
-  margin: 0.2em 0;
 }
 
-.regroupement-criticite .graphique {
-  height: 150px;
-  border-radius: 1em 1em 0 0;
-}
-
-.indispensables {
-  display: flex;
+.indispensables, .recommandees {
+  display: inline-flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
+
+  box-sizing: border-box;
+  width: calc(50% - 0.1em);
+  height: 210px;
+  margin-bottom: 0.2em;
+}
+
+.indispensables {
+  margin-right: 0.1em;
+  border-top-left-radius: 1em;
+}
+
+.recommandees {
+  margin-left: 0.1em;
+  border-top-right-radius: 1em;
 }
 
 .indispensables h4::after {
@@ -185,16 +194,16 @@ section > h2 {
   background-repeat: no-repeat;
   background-size: contain;
 
-  height: 1.2em;
-  width: 1.2em;
+  height: 1.1em;
+  width: 1.1em;
   margin-left: 0.5em;
-  transform: translateY(0.2em);
+  transform: translateY(0.15em);
 }
 
-.indispensables h4 {
+:is(.indispensables, .recommandees) h4 {
   width: 100%;
   margin: 0;
-  font-size: 1em;
+  font-size: 1.1em;
   color: var(--bleu-anssi);
   text-align: center;
 }

--- a/public/homologation/syntheseSecurite.js
+++ b/public/homologation/syntheseSecurite.js
@@ -3,6 +3,7 @@ import graphiqueCamembert from '../modules/graphiqueCamembert.js';
 
 $(() => {
   graphiqueCamembert('indispensables', '.indispensables');
+  graphiqueCamembert('recommandees', '.recommandees');
 
   $('#telecharger').on('click', telechargementPdf('syntheseSecurite.pdf'));
 });

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -40,6 +40,8 @@ class MesuresGenerales extends ElementsConstructibles {
       indispensablesEnCours: 0,
       misesEnOeuvre: 0,
       recommandeesFaites: 0,
+      recommandeesEnCours: 0,
+      recommandeesNonFaites: 0,
       retenues: 0,
       totalIndispensables: 0,
       totalRecommandees: 0,
@@ -64,6 +66,12 @@ class MesuresGenerales extends ElementsConstructibles {
         : 0;
 
       stats[categorie].recommandeesFaites += (fait(statut) && mesure.estRecommandee()) ? 1 : 0;
+      stats[categorie].recommandeesEnCours += (enCours(statut) && mesure.estRecommandee())
+        ? 1
+        : 0;
+      stats[categorie].recommandeesNonFaites += (nonFait(statut) && mesure.estRecommandee())
+        ? 1
+        : 0;
     });
 
     identifiantsMesuresPersonnalisees

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -65,19 +65,27 @@ class StatistiquesMesures {
     return this.donnees[idCategorie].misesEnOeuvre;
   }
 
-  nombreIndispensables() {
-    const totalIndispensablesStatut = (clefStatut) => Object
+  nombreMesuresParRecommandation(clef) {
+    const totalParStatut = (clefStatut) => Object
       .keys(this.donnees)
       .map((idCategorie) => this.donnees[idCategorie][clefStatut])
       .reduce((acc, nombre) => acc + nombre, 0);
 
-    const indispensables = {
-      fait: totalIndispensablesStatut('indispensablesFaites'),
-      nonFait: totalIndispensablesStatut('indispensablesNonFaites'),
-      enCours: totalIndispensablesStatut('indispensablesEnCours'),
+    const mesures = {
+      fait: totalParStatut(`${clef}Faites`),
+      nonFait: totalParStatut(`${clef}NonFaites`),
+      enCours: totalParStatut(`${clef}EnCours`),
     };
 
-    return indispensables;
+    return mesures;
+  }
+
+  nombreIndispensables() {
+    return this.nombreMesuresParRecommandation('indispensables');
+  }
+
+  nombreRecommandees() {
+    return this.nombreMesuresParRecommandation('recommandees');
   }
 
   retenues(idCategorie) {

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -44,25 +44,46 @@ block append page
         h3 Par niveau de criticité
         .regroupement-criticite
           - const statistiquesMesures = homologation.statistiquesMesures();
-          - const nombreTotalMesuresIndispensables = homologation.nombreTotalMesuresGeneralesIndispensables();
-          - const mesuresFaites = statistiquesMesures.nombreIndispensables().fait;
-          - const mesuresEnCours = statistiquesMesures.nombreIndispensables().enCours;
-          - const mesuresNonFaites = statistiquesMesures.nombreIndispensables().nonFait;
-          - const mesuresARemplir = nombreTotalMesuresIndispensables - mesuresFaites - mesuresEnCours - mesuresNonFaites;
-          - const mesuresRestantes = nombreTotalMesuresIndispensables - mesuresFaites;
+          - const nombreTotalMesuresGenerales = homologation.nombreTotalMesuresGenerales();
 
+          - const nombreTotalMesuresIndispensables = homologation.nombreTotalMesuresGeneralesIndispensables();
+          - const mesuresIndispensablesFaites = statistiquesMesures.nombreIndispensables().fait;
+          - const mesuresIndispensablesEnCours = statistiquesMesures.nombreIndispensables().enCours;
+          - const mesuresIndispensablesNonFaites = statistiquesMesures.nombreIndispensables().nonFait;
+          - const mesuresIndispensablesARemplir = nombreTotalMesuresIndispensables - mesuresIndispensablesFaites - mesuresIndispensablesEnCours - mesuresIndispensablesNonFaites;
+          - const mesuresIndispensablesRestantes = nombreTotalMesuresIndispensables - mesuresIndispensablesFaites;
           .graphique.indispensables(
-              data-faites = mesuresFaites,
-              data-en-cours = mesuresEnCours,
-              data-non-faites = mesuresNonFaites,
-              data-a-remplir = mesuresARemplir,
+              data-faites = mesuresIndispensablesFaites,
+              data-en-cours = mesuresIndispensablesEnCours,
+              data-non-faites = mesuresIndispensablesNonFaites,
+              data-a-remplir = mesuresIndispensablesARemplir,
             )
             h4 Indispensables
             .canvas
               canvas#indispensables
             .reste-mesures
               p Il reste
-              p.mesures-restantes #{mesuresRestantes} mesures
+              p.mesures-restantes #{mesuresIndispensablesRestantes} mesures
+              p à mettre en œuvre
+
+          - const nombreTotalMesuresRecommandees = nombreTotalMesuresGenerales - nombreTotalMesuresIndispensables;
+          - const mesuresRecommandeesFaites = statistiquesMesures.nombreRecommandees().fait;
+          - const mesuresRecommandeesEnCours = statistiquesMesures.nombreRecommandees().enCours;
+          - const mesuresRecommandeesNonFaites = statistiquesMesures.nombreRecommandees().nonFait;
+          - const mesuresRecommandeesARemplir = nombreTotalMesuresRecommandees - mesuresRecommandeesFaites - mesuresRecommandeesEnCours - mesuresRecommandeesNonFaites;
+          - const mesuresRecommandeesRestantes = nombreTotalMesuresRecommandees - mesuresRecommandeesFaites;
+          .graphique.recommandees(
+            data-faites = mesuresRecommandeesFaites,
+            data-en-cours = mesuresRecommandeesEnCours,
+            data-non-faites = mesuresRecommandeesNonFaites,
+            data-a-remplir = mesuresRecommandeesARemplir,
+          )
+            h4 Mesures recommandées
+            .canvas
+              canvas#recommandees
+            .reste-mesures
+              p Il reste
+              p.mesures-restantes #{mesuresRecommandeesRestantes} mesures
               p à mettre en œuvre
 
           .total-mesures

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -159,5 +159,19 @@ describe('La liste des mesures générales', () => {
       expect(stats.une.recommandeesFaites).to.equal(0);
       expect(stats.deux.recommandeesFaites).to.equal(1);
     });
+
+    it('calcule le nombre de mesures recommandées en cours', () => {
+      const mesuresGenerales = creeMesuresGenerales([{ id: 'id2', statut: 'enCours' }]);
+
+      const stats = mesuresGenerales.statistiques(['id2']).toJSON();
+      expect(stats.une.recommandeesEnCours).to.equal(1);
+    });
+
+    it('calcule le nombre de mesures recommandées non faites', () => {
+      const mesuresGenerales = creeMesuresGenerales([{ id: 'id2', statut: 'nonFait' }]);
+
+      const stats = mesuresGenerales.statistiques(['id2']).toJSON();
+      expect(stats.une.recommandeesNonFaites).to.equal(1);
+    });
   });
 });

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -80,6 +80,24 @@ describe('Les statistiques sur les mesures de sécurité', () => {
     expect(stats.nombreIndispensables().enCours).to.equal(3);
   });
 
+  elles('connaissent le nombre de mesures recommandées par statut', () => {
+    const donneesCategorieUne = {
+      retenues: 5,
+      misesEnOeuvre: 2,
+      recommandeesFaites: 1,
+      recommandeesNonFaites: 3,
+      recommandeesEnCours: 1,
+    };
+    const stats = new StatistiquesMesures({
+      une: donneesCategorieUne,
+      deux: { ...donneesCategorieUne, recommandeesEnCours: 2 },
+    }, referentiel);
+
+    expect(stats.nombreRecommandees().fait).to.equal(2);
+    expect(stats.nombreRecommandees().nonFait).to.equal(6);
+    expect(stats.nombreRecommandees().enCours).to.equal(3);
+  });
+
   elles("s'affichent au format JSON", () => {
     const stats = new StatistiquesMesures({
       une: { retenues: 4, misesEnOeuvre: 2 },


### PR DESCRIPTION
Dans la page de synthèse de sécurité (/:id/syntheseSecurite),
Nous souhaitons afficher un graphique représentant les mesures recommandées
![Capture d’écran 2022-10-07 à 17 42 42](https://user-images.githubusercontent.com/39462397/194594092-18f86d1d-8dbf-4295-b185-98e331214da8.png)
