### PR TITLE
🏗 [Preuve de concept] Adaptateur journal MSS Postgres

### DIFF
--- a/src/adaptateurs/adaptateurJournalMSSMemoire.js
+++ b/src/adaptateurs/adaptateurJournalMSSMemoire.js
@@ -1,0 +1,17 @@
+const nouvelAdaptateur = () => {
+  const donnees = { evenements: [] };
+
+  const consigneEvenement = (evenement) => {
+    donnees.evenements.push(evenement);
+    return Promise.resolve();
+  };
+
+  const evenements = () => donnees.evenements;
+
+  return {
+    consigneEvenement,
+    evenements,
+  };
+};
+
+module.exports = { nouvelAdaptateur };

--- a/src/adaptateurs/adaptateurJournalMSSPostgres.js
+++ b/src/adaptateurs/adaptateurJournalMSSPostgres.js
@@ -1,0 +1,28 @@
+const Knex = require('knex');
+const uuid = require('uuid');
+
+const config = {
+  client: 'pg',
+  connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
+  pool: { min: 2, max: 10 },
+  migrations: { tableName: 'knex_migrations' },
+};
+
+const nouvelAdaptateur = () => {
+  const knex = Knex(config);
+
+  const consigneEvenement = (evenement) => {
+    const { type, date } = evenement;
+
+    const id = uuid.v4();
+    const dateIso = new Date(date).toISOString();
+
+    return knex('journal_mss.evenements').insert({ id, type, date: dateIso });
+  };
+
+  return {
+    consigneEvenement,
+  };
+};
+
+module.exports = { nouvelAdaptateur };

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -1,3 +1,4 @@
+const adaptateurJournalMSSMemoire = require('./adaptateurs/adaptateurJournalMSSMemoire');
 const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
