### PR TITLE
Choix simple pour la provenance du service

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -48,13 +48,16 @@ module.exports = {
 
   provenancesService: {
     developpement: {
-      description: 'Développé en interne ou par un prestataire au profit de votre organisation',
+      description: "Développé pour les besoins de l'organisation",
+      exemple: "application mobile ou site développé de A à Z par une agence web ou à partir de briques existantes adaptées aux besoins de l'organisation",
     },
     outilExistant: {
-      description: 'Déployé à partir d’un outil existant',
+      description: "Déployé à partir d'un outil existant",
+      exemple: "outil métier proposé à l'achat par un éditeur ou gratuit et déployé au profit de l'organisation",
     },
     achat: {
-      description: "Acheté sur étagère auprès d'un fournisseur ou obtenu à titre gratuit",
+      description: 'Proposé en ligne par un fournisseur',
+      exemple: 'service standard disponible en ligne (SaaS), gratuitement ou via souscription, développé et déployé mis à disposition par un fournisseur',
     },
   },
 

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -652,7 +652,6 @@ module.exports = {
       applicationAchettee: {
         regles: [{
           presence: ['achat'],
-          absence: ['developpement', 'outilExistant'],
         }],
         mesuresARetirer: [
           'analyseRisques',

--- a/migrations/20221102134033_changeProvenanceService.js
+++ b/migrations/20221102134033_changeProvenanceService.js
@@ -1,0 +1,55 @@
+const PROVENANCES = ['developpement', 'achat', 'outilExistant'];
+
+const reduitProvenance = (provenances) => {
+  if (!provenances) {
+    return undefined;
+  }
+
+  if (!(provenances instanceof Array)) {
+    return undefined;
+  }
+
+  if (provenances.length === 1 && PROVENANCES.includes(provenances[0])) {
+    return provenances[0];
+  }
+
+  if (provenances.length > 1 && (
+    provenances.every((provenance) => PROVENANCES.includes(provenance))
+  )) {
+    return 'outilExistant';
+  }
+
+  return undefined;
+};
+
+const developpeProvenance = (provenance) => {
+  if (!provenance) {
+    return undefined;
+  }
+  if (provenance === 'outilExistant') {
+    return ['developpement', 'achat'];
+  }
+  return PROVENANCES.includes(provenance) ? [provenance] : [];
+};
+
+const changementDescriptionService = (changeProvenance) => (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees?.descriptionService)
+      .map(({ id, donnees: { descriptionService, ...autresDonnees } }) => {
+        descriptionService.provenanceService = changeProvenance(
+          descriptionService.provenanceService
+        );
+        return knex('homologations')
+          .where({ id })
+          .update({ donnees: { descriptionService, ...autresDonnees } });
+      });
+    return Promise.all(misesAJour);
+  });
+
+exports.up = changementDescriptionService(reduitProvenance);
+
+exports.down = changementDescriptionService(developpeProvenance);
+
+exports.reduitProvenance = reduitProvenance;
+exports.developpeProvenance = developpeProvenance;

--- a/public/assets/styles/homologation/formulaire.css
+++ b/public/assets/styles/homologation/formulaire.css
@@ -62,13 +62,13 @@ form.homologation label p, form .decoration {
 }
 
 label.exemple::before {
-  content: 'ex. '
+  content: 'ex : '
 }
 
 label.exemple {
   display: inline-block;
 
-  margin: 0 0 0 1.7em;
+  margin: 0 0 0 2.5em;
 
   font-weight: normal;
   color: var(--texte-clair);

--- a/src/modeles/descriptionService.js
+++ b/src/modeles/descriptionService.js
@@ -13,6 +13,7 @@ class DescriptionService extends InformationsHomologation {
         'localisationDonnees',
         'nomService',
         'presentation',
+        'provenanceService',
         'risqueJuridiqueFinancierReputationnel',
         'statutDeploiement',
       ],
@@ -20,7 +21,6 @@ class DescriptionService extends InformationsHomologation {
         'donneesCaracterePersonnel',
         'fonctionnalites',
         'typeService',
-        'provenanceService',
       ],
       listesAgregats: {
         donneesSensiblesSpecifiques: DonneesSensiblesSpecifiques,

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -25,7 +25,7 @@ mixin formulaireDescriptionService(idHomologation)
       })
 
       +inputChoix({
-        type: 'checkbox',
+        type: 'radio',
         nom: 'provenanceService',
         titre: 'Provenance(s)',
         items: referentiel.provenancesService(),

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -27,7 +27,7 @@ mixin formulaireDescriptionService(idHomologation)
       +inputChoix({
         type: 'radio',
         nom: 'provenanceService',
-        titre: 'Provenance(s)',
+        titre: 'Provenance',
         items: referentiel.provenancesService(),
         objetDonnees: homologation.descriptionService,
       })

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -25,7 +25,7 @@ describe('La description du service', () => {
       nomService: 'Super Service',
       pointsAcces: [{ description: 'Une description' }],
       presentation: 'Une présentation du service',
-      provenanceService: ['uneProvenance'],
+      provenanceService: 'uneProvenance',
       risqueJuridiqueFinancierReputationnel: true,
       statutDeploiement: 'unStatut',
     }, referentielAvecStatutValide('unStatut'));
@@ -37,7 +37,7 @@ describe('La description du service', () => {
     expect(descriptionService.typeService).to.eql(['unType']);
     expect(descriptionService.nomService).to.equal('Super Service');
     expect(descriptionService.presentation).to.equal('Une présentation du service');
-    expect(descriptionService.provenanceService).to.eql(['uneProvenance']);
+    expect(descriptionService.provenanceService).to.eql('uneProvenance');
     expect(descriptionService.risqueJuridiqueFinancierReputationnel).to.be(true);
     expect(descriptionService.statutDeploiement).to.equal('unStatut');
 
@@ -137,6 +137,7 @@ describe('La description du service', () => {
       delaiAvantImpactCritique: 'uneJournee',
       localisationDonnees: 'france',
       presentation: 'Une présentation',
+      provenanceService: 'uneProvenance',
       risqueJuridiqueFinancierReputationnel: true,
       statutDeploiement: 'accessible',
     }, referentielAvecStatutValide('accessible'));

--- a/test_migrations/20221102134033_changeProvenanceService.spec.js
+++ b/test_migrations/20221102134033_changeProvenanceService.spec.js
@@ -1,0 +1,46 @@
+const expect = require('expect.js');
+const { developpeProvenance, reduitProvenance } = require('../migrations/20221102134033_changeProvenanceService');
+
+describe('La migration de la provenance du service depuis valeurs multiple en valeur simple', () => {
+  describe("vers l'avant", () => {
+    it("laisse la provenance non définie lorsqu'elle l'était déjà", () => {
+      expect(reduitProvenance(undefined)).to.be(undefined);
+    });
+
+    it("choisit une provenance non définie dès qu'une provenance est inconnue", () => {
+      expect(reduitProvenance(['inconnue'])).to.be(undefined);
+      expect(reduitProvenance(['achat', 'inconnue'])).to.be(undefined);
+    });
+
+    it('choisit une provenance non définie quand le format de la provenance ne convient pas', () => {
+      expect(reduitProvenance('achat')).to.be(undefined);
+    });
+
+    it("préserve la provenance existante lorsqu'elle est unique", () => {
+      expect(reduitProvenance(['achat'])).to.equal('achat');
+    });
+
+    it("choisit outil existant lorsqu'il y a plusieurs provenances", () => {
+      expect(reduitProvenance(['achat', 'developpement'])).to.equal('outilExistant');
+    });
+  });
+
+  describe("vers l'arrière", () => {
+    it("laisse non définie lorsque la provenance l'était", () => {
+      expect(developpeProvenance(undefined)).to.be(undefined);
+    });
+
+    it('transforme outil existant en développement et achat', () => {
+      expect(developpeProvenance('outilExistant')).to.eql(['developpement', 'achat']);
+    });
+
+    it("préserve la provenance lorsqu'elle est achat ou développement", () => {
+      expect(developpeProvenance('achat')).to.eql(['achat']);
+      expect(developpeProvenance('developpement')).to.eql(['developpement']);
+    });
+
+    it('supprime la provenance non connue', () => {
+      expect(developpeProvenance('inconnue')).to.eql([]);
+    });
+  });
+});


### PR DESCRIPTION
Dans la page Décrire,
La provenance du service deviens une question à choix simple, les textes sont renommés

NOTE : ce dev comporte une migration

<img width="786" alt="Capture d’écran 2022-11-04 à 10 01 34" src="https://user-images.githubusercontent.com/39462397/199933937-7372767c-d0b2-4ce2-b9fe-b31098c20a87.png">

