### PR TITLE
Les mesures de tous statuts et sans pagination en annexe

### DIFF
--- a/public/assets/styles/annexes/mesures.css
+++ b/public/assets/styles/annexes/mesures.css
@@ -1,3 +1,7 @@
+.page:nth-of-type(n + 2) {
+  margin-top: 4em;
+}
+
 .titre-icone {
   display: inline-block;
 
@@ -34,6 +38,10 @@
   background-image: url(../../images/icone_etoile_orange.svg);
   background-repeat: no-repeat;
   background-size: contain;
+}
+
+.mesures-par-statut {
+  margin-top: 4em;
 }
 
 .mesures-par-statut h3 {

--- a/src/vues/homologation/annexes/mesures.pug
+++ b/src/vues/homologation/annexes/mesures.pug
@@ -1,24 +1,29 @@
 extends ../../documentImprimable
 
+mixin mesuresTrieesParStatut( mesuresDuStatut = [], nomStatut = '')
+  section.mesures-par-statut
+      h2=nomStatut
+      each mesures, categorie in mesuresDuStatut
+        h3= categorie || 'Sans catégorie renseignée'
+        ul
+          each mesure in mesures
+            li(class = mesure.indispensable ? 'indispensable' : '')= mesure.description
+            p.modalites!= mesure.modalites
+
 block append styles
   link(href='/statique/assets/styles/pdfs.css', rel='stylesheet')
   link(href = '/statique/assets/styles/annexes/mesures.css', rel = 'stylesheet')
 
 block append page
-  .page
-    .titre-icone
-    .titre
-      h1 Mesures de sécurité détaillées
-      .sous-titre.
-        Toutes les mesures indispensables #[.icone-etoile], recommandées et créées sont classées selon leur statut de mise en œuvre et par catégorie.
-    section.mesures-par-statut
-      h2 En cours
-      - const mesuresEnCours = homologation.mesuresParStatut().enCours
-      each mesures, categorie in mesuresEnCours
-        h3= categorie
-        ul
-          each mesure in mesures
-            li(class = mesure.indispensable ? 'indispensable' : '')= mesure.description
-            p.modalites!= mesure.modalites
+  - const mesuresParStatut = homologation.mesuresParStatut()
+  - const statuts = [{ clef: 'enCours', nom: 'En cours' }, { clef: 'nonFait', nom: 'Non faites' }, { clef: 'fait', nom: 'Faites' }]
+  each statut in statuts
+    .page
+      .titre-icone
+      .titre
+        h1 Mesures de sécurité détaillées
+        .sous-titre.
+          Toutes les mesures indispensables #[.icone-etoile], recommandées et créées sont classées selon leur statut de mise en œuvre et par catégorie.
+      +mesuresTrieesParStatut(mesuresParStatut[statut.clef], statut.nom)
 
   script(type = 'module', src = '/statique/homologation/annexes/mesures.js')


### PR DESCRIPTION
Dans l'annexe des mesures (:id/syntheseSecurite/annexes/mesures),
Toutes les mesures sont affichées ordonnées par statut (en cours, non fait, fait) puis par catégorie.

NOTE : je me suis permis une liberté de faire une catégorie SANS CATÉGORIE RENSEIGNÉE quand une mesure spécifique n'a pas de catégorie (ce qui n'est pas prévu normalement)

Cette page sera bientôt abandonnée

<img width="584" alt="Capture d’écran 2022-11-10 à 10 34 07" src="https://user-images.githubusercontent.com/39462397/201054226-6da14fdc-38e3-4aaa-adca-4fb535370838.png">
