### PR TITLE
[CORRECTION] Jeu des migrations sur les tables `homologations` _et_ `services`

### DIFF
--- a/migrations/20221021094600_suppressionMesuresGeneralesObsoletes.js
+++ b/migrations/20221021094600_suppressionMesuresGeneralesObsoletes.js
@@ -11,16 +11,21 @@ const IDS_MESURES_OBSOLETES = [
   'sensibilisationRisques',
 ];
 
-exports.up = (knex) => knex('homologations')
+const supprimeMesuresObsoletesDansTable = (knex, table) => knex(table)
   .then((lignes) => {
     const misesAJour = lignes.map(({ id, donnees }) => {
       donnees.mesuresGenerales ||= [];
       donnees.mesuresGenerales = donnees.mesuresGenerales
         .filter((m) => !IDS_MESURES_OBSOLETES.includes(m.id));
-      return knex('homologations').where({ id }).update({ donnees });
+      return knex(table).where({ id }).update({ donnees });
     });
 
     return Promise.all(misesAJour);
   });
+
+exports.up = (knex) => Promise.all(
+  ['homologations', 'services']
+    .map((table) => supprimeMesuresObsoletesDansTable(knex, table))
+);
 
 exports.down = () => Promise.resolve();

--- a/migrations/20221102134033_changeProvenanceService.js
+++ b/migrations/20221102134033_changeProvenanceService.js
@@ -32,7 +32,7 @@ const developpeProvenance = (provenance) => {
   return PROVENANCES.includes(provenance) ? [provenance] : [];
 };
 
-const changementDescriptionService = (changeProvenance) => (knex) => knex('homologations')
+const changementDescriptionServicePourTable = (knex, table, changeProvenance) => knex(table)
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees?.descriptionService)
@@ -40,12 +40,17 @@ const changementDescriptionService = (changeProvenance) => (knex) => knex('homol
         descriptionService.provenanceService = changeProvenance(
           descriptionService.provenanceService
         );
-        return knex('homologations')
+        return knex(table)
           .where({ id })
           .update({ donnees: { descriptionService, ...autresDonnees } });
       });
     return Promise.all(misesAJour);
   });
+
+const changementDescriptionService = (changeProvenance) => (knex) => Promise.all(
+  ['homologations', 'services']
+    .map((table) => changementDescriptionServicePourTable(knex, table, changeProvenance))
+);
 
 exports.up = changementDescriptionService(reduitProvenance);
 

--- a/migrations/20221115150500_suppressionDiffusionRestreinte.js
+++ b/migrations/20221115150500_suppressionDiffusionRestreinte.js
@@ -2,7 +2,7 @@
 // 'donneesCaracterePersonnel' de la description des services.
 // Car 'Diffusion restreinte' est supprimée du référentiel.
 
-exports.up = (knex) => knex('homologations')
+const supprimeDiffusionRestreinteDansTable = (knex, table) => knex(table)
   .then((lignes) => {
     const misesAJour = lignes
       .filter(({ donnees }) => donnees.descriptionService?.donneesCaracterePersonnel)
@@ -12,10 +12,15 @@ exports.up = (knex) => knex('homologations')
           .donneesCaracterePersonnel
           .filter((d) => d !== 'diffusionRestreinte');
 
-        return knex('homologations').where({ id }).update({ donnees });
+        return knex(table).where({ id }).update({ donnees });
       });
 
     return Promise.all(misesAJour);
   });
+
+exports.up = (knex) => Promise.all(
+  ['homologations', 'services']
+    .map((table) => supprimeDiffusionRestreinteDansTable(knex, table))
+);
 
 exports.down = () => Promise.resolve();


### PR DESCRIPTION
Jusqu'ici, ces trois (dernières) migrations ne mettaient pas à jour les données dans la table `services`, ce qui entraînait une divergence entre les deux tables.

Cette PR corrige le problème (et nécessite de rejouer ces trois migrations dans les environnements de déploiement).