### PR TITLE
[Annexe Mesures] Affiche le nombre des mesures « À remplir »

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -122,6 +122,10 @@ class Homologation {
     return this.mesures.nombreTotalMesuresGenerales();
   }
 
+  nombreTotalMesuresARemplirToutesCategories() {
+    return this.statistiquesMesures().aRemplirToutesCategories();
+  }
+
   nomService() { return this.descriptionService.nomService; }
 
   piloteProjet() { return this.rolesResponsabilites.piloteProjet; }

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -47,6 +47,11 @@ class StatistiquesMesures {
       - this.nonFaites(idCategorie);
   }
 
+  aRemplirToutesCategories() {
+    return this.categories()
+      .reduce((total, categorie) => total + this.aRemplir(categorie), 0);
+  }
+
   categories() {
     return categories(this.donnees);
   }

--- a/src/routes/routesPdf.js
+++ b/src/routes/routesPdf.js
@@ -10,6 +10,7 @@ const routesPdf = (middleware, referentiel, adaptateurPdf) => {
       categories: referentiel.categoriesMesures(),
       nomService: homologation.nomService(),
       mesuresParStatut: homologation.mesuresParStatut(),
+      nbMesuresARemplirToutesCategories: homologation.nombreTotalMesuresARemplirToutesCategories(),
       CHEMIN_BASE_ABSOLU: process.env.CHEMIN_BASE_ABSOLU,
     };
     adaptateurPdf.genereAnnexeMesures(donnees)

--- a/src/vuesTex/annexeMesures.template.tex
+++ b/src/vuesTex/annexeMesures.template.tex
@@ -60,4 +60,14 @@
     __~__
     \end{tcolorbox}
   __~__
+
+  __? donnees.nbMesuresARemplirToutesCategories > 0 __
+    \pagebreak[4]\begin{tcolorbox}[breakable, colback=white, colframe=lisere, boxrule=1px, bottom=20pt]
+      \vspace{-16.5pt}\hspace{-3pt}\raisebox{10pt}{\colorbox{blanc}{\textbf{NON RENSEIGNÉES}}}
+        \par
+          Il reste __= donnees.nbMesuresARemplirToutesCategories __
+          __? donnees.nbMesuresARemplirToutesCategories === 1 __ mesure __??__ mesures __?__
+          à compléter pour obtenir 100\% des mesures de sécurité proposées par l'ANSSI remplies.
+    \end{tcolorbox}
+  __?__
 \end{document}

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -272,6 +272,17 @@ describe('Une homologation', () => {
     expect(statistiquesMesuresAppelees).to.be(true);
   });
 
+  it('délègue aux statistiques le calcul du nombre de mesures à remplir toutes catégories confondues', () => {
+    const homologation = new Homologation({ mesuresGenerales: [] });
+    homologation.statistiquesMesures = () => ({
+      aRemplirToutesCategories: () => 42,
+    });
+
+    const nombre = homologation.nombreTotalMesuresARemplirToutesCategories();
+
+    expect(nombre).to.equal(42);
+  });
+
   it('délègue aux mesures le calcul du nombre de mesures spécifiques', () => {
     const homologation = new Homologation({ mesuresGenerales: [] });
     homologation.mesures.nombreMesuresSpecifiques = () => 42;

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -97,6 +97,26 @@ describe('Les statistiques sur les mesures de sécurité', () => {
     expect(stats.aRemplir('une')).to.equal(mesuresIndispensableARemplir + mesuresRecommandeesARemplir);
   });
 
+  elles('connaissent les mesures à remplir pour toutes les catégories', () => {
+    const deuxNonRemplies = {
+      misesEnOeuvre: 16,
+      retenues: 16,
+      indispensables: { total: 8, fait: 7, enCours: 0, nonFait: 0 },
+      recommandees: { total: 10, fait: 9, enCours: 0, nonFait: 0 },
+    };
+
+    const stats = new StatistiquesMesures(
+      {
+        une: deuxNonRemplies,
+        deux: deuxNonRemplies,
+        trois: deuxNonRemplies,
+      },
+      referentiel
+    );
+
+    expect(stats.aRemplirToutesCategories()).to.equal(3 * 2);
+  });
+
   elles("s'affichent au format JSON", () => {
     const stats = new StatistiquesMesures({
       une: { retenues: 4, misesEnOeuvre: 2 },


### PR DESCRIPTION
Sur la dernière page, on veut afficher le nombre de mesures personnalisées qui n'ont pas de statut.

Si toutes les mesures sont remplies : pas de page en plus dans l'annexe 
![image](https://user-images.githubusercontent.com/24898521/205382361-3b630d6d-0a2f-4e3d-9d0b-e960b319bd16.png)

Sinon, une page supplémentaire qui fait attention au nombre de mesures :
![image](https://user-images.githubusercontent.com/24898521/205382496-c413f34b-e157-4ed5-89b8-e3a9e8de27cd.png)
![image](https://user-images.githubusercontent.com/24898521/205382512-f3e03974-e0b4-46bf-ae73-790c8910add8.png)
