### PR TITLE
Supprime « Diffusion restreinte » des données à caractère personnel

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -168,10 +168,6 @@ module.exports = {
       exemple: 'orientation sexuelle, origine, orientations politiques, religieuses.',
       seuilCriticite: 'critique',
     },
-    diffusionRestreinte: {
-      description: 'Données de niveau « Diffusion Restreinte »',
-      seuilCriticite: 'critique',
-    },
   },
 
   delaisAvantImpactCritique: {

--- a/migrations/20221115150500_suppressionDiffusionRestreinte.js
+++ b/migrations/20221115150500_suppressionDiffusionRestreinte.js
@@ -1,0 +1,21 @@
+// Il s'agit de supprimer la valeur 'diffusionRestreinte' dans les
+// 'donneesCaracterePersonnel' de la description des services.
+// Car 'Diffusion restreinte' est supprimée du référentiel.
+
+exports.up = (knex) => knex('homologations')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees.descriptionService)
+      .map(({ id, donnees }) => {
+        donnees.descriptionService.donneesCaracterePersonnel = donnees
+          .descriptionService
+          .donneesCaracterePersonnel
+          .filter((d) => d !== 'diffusionRestreinte');
+
+        return knex('homologations').where({ id }).update({ donnees });
+      });
+
+    return Promise.all(misesAJour);
+  });
+
+exports.down = () => Promise.resolve();


### PR DESCRIPTION
Cette PR fait disparaître le choix « Diffusion restreinte » du référentiel.

Il apparaissait à la place du cadre rouge :

![image](https://user-images.githubusercontent.com/24898521/201945201-1c51cc6b-7e77-47e1-965e-58a8b673e9c3.png)
