### PR TITLE
La règle "sauvegarde des données" est rendue indispensable pour le profil MSS+

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -605,7 +605,6 @@ module.exports = {
     sauvegardeDonnees: {
       description: 'Mettre en place une sauvegarde régulière des données dans un environnement non connecté au service numérique',
       categorie: 'resilience',
-      indispensable: true,
       descriptionLongue: "Cette mesure vise à permettre de protéger l'ensemble des données contenues dans le service et permettre à nouveau leur accès dans le cas où le service serait compromis, par exemple, par un rançongiciel qui aurait « chiffré » et donc rendu inaccessibles ces données. Il est recommandé de procéder à cette sauvegarde au minimum, une fois par semaine.",
     },
     sauvegardeMachineVirtuelle: {
@@ -662,7 +661,6 @@ module.exports = {
           'dissocierComptesAdmin',
           'testIntrusion',
           'supervision',
-          'sauvegardeDonnees',
         ],
       },
       applicationAchettee: {
@@ -708,6 +706,9 @@ module.exports = {
           'formaliserModalitesSecurite',
           'testIntrusion',
           'supervision',
+        ],
+        mesuresARendreIndispensables: [
+          'sauvegardeDonnees',
         ],
       },
     },
@@ -760,6 +761,7 @@ module.exports = {
       'politiqueInformation',
       'sauvegardeMachineVirtuelle',
       'testsSauvegardes',
+      'sauvegardeDonnees',
     ],
   },
   departements,

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -40,13 +40,13 @@ class Homologation {
     this.descriptionService = new DescriptionService(descriptionService, referentiel);
 
     let { mesuresGenerales = [] } = donnees;
-    const mesuresApplicables = moteurRegles.mesures(this.descriptionService);
-    const idMesuresApplicables = Object.keys(mesuresApplicables);
-    mesuresGenerales = mesuresGenerales.filter((m) => idMesuresApplicables.includes(m.id));
+    const mesuresPersonnalisees = moteurRegles.mesures(this.descriptionService);
+    const idMesuresPersonnalisees = Object.keys(mesuresPersonnalisees);
+    mesuresGenerales = mesuresGenerales.filter((m) => idMesuresPersonnalisees.includes(m.id));
     this.mesures = new Mesures(
       { mesuresGenerales, mesuresSpecifiques },
       referentiel,
-      idMesuresApplicables,
+      mesuresPersonnalisees,
     );
 
     this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -34,16 +34,20 @@ class Homologation {
       avisExpertCyber = {},
     } = donnees;
 
-    let { mesuresGenerales = [] } = donnees;
-
     this.id = id;
     if (createur.email) this.createur = new Utilisateur(createur);
     this.contributeurs = contributeurs.map((c) => new Utilisateur(c));
     this.descriptionService = new DescriptionService(descriptionService, referentiel);
 
-    const idMesures = Object.keys(moteurRegles.mesures(this.descriptionService));
-    mesuresGenerales = mesuresGenerales.filter((m) => idMesures.includes(m.id));
-    this.mesures = new Mesures({ mesuresGenerales, mesuresSpecifiques }, referentiel, idMesures);
+    let { mesuresGenerales = [] } = donnees;
+    const mesuresApplicables = moteurRegles.mesures(this.descriptionService);
+    const idMesuresApplicables = Object.keys(mesuresApplicables);
+    mesuresGenerales = mesuresGenerales.filter((m) => idMesuresApplicables.includes(m.id));
+    this.mesures = new Mesures(
+      { mesuresGenerales, mesuresSpecifiques },
+      referentiel,
+      idMesuresApplicables,
+    );
 
     this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);
     this.risques = new Risques(

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -2,7 +2,7 @@ const Mesure = require('./mesure');
 const { ErreurMesureInconnue } = require('../erreurs');
 
 class MesureGenerale extends Mesure {
-  constructor(donneesMesure, referentiel) {
+  constructor(donneesMesure, referentiel, indispensable = false) {
     super({
       proprietesAtomiquesRequises: ['id', 'statut'],
       proprietesAtomiquesFacultatives: ['modalites'],
@@ -11,6 +11,7 @@ class MesureGenerale extends Mesure {
     MesureGenerale.valide(donneesMesure, referentiel);
     this.renseigneProprietes(donneesMesure);
 
+    this.rendueIndispensable = indispensable;
     this.referentiel = referentiel;
   }
 
@@ -23,7 +24,7 @@ class MesureGenerale extends Mesure {
   }
 
   estIndispensable() {
-    return !!this.donneesReferentiel().indispensable;
+    return !!this.donneesReferentiel().indispensable || this.rendueIndispensable;
   }
 
   estRecommandee() {

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -2,7 +2,7 @@ const Mesure = require('./mesure');
 const { ErreurMesureInconnue } = require('../erreurs');
 
 class MesureGenerale extends Mesure {
-  constructor(donneesMesure, referentiel, indispensable = false) {
+  constructor(donneesMesure, referentiel, rendueIndispensable = false) {
     super({
       proprietesAtomiquesRequises: ['id', 'statut'],
       proprietesAtomiquesFacultatives: ['modalites'],
@@ -11,7 +11,7 @@ class MesureGenerale extends Mesure {
     MesureGenerale.valide(donneesMesure, referentiel);
     this.renseigneProprietes(donneesMesure);
 
-    this.rendueIndispensable = indispensable;
+    this.rendueIndispensable = rendueIndispensable;
     this.referentiel = referentiel;
   }
 

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -4,7 +4,11 @@ const MesuresSpecifiques = require('./mesuresSpecifiques');
 const Referentiel = require('../referentiel');
 
 class Mesures extends InformationsHomologation {
-  constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide(), identifiantsMesures) {
+  constructor(
+    donnees = {},
+    referentiel = Referentiel.creeReferentielVide(),
+    mesuresPersonnalisees = {},
+  ) {
     super({
       listesAgregats: {
         mesuresGenerales: MesuresGenerales,
@@ -13,11 +17,15 @@ class Mesures extends InformationsHomologation {
     });
     this.renseigneProprietes(donnees, referentiel);
     this.referentiel = referentiel;
-    this.identifiantsMesures = identifiantsMesures || this.referentiel.identifiantsMesures();
+    this.mesuresPersonnalisees = mesuresPersonnalisees;
   }
 
   indiceCyber() {
     return this.statistiques().indiceCyber();
+  }
+
+  nombreMesuresPersonnalisees() {
+    return Object.keys(this.mesuresPersonnalisees).length;
   }
 
   nombreMesuresSpecifiques() {
@@ -25,7 +33,7 @@ class Mesures extends InformationsHomologation {
   }
 
   nombreTotalMesuresGenerales() {
-    return this.identifiantsMesures.length;
+    return this.nombreMesuresPersonnalisees();
   }
 
   nonSaisies() {
@@ -37,13 +45,13 @@ class Mesures extends InformationsHomologation {
   }
 
   statistiques() {
-    return this.mesuresGenerales.statistiques(this.identifiantsMesures);
+    return this.mesuresGenerales.statistiques(this.mesuresPersonnalisees);
   }
 
   statutSaisie() {
     const statutSaisieMesures = super.statutSaisie();
     if (statutSaisieMesures === Mesures.COMPLETES
-      && this.identifiantsMesures.length !== this.mesuresGenerales.nombre()) {
+      && this.nombreMesuresPersonnalisees() !== this.mesuresGenerales.nombre()) {
       return Mesures.A_COMPLETER;
     }
 

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -29,7 +29,7 @@ class MesuresGenerales extends ElementsConstructibles {
     return nbTotal ? nbMisesEnOeuvre / nbTotal : 1;
   }
 
-  statistiques(identifiantsMesuresPersonnalisees) {
+  statistiques(mesuresPersonnalisees) {
     const statuts = MesureGenerale.statutsPossibles();
 
     const statsPartiellesAvecStatut = () => statuts
@@ -64,7 +64,7 @@ class MesuresGenerales extends ElementsConstructibles {
       }
     });
 
-    identifiantsMesuresPersonnalisees
+    Object.keys(mesuresPersonnalisees)
       .map((id) => new MesureGenerale({ id }, this.referentiel))
       .reduce((acc, mesure) => {
         const { categorie } = this.referentiel.mesure(mesure.id);

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -65,7 +65,11 @@ class MesuresGenerales extends ElementsConstructibles {
     });
 
     Object.keys(mesuresPersonnalisees)
-      .map((id) => new MesureGenerale({ id }, this.referentiel))
+      .map((id) => new MesureGenerale(
+        { id },
+        this.referentiel,
+        mesuresPersonnalisees[id].indispensable,
+      ))
       .reduce((acc, mesure) => {
         const { categorie } = this.referentiel.mesure(mesure.id);
         if (mesure.estIndispensable()) acc[categorie].indispensables.total += 1;

--- a/src/modeles/profils/mesures.js
+++ b/src/modeles/profils/mesures.js
@@ -1,7 +1,8 @@
 class Mesures {
-  constructor({ ajouter, retirer } = {}) {
-    this.ajouter = ajouter || [];
-    this.retirer = retirer || [];
+  constructor({ ajouter = [], retirer = [], rendreIndispensables = [] } = {}) {
+    this.ajouter = ajouter;
+    this.retirer = retirer;
+    this.rendreIndispensables = rendreIndispensables;
   }
 }
 

--- a/src/modeles/profils/profil.js
+++ b/src/modeles/profils/profil.js
@@ -25,6 +25,10 @@ class Profil {
     return this.mesuresACibler(cles, 'ajouter');
   }
 
+  mesuresARendreIndispensables(cles) {
+    return this.mesuresACibler(cles, 'rendreIndispensables');
+  }
+
   mesuresARetirer(cles) {
     return this.mesuresACibler(cles, 'retirer');
   }

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -21,7 +21,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const localisationsDonnees = () => donnees.localisationsDonnees;
   const identifiantsLocalisationsDonnees = () => Object.keys(localisationsDonnees());
   const mesureIndispensable = (idMesure) => !!donnees.mesures[idMesure].indispensable;
-  const mesures = () => donnees.mesures;
+  const mesures = () => JSON.parse(JSON.stringify(donnees.mesures));
   const identifiantsMesures = () => Object.keys(mesures());
   const mesure = (id) => mesures()[id];
   const typesService = () => donnees.typesService;

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -79,7 +79,9 @@ describe('Une mesure de sécurité', () => {
     expect(mesure.estRecommandee()).to.be(true);
   });
 
-  it('peut être rendue indispensable', () => {
+  it('peut être rendue indispensable, même si le référentiel dit le contraire', () => {
+    expect(referentiel.mesureIndispensable('identifiantMesure')).to.be(false);
+
     const mesureRendueIndispensable = true;
     const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait' }, referentiel, mesureRendueIndispensable);
     expect(mesure.estIndispensable()).to.be(true);

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -78,4 +78,10 @@ describe('Une mesure de sécurité', () => {
     const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait' }, referentiel);
     expect(mesure.estRecommandee()).to.be(true);
   });
+
+  it('peut être rendue indispensable', () => {
+    const mesureRendueIndispensable = true;
+    const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait' }, referentiel, mesureRendueIndispensable);
+    expect(mesure.estIndispensable()).to.be(true);
+  });
 });

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -8,6 +8,13 @@ const Referentiel = require('../../src/referentiel');
 const elles = it;
 
 describe('Les mesures liées à une homologation', () => {
+  elles('comptent les mesures personnalisees', () => {
+    const mesuresPersonnalisees = { uneMesure: {} };
+    const mesures = new Mesures({}, Referentiel.creeReferentielVide(), mesuresPersonnalisees);
+
+    expect(mesures.nombreMesuresPersonnalisees()).to.equal(1);
+  });
+
   elles('agrègent des mesures spécifiques', () => {
     const mesures = new Mesures({ mesuresSpecifiques: [
       { description: 'Une mesure spécifique' },
@@ -40,9 +47,10 @@ describe('Les mesures liées à une homologation', () => {
   elles('délèguent le calcul statistique aux mesures générales', () => {
     let calculStatistiqueAppele = false;
 
-    const mesures = new Mesures({}, Referentiel.creeReferentielVide(), ['id1', 'id2']);
+    const mesuresRecommandees = {};
+    const mesures = new Mesures({}, Referentiel.creeReferentielVide(), mesuresRecommandees);
     mesures.mesuresGenerales.statistiques = (identifiantsMesuresPersonnalisees) => {
-      expect(identifiantsMesuresPersonnalisees).to.eql(['id1', 'id2']);
+      expect(identifiantsMesuresPersonnalisees).to.equal(mesuresRecommandees);
       calculStatistiqueAppele = true;
       return 'résultat';
     };
@@ -66,12 +74,11 @@ describe('Les mesures liées à une homologation', () => {
 
   elles('connaissent le nombre total de mesures générales', () => {
     const referentiel = Referentiel.creeReferentielVide();
-    referentiel.identifiantsMesures = () => ['mesure 1', 'mesure 2'];
 
     const mesures = new Mesures({
       mesuresGenerales: [],
       mesuresSpecifiques: [],
-    }, referentiel);
+    }, referentiel, { m1: {}, m2: {} });
 
     expect(mesures.nombreTotalMesuresGenerales()).to.equal(2);
   });

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -61,7 +61,7 @@ describe('La liste des mesures générales', () => {
         { id: 'id2', statut: 'fait' },
       ]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.une.retenues).to.equal(2);
       expect(stats.une.misesEnOeuvre).to.equal(2);
     });
@@ -69,7 +69,7 @@ describe('La liste des mesures générales', () => {
     it('initialise les catégories sans mesure renseignée', () => {
       const mesuresGenerales = creeMesuresGenerales([{ id: 'id1', statut: 'fait' }]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.deux.retenues).to.equal(0);
       expect(stats.deux.misesEnOeuvre).to.equal(0);
     });
@@ -80,7 +80,7 @@ describe('La liste des mesures générales', () => {
         { id: 'id2', statut: 'enCours' },
       ]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.une.retenues).to.equal(2);
       expect(stats.une.misesEnOeuvre).to.equal(1);
     });
@@ -91,7 +91,7 @@ describe('La liste des mesures générales', () => {
         { id: 'id2', statut: 'nonRetenu' },
       ]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.une.retenues).to.equal(1);
       expect(stats.une.misesEnOeuvre).to.equal(0);
     });
@@ -102,7 +102,7 @@ describe('La liste des mesures générales', () => {
         { id: 'id3', statut: 'fait' },
       ]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.deux.retenues).to.equal(1);
       expect(stats.deux.misesEnOeuvre).to.equal(1);
     });
@@ -110,7 +110,7 @@ describe('La liste des mesures générales', () => {
     it('calcule le nombre total de mesures indispensables personnalisées', () => {
       const mesuresGenerales = creeMesuresGenerales([]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.une.indispensables.total).to.equal(1);
       expect(stats.deux.indispensables.total).to.equal(0);
     });
@@ -118,14 +118,14 @@ describe('La liste des mesures générales', () => {
     it('ignore les mesures indispensables non personnalisées', () => {
       const mesuresGenerales = creeMesuresGenerales([]);
 
-      const stats = mesuresGenerales.statistiques(['id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id2: {}, id3: {} }).toJSON();
       expect(stats.une.indispensables.total).to.equal(0);
     });
 
     it('calcule le nombre total de mesures recommandées personnalisées', () => {
       const mesuresGenerales = creeMesuresGenerales([]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.une.recommandees.total).to.equal(1);
       expect(stats.deux.recommandees.total).to.equal(1);
     });
@@ -133,7 +133,7 @@ describe('La liste des mesures générales', () => {
     it('calcule le nombre de mesures indispensables faites', () => {
       const mesuresGenerales = creeMesuresGenerales([{ id: 'id1', statut: 'fait' }]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {} }).toJSON();
       expect(stats.une.indispensables.fait).to.equal(1);
       expect(stats.deux.indispensables.fait).to.equal(0);
     });
@@ -141,7 +141,7 @@ describe('La liste des mesures générales', () => {
     it('calcule le nombre de mesures indispensables en cours', () => {
       const mesuresGenerales = creeMesuresGenerales([{ id: 'id1', statut: 'enCours' }]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {} }).toJSON();
       expect(stats.une.indispensables.enCours).to.equal(1);
       expect(stats.deux.indispensables.enCours).to.equal(0);
     });
@@ -149,7 +149,7 @@ describe('La liste des mesures générales', () => {
     it('calcule le nombre de mesures indispensables non faites', () => {
       const mesuresGenerales = creeMesuresGenerales([{ id: 'id1', statut: 'nonFait' }]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {} }).toJSON();
       expect(stats.une.indispensables.nonFait).to.equal(1);
       expect(stats.deux.indispensables.nonFait).to.equal(0);
     });
@@ -157,7 +157,7 @@ describe('La liste des mesures générales', () => {
     it('calcule le nombre de mesures recommandées faites', () => {
       const mesuresGenerales = creeMesuresGenerales([{ id: 'id3', statut: 'fait' }]);
 
-      const stats = mesuresGenerales.statistiques(['id1', 'id2', 'id3']).toJSON();
+      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
       expect(stats.une.recommandees.fait).to.equal(0);
       expect(stats.deux.recommandees.fait).to.equal(1);
     });

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -115,6 +115,13 @@ describe('La liste des mesures générales', () => {
       expect(stats.deux.indispensables.total).to.equal(0);
     });
 
+    it('tient compte des mesures rendues indispensables', () => {
+      const mesuresGenerales = creeMesuresGenerales([]);
+
+      const stats = mesuresGenerales.statistiques({ id2: { indispensable: true } }).toJSON();
+      expect(stats.une.indispensables.total).to.equal(1);
+    });
+
     it('ignore les mesures indispensables non personnalisées', () => {
       const mesuresGenerales = creeMesuresGenerales([]);
 

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -119,12 +119,25 @@ describe('Le référentiel', () => {
     expect(referentiel.delaisAvantImpactCritique()).to.eql({ uneClef: 'une valeur' });
   });
 
-  it('connaît la liste des mesures', () => {
-    const referentiel = Referentiel.creeReferentiel({
-      mesures: { uneClef: 'une valeur' },
+  describe('sur demande de la liste des mesures', () => {
+    it('retourne la liste', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        mesures: { uneClef: 'une valeur' },
+      });
+
+      expect(referentiel.mesures()).to.eql({ uneClef: 'une valeur' });
     });
 
-    expect(referentiel.mesures()).to.eql({ uneClef: 'une valeur' });
+    it('retourne toujours la même liste', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        mesures: { idMesure: { attributModifiable: 'Une valeur de référence' } },
+      });
+
+      const mesure = referentiel.mesure('idMesure');
+      mesure.attributModifiable = 'Une valeur modifiée';
+
+      expect(referentiel.mesures()).to.eql({ idMesure: { attributModifiable: 'Une valeur de référence' } });
+    });
   });
 
   it('sait si une mesure est indispensable', () => {


### PR DESCRIPTION
Le moteur de règles peut maintenant rendre indispensable une liste de mesures pour un profil donné.

La pastille "indispensable" est mise à jour dans la page des mesures.
Les statistiques sont mises à jour dans la page de synthèse du PDF.