### PR TITLE
Camembert – Traitement du cas où la valeur vaut `0`

### DIFF
--- a/public/scripts/statistiquesMesures.js
+++ b/public/scripts/statistiquesMesures.js
@@ -59,6 +59,7 @@ const dessineCamembert = ($canevas, {
               font: { weight: 'bold' },
               align: 'start',
               offset: [-15, -15, -15, -20],
+              formatter: (valeur) => (valeur || ''),
             },
           },
         ],


### PR DESCRIPTION
Si jamais la valeur vaut `0`, on n'affiche pas le label.