### PR TITLE
🧹 Nettoie services créés pour les tests

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -29,6 +29,13 @@ class ConsoleAdministration {
     return this.depotDonnees.supprimeHomologation(idHomologation);
   }
 
+  supprimeHomologationsDeUtilisateur(idUtilisateur, idsHomologationsAConserver) {
+    return this.depotDonnees.supprimeHomologationsCreeesPar(
+      idUtilisateur,
+      idsHomologationsAConserver
+    );
+  }
+
   genereEvenementsDeCreationService(dateLimite, persisteEvenements = false) {
     const jourSuivant = (date) => {
       const timestampJourSuivant = new Date(date).setDate(date.getDate() + 1);

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -113,6 +113,15 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     donnees.autorisations.find((a) => a.id === id)
   );
 
+  const autorisationsCreation = (idUtilisateur, idsHomologationsAExclure = []) => Promise.resolve(
+    donnees.autorisations
+      .filter((as) => (
+        as.idUtilisateur === idUtilisateur
+          && as.type === 'createur'
+          && !idsHomologationsAExclure.includes(as.idHomologation)))
+      .map((a) => a.idHomologation)
+  );
+
   const autorisationPour = (idUtilisateur, idHomologation) => Promise.resolve(
     donnees.autorisations
       .find((a) => a.idUtilisateur === idUtilisateur && a.idHomologation === idHomologation)
@@ -155,6 +164,7 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     autorisation,
     autorisationPour,
     autorisations,
+    autorisationsCreation,
     homologation,
     homologationAvecNomService,
     homologations,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -146,6 +146,12 @@ const nouvelAdaptateur = (env) => {
     .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
     .then((rows) => rows.map(convertisLigneEnObjet));
 
+  const autorisationsCreation = (idUtilisateur, idsHomologationsAExclure = []) => knex('autorisations')
+    .whereRaw("donnees->>'idUtilisateur'=? AND donnees->>'type'='createur'", idUtilisateur)
+    .whereNotIn(knex.raw("donnees->>'idHomologation'"), idsHomologationsAExclure)
+    .select({ idHomologation: knex.raw("donnees->>'idHomologation'") })
+    .then((lignes) => lignes.map(({ idHomologation }) => idHomologation));
+
   const ajouteAutorisation = (...params) => ajouteLigneDansTable('autorisations', ...params);
 
   const supprimeAutorisation = (idUtilisateur, idHomologation) => knex('autorisations')
@@ -180,6 +186,7 @@ const nouvelAdaptateur = (env) => {
     autorisation,
     autorisationPour,
     autorisations,
+    autorisationsCreation,
     homologation,
     homologationAvecNomService,
     homologations,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -44,6 +44,7 @@ const creeDepot = (config = {}) => {
     remplaceMesuresSpecifiquesPourHomologation,
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeHomologation,
+    supprimeHomologationsCreeesPar,
   } = depotHomologations;
 
   const {
@@ -99,6 +100,7 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeContributeur,
     supprimeHomologation,
+    supprimeHomologationsCreeesPar,
     supprimeIdResetMotDePassePourUtilisateur,
     supprimeUtilisateur,
     transfereAutorisations,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -202,6 +202,11 @@ const creeDepot = (config = {}) => {
       adaptateurPersistance.supprimeService(idHomologation),
     ]));
 
+  const supprimeHomologationsCreeesPar = (idUtilisateur, idsHomologationsAConserver = []) => (
+    adaptateurPersistance.autorisationsCreation(idUtilisateur, idsHomologationsAConserver)
+      .then((idsHomologations) => Promise.all(idsHomologations.map(supprimeHomologation)))
+  );
+
   return {
     ajouteAvisExpertCyberAHomologation,
     ajouteDescriptionServiceAHomologation,
@@ -218,6 +223,7 @@ const creeDepot = (config = {}) => {
     remplaceMesuresSpecifiquesPourHomologation,
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeHomologation,
+    supprimeHomologationsCreeesPar,
   };
 };
 


### PR DESCRIPTION
Cette PR ajoute la possibilité de supprimer les services créés par des utilisateurs, via leur identifiant.
L'objectif est de supprimer les services existants à tort en PROD.

⚠️ Pour ne pas supprimer le service « MSS », il est possible de spécifier des identifiants de service à toujours conserver.

La suppression se déclenche par `ConsoleAdministration` chez Scalingo :
```js
ConsoleAdministration = require('./consoleAdministration')
admin = new ConsoleAdministration();

utilisateur = 'uuid-utilisateur';
monServiceSecurise = 'uuid-mss';

admin.supprimeHomologationsDeUtilisateur(utilisateur, [monServiceSecurise])
  .then(() => console.log('OK'))
```

ℹ️  Les discussion avec @egaillot ont permis d'identifier 9 comptes utilisateurs à nettoyer via la console.


--------------------

📋  Pour rappel, la feuille de route que nous avions estimé ensemble :
- [X] ~~Une PR adaptateur Postgres.~~
  - #511
- [ ] **Une PR pour nettoyer la PROD des services de test. ⬅️ Cette PR**
- [X] ~~Une nouvelle PR, dans consoleAdministration on veut une commande genereEvenementsDeCreationService.~~ 
  - #520 
- [ ] Une PR pour la North star metric : un service mis à jour doit générer un événement qui donne sa complétude
  -   #527 
- [ ] Une PR pour les créations de compte utilisateur, permettant de croiser les données entre Service et Utilisateur