### PR TITLE
Correction de la position du bandeau des nouvelles fonctionnalités

### DIFF
--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -57,6 +57,10 @@ section:last-of-type {
   text-align: left;
 }
 
+.retour:empty {
+  display: none;
+}
+
 .invisible {
   display: none;
 }


### PR DESCRIPTION
Sur la page Espace personnel,
Le bandeau des nouvelles fonctionnalités est détaché du header
<img width="1203" alt="Capture d’écran 2022-10-27 à 11 07 08" src="https://user-images.githubusercontent.com/39462397/198242674-287841ad-8028-41ff-aac1-b4c718d1ed96.png">
