### PR TITLE
Correction des statistiques en tenant compte des mesures rendues indispensables

### DIFF
--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -49,6 +49,7 @@ class MesuresGenerales extends ElementsConstructibles {
     this.items.forEach((mesure) => {
       const { id, statut } = mesure;
       const { categorie } = this.referentiel.mesure(id);
+      mesure.rendueIndispensable = mesuresPersonnalisees[id].indispensable;
 
       if (statut === MesureGenerale.STATUT_FAIT) {
         stats[categorie].misesEnOeuvre += 1;

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -145,6 +145,13 @@ describe('La liste des mesures générales', () => {
       expect(stats.deux.indispensables.fait).to.equal(0);
     });
 
+    it('tient compte des mesures faites rendues indispensables', () => {
+      const mesuresGenerales = creeMesuresGenerales([{ id: 'id2', statut: 'fait' }]);
+
+      const stats = mesuresGenerales.statistiques({ id2: { indispensable: true } }).toJSON();
+      expect(stats.une.indispensables.fait).to.equal(1);
+    });
+
     it('calcule le nombre de mesures indispensables en cours', () => {
       const mesuresGenerales = creeMesuresGenerales([{ id: 'id1', statut: 'enCours' }]);
 


### PR DESCRIPTION
Corrige le bug qui affichait des nombres négatif dans les camemberts

Avant
<img width="967" alt="Capture d’écran 2022-10-26 à 20 06 04" src="https://user-images.githubusercontent.com/39462397/198102734-b9e20944-65be-4ceb-b629-ac585291bf8b.png">

Après
<img width="983" alt="Capture d’écran 2022-10-26 à 20 06 48" src="https://user-images.githubusercontent.com/39462397/198102809-7fabfe52-c4ef-48f1-8ead-d1f4a86e0eee.png">
