### PR TITLE
Espace la fin du titre et le bouton de téléchargement

### DIFF
--- a/public/assets/styles/homologation/synthese.css
+++ b/public/assets/styles/homologation/synthese.css
@@ -4,8 +4,8 @@
 
 .tableau-bord {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  column-gap: 1em;
 
   margin-bottom: 1em;
 }


### PR DESCRIPTION
Suite à notre livraison de la troncature, on nous a demandé d'espacer un peu les "…" et le bouton.

#### Sans la PR

![image](https://user-images.githubusercontent.com/24898521/195859961-f6f3d8e0-8bf8-47f3-bddf-cdfb193552fe.png)


#### Avec la PR

![image](https://user-images.githubusercontent.com/24898521/195859996-f5b409ec-b744-4a9f-868a-c21e9abfc73a.png)
