### PR TITLE
Affiche les mesures restantes dans le PDF de synthèse

### DIFF
--- a/public/assets/images/forme_fleche_bleue.svg
+++ b/public/assets/images/forme_fleche_bleue.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="45" viewBox="0 0 21 45" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20.5312 22.4766L0.281248 44.1272L0.28125 0.825927L20.5312 22.4766Z" fill="#0F7AC7"/>
+</svg>

--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -213,6 +213,28 @@ section > h2 {
   height: 10em;
 }
 
+.statistiques-mesures .fleche {
+  width: 1em;
+  height: 1.3em;
+
+  background-image: url(../images/forme_fleche_bleue.svg);
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+
+.statistiques-mesures .mesures-restantes {
+  padding: 1em;
+  border-radius: 0.5em;
+
+  background-color: white;
+  color: var(--texte-moyen-fonce);
+  line-height: 0.25em;
+}
+
+.statistiques-mesures .nombre-restantes {
+  color: var(--bleu-mise-en-avant);
+}
+
 .total-mesures {
   margin: 0;
   padding: 1.2em;

--- a/src/vues/fragments/statistiquesMesures.pug
+++ b/src/vues/fragments/statistiquesMesures.pug
@@ -3,7 +3,7 @@ block append scripts
   script(src='/bibliotheques/chartjs-plugin-datalabels.js')
   script(src = '/statique/scripts/statistiquesMesures.js')
 
-mixin statistiquesMesures(id, titre, styleTitre = '')
+mixin statistiquesMesures(id, nombreTotalMesuresRestantes, titre, styleTitre = '')
   .statistiques-mesures
     h4(class = styleTitre)= titre
     .details
@@ -17,6 +17,8 @@ mixin statistiquesMesures(id, titre, styleTitre = '')
           data-mesures-faites = 20,
         )
       .fleche
-        // Une image à insérer
       .mesures-restantes
         // La zone blanche à insérer
+        p Il reste
+        p.nombre-restantes #{nombreTotalMesuresRestantes} #{nombreTotalMesuresRestantes <= 1 ? `mesure`: `mesures`}
+        p à mettre en œuvre

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -55,8 +55,8 @@ block append page
 
         h3 Par niveau de criticité
         .statistiques-par-criticite
-          +statistiquesMesures('mesures-indispensables', 'Indispensables', 'important')
-          +statistiquesMesures('mesures-recommandees', 'Recommandées')
+          +statistiquesMesures('mesures-indispensables', 0, 'Indispensables', 'important')
+          +statistiquesMesures('mesures-recommandees', 2, 'Recommandées')
         .total-mesures
           .total
             strong Total :


### PR DESCRIPTION
Cette PR ajoute la flèche et l'encart blanc indiquant le nombre de mesures restantes.

![image](https://user-images.githubusercontent.com/480228/195042528-cafb73e3-2abc-44e2-b739-7b026028ed61.png)

:warning: Le nombre de mesures restantes est codé en dur pour l'exemple, pour l'instant.

Une simulation d'intégration du camembert avec un `div` factice :

![image](https://user-images.githubusercontent.com/480228/195043486-78ddc0ca-5eaa-4933-b34e-5fd3797fbfdf.png)
