### PR TITLE
Crée et utilise network Docker « mss-network »

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,7 +22,7 @@ LOGIN_SERVEUR_SMTP= # login serveur envoi de mails
 MOT_DE_PASSE_SERVEUR_SMTP= # mot de passe serveur envoi de mails
 CLEF_API_SENDINBLUE= # clef d'API sendinblue utilisée pour envoi des mails
 
-URL_SERVEUR_BASE_DONNEES= # URL du serveur de base de données, ex. postgres://user@db/mss
+URL_SERVEUR_BASE_DONNEES= # URL du serveur de base de données, ex. postgres://user@mss-db/mss
 
 SECRET_COOKIE= # chaîne utilisée pour chiffrer le cookie de session
 SECRET_JWT= # chaîne utilisée pour chiffrer le JWT

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Commencer par récupérer les sources du projet et aller dans le répertoire cr�
 $ git clone https://github.com/betagouv/mon-service-securise.git && cd mon-service-securise
 ```
 
+Créer un `network` Docker pour accueillir MonServiceSécurisé en local.
+
+```sh
+$ docker network create mss-network
+```
+
 Créer un fichier `.env` à partir du fichier `.env.template` et renseigner les diverses variables d'environnement.
 
 Lancer le script `scripts/start.sh`
@@ -25,13 +31,13 @@ Lancer le script `scripts/start.sh`
 Se connecter au conteneur de la base de données et créer une nouvelle base `mss` pour un utilisateur postgres.
 
 ```sh
-$ docker exec -t mon-service-securise_db_1 createdb -U postgres mss
+$ docker compose exec mss-db createdb -U postgres mss
 ```
 
 Exécuter les migrations depuis le conteneur du serveur web.
 
 ```sh
-$ docker exec -t mon-service-securise_web_1 npx knex migrate:latest
+$ docker compose exec web npx knex migrate:latest
 ```
 
 Le serveur est configuré et prêt à être redémarré.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,12 @@ x-app:
     - node_modules:/usr/src/app/node_modules/
 
 services:
-  db:
+  mss-db:
     image: postgres
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
-      - postgres
+      - mss-network
     volumes:
       - /var/lib/postgresql/data
 
@@ -32,14 +32,15 @@ services:
     environment:
       - NODE_ENV=development
     networks:
-      - postgres
+      - mss-network
     ports:
       - "${PORT_MSS}:3000"
     depends_on:
-      - db
+      - mss-db
 
 networks:
-  postgres:
+  mss-network:
+    external: true
 
 volumes:
   node_modules:


### PR DESCRIPTION
Dans le cadre de la cohabitation avec mss-journal, on veut un network nommé et 'external'. 

Pour que les conteneurs de mss-journal utilisent le même.

[La PR côté mss-journal](https://github.com/betagouv/mon-service-securise-journal/pull/3)