### PR TITLE
Libellé du lien vers la page d'inscription

### DIFF
--- a/src/vues/index.pug
+++ b/src/vues/index.pug
@@ -15,5 +15,5 @@ block main
         à sécuriser et à homologuer rapidement leurs sites web, applications mobiles et API.
       nav
         a.bouton(href = '/inscription').
-          Sécuriser un service numérique
+          S'inscrire
     .image-intro-mss


### PR DESCRIPTION
Dans la page d'accueil,
Le bouton renvoyant vers la page d'inscription reprend son ancien libellé **S'inscrire**
<img width="897" alt="Capture d’écran 2022-10-12 à 14 31 54" src="https://user-images.githubusercontent.com/39462397/195343522-1f4ad609-09dd-46bb-b11e-dbf07e083c81.png">