@@ -8,6 +9,7 @@ const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 
 const creeDepot = (config = {}) => {
   const {
+    adaptateurJournalMSS = adaptateurJournalMSSMemoire.nouvelAdaptateur(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
     adaptateurUUID = adaptateurUUIDParDefaut,
@@ -15,7 +17,7 @@ const creeDepot = (config = {}) => {
   } = config;
 
   const depotHomologations = depotDonneesHomologations.creeDepot({
-    adaptateurPersistance, adaptateurUUID, referentiel,
+    adaptateurJournalMSS, adaptateurPersistance, adaptateurUUID, referentiel,
   });
 
   const depotUtilisateurs = depotDonneesUtilisateurs.creeDepot({

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -1,4 +1,4 @@
-const adaptateurJournalMSSMemoire = require('./adaptateurs/adaptateurJournalMSSMemoire');
+const adaptateurJournalMSSPostgres = require('./adaptateurs/adaptateurJournalMSSPostgres');
 const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
@@ -9,7 +9,7 @@ const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 
 const creeDepot = (config = {}) => {
   const {
-    adaptateurJournalMSS = adaptateurJournalMSSMemoire.nouvelAdaptateur(),
+    adaptateurJournalMSS = adaptateurJournalMSSPostgres.nouvelAdaptateur(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
     adaptateurUUID = adaptateurUUIDParDefaut,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -5,7 +5,7 @@ const {
 const Homologation = require('../modeles/homologation');
 
 const creeDepot = (config = {}) => {
-  const { adaptateurPersistance, adaptateurUUID, referentiel } = config;
+  const { adaptateurJournalMSS, adaptateurPersistance, adaptateurUUID, referentiel } = config;
 
   const homologation = (idHomologation) => adaptateurPersistance.homologation(idHomologation)
     .then((h) => (h ? new Homologation(h, referentiel) : undefined));
@@ -137,6 +137,7 @@ const creeDepot = (config = {}) => {
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
         idUtilisateur, idHomologation, type: 'createur',
       }))
+      .then(() => adaptateurJournalMSS.consigneEvenement({ type: 'NOUVELLE_HOMOLOGATION_CREEE' }))
       .then(() => idHomologation);
   };
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -3,6 +3,7 @@ const {
   ErreurNomServiceManquant,
 } = require('../erreurs');
 const Homologation = require('../modeles/homologation');
+const Evenement = require('../modeles/journalMSS/evenement');
 
 const creeDepot = (config = {}) => {
   const { adaptateurJournalMSS, adaptateurPersistance, adaptateurUUID, referentiel } = config;
@@ -137,7 +138,7 @@ const creeDepot = (config = {}) => {
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
         idUtilisateur, idHomologation, type: 'createur',
       }))
-      .then(() => adaptateurJournalMSS.consigneEvenement({ type: 'NOUVELLE_HOMOLOGATION_CREEE' }))
+      .then(() => adaptateurJournalMSS.consigneEvenement(new Evenement('NOUVELLE_HOMOLOGATION_CREEE')))
       .then(() => idHomologation);
   };
 

--- a/src/modeles/journalMSS/evenement.js
+++ b/src/modeles/journalMSS/evenement.js
@@ -1,10 +1,14 @@
 class Evenement {
-  constructor(type) {
+  constructor(type, date = Date.now()) {
     this.type = type;
+    this.date = date;
   }
 
   toJSON() {
-    return { type: this.type };
+    return {
+      type: this.type,
+      date: this.date,
+    };
   }
 }
 

--- a/src/modeles/journalMSS/evenement.js
+++ b/src/modeles/journalMSS/evenement.js
@@ -1,0 +1,11 @@
+class Evenement {
+  constructor(type) {
+    this.type = type;
+  }
+
+  toJSON() {
+    return { type: this.type };
+  }
+}
+
+module.exports = Evenement;

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -545,7 +545,7 @@ describe('Le dépôt de données des homologations', () => {
         depot.nouvelleHomologation('123', { nomService: 'Super Service' })
           .then(() => {
             const evenement = adaptateurJournalMSS.evenements()[0];
-            expect(evenement.type).to.be('NOUVELLE_HOMOLOGATION_CREEE');
+            expect(evenement.toJSON().type).to.be('NOUVELLE_HOMOLOGATION_CREEE');
             done();
           })
           .catch(done);

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -26,7 +26,7 @@ const RolesResponsabilites = require('../../src/modeles/rolesResponsabilites');
 
 const copie = require('../../src/utilitaires/copie');
 
-describe('Le dépot de données des homologations', () => {
+describe('Le dépôt de données des homologations', () => {
   it("connaît toutes les homologations d'un utilisateur donné", (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [

--- a/test/modeles/journalMSS/evenement.spec.js
+++ b/test/modeles/journalMSS/evenement.spec.js
@@ -1,0 +1,11 @@
+const expect = require('expect.js');
+
+const Evenement = require('../../../src/modeles/journalMSS/evenement');
+
+describe('Un événement du journal MSS', () => {
+  it('sait se convertir en JSON', () => {
+    const evenement = new Evenement('TEST_EXECUTE');
+
+    expect(evenement.toJSON()).to.eql({ type: 'TEST_EXECUTE' });
+  });
+});

--- a/test/modeles/journalMSS/evenement.spec.js
+++ b/test/modeles/journalMSS/evenement.spec.js
@@ -4,8 +4,8 @@ const Evenement = require('../../../src/modeles/journalMSS/evenement');
 
 describe('Un événement du journal MSS', () => {
   it('sait se convertir en JSON', () => {
-    const evenement = new Evenement('TEST_EXECUTE');
+    const evenement = new Evenement('TEST_EXECUTE', '17/11/2022');
 
-    expect(evenement.toJSON()).to.eql({ type: 'TEST_EXECUTE' });
+    expect(evenement.toJSON()).to.eql({ type: 'TEST_EXECUTE', date: '17/11/2022' });
   });
 });


### PR DESCRIPTION
##  🏗  Preuve de concept : ne pas review
Cette PR sert à valider que l'architecture envisagée pour le Journal MSS alimentant Metabase fonctionne.

Le but est de valider que l'environnement Scalingo `demo-pr…` associé à cette PR est capable de dialoguer avec la base de données `Journal` déjà déployée sur Scalingo.

## Actions

Ci-dessous l'inventaire de ce que j'ai fait 


* Créer une app scalingo `anssi-mss-journal-demo-preuve-de-concept` depuis https://my.scalingo.com/deploy?source=https://github.com/Scalingo/metabase-scalingo
  * J'ai choisi une taille 512 Mo
  * après la création, l'app est visible en https://anssi-mss-journal-demo-preuve-de-concept.osc-fr1.scalingo.io/setup
* Aller sur le dashboard Postgres de l'app, partie « utilisateurs »
    * Avec le formulaire Add User je crée un utilisateur `metabase` en read-only
    * C'est ce qui est décrit [dans cette doc beta.gouv](https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/metabase#creer-un-utilisateur-de-base-de-donnees-specifique-a-metabase)
* se connecter à la BDD via CLI
  * Créer table evenements dans le schéma journal_mss
```sql
CREATE SCHEMA journal_mss 
  CREATE TABLE evenements ( 
    id UUID primary key,
    date date, 
    type varchar,
    donnees json
  );
```
* Donner les droits à l'utilisateur `metabase`
```sql
GRANT USAGE ON SCHEMA journal_mss TO metabase;
GRANT SELECT ON ALL TABLES IN SCHEMA journal_mss TO metabase;
```
:warning: Arrivé ici, dans le GUI Metabase je vois quand même les tables qui sont hors `journal_mss`.  
Ce serait mieux de ne voir **QUE** `journal_mss`.

* De retour côté MSS : [la PR](https://github.com/betagouv/mon-service-securise/pull/483) qui code l'adaptateur Postgres du journal
  * La chaîne de connexion à utiliser pour taper la BDD journal est disponible dans les variables d'env. Scalingo de l'application Journal
   * :warning: Attention au déploiement, le code essaye d'instancier un adaptateur JournalPostgres et si la variable d'env contenant la chaîne de connexion n'existe pas, ça plante le déploiement
  * :arrow_right: il faut créer la variable d'env en DEMO et PROD AVANT de déployer

