### PR TITLE
Retrait de « etc. »

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -150,7 +150,7 @@ module.exports = {
     },
     banque: {
       description: 'Données de paiement',
-      exemple: 'nº de carte bancaire, etc.',
+      exemple: 'nº de carte bancaire.',
       seuilCriticite: 'critique',
     },
     mineurs: {


### PR DESCRIPTION
C'est la seule donnée pour laquelle il y avait « etc. » après un exemple.