### PR TITLE
Le service peut avoir pour provenance un outil existant

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -652,7 +652,7 @@ module.exports = {
       applicationAchettee: {
         regles: [{
           presence: ['achat'],
-          absence: ['developpement'],
+          absence: ['developpement', 'outilExistant'],
         }],
         mesuresARetirer: [
           'analyseRisques',

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -50,6 +50,9 @@ module.exports = {
     developpement: {
       description: 'Développé en interne ou par un prestataire au profit de votre organisation',
     },
+    outilExistant: {
+      description: 'Déployé à partir d’un outil existant',
+    },
     achat: {
       description: "Acheté sur étagère auprès d'un fournisseur ou obtenu à titre gratuit",
     },


### PR DESCRIPTION
Dans la page Décrire,
La provenance du service peut être un outil existant.

NOTE : Mise à jour du profil Application Achetée

<img width="664" alt="Capture d’écran 2022-11-02 à 14 25 04" src="https://user-images.githubusercontent.com/39462397/199501120-047c5ff1-fe27-4e90-ac2d-e0b961398076.png">
