### PR TITLE
Parle de « Service » plutôt que « d'Homologation »

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -3,7 +3,7 @@ const {
   ErreurNomServiceManquant,
 } = require('../erreurs');
 const Homologation = require('../modeles/homologation');
-const { EvenementNouvelleHomologationCreee } = require('../modeles/journalMSS/evenements');
+const { EvenementNouveauServiceCree } = require('../modeles/journalMSS/evenements');
 
 const creeDepot = (config = {}) => {
   const { adaptateurJournalMSS, adaptateurPersistance, adaptateurUUID, referentiel } = config;
@@ -138,7 +138,7 @@ const creeDepot = (config = {}) => {
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
         idUtilisateur, idHomologation, type: 'createur',
       }))
-      .then(() => adaptateurJournalMSS.consigneEvenement(new EvenementNouvelleHomologationCreee()))
+      .then(() => adaptateurJournalMSS.consigneEvenement(new EvenementNouveauServiceCree()))
       .then(() => idHomologation);
   };
 

--- a/src/modeles/journalMSS/evenements.js
+++ b/src/modeles/journalMSS/evenements.js
@@ -12,10 +12,10 @@ class Evenements {
   }
 }
 
-class EvenementNouvelleHomologationCreee extends Evenements {
+class EvenementNouveauServiceCree extends Evenements {
   constructor(date = Date.now()) {
-    super('NOUVELLE_HOMOLOGATION_CREEE', date);
+    super('NOUVEAU_SERVICE_CREE', date);
   }
 }
 
-module.exports = { EvenementNouvelleHomologationCreee };
+module.exports = { EvenementNouveauServiceCree };

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -25,8 +25,9 @@ const RisqueSpecifique = require('../../src/modeles/risqueSpecifique');
 const RisquesSpecifiques = require('../../src/modeles/risquesSpecifiques');
 const RolesResponsabilites = require('../../src/modeles/rolesResponsabilites');
 
+const { EvenementNouveauServiceCree } = require('../../src/modeles/journalMSS/evenements');
+
 const copie = require('../../src/utilitaires/copie');
-const { EvenementNouvelleHomologationCreee } = require('../../src/modeles/journalMSS/evenements');
 
 describe('Le dépôt de données des homologations', () => {
   it("connaît toutes les homologations d'un utilisateur donné", (done) => {
@@ -544,7 +545,7 @@ describe('Le dépôt de données des homologations', () => {
     describe("le journal MSS est utilisé pour consigner l'enregistrement", () => {
       it('avec un événement typé', (done) => {
         adaptateurJournalMSS.consigneEvenement = (evenement) => {
-          expect(evenement).to.be.an(EvenementNouvelleHomologationCreee);
+          expect(evenement).to.be.an(EvenementNouveauServiceCree);
           done();
         };
 

--- a/test/modeles/journalMSS/evenements.spec.js
+++ b/test/modeles/journalMSS/evenements.spec.js
@@ -1,10 +1,10 @@
 const expect = require('expect.js');
-const { EvenementNouvelleHomologationCreee } = require('../../../src/modeles/journalMSS/evenements');
+const { EvenementNouveauServiceCree } = require('../../../src/modeles/journalMSS/evenements');
 
-describe('Un événement de nouvelle homologation créée', () => {
+describe('Un événement de nouveau service créé', () => {
   it('sait se convertir en JSON', () => {
-    const evenement = new EvenementNouvelleHomologationCreee('17/11/2022');
+    const evenement = new EvenementNouveauServiceCree('17/11/2022');
 
-    expect(evenement.toJSON()).to.eql({ type: 'NOUVELLE_HOMOLOGATION_CREEE', date: '17/11/2022' });
+    expect(evenement.toJSON()).to.eql({ type: 'NOUVEAU_SERVICE_CREE', date: '17/11/2022' });
   });
 });


### PR DESCRIPTION
Suite à notre décision commune de parler de _« Service »_ dès le départ dans les Événements.