### PR TITLE
Supprime interrupteur AVEC_INDICE_CYBER

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,6 +27,5 @@ SECRET_COOKIE= # chaîne utilisée pour chiffrer le cookie de session
 SECRET_JWT= # chaîne utilisée pour chiffrer le JWT
 
 # interrupteurs de fonctionnalités (feature switches)
-AVEC_INDICE_CYBER= # renseigner à `true` si on veut afficher l'indice cyber
 AVEC_SYNTHESE_V2= # renseigner à `true` si on veut afficher la nouvelle version de la synthèse de sécurité
 AVEC_MAIL_VIA_SENDINBLUE= # renseigner à `true` pour envoyer les mails via Sendinblue plutôt que SMTP

--- a/src/vues/homologation.pug
+++ b/src/vues/homologation.pug
@@ -35,6 +35,5 @@ block zone-principale
             +action(actionSaisie)
 
 block cartes-informations
-  if process.env.AVEC_INDICE_CYBER
-    - const indiceCyber = homologation.indiceCyber()
-    +indiceCyber({ referentiel, indiceCyber })
+  - const indiceCyber = homologation.indiceCyber()
+  +indiceCyber({ referentiel, indiceCyber })

--- a/src/vues/homologation/synthese.pug
+++ b/src/vues/homologation/synthese.pug
@@ -55,9 +55,8 @@ block zone-principale
       a.ancienne-version.vers-complements(href = `/homologation/${service.id}/decision`) Télécharger les annexes (+ synthèse 1ère version)
 
 block cartes-informations
-  if process.env.AVEC_INDICE_CYBER
-    - const indiceCyber = service.indiceCyber()
-    +indiceCyber({ referentiel, indiceCyber })
+  - const indiceCyber = service.indiceCyber()
+  +indiceCyber({ referentiel, indiceCyber })
 
   +carteInformations({ titre: 'Pour les services référencés avant le 12/10/2022' })
     .liens


### PR DESCRIPTION
L'indice cyber est activé jusqu'en Production. L'interrupteur n'est plus nécessaire.