### PR TITLE
[CORRECTION] Convertis l'email en minuscules pour éviter les comptes en doublon

### DIFF
--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -223,7 +223,8 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
     middleware.aseptise('emailContributeur'),
     (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
-      const { emailContributeur, idHomologation } = requete.body;
+      const { idHomologation } = requete.body;
+      const emailContributeur = requete.body.emailContributeur?.toLowerCase();
 
       const verifiePermission = (...params) => depotDonnees.autorisationPour(...params)
         .then((a) => (

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -811,6 +811,27 @@ describe('Le serveur MSS des routes /api/*', () => {
         testeur.depotDonnees().homologation = () => Promise.resolve(homologation);
       });
 
+      describe('avec un email en majuscules', () => {
+        it('retrouve le compte et le ne recrée donc pas', (done) => {
+          testeur.depotDonnees().utilisateurAvecEmail = (emailRecherche) => {
+            const enMinuscules = 'jean.dupont@mail.fr';
+            expect(emailRecherche).to.be(enMinuscules);
+            done();
+            return Promise.resolve({ email: enMinuscules });
+          };
+
+          testeur.depotDonnees().nouvelUtilisateur = () => {
+            done("L'utilisateur ne devrait pas être re-créé");
+          };
+
+          axios.post('http://localhost:1234/api/autorisation', {
+            emailContributeur: 'Jean.DUPONT@mail.fr',
+            idHomologation: '123',
+          })
+            .catch((e) => done(e.response?.data || e));
+        });
+      });
+
       describe("si le contributeur n'a pas déjà été invité", () => {
         it('envoie un email de notification au contributeur', (done) => {
           let emailEnvoye = false;
@@ -919,6 +940,21 @@ describe('Le serveur MSS des routes /api/*', () => {
             expect(nouveauContributeurCree).to.be(true);
             done();
           })
+          .catch((e) => done(e.response?.data || e));
+      });
+
+      it('crée le compte avec un email converti en minuscules', (done) => {
+        testeur.depotDonnees().nouvelUtilisateur = (donneesUtilisateur) => {
+          const enMinuscules = 'jean.dupont@mail.fr';
+          expect(donneesUtilisateur.email).to.be(enMinuscules);
+          done();
+          return Promise.resolve(contributeurCree);
+        };
+
+        axios.post('http://localhost:1234/api/autorisation', {
+          emailContributeur: 'Jean.DUPONT@mail.fr',
+          idHomologation: '123',
+        })
           .catch((e) => done(e.response?.data || e));
       });
 


### PR DESCRIPTION
**Bug remonté en PROD :**
Si Rémi Martin crée son compte utilisateur avec son adresse mail…  
… et que Sophie Dubois invite Rémi Martin à contribuer sur un dossier qu'elle a créé avec une adresse mail où il y a des majuscules (ex. Remi.MARTIN@example.com)
…alors MSS ne reconnaît pas qu'il existe déjà un compte associé à cette adresse, crée un deuxième compte, et n'associe pas le dossier au bon compte. Rémi peut se connecter un premier coup avec ce nouveau compte (parcours de finalisation), accéder au dossier qu'on lui a partagé  
… mais ensuite il ne peut plus se connecter à ce deuxième compte et a l'impression d'avoir perdu ses données.  
En fait, non, il n'a rien perdu, c'est juste qu'il n'a pas accès à ce deuxième compte avec des majuscules.

**Explication :**
Si on invite un contributeur avec un email contenant des majuscules, la détection d'unicité de compte ne se fait pas correctement et un deuxième compte est créé par erreur.