### PR TITLE
Affiche la légende

### DIFF
--- a/public/assets/styles/palette.css
+++ b/public/assets/styles/palette.css
@@ -19,6 +19,10 @@
   --fond-pale: #fafbfc;
   --fond-gris-clair: var(--liseres);
 
+  --graphique-bleu-clair:#e4efff;
+  --graphique-bleu-moyen:#75a1e8;
+  --graphique-bleu-fonce:#0a4c8c;
+
   --vert-anssi: #4cb963;
   --jaune-anssi: #fcdf41;
   --orange-anssi: #ff9940;

--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -235,18 +235,6 @@ section > h2 {
   color: var(--bleu-mise-en-avant);
 }
 
-.total-mesures {
-  margin: 0;
-  padding: 1.2em;
-  border-radius: 0 0 1em 1em;
-
-  text-align: center;
-}
-
-.total-mesures .total {
-  color: var(--texte-moyen-fonce);
-}
-
 .score-indice-cyber {
   width: 6em;
   height: 6em;
@@ -282,10 +270,59 @@ section > h2 {
   font-weight: bold;
 }
 
-
 .indices-par-categories dd {
   color: var(--bleu-mise-en-avant);
   text-align: right;
+}
+
+.total-mesures {
+  display: flex;
+  margin: 0;
+  padding: 1.2em 2em;
+  border-radius: 0 0 1em 1em;
+}
+
+.total, .legende {
+  flex: 1;
+}
+
+.total-mesures .total {
+  color: var(--texte-moyen-fonce);
+}
+
+.total-mesures .legende {
+  display: flex;
+  justify-content: flex-end;
+  column-gap: 1em;
+}
+
+.legende > *::before {
+  content: '';
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: solid 1px var(--gris-inactif);
+  border-radius: 2px;
+  margin-right: 0.5em;
+  transform: translateY(2px);
+}
+
+.legende-faites::before {
+  background: var(--graphique-bleu-fonce);
+  border-color: var(--graphique-bleu-fonce);
+}
+
+.legende-en-cours::before {
+  background: var(--graphique-bleu-moyen);
+  border-color: var(--graphique-bleu-moyen);
+}
+
+.legende-non-faites::before {
+  background: var(--graphique-bleu-clair);
+}
+
+.legende-a-remplir::before{
+  background: #fff;
 }
 
 footer {

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -70,6 +70,11 @@ block append page
           .total
             strong Total :
             span &nbsp;#{homologation.nombreTotalMesuresGenerales()} mesures proposées par l'ANSSI.
+          .legende
+            .legende-faites Faites
+            .legende-en-cours En cours
+            .legende-non-faites Non faites
+            .legende-a-remplir À remplir
 
     footer
       .infos-indice-cyber.
@@ -81,7 +86,5 @@ block append page
       .nature-document
         span.nom-mss MonServiceSécurisé – 
         span Homologation de sécurité du service « #{homologation.nomService()} »
-
-
 
   script(type = 'module', src = '/statique/homologation/syntheseSecurite.js')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24898521/195188933-bcf7b8b4-b64f-468f-9952-91e0f2916123.png)

Cette PR ajoute la légende sous les camemberts.

On note qu'en version PDF imprimable, le *gap* entre chaque élément de légende est agrandi… mais la légende continue de tenir en une ligne.

![image](https://user-images.githubusercontent.com/24898521/195189150-71c41191-9b87-47f2-8e6b-39b0ac749ac1.png)
