### PR TITLE
Correction -  Retrait import de style inexistant

### DIFF
--- a/src/vues/fragments/modaleNouveauService.pug
+++ b/src/vues/fragments/modaleNouveauService.pug
@@ -4,7 +4,6 @@ block append styles
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/formulaire.css', rel='stylesheet')
   link(href = '/statique/assets/styles/bouton.css', rel='stylesheet')
-  link(href = '/statique/assets/styles/modaleNouveauService.css', rel='stylesheet')
 
 mixin modaleNouveauService
   .rideau#modale-nouveau-service


### PR DESCRIPTION
Un mauvais import de style c'était glissé dans le code,
Il a été sorti