### PR TITLE
Correction - Répare l'ajout d'un contributeur

### DIFF
--- a/public/modules/interactions/saisieContributeur.js
+++ b/public/modules/interactions/saisieContributeur.js
@@ -1,15 +1,15 @@
 const brancheComportementSaisieContributeur = (selecteurAjoutContributeur) => {
   $(selecteurAjoutContributeur).on('click', (e) => {
-    const idHomologation = $(e.target).data('id-homologation');
-    $('input#idHomologation').val(idHomologation);
+    const idService = $(e.target).data('id-service');
+    $('input#idService').val(idService);
   });
 
   $('.bouton#nouveau-contributeur').on('click', (e) => {
     e.stopPropagation();
     const emailContributeur = $('input#emailContributeur').val();
-    const idHomologation = $('input#idHomologation').val();
+    const idService = $('input#idService').val();
 
-    axios.post('/api/autorisation', { emailContributeur, idHomologation })
+    axios.post('/api/autorisation', { emailContributeur, idService })
       .then(() => (window.location = '/espacePersonnel'));
   });
 };


### PR DESCRIPTION
Suite au renommage des variables homologation en service nous ne renseignons plus l'identifiant à passer pour la requête d'ajout d'un contributeur. (Une erreur 500 généré car l'autorisation entre l'utilisateur et l'id de l'homologation (non renseigné) n'était pas trouvée.) Ce commit corrige ce problème.