### PR TITLE
Calcul de la complétude des mesures

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -68,6 +68,10 @@ class Homologation {
 
   indiceCyber() { return this.mesures.indiceCyber(); }
 
+  completudeMesures() {
+    return this.statistiquesMesures().completude();
+  }
+
   delegueProtectionDonnees() {
     return this.rolesResponsabilites.delegueProtectionDonnees;
   }

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -46,7 +46,10 @@ class Mesures extends InformationsHomologation {
   }
 
   statistiques() {
-    return this.mesuresGenerales.statistiques(this.mesuresPersonnalisees);
+    return this.mesuresGenerales.statistiques(
+      this.mesuresPersonnalisees,
+      this.mesuresSpecifiques
+    );
   }
 
   statutSaisie() {

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -36,10 +36,6 @@ class Mesures extends InformationsHomologation {
     return this.nombreMesuresPersonnalisees();
   }
 
-  nonSaisies() {
-    return this.mesuresGenerales.nonSaisies();
-  }
-
   parStatutEtCategorie() {
     const mesuresGeneralesParStatut = this.mesuresGenerales.parStatutEtCategorie();
     return this.mesuresSpecifiques.parStatutEtCategorie(mesuresGeneralesParStatut);

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -33,7 +33,7 @@ class MesuresGenerales extends ElementsConstructibles {
       .reduce(rangeMesureParStatut, accumulateur);
   }
 
-  statistiques(mesuresPersonnalisees) {
+  statistiques(mesuresPersonnalisees, mesuresSpecifiques) {
     const stats = StatistiquesMesures.donneesAZero(
       MesureGenerale.statutsPossibles(),
       this.referentiel.identifiantsCategoriesMesures()
@@ -71,7 +71,7 @@ class MesuresGenerales extends ElementsConstructibles {
         return acc;
       }, stats);
 
-    return new StatistiquesMesures(stats, this.referentiel);
+    return new StatistiquesMesures(stats, this.referentiel, mesuresSpecifiques);
   }
 
   statutSaisie() {

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -4,7 +4,7 @@ const Referentiel = require('../referentiel');
 
 class MesuresSpecifiques extends ElementsConstructibles {
   constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide()) {
-    const { mesuresSpecifiques } = donnees;
+    const { mesuresSpecifiques = [] } = donnees;
     super(MesureSpecifique, { items: mesuresSpecifiques }, referentiel);
   }
 
@@ -18,6 +18,10 @@ class MesuresSpecifiques extends ElementsConstructibles {
       });
       return acc;
     }, accumulateur);
+  }
+
+  nombreDeSansStatut() {
+    return this.toutes().filter((ms) => !ms.statutRenseigne()).length;
   }
 }
 

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -71,6 +71,13 @@ class StatistiquesMesures {
     return categories(this.donnees);
   }
 
+  completude() {
+    const nombreTotalMesures = this.indispensables().total + this.recommandees().total;
+    const nombreMesuresCompletes = nombreTotalMesures - this.aRemplirToutesCategories();
+
+    return { nombreTotalMesures, nombreMesuresCompletes };
+  }
+
   enCours(idCategorie) {
     const stats = this.donnees[idCategorie];
     return stats.retenues - stats.misesEnOeuvre;

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -47,10 +47,11 @@ class StatistiquesMesures {
       .reduce((acc, categorie) => ({ ...acc, [categorie]: statsInitiales() }), {});
   }
 
-  constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide()) {
+  constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide(), mesuresSpecifiques) {
     valide(donnees, referentiel);
     this.donnees = donnees;
     this.referentiel = referentiel;
+    this.mesuresSpecifiques = mesuresSpecifiques;
   }
 
   aRemplir(idCategorie) {
@@ -72,8 +73,13 @@ class StatistiquesMesures {
   }
 
   completude() {
-    const nombreTotalMesures = this.indispensables().total + this.recommandees().total;
-    const nombreMesuresCompletes = nombreTotalMesures - this.aRemplirToutesCategories();
+    const nombreTotalMesures = this.indispensables().total
+        + this.recommandees().total
+        + this.mesuresSpecifiques.nombre();
+
+    const nombreMesuresCompletes = nombreTotalMesures
+        - this.aRemplirToutesCategories()
+        - this.mesuresSpecifiques.nombreDeSansStatut();
 
     return { nombreTotalMesures, nombreMesuresCompletes };
   }

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -301,6 +301,16 @@ describe('Une homologation', () => {
     expect(nombre).to.equal(42);
   });
 
+  it('délègue aux statistiques le calcul de la complétude des mesures', () => {
+    const completudeVide = {};
+    const homologation = new Homologation({});
+    homologation.statistiquesMesures = () => ({ completude: () => completudeVide });
+
+    const completude = homologation.completudeMesures();
+
+    expect(completude).to.be(completudeVide);
+  });
+
   it('délègue aux mesures le calcul du nombre de mesures spécifiques', () => {
     const homologation = new Homologation({ mesuresGenerales: [] });
     homologation.mesures.nombreMesuresSpecifiques = () => 42;

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -274,6 +274,33 @@ describe('Les statistiques sur les mesures de sécurité', () => {
     expect(stats.recommandees().total).to.equal(12 + 15);
   });
 
+  describe('sur demande de la complétude', () => {
+    elles('savent calculer la complétude à partir des mesures personnalisées fournies', () => {
+      const troisRempliesSurDix = { total: 10, fait: 1, enCours: 1, nonFait: 1 };
+      const quatreRempliesSurDix = { total: 10, fait: 2, enCours: 1, nonFait: 1 };
+
+      const statsUneCategorie = new StatistiquesMesures({
+        une: {
+          indispensables: troisRempliesSurDix,
+          recommandees: quatreRempliesSurDix,
+          retenues: (1 + 1) + (2 + 1),
+          misesEnOeuvre: 1 + 2,
+        },
+        deux: {
+          indispensables: troisRempliesSurDix,
+          recommandees: quatreRempliesSurDix,
+          retenues: (1 + 1) + (2 + 1),
+          misesEnOeuvre: 1 + 2,
+        },
+      }, referentiel);
+
+      expect(statsUneCategorie.completude()).to.eql({
+        nombreTotalMesures: (10 + 10) * 2,
+        nombreMesuresCompletes: (3 + 4) * 2,
+      });
+    });
+  });
+
   elles('savent créer un JSON de statistiques à 0 à partir de statuts et de categories', () => {
     const statsZero = StatistiquesMesures.donneesAZero(
       ['fait', 'enCours', 'nonFait'],


### PR DESCRIPTION
Nous voulons mesurer dans Metabase le nombre de services ayant été « complétés à plus de 50 % ».
Cette PR ajoute le calcul de cette complétude à notre modèle.
C'est `StatistiquesMesures` qui porte l'intelligence

🧹 Sur Mattermost j'avais évoqué l'idée de supprimer du code mort. En fait ce code est supprimé par #496 donc je ne le fais pas ici.

------------------

📋  Pour rappel, la feuille de route que nous avions estimé ensemble :
- [X] Une PR adaptateur Postgres.
  - #511
- [X] Une PR pour nettoyer la PROD des services de test.
- [X] Une nouvelle PR, dans consoleAdministration on veut une commande genereEvenementsDeCreationService. 
  - #520 
- [ ] **Une PR pour la North star metric : un service mis à jour doit générer un événement qui donne sa complétude** 
  -   ☝️  **La présente PR contribue à ce point.**
- [ ] Une PR pour les créations de compte utilisateur, permettant de croiser les données entre Service et Utilisateur