### PR TITLE
Annexe des mesures ajout des modalités

### DIFF
--- a/public/assets/styles/annexes/mesures.css
+++ b/public/assets/styles/annexes/mesures.css
@@ -84,3 +84,12 @@
   background-image: url(../../images/icone_etoile_orange.svg);
   transform: translateY(0.2em);
 }
+
+.mesures-par-statut p.modalites {
+  margin: 0 0 0.4em 2.4em;
+  color: var(--texte-moyen);
+}
+
+.mesures-par-statut p.modalites:empty {
+  margin: 0;
+}

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -22,6 +22,7 @@ class MesuresGenerales extends ElementsConstructibles {
         acc[mesure.statut][mesureReference.categorie].push({
           description: mesure.descriptionMesure(),
           indispensable: mesure.estIndispensable(),
+          modalites: mesure.modalites,
         });
         return acc;
       }, mesuresParStatut);

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -13,6 +13,7 @@ class MesuresSpecifiques extends ElementsConstructibles {
       acc[mesure.statut][mesure.categorie] ||= [];
       acc[mesure.statut][mesure.categorie].push({
         description: mesure.descriptionMesure(),
+        modalites: mesure.modalites,
       });
       return acc;
     }, accumulateur);

--- a/src/vues/homologation/annexes/mesures.pug
+++ b/src/vues/homologation/annexes/mesures.pug
@@ -19,5 +19,6 @@ block append page
         ul
           each mesure in mesures
             li(class = mesure.indispensable ? 'indispensable' : '')= mesure.description
+            p.modalites!= mesure.modalites
 
   script(type = 'module', src = '/statique/homologation/annexes/mesures.js')

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -214,5 +214,12 @@ describe('La liste des mesures générales', () => {
 
       expect(mesures.parStatut().fait.categorie1[0].description).to.equal('Mesure une');
     });
+
+    it('ajoute les modalités de la mesure', () => {
+      const mesuresGenerales = [{ id: 'mesure1', statut: 'fait', modalites: 'Modalités de la mesure' }];
+      const mesures = new MesuresGenerales({ mesuresGenerales }, referentiel, ['mesure1']);
+
+      expect(mesures.parStatut().fait.categorie1[0].modalites).to.equal('Modalités de la mesure');
+    });
   });
 });

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -28,12 +28,25 @@ describe('La liste des mesures spécifiques', () => {
 
   elle('peut être triée par statut', () => {
     const mesures = new MesuresSpecifiques({
-      mesuresSpecifiques: [{ description: 'Mesure Spécifique 1', statut: 'fait', categorie: 'categorie1' }],
+      mesuresSpecifiques: [
+        { description: 'Mesure Spécifique 1', statut: 'fait', categorie: 'categorie1' },
+        { description: 'Mesure Spécifique 2', statut: 'nonFait', categorie: 'categorie1' },
+      ],
+    },
+    referentiel);
+
+    expect(mesures.parStatut().fait.categorie1[0].description).to.equal('Mesure Spécifique 1');
+    expect(mesures.parStatut().nonFait.categorie1[0].description).to.equal('Mesure Spécifique 2');
+  });
+
+  elle('prend le modalités lors du tri par statut', () => {
+    const mesures = new MesuresSpecifiques({
+      mesuresSpecifiques: [{ description: 'Mesure Spécifique 1', statut: 'fait', categorie: 'categorie1', modalites: 'Modalités' }],
     },
     referentiel);
 
     expect(mesures.parStatut().fait.categorie1.length).to.equal(1);
-    expect(mesures.parStatut().fait.categorie1[0].description).to.equal('Mesure Spécifique 1');
+    expect(mesures.parStatut().fait.categorie1[0].modalites).to.equal('Modalités');
   });
 
   elle('peut être triée par statut en utilisant un accumulateur personnalisé', () => {


### PR DESCRIPTION
Dans la page des annexes des mesures `:id/syntheseSecurite/annexes/mesures`
Les modalités sont affichées quand elles sont renseignées

NOTE : valable pour les mesures générales et spécifiques
<img width="683" alt="Capture d’écran 2022-10-27 à 15 53 24" src="https://user-images.githubusercontent.com/39462397/198303718-42000757-0e7a-4f65-93cc-9adf28be946d.png">
