### PR TITLE
Troncature du titre du service si nécessaire

### DIFF
--- a/public/assets/styles/homologation/synthese.css
+++ b/public/assets/styles/homologation/synthese.css
@@ -10,6 +10,16 @@
   margin-bottom: 1em;
 }
 
+.titre-service {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.tableau-bord .bouton {
+  flex-shrink: 0;
+}
+
 .actions {
   display: flex;
   column-gap: 1.5em;

--- a/src/vues/homologation/synthese.pug
+++ b/src/vues/homologation/synthese.pug
@@ -25,8 +25,7 @@ block retour
 block zone-principale
   .details-service
     .tableau-bord
-      .titre-service
-        h1!= service.nomService()
+      h1.titre-service!= service.nomService()
       a.bouton(href = `/homologation/${service.id}/syntheseSecurite`) Télécharger la synthèse
 
     .actions


### PR DESCRIPTION
Cette PR affiche le titre tronqué suivi de `…` lorsqu'il est trop long.

**Sans** la PR :
![image](https://user-images.githubusercontent.com/24898521/195553058-2d5594dc-313c-40e8-81b5-33f0231c57bb.png)


**Avec** la PR :
![image](https://user-images.githubusercontent.com/24898521/195553217-62bece2d-41c4-4b49-aafc-5e3f1a56e598.png)

Pour rappel, un titre qui n'a pas besoin de troncature s'affiche comme suit (avec et sans la PR) :
![image](https://user-images.githubusercontent.com/24898521/195554066-039234b1-89b5-4c8a-baf3-8dc03260c221.png)

Le PDF n'est pas soumis à la troncature. J'ai trouvé l'affichage satisfaisant sans l'appliquer :
![image](https://user-images.githubusercontent.com/24898521/195554404-f04b1400-1f6f-4f4c-9bdf-e5d444e3c0ec.png)

Aucune troncature non plus dans le pied de page du PDF, qui mentionne le nom du service :
![image](https://user-images.githubusercontent.com/24898521/195560334-b7c1ac21-dfe0-4354-862c-43d635475e9e.png)


Si vous pensez qu'il faut soumettre la question à l'équipe d'UX, faites-moi signe.