### PR TITLE
[CORRECTION]Échappement des sauts de ligne pour génération des fichiers LaTeX

### DIFF
--- a/src/latex/miseEnFormeDonnees.js
+++ b/src/latex/miseEnFormeDonnees.js
@@ -12,6 +12,7 @@ const caracteresSpeciauxLatex = [
   { special: '}', latex: '\\}' },
   { special: '~', latex: '\\textasciitilde' },
   { special: '^', latex: '\\textasciicircum' },
+  { special: '\r', latex: '\\\\' },
 ];
 
 const echappeCaracteresSpeciauxLatex = (texte) => caracteresSpeciauxLatex.reduce(

--- a/test/latex/miseEnFormeDonnees.spec.js
+++ b/test/latex/miseEnFormeDonnees.spec.js
@@ -13,6 +13,12 @@ describe('La mise en forme de données', () => {
         '\\textbackslash \\& \\% \\textdollar \\# \\_ \\{ \\} \\textasciitilde \\textasciicircum'
       );
     });
+
+    it('échappe les sauts de lignes', () => {
+      expect(miseEnFormeLatex('Un texte\r\navec un saut de ligne')).to.equal(
+        'Un texte\\\\\navec un saut de ligne'
+      );
+    });
   });
 
   describe("sur une demande de mise en forme d'un objet", () => {


### PR DESCRIPTION
À l'heure actuelle, s'il y a un double saut de ligne dans les modalités décrites pour une mesure, ce saut est interprété par LaTeX comme le début d'un nouveau paragraphe, ce qui ne peut pas avoir lieu dans une balise `\textcolor`.

Le présent commit corrige ce problème.