### PR TITLE
[CORRECTION] Affiche correctement logo sous Chrome

### DIFF
--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -73,16 +73,16 @@ header nav a:hover {
   font-size: 1.2em;
 }
 
-.logo-mss:before {
+.logo-mss::before {
   display: inline-block;
   content: '';
   width: 1.5em;
   height: 1.5em;
   margin-right: 0.4em;
 
-  mask-image: url(../images/logo_mss.svg);
-  mask-repeat: no-repeat;
-  mask-position: center;
+  -webkit-mask: url(../images/logo_mss.svg) no-repeat center;
+  mask: url(../images/logo_mss.svg) no-repeat center;
+  -webkit-mask-size: contain;
   mask-size: contain;
   background-color: var(--bleu-anssi);
 }


### PR DESCRIPTION
Pour corriger ce problème de logo carré sous Chrome :

![image](https://user-images.githubusercontent.com/24898521/197771217-616abd3a-6cd9-4d04-948f-59c1c62175f1.png)
