### PR TITLE
Décodage des caractères html pour le latex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express": "^4.17.3",
         "express-basic-auth": "^1.2.1",
         "express-validator": "^6.14.0",
+        "html-entities": "^2.3.3",
         "jsonwebtoken": "^8.5.1",
         "knex": "^1.0.4",
         "mathjax-node": "^2.1.1",
@@ -2498,6 +2499,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "node_modules/http-errors": {
       "version": "1.8.1",
@@ -8040,6 +8046,11 @@
       "requires": {
         "whatwg-encoding": "^2.0.0"
       }
+    },
+    "html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "http-errors": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "express": "^4.17.3",
     "express-basic-auth": "^1.2.1",
     "express-validator": "^6.14.0",
+    "html-entities": "^2.3.3",
     "jsonwebtoken": "^8.5.1",
     "knex": "^1.0.4",
     "mathjax-node": "^2.1.1",

--- a/src/adaptateurs/adaptateurPdfLatex.js
+++ b/src/adaptateurs/adaptateurPdfLatex.js
@@ -2,11 +2,15 @@ const fsPromises = require('fs/promises');
 const pdflatex = require('node-pdflatex').default;
 
 const fabriquantGabarit = require('../latex/fabriquantGabarit');
+const { miseEnFormeLatex } = require('../latex/miseEnFormeDonnees');
 
 const generationPdfLatex = (cheminFichierTex, donnees = {}) => fsPromises
   .readFile(cheminFichierTex)
   .then((donneesFichier) => {
-    const texConfectionne = fabriquantGabarit.confectionne(donneesFichier.toString(), donnees);
+    const donneesMisesEnForme = miseEnFormeLatex(donnees);
+    const texConfectionne = fabriquantGabarit.confectionne(
+      donneesFichier.toString(), donneesMisesEnForme
+    );
     return pdflatex(texConfectionne);
   });
 

--- a/src/latex/miseEnFormeDonnees.js
+++ b/src/latex/miseEnFormeDonnees.js
@@ -1,0 +1,32 @@
+const { decode } = require('html-entities');
+
+const decodeCaracteresHtml = (texte) => decode(texte);
+
+const miseEnForme = (operation) => {
+  const metEnForme = (objet) => {
+    if (typeof objet === 'string') {
+      return operation(objet);
+    }
+
+    if (Array.isArray(objet)) {
+      return objet.map((element) => metEnForme(element));
+    }
+
+    if (typeof objet === 'object' && objet) {
+      return Object.keys(objet).reduce((accumulateur, propriete) => (
+        { ...accumulateur, [propriete]: metEnForme(objet[propriete]) }
+      ), {});
+    }
+
+    return objet;
+  };
+
+  return metEnForme;
+};
+
+const miseEnFormeLatex = miseEnForme(decodeCaracteresHtml);
+
+module.exports = {
+  miseEnForme,
+  miseEnFormeLatex,
+};

--- a/src/routes/routesPdf.js
+++ b/src/routes/routesPdf.js
@@ -4,7 +4,13 @@ const routesPdf = (adaptateurPdf) => {
   const routes = express.Router();
 
   routes.get('/:id/annexeMesures.pdf', (_requete, reponse, suite) => {
-    adaptateurPdf.genereAnnexeMesures({ categorie: 'GOUVERNANCE' })
+    const echantillonDonnees = {
+      categorie: 'GOUVERNANCE',
+      mesure: {
+        description: 'Héberger le service numérique et les données au sein de l&#39;Union européenne',
+      },
+    };
+    adaptateurPdf.genereAnnexeMesures(echantillonDonnees)
       .then((pdf) => {
         reponse.contentType('application/pdf');
         reponse.send(pdf);

--- a/src/vuesTex/annexeMesures.template.tex
+++ b/src/vuesTex/annexeMesures.template.tex
@@ -37,7 +37,7 @@
   \begin{tcolorbox}[colback=white, colframe=lisere, boxrule=1px]
     \textcolor{bleu}{__= donnees.categorie __}
     \begin{itemize}
-      \item * Limiter et connaître les interconnexions du service avec d'autres systèmes
+      \item * __= donnees.mesure.description __
 
         \textcolor{gris}{Le service est complètement autonome et n'est connecté à aucun autre
         service.}

--- a/test/latex/miseEnFormeDonnees.spec.js
+++ b/test/latex/miseEnFormeDonnees.spec.js
@@ -1,0 +1,45 @@
+const expect = require('expect.js');
+
+const { miseEnForme, miseEnFormeLatex } = require('../../src/latex/miseEnFormeDonnees');
+
+describe('La mise en forme de données', () => {
+  describe('pour le LaTeX', () => {
+    it('décode les caractères html', () => {
+      expect(miseEnFormeLatex('l&#39;orage est proche')).to.equal("l'orage est proche");
+    });
+  });
+
+  describe("sur une demande de mise en forme d'un objet", () => {
+    it("met en forme directement quand l'objet est un chaîne de caractères", () => {
+      const operation = (texte) => texte.replaceAll('#', '');
+
+      expect(miseEnForme(operation)('Texte avec ##croisillons')).to.equal('Texte avec croisillons');
+    });
+
+    it("met en forme les valeurs des propriétés de l'objet quand elles sont des chaînes de caractères", () => {
+      const operation = (texte) => texte.replaceAll('#', '');
+
+      expect(miseEnForme(operation)({ clef: '##croisillons' })).to.eql({ clef: 'croisillons' });
+    });
+
+    it("met en forme les valeurs des propriétés enfouies de l'objet quand elles sont des chaînes de caractères", () => {
+      const operation = (texte) => texte.replaceAll('#', '');
+
+      expect(miseEnForme(operation)({ clef: { clef2: '##croisillons' } })).to.eql({ clef: { clef2: 'croisillons' } });
+    });
+
+    it("met en forme les valeurs des collections de l'objet quand elles sont composées de chaînes de caractères", () => {
+      const operation = (texte) => texte.replaceAll('#', '');
+
+      expect(miseEnForme(operation)({ clef: ['##croisillons', '#@#'] })).to.eql({ clef: ['croisillons', '@'] });
+    });
+
+    it("reste robuste quand des valeurs dans l'objet ne sont pas des chaînes de caractères", () => {
+      const operation = (texte) => texte.replaceAll('#', '');
+
+      expect(miseEnForme(operation)({ clef: 12 })).to.eql({ clef: 12 });
+      expect(miseEnForme(operation)(undefined)).to.equal(undefined);
+      expect(miseEnForme(operation)(null)).to.equal(null);
+    });
+  });
+});


### PR DESCRIPTION
Dans le processus de création de l'annexe des mesures en latex,
Une 4ème étape est le décodage des caractères html issue de l'aseptisation avant l'interpolation dans le latex
La route est /pdf/:id/annexeMesures.pdf et le pdf est un pdf statique obtenu à partir de latex avec un échantillon de données injecté contenant un caractère html

- Ajout de la bibliothèque html-entities https://github.com/mdevils/html-entities#readme