### PR TITLE
Alignement de la Marianne avec le logo ANSSI

### DIFF
--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -2,7 +2,7 @@ header {
   display: flex;
   column-gap: 1.4em;
   align-items: center;
-  padding: 1em 0 1.5em;
+  padding: 1em 0;
 }
 
 header a {
@@ -40,21 +40,21 @@ header nav a, .nom-utilisateur-courant {
 }
 
 .marianne {
-  height: 0.8em;
+  height: 0.75em;
 
   background-image: url(../images/marianne.svg);
 }
 
 .devise {
-  height: 2em;
+  height: 1.38em;
 
   background-image: url(../images/devise.svg);
 }
 
 .republique-francaise {
-  padding: 0.25em 0 0.5em;
+  padding: 0.36em 0;
 
-  line-height: 100%;
+  line-height: 1.075em;
   color: #000;
   font-size: 0.7em;
   font-weight: bold;


### PR DESCRIPTION
Cette PR corrige l'alignement de la Marianne avec les autres logos. 
C'est un retour qu'on a eu via le recettage de l'entête.

#### AVANT

![image](https://user-images.githubusercontent.com/24898521/198263535-1d94d936-ff2a-490f-8759-1799c92021e3.png)

#### APRÈS

![image](https://user-images.githubusercontent.com/24898521/198263611-cff380e8-245f-4101-b578-261e4cc2d616.png)

