### PR TITLE
Annexe risques - Style comme les mesures

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -8,6 +8,7 @@ const Mesures = require('./mesures');
 const Risques = require('./risques');
 const RolesResponsabilites = require('./rolesResponsabilites');
 const Utilisateur = require('./utilisateur');
+const VueAnnexePDFRisques = require('./objetsVues/vueAnnexePDFRisques');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -134,6 +135,10 @@ class Homologation {
 
   risquesSpecifiques() {
     return this.risques.risquesSpecifiques;
+  }
+
+  vueAnnexePDFRisques() {
+    return new VueAnnexePDFRisques(this, this.referentiel);
   }
 
   statistiquesMesures() {

--- a/src/modeles/objetsVues/vueAnnexePDFRisques.js
+++ b/src/modeles/objetsVues/vueAnnexePDFRisques.js
@@ -1,0 +1,17 @@
+const Referentiel = require('../../referentiel');
+
+class VueAnnexePDFRisques {
+  constructor(homologation, referentiel = Referentiel.creeReferentielVide()) {
+    this.referentiel = referentiel;
+    this.homologation = homologation;
+  }
+
+  donnees() {
+    return {
+      niveauxGravite: this.referentiel.infosNiveauxGraviteConcernes(true),
+      nomService: this.homologation.nomService(),
+    };
+  }
+}
+
+module.exports = VueAnnexePDFRisques;

--- a/src/routes/routesPdf.js
+++ b/src/routes/routesPdf.js
@@ -20,9 +20,10 @@ const routesPdf = (middleware, referentiel, adaptateurPdf) => {
       .catch(suite);
   });
 
-  routes.get('/:id/annexeRisques.pdf', (_requete, reponse, suite) => {
-    const niveauxGravite = referentiel.infosNiveauxGraviteConcernes(true);
-    adaptateurPdf.genereAnnexeRisques({ niveauxGravite })
+  routes.get('/:id/annexeRisques.pdf', middleware.trouveHomologation, (requete, reponse, suite) => {
+    const { homologation } = requete;
+    const donnees = homologation.vueAnnexePDFRisques().donnees();
+    adaptateurPdf.genereAnnexeRisques(donnees)
       .then((pdf) => {
         reponse.contentType('application/pdf');
         reponse.send(pdf);

--- a/src/vuesTex/annexeRisques.template.tex
+++ b/src/vuesTex/annexeRisques.template.tex
@@ -3,38 +3,41 @@
 \usepackage[T1]{fontenc}
 
 \usepackage{array}
-\usepackage[a4paper, margin=10mm]{geometry}
+\usepackage{enumitem}
+\usepackage[a4paper, margin=10mm, includehead, includefoot, headheight=15mm]{geometry}
 
 \usepackage[scaled]{helvet}
 \renewcommand*\familydefault{\sfdefault}
 
-\usepackage{nopageno}
-
 \usepackage{tcolorbox}
+\tcbuselibrary{breakable}
 
-\usepackage{xcolor}
+\usepackage{xcolor,multicol,setspace}
+\definecolor{blanc}{rgb}{1, 1, 1}
 \definecolor{bleu}{rgb}{0.03, 0.25, 0.42}
 \definecolor{gris}{rgb}{0.37, 0.37, 0.37}
 \definecolor{lisere}{rgb}{0.71, 0.76, 0.82}
 
-\setlength\parindent{0cm}
+\doublespacing
+
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[L]{
+    \large\textbf{RISQUES DE SÉCURITÉ}
+    \\\small\textcolor{gris}{Tous les risques que l'on peut rencontrer pour votre service, classés par niveau de gravité en matière d'impact.}
+}
+\fancyfoot[L]{\small{\textcolor{bleu}{\textbf{MonServiceSécurisé -}} __= donnees.nomService __}}
+\fancyfoot[R]{\thepage}
+
+\renewcommand{\headrulewidth}{0pt}
 
 \begin{document}
-  \textbf{RISQUES DE SÉCURITÉ}
-
-  \textcolor{gris}{Tous les risques que l'on peut rencontrer pour votre service, classés par niveau de gravité en matière d'impact.}
-
-  \vskip 0.5cm
-
-  __~ donnees.niveauxGravite :niveaux __
-    \textbf{__= niveaux.description __}
-
-    \begin{tcolorbox}[colback=white, colframe=lisere, boxrule=1px]
-        \textcolor{gris}{__= niveaux.descriptionLongue __}
+  __~ donnees.niveauxGravite :niveau __
+    \begin{tcolorbox}[breakable, colback=white, colframe=lisere, boxrule=1px, bottom=20pt]
+      \vspace{-16.5pt}\hspace{-3pt}\raisebox{10pt}{\colorbox{blanc}{\textbf{__= niveau.description __}}}
+      \singlespacing\textcolor{gris}{__= niveau.descriptionLongue __}
     \end{tcolorbox}
+    \vskip 5mm
   __~__
-
-  \vskip 1cm
-
-  \textcolor{bleu}{\textbf{MonServiceSécurisé}}, service proposé par l'ANSSI.
 \end{document}

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -5,6 +5,7 @@ const InformationsHomologation = require('../../src/modeles/informationsHomologa
 const Homologation = require('../../src/modeles/homologation');
 const MesureGenerale = require('../../src/modeles/mesureGenerale');
 const Utilisateur = require('../../src/modeles/utilisateur');
+const VueAnnexePDFRisques = require('../../src/modeles/objetsVues/vueAnnexePDFRisques');
 
 describe('Une homologation', () => {
   it('connaît le nom du service', () => {
@@ -338,5 +339,15 @@ describe('Une homologation', () => {
     }, referentiel);
 
     expect(homologation.descriptionLocalisationDonnees()).to.equal('France');
+  });
+
+  it("récupère un objet de vue pour le pdf de l'annexe des risques", () => {
+    const homologation = new Homologation({
+      id: '123',
+      idUtilisateur: '456',
+      descriptionService: { nomService: 'nom' },
+    });
+
+    expect(homologation.vueAnnexePDFRisques()).to.be.a(VueAnnexePDFRisques);
   });
 });

--- a/test/modeles/objetsVues/vueAnnexePDFRisques.spec.js
+++ b/test/modeles/objetsVues/vueAnnexePDFRisques.spec.js
@@ -1,0 +1,82 @@
+const expect = require('expect.js');
+
+const Homologation = require('../../../src/modeles/homologation');
+const Referentiel = require('../../../src/referentiel');
+const VueAnnexePDFRisques = require('../../../src/modeles/objetsVues/vueAnnexePDFRisques');
+
+describe("L'objet de vue des descriptions des risques", () => {
+  const homologation = new Homologation({
+    id: '123',
+    idUtilisateur: '456',
+    descriptionService: { nomService: 'Nom Service' },
+  });
+
+  describe('avec des informations de niveaux de gravité dans le référentiel', () => {
+    const donneesReferentiel = {
+      niveauxGravite: {
+        nonConcerne: {
+          position: 0,
+          couleur: 'blanc',
+          description: 'Non concerné',
+          descriptionLongue: '',
+          nonConcerne: true,
+        },
+        grave: {
+          position: 3,
+          couleur: 'orange',
+          description: 'Grave',
+          descriptionLongue: 'Niveaux de gravité grave',
+        },
+        critique: {
+          position: 4,
+          couleur: 'rouge',
+          description: 'Critique',
+          descriptionLongue: 'Niveaux de gravité critique',
+        },
+      },
+    };
+
+    let referentiel;
+
+    beforeEach(() => {
+      referentiel = Referentiel.creeReferentiel(donneesReferentiel);
+    });
+
+    it('utilise les informations du référentiel', () => {
+      const vueAnnexePDFRisques = new VueAnnexePDFRisques(homologation, referentiel);
+
+      const donnees = vueAnnexePDFRisques.donnees();
+
+      expect(donnees).to.have.key('niveauxGravite');
+      expect(donnees.niveauxGravite).to.contain(donneesReferentiel.niveauxGravite.critique);
+    });
+
+    it('ignore le niveau de gravité non concerné', () => {
+      const vueAnnexePDFRisques = new VueAnnexePDFRisques(homologation, referentiel);
+
+      const { niveauxGravite } = vueAnnexePDFRisques.donnees();
+
+      expect(niveauxGravite.length).to.equal(2);
+      expect(niveauxGravite.map((niveaux) => niveaux.description)).to.not.contain('Non concerné');
+    });
+
+    it('trie les niveaux de gravité par position décroissante', () => {
+      const vueAnnexePDFRisques = new VueAnnexePDFRisques(homologation, referentiel);
+
+      const { niveauxGravite } = vueAnnexePDFRisques.donnees();
+
+      const positions = niveauxGravite.map((niveaux) => niveaux.position);
+      expect(positions[0]).to.equal(4);
+      expect(positions[1]).to.equal(3);
+    });
+  });
+
+  it('ajoute le nom du service', () => {
+    const vueAnnexePDFRisques = new VueAnnexePDFRisques(homologation);
+
+    const donnees = vueAnnexePDFRisques.donnees();
+
+    expect(donnees).to.have.key('nomService');
+    expect(donnees.nomService).to.equal('Nom Service');
+  });
+});

--- a/test/routes/routesPdf.spec.js
+++ b/test/routes/routesPdf.spec.js
@@ -75,6 +75,13 @@ describe('Le serveur MSS des routes /pdf/*', () => {
       testeur.referentiel().recharge({ niveauxGravite });
     });
 
+    it("recherche l'homologation correspondante", (done) => {
+      testeur.middleware().verifieRechercheHomologation(
+        'http://localhost:1234/pdf/456/annexeRisques.pdf',
+        done,
+      );
+    });
+
     it('sert un fichier de type pdf', (done) => {
       axios.get('http://localhost:1234/pdf/456/annexeRisques.pdf')
         .then((pdf) => {
@@ -96,41 +103,6 @@ describe('Le serveur MSS des routes /pdf/*', () => {
           expect(adaptateurPdfAppele).to.be(true);
           done();
         })
-        .catch(done);
-    });
-
-    it('utilise les informations de niveaux de gravité du référentiel', (done) => {
-      testeur.adaptateurPdf().genereAnnexeRisques = (donnees) => {
-        expect(donnees.niveauxGravite).to.contain(niveauxGravite.critique);
-        return Promise.resolve('Pdf annexes risques');
-      };
-
-      axios.get('http://localhost:1234/pdf/456/annexeRisques.pdf')
-        .then(() => done())
-        .catch(done);
-    });
-
-    it('ignore le niveaux de gravité non concerné', (done) => {
-      testeur.adaptateurPdf().genereAnnexeRisques = (donnees) => {
-        expect(donnees.niveauxGravite.map((niveaux) => niveaux.description)).to.not.contain('Non concerné');
-        return Promise.resolve('Pdf annexes risques');
-      };
-
-      axios.get('http://localhost:1234/pdf/456/annexeRisques.pdf')
-        .then(() => done())
-        .catch(done);
-    });
-
-    it('trie les niveaux de gravité par position décroissante', (done) => {
-      testeur.adaptateurPdf().genereAnnexeRisques = (donnees) => {
-        const positions = donnees.niveauxGravite.map((niveaux) => niveaux.position);
-        expect(positions[0]).to.equal(4);
-        expect(positions[1]).to.equal(3);
-        return Promise.resolve('Pdf annexes risques');
-      };
-
-      axios.get('http://localhost:1234/pdf/456/annexeRisques.pdf')
-        .then(() => done())
         .catch(done);
     });
   });


### PR DESCRIPTION
Dans le processus de création de l'annexe des risques en latex,
Une 3ème étape est l'ajout d'un style comme l'annexe des mesures
La route est /pdf/:id/annexeRisques.pdf

<img width="878" alt="Capture d’écran 2022-12-02 à 11 32 38" src="https://user-images.githubusercontent.com/39462397/205273234-d928e036-6c83-4ccf-b8b2-6c0e6dce9013.png">
