### PR TITLE
Correction de la suppression d'utilisateur

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -112,7 +112,7 @@ const nouvelAdaptateur = (env) => {
 
   const supprimeHomologation = (...params) => supprimeEnregistrement('homologations', ...params);
   const supprimeService = (...params) => supprimeEnregistrement('services', ...params);
-  const supprimeUtilisateur = (...params) => supprimeEnregistrement('utilisaateurs', ...params);
+  const supprimeUtilisateur = (...params) => supprimeEnregistrement('utilisateurs', ...params);
 
   const supprimeHomologations = () => knex('homologations').del();
 


### PR DESCRIPTION
L'erreur a été détectée en lisant dans les logs d'un environnement de DEMO :
> error: delete from "utilisaateurs" where "id" = $1 - relation "utilisaateurs" does not exist

Pendant les tests en DEMO autour de l'utilisation de Sendinblue pour l'envoi d'e-mails.