### PR TITLE
L'annexe avec les mesures en cours

### DIFF
--- a/public/assets/images/forme_point_bleu.svg
+++ b/public/assets/images/forme_point_bleu.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 16C12.2727 16 16 12.4138 16 8C16 3.67816 12.2727 0 8 0C3.54545 0 0 3.67816 0 8C0 12.4138 3.54545 16 8 16Z" fill="#0F7AC7"/>
+</svg>

--- a/public/assets/styles/annexes/mesures.css
+++ b/public/assets/styles/annexes/mesures.css
@@ -35,3 +35,52 @@
   background-repeat: no-repeat;
   background-size: contain;
 }
+
+.mesures-par-statut h3 {
+  display: inline-block;
+
+  margin-bottom: 0;
+  padding: 0.3em 0.8em;
+
+  border-radius: 0.4em;
+  background-color: var(--pdf-bleu-clair);
+
+  color: var(--bleu-anssi);
+  text-transform: uppercase;
+}
+
+.mesures-par-statut ul {
+  padding: 0;
+
+  line-height: 2em;
+}
+
+.mesures-par-statut li {
+  list-style-type: none;
+}
+
+.mesures-par-statut li::before {
+  content: '';
+  display: inline-block;
+
+  width: 1.4em;
+  margin-right: 1em;
+
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
+}
+
+.mesures-par-statut li:not(.indispensable)::before {
+  height: 0.6em;
+
+  background-image: url(../../images/forme_point_bleu.svg);
+}
+
+.mesures-par-statut li.indispensable::before {
+  height: 1.4em;
+  margin-left: 0;
+
+  background-image: url(../../images/icone_etoile_orange.svg);
+  transform: translateY(0.2em);
+}

--- a/public/assets/styles/palette.css
+++ b/public/assets/styles/palette.css
@@ -19,7 +19,8 @@
   --fond-pale: #fafbfc;
   --fond-gris-clair: var(--liseres);
 
-  --graphique-bleu-clair:#e4efff;
+  --pdf-bleu-clair: #e4efff;
+
   --graphique-bleu-moyen:#75a1e8;
   --graphique-bleu-fonce:#0a4c8c;
 

