### PR TITLE
Icônes qui suivent la taille de police

### DIFF
--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -123,18 +123,18 @@ header nav a, .nom-utilisateur-courant {
   display: inline-block;
 
   content: '';
-  -webkit-mask-size: contain;
-  mask-size: contain;
   background-color: var(--systeme-design-etat-bleu);
 }
 
 :is(.connexion, .nom-utilisateur-courant)::before {
   width: 1.3em;
-  height: 1.3em;
+  height: 1.1em;
   margin-right: 0.3em;
 
   -webkit-mask: url(../images/icone_utilisateur.svg) no-repeat center;
   mask: url(../images/icone_utilisateur.svg) no-repeat center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
 }
 
 .nom-utilisateur-courant::after {
@@ -144,6 +144,8 @@ header nav a, .nom-utilisateur-courant {
 
   -webkit-mask: url(../images/icone_fleche_bas.svg) no-repeat center;
   mask: url(../images/icone_fleche_bas.svg) no-repeat center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
   -webkit-mask-position-y: 0.2em;
   mask-position-y: 0.2em;
 }


### PR DESCRIPTION
Sans cette PR, les icônes ne suivent pas la taille du texte.

Par exemple avec une règle `html { font-size: 40px; }`

#### SANS
![image](https://user-images.githubusercontent.com/24898521/199781489-1cf6e083-7b4b-42e9-97f0-139c21a5ce6e.png)


#### AVEC
![image](https://user-images.githubusercontent.com/24898521/199781677-1c9ac491-fc10-42d7-9985-015fb0d68e36.png)

