### PR TITLE
Exécution des migrations knex au lancement de l'application en local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
 
   web:
     <<: *configuration-base
-    command: "npx nodemon server.js"
+    command: bash -c "npx knex migrate:latest && npx nodemon server.js"
     environment:
       - NODE_ENV=development
     networks:


### PR DESCRIPTION
On veut éviter une situation où un membre de l'équipe a un schéma de BDD qui n'est pas le dernier, sans pour autant que l'application ne plante. Ce serait le pire : avoir un modèle de données non conforme au reste de l'équipe, mais pas de plantage.

En forçant les migrations knex, on évite ce problème.

Exemple : #459 contient une migration. Si cette migration n'est pas exécutée, l'application en plante pas. Elle enregistre une chaîne de caractères dans un champs de `donnees` qui est normalement devenu un tableau.

### Raison du draft
⚠️ ~~Cette PR utilise la syntaxe `sh -c` pour donner plusieurs commandes au conteneur qui se lance.
En utilisant cette syntaxe, l'arrêt *graceful* du conteneur semble devenu impossible.  
Le conteneur affiche `Gracefully stopping... (press Ctrl+C again to force)` pendant 10 secondes puis le conteneur s'arrête…laissant croire que c'est le délai de 10 secondes atteint qui a forcé le Docker engine a envoyer une `KILL` au conteneur.~~

~~Sans cette PR, l'arrêt du conteneur prend entre 1 et 2 secondes.~~

EDIT : nous avons [une solution](https://github.com/betagouv/mon-service-securise/pull/460#issuecomment-1302382946) qui fonctionne.