### PR TITLE
Nombre de mesures spécifiques dans le Pdf de synthèse

### DIFF
--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -363,7 +363,6 @@ footer .nom-mss {
 
 .graphique .statut {
   padding: 0.8em;
-  flex-grow: 1;
   margin-top: 1em;
   text-align: center;
 }

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -106,6 +106,10 @@ class Homologation {
 
   mesuresSpecifiques() { return this.mesures.mesuresSpecifiques; }
 
+  nombreMesuresSpecifiques() {
+    return this.mesures.nombreMesuresSpecifiques();
+  }
+
   nombreTotalMesuresGenerales() {
     return this.mesures.nombreTotalMesuresGenerales();
   }

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -20,6 +20,10 @@ class Mesures extends InformationsHomologation {
     return this.statistiques().indiceCyber();
   }
 
+  nombreMesuresSpecifiques() {
+    return this.mesuresSpecifiques.nombre();
+  }
+
   nombreTotalMesuresGenerales() {
     return this.identifiantsMesures.length;
   }

--- a/src/vues/fragments/totalMesures.pug
+++ b/src/vues/fragments/totalMesures.pug
@@ -1,0 +1,15 @@
+mixin totalMesures(totalMesuresGenerales, totalMesuresSpecifiques)
+  .total-mesures
+    .total
+      strong Total :
+      span.
+        &nbsp;#{totalMesuresGenerales} #{totalMesuresGenerales <= 1 ? `mesure proposée`: `mesures proposées`} par l'ANSSI
+      if totalMesuresSpecifiques
+        span &nbsp;+ #{totalMesuresSpecifiques} #{totalMesuresSpecifiques <= 1 ? `ajoutée`: `ajoutées`} par l'équipe.
+      else
+        span .
+    .legende
+      .legende-faites Faites
+      .legende-en-cours En cours
+      .legende-non-faites Non faites
+      .legende-a-remplir À remplir

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -1,19 +1,9 @@
 extends ../documentImprimable
-include ../fragments/statistiquesMesures
-include ../fragments/scoreIndiceCyber
-include ../fragments/indicesCyberParCategorie
 include ../fragments/descriptionIndiceCyber
-
-mixin totalMesures(nombreTotalMesuresGenerales)
-  .total-mesures
-    .total
-      strong Total :
-      span &nbsp;#{nombreTotalMesuresGenerales} mesures proposées par l'ANSSI.
-    .legende
-      .legende-faites Faites
-      .legende-en-cours En cours
-      .legende-non-faites Non faites
-      .legende-a-remplir À remplir
+include ../fragments/indicesCyberParCategorie
+include ../fragments/scoreIndiceCyber
+include ../fragments/statistiquesMesures
+include ../fragments/totalMesures
 
 block append styles
   link(href='/statique/assets/styles/syntheseSecurite.css', rel='stylesheet')
@@ -99,7 +89,7 @@ block append page
                   .statut.non-faites= nonFaites(idCategorie)
                 if aRemplir(idCategorie)
                   .statut.a-remplir= aRemplir(idCategorie)
-        +totalMesures(homologation.nombreTotalMesuresGenerales())
+        +totalMesures(homologation.nombreTotalMesuresGenerales(), 8)
 
     footer
       .infos-indice-cyber

--- a/src/vues/homologation/syntheseSecurite.pug
+++ b/src/vues/homologation/syntheseSecurite.pug
@@ -89,7 +89,7 @@ block append page
                   .statut.non-faites= nonFaites(idCategorie)
                 if aRemplir(idCategorie)
                   .statut.a-remplir= aRemplir(idCategorie)
-        +totalMesures(homologation.nombreTotalMesuresGenerales(), 8)
+        +totalMesures(homologation.nombreTotalMesuresGenerales(), homologation.nombreMesuresSpecifiques())
 
     footer
       .infos-indice-cyber

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -272,6 +272,13 @@ describe('Une homologation', () => {
     expect(statistiquesMesuresAppelees).to.be(true);
   });
 
+  it('délègue aux mesures le calcul du nombre de mesures spécifiques', () => {
+    const homologation = new Homologation({ mesuresGenerales: [] });
+    homologation.mesures.nombreMesuresSpecifiques = () => 42;
+
+    expect(homologation.nombreMesuresSpecifiques()).to.equal(42);
+  });
+
   it('sait décrire le statut de déploiement', () => {
     const referentiel = Referentiel.creeReferentiel({
       statutsDeploiement: {

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -75,4 +75,12 @@ describe('Les mesures liées à une homologation', () => {
 
     expect(mesures.nombreTotalMesuresGenerales()).to.equal(2);
   });
+
+  elles('connaissent le nombre de mesures spécifiques', () => {
+    const mesures = new Mesures({
+      mesuresSpecifiques: [{ description: 'Une mesure spécifique', modalites: 'Des modalités' }],
+    });
+
+    expect(mesures.nombreMesuresSpecifiques()).to.equal(1);
+  });
 });

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -11,7 +11,7 @@ describe('La liste des mesures spécifiques', () => {
     expect(mesures.nombre()).to.equal(0);
   });
 
-  elle('est composée de risques spécifiques', () => {
+  elle('est composée de mesures spécifiques', () => {
     const mesures = new MesuresSpecifiques({ mesuresSpecifiques: [
       { description: 'Une mesure spécifique', modalites: 'Des modalités' },
     ] });


### PR DESCRIPTION
Dans la page de synthèse de sécurité,
nous souhaitons voir apparaitre le nombre de mesures ajoutés par l'utilisateur (mesures spécifiques)
<img width="1028" alt="Capture d’écran 2022-10-14 à 10 37 01" src="https://user-images.githubusercontent.com/39462397/195802679-38c329c0-7e16-4a30-aef7-abb9896cac2c.png">
