### PR TITLE
Moteur de modèle pour générer le latex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.26.1",
         "bcrypt": "^5.0.1",
         "cookie-session": "^2.0.0",
+        "dot": "^1.1.3",
         "dotenv": "^14.3.2",
         "express": "^4.17.3",
         "express-basic-auth": "^1.2.1",
@@ -1265,6 +1266,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dot": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.3.tgz",
+      "integrity": "sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg==",
+      "engines": [
+        "node >=0.2.6"
+      ],
+      "bin": {
+        "dottojs": "bin/dot-packer"
       }
     },
     "node_modules/dotenv": {
@@ -7101,6 +7113,11 @@
       "requires": {
         "webidl-conversions": "^7.0.0"
       }
+    },
+    "dot": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.3.tgz",
+      "integrity": "sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg=="
     },
     "dotenv": {
       "version": "14.3.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "axios": "^0.26.1",
     "bcrypt": "^5.0.1",
     "cookie-session": "^2.0.0",
+    "dot": "^1.1.3",
     "dotenv": "^14.3.2",
     "express": "^4.17.3",
     "express-basic-auth": "^1.2.1",

--- a/src/adaptateurs/adaptateurPdfLatex.js
+++ b/src/adaptateurs/adaptateurPdfLatex.js
@@ -1,10 +1,15 @@
 const fsPromises = require('fs/promises');
 const pdflatex = require('node-pdflatex').default;
 
-const generationPdfLatex = (cheminFichierTex) => fsPromises
-  .readFile(cheminFichierTex)
-  .then((donneesFichier) => pdflatex(donneesFichier.toString()));
+const fabriquantGabarit = require('../latex/fabriquantGabarit');
 
-const genereAnnexeMesures = () => generationPdfLatex('src/vuesTex/annexeMesures.tex');
+const generationPdfLatex = (cheminFichierTex, donnees = {}) => fsPromises
+  .readFile(cheminFichierTex)
+  .then((donneesFichier) => {
+    const texConfectionne = fabriquantGabarit.confectionne(donneesFichier.toString(), donnees);
+    return pdflatex(texConfectionne);
+  });
+
+const genereAnnexeMesures = (donnees) => generationPdfLatex('src/vuesTex/annexeMesures.template.tex', donnees);
 
 module.exports = { genereAnnexeMesures };

--- a/src/latex/fabriquantGabarit.js
+++ b/src/latex/fabriquantGabarit.js
@@ -1,0 +1,37 @@
+const dot = require('dot');
+
+/**
+ * La configuration de dot.js est définie avec le caractère `_`
+ * avec une utilisation comme suit
+ * __ __ pour évaluer
+ * __= __ pour interpoler
+ * __! __ pour interpoler avec encodage
+ * __# __ pour inclure partiellement du code et évaluer
+ * __## #__ pour définir des blocs pouvant être appelés
+ * __? __ pour les conditions
+ * __~ __ pour itérer dans un tableau
+ *
+ * L'objet de données est `donnees`
+ * et la suppression des espaces et des retours à la ligne est annulée.
+ *
+ */
+/* eslint-disable no-useless-escape */
+dot.templateSettings = {
+  evaluate: /__([\s\S]+?)__/g,
+  interpolate: /__=([\s\S]+?)__/g,
+  encode: /__!([\s\S]+?)__/g,
+  use: /__#([\s\S]+?)__/g,
+  define: /__##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#__/g,
+  conditional: /__\?(\?)?\s*([\s\S]*?)\s*__/g,
+  iterate: /__~\s*(?:__|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*__)/g,
+  varname: 'donnees',
+  strip: false,
+};
+/* eslint-enable no-useless-escape */
+
+const confectionne = (gabarit, donnees) => {
+  const template = dot.template(gabarit);
+  return template(donnees);
+};
+
+module.exports = { confectionne };

--- a/src/routes/routesPdf.js
+++ b/src/routes/routesPdf.js
@@ -4,7 +4,7 @@ const routesPdf = (adaptateurPdf) => {
   const routes = express.Router();
 
   routes.get('/:id/annexeMesures.pdf', (_requete, reponse, suite) => {
-    adaptateurPdf.genereAnnexeMesures()
+    adaptateurPdf.genereAnnexeMesures({ categorie: 'GOUVERNANCE' })
       .then((pdf) => {
         reponse.contentType('application/pdf');
         reponse.send(pdf);

--- a/src/vuesTex/annexeMesures.template.tex
+++ b/src/vuesTex/annexeMesures.template.tex
@@ -35,7 +35,7 @@
   \textbf{En cours}
 
   \begin{tcolorbox}[colback=white, colframe=lisere, boxrule=1px]
-    \textcolor{bleu}{GOUVERNANCE}
+    \textcolor{bleu}{__= donnees.categorie __}
     \begin{itemize}
       \item * Limiter et connaître les interconnexions du service avec d'autres systèmes
 

--- a/test/latex/fabriquantGabarit.spec.js
+++ b/test/latex/fabriquantGabarit.spec.js
@@ -1,0 +1,10 @@
+const expect = require('expect.js');
+
+const { confectionne } = require('../../src/latex/fabriquantGabarit');
+
+describe('Le fabriquant avec gabarit', () => {
+  it("confectionne à partir d'un gabarit et de données", () => {
+    const texteGabarit = '__= donnees.titre __ __= donnees.numero __';
+    expect(confectionne(texteGabarit, { titre: 'Le titre', numero: 1 })).to.equal('Le titre 1');
+  });
+});


### PR DESCRIPTION
Dans le processus de création de l'annexe des mesures en latex,
Une 3ème étape est l'utilisation d'un moteur de modèle pour générer le latex
La route est `/pdf/:id/annexeMesures.pdf` et le pdf est un pdf statique obtenu à partir de latex avec le texte GOUVERNANCE injecté

- Utilisation de la bibliothèque DoT https://olado.github.io/doT/