--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -301,7 +301,7 @@ h1 {
 }
 
 .legende-non-faites::before {
-  background: var(--graphique-bleu-clair);
+  background: var(--pdf-bleu-clair);
 }
 
 .legende-a-remplir::before{
@@ -371,7 +371,7 @@ footer .nom-mss {
 }
 
 .graphique .non-faites {
-  background-color: var(--graphique-bleu-clair);
+  background-color: var(--pdf-bleu-clair);
   color: var(--graphique-bleu-fonce);
 }
 

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -108,6 +108,10 @@ class Homologation {
     return this.descriptionService.localisationDonnees;
   }
 
+  mesuresParStatut() {
+    return this.mesures.parStatut();
+  }
+
   mesuresSpecifiques() { return this.mesures.mesuresSpecifiques; }
 
   nombreMesuresSpecifiques() {

--- a/src/modeles/mesure.js
+++ b/src/modeles/mesure.js
@@ -24,6 +24,13 @@ class Mesure extends InformationsHomologation {
 
   static statutsPossibles() { return Object.values(STATUTS); }
 
+  static statutRenseigne(statut) {
+    return Object.keys(STATUTS)
+      .filter((clef) => clef !== 'STATUT_NON_RETENU')
+      .map((clef) => STATUTS[clef])
+      .includes(statut);
+  }
+
   static valide({ statut }) {
     if (statut && !this.statutsPossibles().includes(statut)) {
       throw new ErreurStatutMesureInvalide(`Le statut "${statut}" est invalide`);

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -35,6 +35,10 @@ class MesureGenerale extends Mesure {
     return this.statut === Mesure.STATUT_NON_RETENU;
   }
 
+  statutRenseigne() {
+    return Mesure.statutRenseigne(this.statut);
+  }
+
   static valide({ id, statut }, referentiel) {
     super.valide({ statut }, referentiel);
 

--- a/src/modeles/mesureSpecifique.js
+++ b/src/modeles/mesureSpecifique.js
@@ -19,6 +19,10 @@ class MesureSpecifique extends Mesure {
     return this.description;
   }
 
+  statutRenseigne() {
+    return Mesure.statutRenseigne(this.statut);
+  }
+
   static valide({ categorie, statut }, referentiel) {
     super.valide({ statut });
 

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -40,6 +40,11 @@ class Mesures extends InformationsHomologation {
     return this.mesuresGenerales.nonSaisies();
   }
 
+  parStatut() {
+    const mesuresGeneralesParStatut = this.mesuresGenerales.parStatut();
+    return this.mesuresSpecifiques.parStatut(mesuresGeneralesParStatut);
+  }
+
   proportion(...params) {
     return this.mesuresGenerales.proportion(...params);
   }

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -12,6 +12,22 @@ class MesuresGenerales extends ElementsConstructibles {
     return this.nombre() === 0;
   }
 
+  parStatut() {
+    let mesuresParStatut = { fait: {}, enCours: {}, nonFait: {} };
+    mesuresParStatut = this.toutes()
+      .filter((mesure) => mesure.statutRenseigne())
+      .reduce((acc, mesure) => {
+        const mesureReference = this.referentiel.mesure(mesure.id);
+        acc[mesure.statut][mesureReference.categorie] ||= [];
+        acc[mesure.statut][mesureReference.categorie].push({
+          description: mesure.descriptionMesure(),
+          indispensable: mesure.estIndispensable(),
+        });
+        return acc;
+      }, mesuresParStatut);
+    return mesuresParStatut;
+  }
+
   proportion(nbMisesEnOeuvre, idsMesures) {
     const identifiantsMesuresNonRetenues = () => this.items
       .filter((m) => m.nonRetenue())

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -7,6 +7,16 @@ class MesuresSpecifiques extends ElementsConstructibles {
     const { mesuresSpecifiques } = donnees;
     super(MesureSpecifique, { items: mesuresSpecifiques }, referentiel);
   }
+
+  parStatut(accumulateur = { fait: {}, enCours: {}, nonFait: {} }) {
+    return this.toutes().reduce((acc, mesure) => {
+      acc[mesure.statut][mesure.categorie] ||= [];
+      acc[mesure.statut][mesure.categorie].push({
+        description: mesure.descriptionMesure(),
+      });
+      return acc;
+    }, accumulateur);
+  }
 }
 
 module.exports = MesuresSpecifiques;

--- a/src/vues/homologation/annexes/mesures.pug
+++ b/src/vues/homologation/annexes/mesures.pug
@@ -11,7 +11,13 @@ block append page
       h1 Mesures de sécurité détaillées
       .sous-titre.
         Toutes les mesures indispensables #[.icone-etoile], recommandées et créées sont classées selon leur statut de mise en œuvre et par catégorie.
-    section
+    section.mesures-par-statut
       h2 En cours
+      - const mesuresEnCours = homologation.mesuresParStatut().enCours
+      each mesures, categorie in mesuresEnCours
+        h3= categorie
+        ul
+          each mesure in mesures
+            li(class = mesure.indispensable ? 'indispensable' : '')= mesure.description
 
   script(type = 'module', src = '/statique/homologation/annexes/mesures.js')

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -279,6 +279,13 @@ describe('Une homologation', () => {
     expect(homologation.nombreMesuresSpecifiques()).to.equal(42);
   });
 
+  it('délègue aux mesures la récupération des mesures par statut et par catégorie', () => {
+    const homologation = new Homologation({ mesuresGenerales: [{ id: 'mesure1', statut: 'enCours' }] });
+    homologation.mesures.parStatut = () => ({ unStatut: {} });
+
+    expect(homologation.mesuresParStatut()).to.eql({ unStatut: {} });
+  });
+
   it('sait décrire le statut de déploiement', () => {
     const referentiel = Referentiel.creeReferentiel({
       statutsDeploiement: {

--- a/test/modeles/mesure.spec.js
+++ b/test/modeles/mesure.spec.js
@@ -17,4 +17,18 @@ describe('Une mesure', () => {
       done("La validation de la mesure sans statut n'aurait pas dû lever d'exception.");
     }
   });
+
+  describe('sur une interrogation de statut renseigné', () => {
+    elle('répond favorablement quand le statut est dans les statuts concernés', () => {
+      expect(Mesure.statutRenseigne('fait')).to.be(true);
+    });
+
+    elle('répond défavorablement quand le statut est non retenu', () => {
+      expect(Mesure.statutRenseigne('nonRetenu')).to.be(false);
+    });
+
+    elle("répond défavorablement quand le statut n'est pas renseigné", () => {
+      expect(Mesure.statutRenseigne()).to.be(false);
+    });
+  });
 });

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -86,4 +86,9 @@ describe('Une mesure de sécurité', () => {
     const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait' }, referentiel, mesureRendueIndispensable);
     expect(mesure.estIndispensable()).to.be(true);
   });
+
+  it('sait si son statut est renseigné', () => {
+    const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait' }, referentiel);
+    expect(mesure.statutRenseigne()).to.be(true);
+  });
 });

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -76,4 +76,9 @@ describe('Une mesure spécifique', () => {
     const mesure = new MesureSpecifique();
     expect(mesure.estRecommandee()).to.be(false);
   });
+
+  elle('sait si son statut est renseigné', () => {
+    const mesure = new MesureSpecifique({ statut: 'fait' });
+    expect(mesure.statutRenseigne()).to.be(true);
+  });
 });

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -1,6 +1,7 @@
 const expect = require('expect.js');
 
 const MesuresGenerales = require('../../src/modeles/mesuresGenerales');
+const Referentiel = require('../../src/referentiel');
 
 const { A_SAISIR, COMPLETES, A_COMPLETER } = MesuresGenerales;
 
@@ -167,6 +168,44 @@ describe('La liste des mesures générales', () => {
       const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.une.recommandees.fait).to.equal(0);
       expect(stats.deux.recommandees.fait).to.equal(1);
+    });
+  });
+
+  describe('sur une demande de mesures par statut', () => {
+    beforeEach(() => {
+      referentiel = Referentiel.creeReferentiel({
+        mesures: {
+          mesure1: {
+            description: 'Mesure une',
+            categorie: 'categorie1',
+            indispensable: true,
+          },
+        },
+      });
+    });
+
+    it('regroupe par statut les mesures', () => {
+      const mesures = new MesuresGenerales({ mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] }, referentiel);
+
+      expect(mesures.parStatut().fait).to.be.ok();
+    });
+
+    it('regroupe par catégorie les mesures', () => {
+      const mesures = new MesuresGenerales({ mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] }, referentiel);
+
+      expect(mesures.parStatut().fait.categorie1.length).to.equal(1);
+    });
+
+    it("ajoute l'importance de la mesure", () => {
+      const mesures = new MesuresGenerales({ mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] }, referentiel);
+
+      expect(mesures.parStatut().fait.categorie1[0].indispensable).to.be(true);
+    });
+
+    it('ajoute la description de la mesure', () => {
+      const mesures = new MesuresGenerales({ mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] }, referentiel);
+
+      expect(mesures.parStatut().fait.categorie1[0].description).to.equal('Mesure une');
     });
   });
 });

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -2,10 +2,17 @@ const expect = require('expect.js');
 
 const MesureSpecifique = require('../../src/modeles/mesureSpecifique');
 const MesuresSpecifiques = require('../../src/modeles/mesuresSpecifiques');
