### PR TITLE
Utilisation de l'entête de « Connexion » pour l'inscription

### DIFF
--- a/src/vues/mssInscription.pug
+++ b/src/vues/mssInscription.pug
@@ -1,4 +1,4 @@
-extends ./mssDeconnecte
+extends ./mssConnexionEnCours
 
 include ./fragments/formulaireUtilisateur
 


### PR DESCRIPTION
En accord avec les dernières maquettes, l'entête pendant l'inscription n'est plus…

![image](https://user-images.githubusercontent.com/24898521/197362059-005ac909-1be7-49c5-ac30-2fe530af298a.png)

…mais devient :

![image](https://user-images.githubusercontent.com/24898521/197362062-4adcf03c-aa1e-4ee8-969d-05254cc6b81d.png)

J'ai choisi de réutiliser le template `mssConnexionEnCours` depuis l'inscription.

Une alternative serait de déclarer `block navigation` dans `vues/inscription.pug`. Mais bon…pour minimiser les cas différents de `navigation`, j'ai préféré réutiliser `mssConnexionEnCours`.

Ça justifie peut-être un renommage du template `mssConnexionEnCours` : `mssAccesEnCours` peut-être ? 