### PR TITLE
Annexe risques - risques spécifiques par niveau

### DIFF
--- a/src/modeles/risques.js
+++ b/src/modeles/risques.js
@@ -21,7 +21,8 @@ class Risques extends InformationsHomologation {
   }
 
   parNiveauGravite() {
-    return this.risquesGeneraux.parNiveauGravite();
+    const risquesParNiveauGravite = this.risquesGeneraux.parNiveauGravite();
+    return this.risquesSpecifiques.parNiveauGravite(risquesParNiveauGravite);
   }
 }
 

--- a/test/modeles/risques.spec.js
+++ b/test/modeles/risques.spec.js
@@ -113,15 +113,22 @@ describe('Les risques liés à une homologation', () => {
   });
 
   describe('sur une demande des risques par niveau de gravité', () => {
-    it('délègue la demande aux risques généraux', () => {
+    ils('fusionnent les risques récupérés généraux et spécifiques', () => {
       const referentiel = Referentiel.creeReferentiel({
         risques: { unRisque: { description: 'Un risque' } },
         niveauxGravite: { grave: {} },
       });
-      const risques = new Risques({ risquesGeneraux: [{ id: 'unRisque', niveauGravite: 'grave' }] }, referentiel);
+      const risques = new Risques({
+        risquesGeneraux: [{ id: 'unRisque', niveauGravite: 'grave' }],
+        risquesSpecifiques: [{ description: 'Un risque deux', niveauGravite: 'grave' }],
+      }, referentiel);
       risques.risquesGeneraux.parNiveauGravite = () => ({ grave: [{ description: 'Un risque' }] });
+      risques.risquesSpecifiques.parNiveauGravite = (risquesParNiveauGravite) => {
+        expect(risquesParNiveauGravite).to.eql({ grave: [{ description: 'Un risque' }] });
+        return { grave: [{ description: 'Un risque' }, { description: 'Un risque deux' }] };
+      };
 
-      expect(risques.parNiveauGravite()).to.eql({ grave: [{ description: 'Un risque' }] });
+      expect(risques.parNiveauGravite()).to.eql({ grave: [{ description: 'Un risque' }, { description: 'Un risque deux' }] });
     });
   });
 });


### PR DESCRIPTION
Dans le processus de création de l'annexe des risques en latex,
Une 5ème étape est la mise à disposition des risques par niveau de gravité
La route est /pdf/:id/annexeRisques.pdf

NOTE : l'insertion dans l'objet de pdf annexe risques et l'utilisation dans le pdf suivent