### PR TITLE
[CORRECTION] Le mot de passe est aseptisé par erreur

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,4 +27,5 @@ SECRET_COOKIE= # chaîne utilisée pour chiffrer le cookie de session
 SECRET_JWT= # chaîne utilisée pour chiffrer le JWT
 
 # interrupteurs de fonctionnalités (feature switches)
+AVEC_CORRECTION_ASEPTISATION_MOT_DE_PASSE= # renseigner à `true` pour ne plus aseptiser les mots de passe à la mise à jour du profil
 AVEC_MAIL_VIA_SENDINBLUE= # renseigner à `true` pour envoyer les mails via Sendinblue plutôt que SMTP

--- a/src/mss.js
+++ b/src/mss.js
@@ -143,8 +143,8 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
     serveur = app.listen(port, succes);
   };
 
-  const arreteEcoute = () => {
-    serveur.close();
+  const arreteEcoute = (suite) => {
+    serveur.close(suite);
   };
 
   return { ecoute, arreteEcoute };

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -146,11 +146,18 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
       .catch(suite);
   });
 
+  const parametresPutUtilisateurAAseptiser = () => {
+    const resultat = [...Utilisateur.nomsProprietesBase().filter((nom) => nom !== 'email')];
+    if (!process.env.AVEC_CORRECTION_ASEPTISATION_MOT_DE_PASSE) {
+      resultat.push('motDePasse');
+    }
+
+    return resultat;
+  };
+
   routes.put('/utilisateur', middleware.verificationJWT,
-    middleware.aseptise(
-      'motDePasse',
-      ...Utilisateur.nomsProprietesBase().filter((nom) => nom !== 'email'),
-    ), (requete, reponse, suite) => {
+    middleware.aseptise(parametresPutUtilisateurAAseptiser()),
+    (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       const donnees = obtentionDonneesDeBaseUtilisateur(requete.body);
       const cguAcceptees = valeurBooleenne(requete.body.cguAcceptees);

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -389,23 +389,60 @@ describe('Le serveur MSS des routes /api/*', () => {
       );
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        [
-          'motDePasse',
-          'prenom',
-          'nom',
-          'telephone',
-          'cguAcceptees',
-          'poste',
-          'rssi',
-          'delegueProtectionDonnees',
-          'nomEntitePublique',
-          'departementEntitePublique',
-        ],
-        { method: 'put', url: 'http://localhost:1234/api/utilisateur', data: donneesRequete },
-        done
-      );
+    describe("suivant la valeur de la variable d'environnement `AVEC_CORRECTION_ASEPTISATION_MOT_DE_PASSE`", () => {
+      let variableEnvironnement;
+
+      beforeEach(() => {
+        variableEnvironnement = process.env.AVEC_CORRECTION_ASEPTISATION_MOT_DE_PASSE;
+      });
+
+      afterEach(() => {
+        process.env.AVEC_CORRECTION_ASEPTISATION_MOT_DE_PASSE = variableEnvironnement;
+      });
+
+      it('aseptise les paramètres de la requête (y compris le mot de passe) par défaut', (done) => {
+        delete process.env.AVEC_CORRECTION_ASEPTISATION_MOT_DE_PASSE;
+        testeur.reinitialise(() => {
+          testeur.middleware().verifieAseptisationParametres(
+            [
+              'prenom',
+              'nom',
+              'telephone',
+              'cguAcceptees',
+              'poste',
+              'rssi',
+              'delegueProtectionDonnees',
+              'nomEntitePublique',
+              'departementEntitePublique',
+              'motDePasse',
+            ],
+            { method: 'put', url: 'http://localhost:1234/api/utilisateur', data: donneesRequete },
+            done
+          );
+        });
+      });
+
+      it('aseptise les paramètres de la requête (mais pas le mot de passe) si cette variable est renseignée à `"true"`', (done) => {
+        process.env.AVEC_CORRECTION_ASEPTISATION_MOT_DE_PASSE = 'true';
+
+        testeur.reinitialise(() => {
+          testeur.middleware().verifieAseptisationParametres(
+            [
+              'prenom',
+              'nom',
+              'telephone',
+              'cguAcceptees',
+              'poste',
+              'rssi',
+              'delegueProtectionDonnees',
+              'nomEntitePublique',
+              'departementEntitePublique',
+            ],
+            { method: 'put', url: 'http://localhost:1234/api/utilisateur', data: donneesRequete },
+            done
+          );
+        });
+      });
     });
 
     it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", (done) => {

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -58,7 +58,9 @@ const testeurMss = () => {
       });
   };
 
-  const arrete = () => (serveur.arreteEcoute());
+  const arrete = (suite = () => {}) => (serveur.arreteEcoute(suite));
+
+  const reinitialise = (done) => arrete(() => initialise(done));
 
   return {
     adaptateurEquations: () => adaptateurEquations,
@@ -70,6 +72,7 @@ const testeurMss = () => {
     referentiel: () => referentiel,
     arrete,
     initialise,
+    reinitialise,
     verifieRequeteGenereErreurHTTP,
     verifieJetonDepose,
   };


### PR DESCRIPTION
Description du bug : 
Quand un utilisateur possède un mot de passe avec des caractères aseptisables (ex : &), la connexion ne se fait pas

Dans api/utilisateur on aseptise le mot de passe donc les caractères mais pas dans /api/token ce bug vient d'une modification sur la route PUT /api/utilisateur https://github.com/betagouv/mon-service-securise/commit/33b716e2164c22f7e322f480cffc83fbb8266bac#diff-bb9fee1edd1c7cc853a1c85ca33c152f511b18687e9955c3fba901c174bdea44
Qui est en prod depuis le 26 aout https://github.com/betagouv/mon-service-securise/pull/324