### PR TITLE
Suppression du choix « non concerné »

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -294,7 +294,6 @@ module.exports = {
     fait: 'Fait',
     enCours: 'En cours',
     nonFait: 'Non fait',
-    nonRetenu: 'Non concerné',
   },
 
   mesures: {

--- a/migrations/20221130100733_suppressionStatutMesureNonConcerne.js
+++ b/migrations/20221130100733_suppressionStatutMesureNonConcerne.js
@@ -1,0 +1,35 @@
+const nouveauStatut = (statut) => (statut === 'nonRetenu' ? 'nonFait' : statut);
+
+const supprimeStatut = (knex, table) => knex(table)
+  .then((lignes) => {
+    const misesAJour = lignes
+      .filter(({ donnees }) => donnees?.mesuresGenerales || donnees?.mesuresSpecifiques)
+      .map(({ id, donnees: { mesuresGenerales, mesuresSpecifiques, ...autresDonnees } }) => {
+        const nouvellesMesuresGenerales = mesuresGenerales?.map((mesure) => (
+          { ...mesure, statut: nouveauStatut(mesure.statut) }
+        ));
+        const nouvellesMesuresSpecifiques = mesuresSpecifiques?.map((mesure) => (
+          { ...mesure, statut: nouveauStatut(mesure.statut) }
+        ));
+
+        return knex(table)
+          .where({ id })
+          .update({
+            donnees: {
+              mesuresGenerales: nouvellesMesuresGenerales,
+              mesuresSpecifiques: nouvellesMesuresSpecifiques,
+              ...autresDonnees,
+            },
+          });
+      });
+
+    return Promise.all(misesAJour);
+  });
+
+exports.up = (knex) => Promise.all(
+  ['homologations', 'services'].map((table) => supprimeStatut(knex, table))
+);
+
+exports.down = () => Promise.resolve();
+
+exports.nouveauStatut = nouveauStatut;

--- a/public/assets/styles/decision.css
+++ b/public/assets/styles/decision.css
@@ -335,10 +335,6 @@ section.detail-mesures .statut.nonFait, .legende .nonFait:before {
   background: var(--bleu-anssi);
 }
 
-section.detail-mesures .statut.nonRetenu, .legende .nonRetenu:before {
-  background: #fff;
-}
-
 @page print {
   * {
       -webkit-print-color-adjust: exact !important;

--- a/src/modeles/mesure.js
+++ b/src/modeles/mesure.js
@@ -10,7 +10,6 @@ const STATUTS = {
   STATUT_FAIT: 'fait',
   STATUT_EN_COURS: 'enCours',
   STATUT_NON_FAIT: 'nonFait',
-  STATUT_NON_RETENU: 'nonRetenu',
 };
 
 class Mesure extends InformationsHomologation {
@@ -26,7 +25,6 @@ class Mesure extends InformationsHomologation {
 
   static statutRenseigne(statut) {
     return Object.keys(STATUTS)
-      .filter((clef) => clef !== 'STATUT_NON_RETENU')
       .map((clef) => STATUTS[clef])
       .includes(statut);
   }

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -31,10 +31,6 @@ class MesureGenerale extends Mesure {
     return !this.estIndispensable();
   }
 
-  nonRetenue() {
-    return this.statut === Mesure.STATUT_NON_RETENU;
-  }
-
   statutRenseigne() {
     return Mesure.statutRenseigne(this.statut);
   }

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -45,10 +45,6 @@ class Mesures extends InformationsHomologation {
     return this.mesuresSpecifiques.parStatut(mesuresGeneralesParStatut);
   }
 
-  proportion(...params) {
-    return this.mesuresGenerales.proportion(...params);
-  }
-
   statistiques() {
     return this.mesuresGenerales.statistiques(this.mesuresPersonnalisees);
   }

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -29,23 +29,6 @@ class MesuresGenerales extends ElementsConstructibles {
     return mesuresParStatut;
   }
 
-  proportion(nbMisesEnOeuvre, idsMesures) {
-    const identifiantsMesuresNonRetenues = () => this.items
-      .filter((m) => m.nonRetenue())
-      .map((m) => m.id);
-
-    const nbTotalMesuresRetenuesParmi = (identifiantsMesures) => {
-      const nonRetenues = identifiantsMesuresNonRetenues();
-
-      return identifiantsMesures
-        .filter((id) => !nonRetenues.includes(id))
-        .length;
-    };
-
-    const nbTotal = nbTotalMesuresRetenuesParmi(idsMesures);
-    return nbTotal ? nbMisesEnOeuvre / nbTotal : 1;
-  }
-
   statistiques(mesuresPersonnalisees) {
     const statuts = MesureGenerale.statutsPossibles();
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -207,7 +207,7 @@ describe('Une homologation', () => {
       const homologation = new Homologation({
         mesuresGenerales: [
           { id: 'm1', statut: MesureGenerale.STATUT_FAIT },
-          { id: 'm2', statut: MesureGenerale.STATUT_NON_RETENU },
+          { id: 'm2', statut: MesureGenerale.STATUT_FAIT },
         ],
       }, referentiel, moteur);
 

--- a/test/modeles/mesure.spec.js
+++ b/test/modeles/mesure.spec.js
@@ -6,7 +6,7 @@ const elle = it;
 
 describe('Une mesure', () => {
   elle('connaît ses statuts possibles', () => {
-    expect(Mesure.statutsPossibles()).to.eql(['fait', 'enCours', 'nonFait', 'nonRetenu']);
+    expect(Mesure.statutsPossibles()).to.eql(['fait', 'enCours', 'nonFait']);
   });
 
   elle("ne tient pas compte du statut s'il n'est pas renseigné", (done) => {
@@ -21,10 +21,6 @@ describe('Une mesure', () => {
   describe('sur une interrogation de statut renseigné', () => {
     elle('répond favorablement quand le statut est dans les statuts concernés', () => {
       expect(Mesure.statutRenseigne('fait')).to.be(true);
-    });
-
-    elle('répond défavorablement quand le statut est non retenu', () => {
-      expect(Mesure.statutRenseigne('nonRetenu')).to.be(false);
     });
 
     elle("répond défavorablement quand le statut n'est pas renseigné", () => {

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -86,28 +86,6 @@ describe('La liste des mesures générales', () => {
       expect(stats.une.misesEnOeuvre).to.equal(1);
     });
 
-    it('ne tient pas compte des mesures non retenues', () => {
-      const mesuresGenerales = creeMesuresGenerales([
-        { id: 'id1', statut: 'enCours' },
-        { id: 'id2', statut: 'nonRetenu' },
-      ]);
-
-      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
-      expect(stats.une.retenues).to.equal(1);
-      expect(stats.une.misesEnOeuvre).to.equal(0);
-    });
-
-    it('classe les statistiques par catégorie de mesure', () => {
-      const mesuresGenerales = creeMesuresGenerales([
-        { id: 'id1', statut: 'nonRetenu' },
-        { id: 'id3', statut: 'fait' },
-      ]);
-
-      const stats = mesuresGenerales.statistiques({ id1: {}, id2: {}, id3: {} }).toJSON();
-      expect(stats.deux.retenues).to.equal(1);
-      expect(stats.deux.misesEnOeuvre).to.equal(1);
-    });
-
     it('calcule le nombre total de mesures indispensables personnalisées', () => {
       const mesuresGenerales = creeMesuresGenerales([]);
 

--- a/test_migrations/20221130100733_suppressionStatutMesureNonConcerne.spec.js
+++ b/test_migrations/20221130100733_suppressionStatutMesureNonConcerne.spec.js
@@ -1,0 +1,23 @@
+const expect = require('expect.js');
+const { nouveauStatut } = require('../migrations/20221130100733_suppressionStatutMesureNonConcerne');
+
+const Statuts = {
+  FAIT: 'fait',
+  NON_FAIT: 'nonFait',
+  NON_CONCERNE: 'nonRetenu',
+};
+
+describe('Le nouveau statut', () => {
+  it("reste le même quand le statut n'est pas non concerné", () => {
+    expect(nouveauStatut(Statuts.FAIT)).to.equal(Statuts.FAIT);
+    expect(nouveauStatut(Statuts.NON_FAIT)).to.equal(Statuts.NON_FAIT);
+  });
+
+  it('devient non fait quand le statut est non concerné', () => {
+    expect(nouveauStatut(Statuts.NON_CONCERNE)).to.equal(Statuts.NON_FAIT);
+  });
+
+  it("reste robuste quand le statut est n'est pas défini", () => {
+    expect(nouveauStatut()).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
Dans la section « sécuriser », le choix « non concerné » disparaît (56d6f6e8a3600a3500de2f37c991c9879b3ffd5d).
Les mesures déjà enregistrées comme « non concerné » deviennent « non fait » (e5fa99858eb5a764e95798f1c9d2aafe851d6c63).