### PR TITLE
Affichage du pied-de-page du PDF « synthèse sécurité »

### DIFF
--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -158,3 +158,22 @@ section > h2 {
 .total-mesures .total {
   color: var(--texte-moyen-fonce);
 }
+
+footer {
+  display: flex;
+  flex-direction: column;
+  row-gap: 2em;
+
+  margin-top: 10em;
+
+  font-size: 0.9em;
+}
+
+footer .infos-indice-cyber {
+  color: var(--texte-moyen-fonce);
+}
+
+footer .nom-mss {
+  color: var(--bleu-anssi);
+  font-weight: bold;
+}

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -46,4 +46,17 @@ block append page
               strong Total :
               span &nbsp;#{homologation.nombreTotalMesuresGenerales()} mesures proposées par l'ANSSI.
 
+    footer
+      .infos-indice-cyber.
+        * L'indice cyber est calculé à partir des mesures de sécurité mises en
+        œuvre renseignées par l'équipe par rapport à l'ensemble des mesures
+        proposées par l'ANSSI. Il fournit une évaluation indicative du niveau
+        de sécurité du service.
+
+      .nature-document
+        span.nom-mss MonServiceSécurisé – 
+        span Homologation de sécurité du service « #{homologation.nomService()} »
+
+
+
   script(type = 'module', src = '/statique/homologation/syntheseSecurite.js')


### PR DESCRIPTION
<img width="704" alt="Screenshot 2022-10-09 at 21 34 29" src="https://user-images.githubusercontent.com/105624/194776099-d6a6d88e-a38f-4522-ade9-6761d7414777.png">

(Note - il ne s'agit pas d'un pied de page à proprement parler comme on pourrait s'y attendre dans du « print »… J'ai l'impression que ça suffira pour l'instant.)