### PR TITLE
Toutes les mesures dans le pdf

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -129,7 +129,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
 
   app.use('/homologation', routesHomologation(middleware, referentiel, moteurRegles));
 
-  app.use('/pdf', routesPdf(adaptateurPdf));
+  app.use('/pdf', routesPdf(middleware, adaptateurPdf));
 
   app.use('/service', routesService(middleware));
 

--- a/src/routes/routesPdf.js
+++ b/src/routes/routesPdf.js
@@ -1,17 +1,14 @@
 const express = require('express');
 
-const routesPdf = (adaptateurPdf) => {
+const routesPdf = (middleware, adaptateurPdf) => {
   const routes = express.Router();
 
-  routes.get('/:id/annexeMesures.pdf', (_requete, reponse, suite) => {
-    const echantillonDonnees = {
-      categorie: 'GOUVERNANCE',
-      mesure: {
-        description: 'Héberger le service numérique et les données au sein de l&#39;Union européenne',
-        modalites: 'Les données sont en France & Espagne % $ # _ { } ~ ^ \\',
-      },
-    };
-    adaptateurPdf.genereAnnexeMesures(echantillonDonnees)
+  routes.get('/:id/annexeMesures.pdf', middleware.trouveHomologation, (requete, reponse, suite) => {
+    const { homologation } = requete;
+    const mesuresParStatut = homologation.mesuresParStatut();
+    const statuts = { enCours: 'En cours', nonFait: 'Non fait', fait: 'Fait' };
+    const donnees = { statuts, mesuresParStatut };
+    adaptateurPdf.genereAnnexeMesures(donnees)
       .then((pdf) => {
         reponse.contentType('application/pdf');
         reponse.send(pdf);

--- a/src/vuesTex/annexeMesures.template.tex
+++ b/src/vuesTex/annexeMesures.template.tex
@@ -32,19 +32,25 @@
 
   \vskip 0.5cm
 
-  \textbf{En cours}
+  __~ Object.keys(donnees.mesuresParStatut) :statut __
+    \textbf{__= donnees.statuts[statut] __}
 
-  \begin{tcolorbox}[colback=white, colframe=lisere, boxrule=1px]
-    \textcolor{bleu}{__= donnees.categorie __}
-    \begin{itemize}
-      \item * __= donnees.mesure.description __
-
-        \textcolor{gris}{__= donnees.mesure.modalites __}
-      \item * Disposer d'une liste à jour des équipements et des logiciels contribuant au
-        fonctionnement du service numérique
-      \item Identifier les données les plus sensibles à protéger
-    \end{itemize}
-  \end{tcolorbox}
+    \begin{tcolorbox}[colback=white, colframe=lisere, boxrule=1px]
+      __~ Object.keys(donnees.mesuresParStatut[statut]) :categorie __
+        \textcolor{bleu}{__= categorie __}
+        __? donnees.mesuresParStatut[statut][categorie] && donnees.mesuresParStatut[statut][categorie].length __
+          \begin{itemize}
+            __~ donnees.mesuresParStatut[statut][categorie] :mesure __
+              \item __? mesure.indispensable__*__?__ __= mesure.description__
+                __? mesure.modalites __
+                  \textcolor{gris}{__= mesure.modalites__}
+                __?__
+            __~__
+          \end{itemize}
+        __?__
+      __~__
+    \end{tcolorbox}
+  __~__
 
   \vskip 1cm
 

--- a/test/routes/routesPdf.spec.js
+++ b/test/routes/routesPdf.spec.js
@@ -15,6 +15,13 @@ describe('Le serveur MSS des routes /pdf/*', () => {
       testeur.adaptateurPdf().genereAnnexeMesures = () => Promise.resolve('Pdf annexe mesures');
     });
 
+    it("recherche l'homologation correspondante", (done) => {
+      testeur.middleware().verifieRechercheHomologation(
+        'http://localhost:1234/pdf/456/annexeMesures.pdf',
+        done,
+      );
+    });
+
     it('sert un fichier de type pdf', (done) => {
       axios.get('http://localhost:1234/pdf/456/annexeMesures.pdf')
         .then((pdf) => {


### PR DESCRIPTION
Dans le processus de création de l'annexe des mesures en latex,
Ceci est la dernière étape pour avoir les mesures sans style et sans pagination
La route est /pdf/:id/annexeMesures.pdf et le pdf affiche toutes les mesures mais non ordonnées et avec les catégories mal écrites