### PR TITLE
Crée adaptateur Postgres du « Journal MSS »

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,5 +27,9 @@ URL_SERVEUR_BASE_DONNEES= # URL du serveur de base de données, ex. postgres://u
 SECRET_COOKIE= # chaîne utilisée pour chiffrer le cookie de session
 SECRET_JWT= # chaîne utilisée pour chiffrer le JWT
 
+# Journal MSS
+URL_SERVEUR_BASE_DONNEES_JOURNAL= # URL de la base de données du Journal MSS. ex. postgres://user@mss-journal-db:5432/mss-journal
+
 # interrupteurs de fonctionnalités (feature switches)
 AVEC_MAIL_VIA_SENDINBLUE= # renseigner à `true` pour envoyer les mails via Sendinblue plutôt que SMTP
+AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire. Sinon le journal utilisera la base de données « URL_SERVEUR_BASE_DONNEES_JOURNAL »

--- a/src/adaptateurs/adaptateurJournalMSSMemoire.js
+++ b/src/adaptateurs/adaptateurJournalMSSMemoire.js
@@ -1,8 +1,8 @@
 const nouvelAdaptateur = () => {
   const donnees = { evenements: [] };
 
-  const consigneEvenement = (evenement) => {
-    donnees.evenements.push(evenement);
+  const consigneEvenement = (donneesEvenements) => {
+    donnees.evenements.push(donneesEvenements);
     return Promise.resolve();
   };
 

--- a/src/adaptateurs/adaptateurJournalMSSPostgres.js
+++ b/src/adaptateurs/adaptateurJournalMSSPostgres.js
@@ -1,0 +1,29 @@
+const Knex = require('knex');
+const uuid = require('uuid');
+
+const config = {
+  client: 'pg',
+  connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
+  pool: { min: 2, max: 10 },
+};
+
+const nouvelAdaptateur = () => {
+  const knex = Knex(config);
+
+  const consigneEvenement = (evenement) => {
+    const { type, donnees, date } = evenement.toJSON();
+
+    return knex('journal_mss.evenements').insert({
+      id: uuid.v4(),
+      type,
+      donnees,
+      date: new Date(date).toISOString(),
+    });
+  };
+
+  return {
+    consigneEvenement,
+  };
+};
+
+module.exports = { nouvelAdaptateur };

--- a/src/adaptateurs/adaptateurJournalMSSPostgres.js
+++ b/src/adaptateurs/adaptateurJournalMSSPostgres.js
@@ -10,8 +10,8 @@ const config = {
 const nouvelAdaptateur = () => {
   const knex = Knex(config);
 
-  const consigneEvenement = (evenement) => {
-    const { type, donnees, date } = evenement.toJSON();
+  const consigneEvenement = (donneesEvenement) => {
+    const { type, donnees, date } = donneesEvenement;
 
     return knex('journal_mss.evenements').insert({
       id: uuid.v4(),

--- a/src/adaptateurs/fabriqueAdaptateurJournalMSS.js
+++ b/src/adaptateurs/fabriqueAdaptateurJournalMSS.js
@@ -1,0 +1,12 @@
+const adaptateurJournalMSSMemoire = require('./adaptateurJournalMSSMemoire');
+const adaptateurJournalMSSPostgres = require('./adaptateurJournalMSSPostgres');
+
+const fabriqueAdaptateurJournal = () => {
+  const adaptateur = process.env.AVEC_JOURNAL_EN_MEMOIRE === 'true'
+    ? adaptateurJournalMSSMemoire
+    : adaptateurJournalMSSPostgres;
+
+  return adaptateur.nouvelAdaptateur();
+};
+
+module.exports = fabriqueAdaptateurJournal;

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -1,6 +1,6 @@
-const adaptateurJournalMSSMemoire = require('./adaptateurs/adaptateurJournalMSSMemoire');
 const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
+const fabriqueAdaptateurJournalMSS = require('./adaptateurs/fabriqueAdaptateurJournalMSS');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
 const Referentiel = require('./referentiel');
 const depotDonneesAutorisations = require('./depots/depotDonneesAutorisations');
@@ -9,7 +9,7 @@ const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 
 const creeDepot = (config = {}) => {
   const {
-    adaptateurJournalMSS = adaptateurJournalMSSMemoire.nouvelAdaptateur(),
+    adaptateurJournalMSS = fabriqueAdaptateurJournalMSS(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
     adaptateurUUID = adaptateurUUIDParDefaut,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -139,7 +139,7 @@ const creeDepot = (config = {}) => {
         idUtilisateur, idHomologation, type: 'createur',
       }))
       .then(() => adaptateurJournalMSS.consigneEvenement(
-        new EvenementNouveauServiceCree({ idUtilisateur })
+        new EvenementNouveauServiceCree({ idUtilisateur }).toJSON()
       ))
       .then(() => idHomologation);
   };

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -25,8 +25,6 @@ const RisqueSpecifique = require('../../src/modeles/risqueSpecifique');
 const RisquesSpecifiques = require('../../src/modeles/risquesSpecifiques');
 const RolesResponsabilites = require('../../src/modeles/rolesResponsabilites');
 
-const { EvenementNouveauServiceCree } = require('../../src/modeles/journalMSS/evenements');
-
 const copie = require('../../src/utilitaires/copie');
 
 describe('Le dépôt de données des homologations', () => {
@@ -545,7 +543,7 @@ describe('Le dépôt de données des homologations', () => {
     describe("le journal MSS est utilisé pour consigner l'enregistrement", () => {
       it('avec un événement typé', (done) => {
         adaptateurJournalMSS.consigneEvenement = (evenement) => {
-          expect(evenement).to.be.an(EvenementNouveauServiceCree);
+          expect(evenement.type).to.equal('NOUVEAU_SERVICE_CREE');
           done();
         };
 

--- a/test/depots/depotVide.js
+++ b/test/depots/depotVide.js
@@ -1,3 +1,4 @@
+const adaptateurJournalMSSMemoire = require('../../src/adaptateurs/adaptateurJournalMSSMemoire');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 const fabriqueAdaptateurPersistance = require('../../src/adaptateurs/fabriqueAdaptateurPersistance');
@@ -5,6 +6,7 @@ const DepotDonnees = require('../../src/depotDonnees');
 
 const depotVide = (config = {
   adaptateurChiffrement: fauxAdaptateurChiffrement,
+  adaptateurJournalMSS: adaptateurJournalMSSMemoire.nouvelAdaptateur(),
   adaptateurPersistance: fabriqueAdaptateurPersistance(),
 }) => {
   const { adaptateurPersistance } = config;


### PR DESCRIPTION
Les tests continuent d'utiliser l'adaptateur mémoire par souci d'isolation et de rapidité. 

L'utilisation de l'adaptateur mémoire peut être forcée via `.env` pour s'économiser le besoin de lancer MSS-Journal lors du développement en local.


#### ⚠️ Cette PR nécessite de créer `URL_SERVEUR_BASE_DONNEES_JOURNAL` avant d'être déployée en DEMO et PROD.




-----------------

📋  Pour rappel, la feuille de route que nous avions estimé ensemble :
- [ ] **Une PR adaptateur Postgres. ⬅️ Cette PR**
- [ ] Une PR pour nettoyer la PROD des services de test.
- [ ] Une nouvelle PR, dans consoleAdministration on veut une commande genereEvenementsDeCreationService.
- [ ] Une PR pour la North star metric : un service mis à jour doit générer un événement qui donne son niveau complétion
- [ ] Une PR pour les créations de compte utilisateur, permettant de croiser les données entre Service et Utilisateur

 créations de compte utilisateur, permettant de croiser les données entre Service et Utilisateur.