### PR TITLE
Duplication des autorisations homologations services

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     'no-unused-vars': ['error', {
       args: 'all',
       argsIgnorePattern: '^_',
+      ignoreRestSiblings: true,
     }],
     'object-curly-newline': ['error', {
       ObjectExpression: { consistent: true },

--- a/migrations/20221129194103_duplicationAutorisationsHomologationsEnAutorisationsServices.js
+++ b/migrations/20221129194103_duplicationAutorisationsHomologationsEnAutorisationsServices.js
@@ -1,0 +1,21 @@
+const pourChaqueLigne = (requete, miseAJour) => import('p-map')
+  .then((module) => {
+    const pMap = module.default;
+
+    return requete.then((lignes) => pMap(lignes, miseAJour, { concurrency: 2 }));
+  });
+
+exports.up = (knex) => pourChaqueLigne(
+  knex('autorisations'),
+  ({ id, donnees }) => {
+    donnees.idService = donnees.idHomologation;
+    return knex('autorisations').where({ id }).update({ donnees });
+  },
+);
+
+exports.down = (knex) => pourChaqueLigne(
+  knex('autorisations'),
+  ({ id, donnees: { idService, ...autresDonnees } }) => knex('autorisations')
+    .where({ id })
+    .update({ donnees: autresDonnees }),
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "mathjax-node": "^2.1.1",
         "node-pdflatex": "^0.3.0",
         "nodemailer": "^6.7.3",
+        "p-map": "^5.5.0",
         "pdf-lib": "^1.17.1",
         "pg": "^8.7.3",
         "pug": "^3.0.2",
@@ -430,6 +431,21 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "dependencies": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -925,6 +941,31 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clean-stack/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -2678,6 +2719,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -4445,6 +4497,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+      "dependencies": {
+        "aggregate-error": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -6497,6 +6563,15 @@
         }
       }
     },
+    "aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "requires": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -6881,6 +6956,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
+    "clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "requires": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
+      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -8222,6 +8312,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -9565,6 +9660,14 @@
       "peer": true,
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-map": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+      "requires": {
+        "aggregate-error": "^4.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mathjax-node": "^2.1.1",
     "node-pdflatex": "^0.3.0",
     "nodemailer": "^6.7.3",
+    "p-map": "^5.5.0",
     "pdf-lib": "^1.17.1",
     "pg": "^8.7.3",
     "pug": "^3.0.2",

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -55,7 +55,7 @@ const creeDepot = (config = {}) => {
       .then(() => verifieHomologationExiste(idHomologation))
       .then(() => verifieAutorisationInexistante(idContributeur, idHomologation))
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
-        idUtilisateur: idContributeur, idHomologation, type: 'contributeur',
+        idUtilisateur: idContributeur, idHomologation, idService: idHomologation, type: 'contributeur',
       }));
   };
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -169,7 +169,7 @@ const creeDepot = (config = {}) => {
         adaptateurPersistance.ajouteService(idHomologation, donnees),
       ]))
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
-        idUtilisateur, idHomologation, type: 'createur',
+        idUtilisateur, idHomologation, idService: idHomologation, type: 'createur',
       }))
       .then(() => adaptateurJournalMSS.consigneEvenement(
         new EvenementNouveauServiceCree({ idService: idHomologation, idUtilisateur }).toJSON()

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -2,7 +2,7 @@ const Base = require('../base');
 
 class AutorisationBase extends Base {
   constructor(donnees = {}) {
-    super({ proprietesAtomiquesRequises: ['id', 'idUtilisateur', 'idHomologation'] });
+    super({ proprietesAtomiquesRequises: ['id', 'idUtilisateur', 'idHomologation', 'idService'] });
     this.renseigneProprietes(donnees);
 
     this.permissionAjoutContributeur = false;

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -221,6 +221,7 @@ describe('Le dépôt de données des autorisations', () => {
         .then((a) => {
           expect(a).to.be.a(AutorisationContributeur);
           expect(a.idHomologation).to.equal('123');
+          expect(a.idService).to.equal('123');
           expect(a.idUtilisateur).to.equal('000');
           done();
         })

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -537,6 +537,7 @@ describe('Le dépôt de données des homologations', () => {
           const autorisation = as[0];
           expect(autorisation).to.be.an(AutorisationCreateur);
           expect(autorisation.idHomologation).to.equal('unUUID');
+          expect(autorisation.idService).to.equal('unUUID');
           expect(autorisation.idUtilisateur).to.equal('123');
           done();
         })


### PR DESCRIPTION
Cette PR fait suite à #388 et s'inscrit de manière plus large dans l'ajout d'un parcours homologation.

Note : on profite de cette PR pour explorer un chemin sans `Promise.all` dans les migrations, en s'appuyant sur [p-map](https://github.com/sindresorhus/p-map). Si ça convient comme tel, je m'occuperai de nettoyer les autres `Promise.all` gênants dans notre code de cette manière.

Prochaines étapes :
- [ ] Migrer les données `homologations` en `services`
  - [x] Dupliquer les données de la table `homologations` dans la table `services`
  - [x] Reporter les requêtes d'ajout / modification d'homologation sur les services
  - [x] Dupliquer les données de `autorisations.donnees->>'idHomologation'` dans `autorisations.donnees->>'idService'`
  - [x] Reporter les requêtes d'ajout / modification des autorisations sur les services
  - [ ] Changer les routes concernant les homologations en routes concernant les services, et reporter les requêtes d'ajout / modification des services en ajout/modification des homologations
  - [ ] Supprimer les reports de requêtes
  - [ ] Supprimer la table `homologations`
- [ ] Différencier l'affichage dans `/service/:id/homologations` suivant qu'il y a ou pas une homologation rattachée au service
- [ ] Ajouter une route `POST /service/:id/homologation` et une route `GET /homologation/:id` (qui permet d'accéder au PDF)
- [ ] Changer la page de synthèse pour offrir les accès à décrire / sécuriser / homologuer.