### PR TITLE
[REMANIEMENT] Déplace la création des statistiques

### DIFF
--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -48,21 +48,10 @@ class MesuresGenerales extends ElementsConstructibles {
   }
 
   statistiques(mesuresPersonnalisees) {
-    const statuts = MesureGenerale.statutsPossibles();
-
-    const statsPartiellesAvecStatut = () => statuts
-      .reduce((acc, statut) => Object.assign(acc, { [statut]: 0 }), { total: 0 });
-
-    const statsInitiales = () => ({
-      indispensables: statsPartiellesAvecStatut(),
-      recommandees: statsPartiellesAvecStatut(),
-
-      misesEnOeuvre: 0,
-      retenues: 0,
-    });
-
-    const stats = this.referentiel.identifiantsCategoriesMesures()
-      .reduce((acc, categorie) => Object.assign(acc, { [categorie]: statsInitiales() }), {});
+    const stats = StatistiquesMesures.creeStatistiquesVides(
+      MesureGenerale.statutsPossibles(),
+      this.referentiel.identifiantsCategoriesMesures()
+    );
 
     this.items.forEach((mesure) => {
       const { id, statut } = mesure;

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -48,7 +48,7 @@ class MesuresGenerales extends ElementsConstructibles {
   }
 
   statistiques(mesuresPersonnalisees) {
-    const stats = StatistiquesMesures.creeStatistiquesVides(
+    const stats = StatistiquesMesures.donneesAZero(
       MesureGenerale.statutsPossibles(),
       this.referentiel.identifiantsCategoriesMesures()
     );

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -32,20 +32,19 @@ const valide = (donnees, referentiel) => {
 };
 
 class StatistiquesMesures {
-  static creeStatistiquesVides(statuts, identifiantsCategoriesMesures) {
-    const statsPartiellesAvecStatut = () => statuts
-      .reduce((acc, statut) => Object.assign(acc, { [statut]: 0 }), { total: 0 });
+  static donneesAZero(statuts, identifiantsCategoriesMesures) {
+    const statutsAZero = () => statuts
+      .reduce((acc, statut) => ({ ...acc, [statut]: 0 }), { total: 0 });
 
     const statsInitiales = () => ({
-      indispensables: statsPartiellesAvecStatut(),
-      recommandees: statsPartiellesAvecStatut(),
-
+      indispensables: statutsAZero(),
+      recommandees: statutsAZero(),
       misesEnOeuvre: 0,
       retenues: 0,
     });
 
     return identifiantsCategoriesMesures
-      .reduce((acc, categorie) => Object.assign(acc, { [categorie]: statsInitiales() }), {});
+      .reduce((acc, categorie) => ({ ...acc, [categorie]: statsInitiales() }), {});
   }
 
   constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide()) {

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -32,6 +32,22 @@ const valide = (donnees, referentiel) => {
 };
 
 class StatistiquesMesures {
+  static creeStatistiquesVides(statuts, identifiantsCategoriesMesures) {
+    const statsPartiellesAvecStatut = () => statuts
+      .reduce((acc, statut) => Object.assign(acc, { [statut]: 0 }), { total: 0 });
+
+    const statsInitiales = () => ({
+      indispensables: statsPartiellesAvecStatut(),
+      recommandees: statsPartiellesAvecStatut(),
+
+      misesEnOeuvre: 0,
+      retenues: 0,
+    });
+
+    return identifiantsCategoriesMesures
+      .reduce((acc, categorie) => Object.assign(acc, { [categorie]: statsInitiales() }), {});
+  }
+
   constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide()) {
     valide(donnees, referentiel);
     this.donnees = donnees;

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -254,13 +254,13 @@ describe('Les statistiques sur les mesures de sécurité', () => {
     expect(stats.recommandees().total).to.equal(12 + 15);
   });
 
-  elles('savent créer des statistiques vides à partir de statuts et de categories', () => {
-    const statsVides = StatistiquesMesures.creeStatistiquesVides(
+  elles('savent créer un JSON de statistiques à 0 à partir de statuts et de categories', () => {
+    const statsZero = StatistiquesMesures.donneesAZero(
       ['fait', 'enCours', 'nonFait'],
       ['categorieA', 'categorieB']
     );
 
-    expect(statsVides).to.eql({
+    expect(statsZero).to.eql({
       categorieA: {
         indispensables: { total: 0, fait: 0, enCours: 0, nonFait: 0 },
         recommandees: { total: 0, fait: 0, enCours: 0, nonFait: 0 },

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -253,4 +253,26 @@ describe('Les statistiques sur les mesures de sécurité', () => {
     expect(stats.recommandees().fait).to.equal(1 + 2);
     expect(stats.recommandees().total).to.equal(12 + 15);
   });
+
+  elles('savent créer des statistiques vides à partir de statuts et de categories', () => {
+    const statsVides = StatistiquesMesures.creeStatistiquesVides(
+      ['fait', 'enCours', 'nonFait'],
+      ['categorieA', 'categorieB']
+    );
+
+    expect(statsVides).to.eql({
+      categorieA: {
+        indispensables: { total: 0, fait: 0, enCours: 0, nonFait: 0 },
+        recommandees: { total: 0, fait: 0, enCours: 0, nonFait: 0 },
+        misesEnOeuvre: 0,
+        retenues: 0,
+      },
+      categorieB: {
+        indispensables: { total: 0, fait: 0, enCours: 0, nonFait: 0 },
+        recommandees: { total: 0, fait: 0, enCours: 0, nonFait: 0 },
+        misesEnOeuvre: 0,
+        retenues: 0,
+      },
+    });
+  });
 });


### PR DESCRIPTION
Pour rendre le code plus simple à comprendre.

On peut ajouter un test explicite autour de la fonction déplacée, pour documenter le comportement.
On réduit la taille de `MesuresGenerales.statistiques()` qui est déjà très grosse.
On réduit le couplage avec la structure interne des statistiques.


💡  J'aimerais que le déplacement du
```js
  this.items.forEach((mesure) => { … }
```
suive.

Ce qui va mettre une grosse pression sur notre possible défaut de design qui est :

```js
  this.items.forEach((mesure) => {
      const { id, statut } = mesure;
      const { categorie } = this.referentiel.mesure(id);
      mesure.rendueIndispensable = mesuresPersonnalisees[id].indispensable; // <--- CETTE LIGNE
```

Je n'ai pas envie d'y passer trop de temps. Je me donne la soirée.