+const Referentiel = require('../../src/referentiel');
 
 const elle = it;
 
 describe('La liste des mesures spécifiques', () => {
+  let referentiel;
+  beforeEach(() => {
+    referentiel = Referentiel.creeReferentielVide();
+    referentiel.identifiantsCategoriesMesures = () => ['categorie1'];
+  });
+
   elle('sait se dénombrer', () => {
     const mesures = new MesuresSpecifiques({ mesuresSpecifiques: [] });
     expect(mesures.nombre()).to.equal(0);
@@ -17,5 +24,27 @@ describe('La liste des mesures spécifiques', () => {
     ] });
 
     expect(mesures.item(0)).to.be.a(MesureSpecifique);
+  });
+
+  elle('peut être triée par statut', () => {
+    const mesures = new MesuresSpecifiques({
+      mesuresSpecifiques: [{ description: 'Mesure Spécifique 1', statut: 'fait', categorie: 'categorie1' }],
+    },
+    referentiel);
+
+    expect(mesures.parStatut().fait.categorie1.length).to.equal(1);
+    expect(mesures.parStatut().fait.categorie1[0].description).to.equal('Mesure Spécifique 1');
+  });
+
+  elle('peut être triée par statut en utilisant un accumulateur personnalisé', () => {
+    const mesures = new MesuresSpecifiques({
+      mesuresSpecifiques: [{ description: 'Mesure Spécifique 1', statut: 'fait', categorie: 'categorie1' }],
+    },
+    referentiel);
+
+    const mesuresParStatut = mesures.parStatut({ fait: { categorie1: [{ description: 'Mesure une', indispensable: true }] }, enCours: {}, nonFait: {} });
+    expect(mesuresParStatut.fait.categorie1.length).to.equal(2);
+    expect(mesuresParStatut.fait.categorie1[0].description).to.equal('Mesure une');
+    expect(mesuresParStatut.fait.categorie1[1].description).to.equal('Mesure Spécifique 1');
   });
 });


### PR DESCRIPTION
dans l'objectif de réaliser une annexe avec les mesures,
J'ai ajouté les mesures en cours à la page `/:id/syntheseSecurite/annexes/mesures`

- Il n'y a pas de saut de page
- Les modalités (commentaires) des mesures n'est pas affiché
- La capture des données inclue les mesures faites et non faites pour un affichage futur

NOTE : les mesures spécifiques sont présentes