### PR TITLE
[CORRECTION] Dimensionne correctement logo MSS

### DIFF
--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -78,8 +78,8 @@ header nav a, .nom-utilisateur-courant {
 }
 
 .logo-mss {
-  width: 11em;
-  height: 4.05em;
+  width: 10.49em;
+  height: 3.7em;
   margin-right: auto;
   padding: 0.3em 0.85em;
 

--- a/public/assets/styles/syntheseSecurite.css
+++ b/public/assets/styles/syntheseSecurite.css
@@ -42,8 +42,9 @@ header {
 }
 
 .logo-mss {
-  width: 14em;
-  height: 5em;
+  width: 12.1em;
+  height: 4.35em;
+  align-self: center;
 
   background-image: url(../images/logo_mss.svg);
   background-origin: content-box;
@@ -58,7 +59,7 @@ header {
   width: 60px;
   height: 60px;
 
-  margin-left: 15px;
+  margin-left: 1.5em;
 
   background-size: contain;
   background-repeat: no-repeat;


### PR DESCRIPTION
Le logo MSS est moins haut que celui de l'ANSSI.