### PR TITLE
[CORRECTION] Désactivation de l'action quand clic sur une pastille créateur / contributeur

### DIFF
--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -1,5 +1,6 @@
 import { $services, $modaleNouveauContributeur } from './modules/elementsDom/services.mjs';
 import { brancheModale } from './modules/interactions/modale.mjs';
+import brancheComportementPastilles from './modules/interactions/pastilles.js';
 import brancheComportementSaisieContributeur from './modules/interactions/saisieContributeur.js';
 
 $(() => {
@@ -14,10 +15,12 @@ $(() => {
     );
 
     $conteneurServices.prepend($conteneursService);
+    brancheComportementPastilles('.pastille');
 
     $('main').append($modaleNouveauContributeur());
     brancheModale('.ajout-contributeur', '#rideau-nouveau-contributeur');
     brancheComportementSaisieContributeur('.ajout-contributeur');
+
     brancheModale('#nouveau-service', '#modale-nouveau-service');
   };
 

--- a/public/modules/interactions/pastilles.js
+++ b/public/modules/interactions/pastilles.js
@@ -1,0 +1,3 @@
+const brancheComportementPastilles = (selecteurPastille) => $(selecteurPastille).on('click', () => false);
+
+export default brancheComportementPastilles;


### PR DESCRIPTION
Jusqu'à présent, lorsqu'on cliquait sur une pastille créateur ou contributeur, l'événement était propagé à la carte service et redirigeait vers la page synthèse de ce service.

La PR corrige ce problème.

(Note : plus tard, le clic sur une pastille déclenchera l'ouverture d'une modale de gestion des contributeurs.)