### PR TITLE
Ordonne les statuts dans l'ordre attendu

### DIFF
--- a/src/modeles/mesure.js
+++ b/src/modeles/mesure.js
@@ -21,7 +21,20 @@ class Mesure extends InformationsHomologation {
     return false;
   }
 
-  static statutsPossibles() { return Object.values(STATUTS); }
+  static accumulateurInitialStatuts(statutFaitALaFin = false) {
+    return Mesure.statutsPossibles(statutFaitALaFin)
+      .reduce((acc, s) => ({ ...acc, [s]: {} }), {});
+  }
+
+  static statutsPossibles(statutFaitALaFin = false) {
+    const resultat = Object.values(STATUTS);
+
+    if (statutFaitALaFin) {
+      const [statutFait, ...reste] = resultat;
+      return [...reste, statutFait];
+    }
+    return resultat;
+  }
 
   static statutRenseigne(statut) {
     return Object.keys(STATUTS)

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -24,10 +24,13 @@ class MesuresGenerales extends ElementsConstructibles {
       return acc;
     };
 
+    const statutFaitALaFin = true;
+    const accumulateur = MesureGenerale.accumulateurInitialStatuts(statutFaitALaFin);
+
     return this.toutes()
       .filter((mesure) => mesure.statutRenseigne())
       .sort((m, _) => (m.estIndispensable() ? -1 : 1))
-      .reduce(rangeMesureParStatut, { fait: {}, enCours: {}, nonFait: {} });
+      .reduce(rangeMesureParStatut, accumulateur);
   }
 
   statistiques(mesuresPersonnalisees) {

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -8,7 +8,7 @@ class MesuresSpecifiques extends ElementsConstructibles {
     super(MesureSpecifique, { items: mesuresSpecifiques }, referentiel);
   }
 
-  parStatutEtCategorie(accumulateur = { fait: {}, enCours: {}, nonFait: {} }) {
+  parStatutEtCategorie(accumulateur = MesureSpecifique.accumulateurInitialStatuts(true)) {
     return this.toutes().reduce((acc, mesure) => {
       if (!mesure.statut || !mesure.categorie) return acc;
       acc[mesure.statut][mesure.categorie] ||= [];

--- a/test/modeles/mesure.spec.js
+++ b/test/modeles/mesure.spec.js
@@ -5,8 +5,15 @@ const Mesure = require('../../src/modeles/mesure');
 const elle = it;
 
 describe('Une mesure', () => {
-  elle('connaît ses statuts possibles', () => {
-    expect(Mesure.statutsPossibles()).to.eql(['fait', 'enCours', 'nonFait']);
+  describe('sur demande des statuts possibles', () => {
+    elle('retourne les statuts avec `fait` en premier par défaut', () => {
+      expect(Mesure.statutsPossibles()).to.eql(['fait', 'enCours', 'nonFait']);
+    });
+
+    elle('peut retourner les statuts avec `fait` en dernier si on le spécifie', () => {
+      const statutFaitALaFin = true;
+      expect(Mesure.statutsPossibles(statutFaitALaFin)).to.eql(['enCours', 'nonFait', 'fait']);
+    });
   });
 
   elle("ne tient pas compte du statut s'il n'est pas renseigné", (done) => {

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -210,6 +210,16 @@ describe('La liste des mesures générales', () => {
       expect(mesures.parStatutEtCategorie().fait.categorie1[0].modalites).to.equal('Modalités de la mesure');
     });
 
+    it('ordonne les statuts comme attendu', () => {
+      const mesures = new MesuresGenerales({ mesuresGenerales: [
+        { id: 'mesure1', statut: 'fait' },
+        { id: 'mesure2', statut: 'nonFait' },
+        { id: 'mesure3', statut: 'enCours' },
+      ] }, referentiel);
+
+      expect(Object.keys(mesures.parStatutEtCategorie())).to.eql(['enCours', 'nonFait', 'fait']);
+    });
+
     it('retourne les mesures indispensables avant les mesures recommandées', () => {
       const mesures = new MesuresGenerales({ mesuresGenerales: [
         { id: 'mesure1', statut: 'fait' },

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -49,6 +49,19 @@ describe('La liste des mesures spécifiques', () => {
     expect(mesures.parStatutEtCategorie().fait.categorie1[0].modalites).to.equal('Modalités');
   });
 
+  elle("ordonne les status comme précisé par l'accumulateur", () => {
+    const mesures = new MesuresSpecifiques({
+      mesuresSpecifiques: [
+        { description: 'Mesure Spécifique 1', statut: 'fait', categorie: 'categorie1' },
+        { description: 'Mesure Spécifique 2', statut: 'nonFait', categorie: 'categorie1' },
+        { description: 'Mesure Spécifique 3', statut: 'enCours', categorie: 'categorie1' },
+      ],
+    },
+    referentiel);
+
+    expect(Object.keys(mesures.parStatutEtCategorie())).to.eql(['enCours', 'nonFait', 'fait']);
+  });
+
   elle('exclut les mesures sans statut', () => {
     const mesures = new MesuresSpecifiques({
       mesuresSpecifiques: [


### PR DESCRIPTION
Dans l'annexe des mesures en PDF, nous voulons que soient listées les mesures en cours, puis à faire, puis faites.