### PR TITLE
Affichage des mesures par catégorie sur le PDF

### DIFF
--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -158,7 +158,7 @@ section > h2 {
   margin-bottom: 2px;
 }
 
-.statistiques-mesures, .total-mesures {
+.statistiques-mesures, .total-mesures, .statistiques-par-categorie {
   background-color: var(--fond-gris-clair);
 }
 
@@ -180,7 +180,7 @@ section > h2 {
   border-top-right-radius: 1em;
 }
 
-.statistiques-mesures h4 {
+:is(.statistiques-mesures, .statistiques-par-categorie) h4 {
   margin: 0;
 
   color: var(--bleu-anssi);
@@ -342,4 +342,58 @@ footer .infos-indice-cyber {
 footer .nom-mss {
   color: var(--bleu-anssi);
   font-weight: bold;
+}
+
+.statistiques-par-categorie {
+  display: flex;
+  column-gap: 2em;
+  padding: 1.8em;
+  margin-bottom: 2px;
+
+  border-radius: 1em 1em 0 0;
+}
+
+.categorie {
+  width: 100%;
+}
+
+.graphique {
+  display: flex;
+}
+
+.graphique .statut {
+  padding: 0.8em;
+  flex-grow: 1;
+  margin-top: 1em;
+  text-align: center;
+}
+
+.graphique .statut:first-of-type {
+  border-top-left-radius: 0.5em;
+  border-bottom-left-radius: 0.5em;
+}
+
+.graphique .statut:last-of-type {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
+}
+
+.graphique .faites {
+  background-color: var(--graphique-bleu-fonce);
+  color: #fff;
+}
+
+.graphique .en-cours {
+  background-color: var(--graphique-bleu-moyen);
+  color: #fff;
+}
+
+.graphique .non-faites {
+  background-color: var(--graphique-bleu-clair);
+  color: var(--graphique-bleu-fonce);
+}
+
+.graphique .a-remplir {
+  background-color: #fff;
+  color: var(--graphique-bleu-fonce);
 }

--- a/public/homologation/syntheseSecurite.js
+++ b/public/homologation/syntheseSecurite.js
@@ -1,5 +1,12 @@
 import telechargementPdf from '../modules/interactions/telechargementPdf.js';
 
+const brancheDimensionnementStatuts = () => {
+  $('.statistiques-par-categorie .statut')
+    .each((_, statut) => $(statut).css('flex', $(statut).text()));
+};
+
 $(() => {
   $('#telecharger').on('click', telechargementPdf('syntheseSecurite.pdf'));
+
+  brancheDimensionnementStatuts();
 });

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -38,8 +38,22 @@ class StatistiquesMesures {
     this.referentiel = referentiel;
   }
 
+  aRemplir(idCategorie) {
+    const total = this.donnees[idCategorie].indispensables.total
+      + this.donnees[idCategorie].recommandees.total;
+    return total
+      - this.misesEnOeuvre(idCategorie)
+      - this.enCours(idCategorie)
+      - this.nonFaites(idCategorie);
+  }
+
   categories() {
     return categories(this.donnees);
+  }
+
+  enCours(idCategorie) {
+    const stats = this.donnees[idCategorie];
+    return stats.retenues - stats.misesEnOeuvre;
   }
 
   filtreesParType(type) {
@@ -81,6 +95,11 @@ class StatistiquesMesures {
 
   misesEnOeuvre(idCategorie) {
     return this.donnees[idCategorie].misesEnOeuvre;
+  }
+
+  nonFaites(idCategorie) {
+    const stats = this.donnees[idCategorie];
+    return stats.indispensables.nonFait + stats.recommandees.nonFait;
   }
 
   recommandees() {

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -4,6 +4,17 @@ include ../fragments/scoreIndiceCyber
 include ../fragments/indicesCyberParCategorie
 include ../fragments/descriptionIndiceCyber
 
+mixin totalMesures(nombreTotalMesuresGenerales)
+  .total-mesures
+    .total
+      strong Total :
+      span &nbsp;#{nombreTotalMesuresGenerales} mesures proposées par l'ANSSI.
+    .legende
+      .legende-faites Faites
+      .legende-en-cours En cours
+      .legende-non-faites Non faites
+      .legende-a-remplir À remplir
+
 block append styles
   link(href='/statique/assets/styles/syntheseSecurite.css', rel='stylesheet')
 
@@ -67,15 +78,20 @@ block append page
             titre: 'Recommandées',
             statistiques: homologation.statistiquesMesuresRecommandees(),
           })
-        .total-mesures
-          .total
-            strong Total :
-            span &nbsp;#{homologation.nombreTotalMesuresGenerales()} mesures proposées par l'ANSSI.
-          .legende
-            .legende-faites Faites
-            .legende-en-cours En cours
-            .legende-non-faites Non faites
-            .legende-a-remplir À remplir
+        +totalMesures(homologation.nombreTotalMesuresGenerales())
+
+        h3 Par catégorie
+        .statistiques-par-categorie
+          - var categories = ['Gouvernance', 'Protection', 'Défense', 'Résilience']
+            each categorie in categories
+              .categorie
+                h4= categorie
+                .graphique
+                  .statut.faites 2
+                  .statut.en-cours 2
+                  .statut.non-faites 4
+                  .statut.a-remplir 3
+        +totalMesures(homologation.nombreTotalMesuresGenerales())
 
     footer
       .infos-indice-cyber

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -91,10 +91,14 @@ block append page
             .categorie
               h4= referentiel.descriptionCategorie(idCategorie)
               .graphique
-                .statut.faites= faites(idCategorie)
-                .statut.en-cours= enCours(idCategorie)
-                .statut.non-faites= nonFaites(idCategorie)
-                .statut.a-remplir= aRemplir(idCategorie)
+                if faites(idCategorie)
+                  .statut.faites= faites(idCategorie)
+                if enCours(idCategorie)
+                  .statut.en-cours= enCours(idCategorie)
+                if nonFaites(idCategorie)
+                  .statut.non-faites= nonFaites(idCategorie)
+                if aRemplir(idCategorie)
+                  .statut.a-remplir= aRemplir(idCategorie)
         +totalMesures(homologation.nombreTotalMesuresGenerales())
 
     footer

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -82,15 +82,19 @@ block append page
 
         h3 Par catégorie
         .statistiques-par-categorie
-          - var categories = ['Gouvernance', 'Protection', 'Défense', 'Résilience']
-            each categorie in categories
-              .categorie
-                h4= categorie
-                .graphique
-                  .statut.faites 2
-                  .statut.en-cours 2
-                  .statut.non-faites 4
-                  .statut.a-remplir 3
+          - const faites = (idCategorie) => homologation.statistiquesMesures().misesEnOeuvre(idCategorie)
+          - const enCours = (idCategorie) => homologation.statistiquesMesures().enCours(idCategorie)
+          - const nonFaites = (idCategorie) => homologation.statistiquesMesures().nonFaites(idCategorie)
+          - const aRemplir = (idCategorie) => homologation.statistiquesMesures().aRemplir(idCategorie)
+
+          each idCategorie in homologation.statistiquesMesures().categories()
+            .categorie
+              h4= referentiel.descriptionCategorie(idCategorie)
+              .graphique
+                .statut.faites= faites(idCategorie)
+                .statut.en-cours= enCours(idCategorie)
+                .statut.non-faites= nonFaites(idCategorie)
+                .statut.a-remplir= aRemplir(idCategorie)
         +totalMesures(homologation.nombreTotalMesuresGenerales())
 
     footer

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -62,6 +62,41 @@ describe('Les statistiques sur les mesures de sécurité', () => {
     expect(stats.misesEnOeuvre('une')).to.equal(2);
   });
 
+  elles('connaissent les mesures en cours pour une catégorie', () => {
+    const stats = new StatistiquesMesures({
+      une: { retenues: 5, misesEnOeuvre: 2 },
+    }, referentiel);
+    expect(stats.enCours('une')).to.equal(5 - 2);
+  });
+
+  elles('connaissent les mesures non faites pour une catégorie', () => {
+    const stats = new StatistiquesMesures({
+      une: {
+        misesEnOeuvre: 3,
+        retenues: 9,
+        indispensables: { total: 4, nonFait: 2 },
+        recommandees: { total: 5, nonFait: 1 },
+      },
+    }, referentiel);
+
+    expect(stats.nonFaites('une')).to.equal(2 + 1);
+  });
+
+  elles('connaissent les mesures à remplir pour une catégorie', () => {
+    const stats = new StatistiquesMesures({
+      une: {
+        misesEnOeuvre: 3,
+        retenues: 9,
+        indispensables: { total: 8, fait: 2, enCours: 3, nonFait: 1 },
+        recommandees: { total: 10, fait: 1, enCours: 3, nonFait: 1 },
+      },
+    }, referentiel);
+
+    const mesuresIndispensableARemplir = 8 - 2 - 3 - 1;
+    const mesuresRecommandeesARemplir = 10 - 1 - 3 - 1;
+    expect(stats.aRemplir('une')).to.equal(mesuresIndispensableARemplir + mesuresRecommandeesARemplir);
+  });
+
   elles("s'affichent au format JSON", () => {
     const stats = new StatistiquesMesures({
       une: { retenues: 4, misesEnOeuvre: 2 },


### PR DESCRIPTION
Cette PR ajoute les segments de mesure par catégorie :

![image](https://user-images.githubusercontent.com/24898521/195632127-96c07fa1-491c-4279-9a82-f3b3746bf78d.png)

L'impression PDF fonctionne :

![image](https://user-images.githubusercontent.com/24898521/195632633-6f119831-37a4-4545-bc17-95eb4182cfde.png)

Un exemple qui offre davantage de couleurs :
![image](https://user-images.githubusercontent.com/24898521/195633660-fa290ae1-733f-4a9a-ad74-94d501d2442b.png)


### Choix délibérés
 - On dimensionne les segments avec des `flex` dont la valeur est le nombre de mesures.
   - 24 mesures faites donne `flex: 24`.
 - Les statistiques sont calculées dans les statistiques des mesures.