### PR TITLE
Annexe risques - les commentaires alignés

### DIFF
--- a/src/vuesTex/annexeRisques.template.tex
+++ b/src/vuesTex/annexeRisques.template.tex
@@ -49,8 +49,8 @@
               __= risque.description __
               __? risque.commentaire __
                 \nopagebreak[4]\item[]
-                  \vbox{\textcolor{gris}{__= risque.commentaire __}}
-                  \vskip 3mm
+                \parbox{\linewidth}{\textcolor{gris}{__= risque.commentaire __}}
+                \vskip 3mm
               __?__%
           __~__%
         \end{itemize}


### PR DESCRIPTION
Les commentaires n'était pas alignés avec les descriptions des risques

Avant
<img width="749" alt="Capture d’écran 2022-12-09 à 12 46 12" src="https://user-images.githubusercontent.com/39462397/206695732-0f4238c6-8a58-44ff-ba38-9e9b19c0a9f4.png">

Maintenant
<img width="744" alt="Capture d’écran 2022-12-09 à 12 45 54" src="https://user-images.githubusercontent.com/39462397/206695775-c2489b51-e185-44df-a478-5855d0361319.png">
