### PR TITLE
[CORRECTION] Dimensionne correctement image accueil

### DIFF
--- a/public/assets/styles/index.css
+++ b/public/assets/styles/index.css
@@ -4,7 +4,7 @@ main {
 
 .introduction {
   display: flex;
-  column-gap: 3em;
+  column-gap: 1em;
 
   margin: 5em auto 3em auto;
 
@@ -68,11 +68,11 @@ main {
 }
 
 .presentation {
-  flex: 2;
+  flex: 1;
 }
 
 .image-intro-mss {
-  flex: 1;
+  flex: 0.9;
 
   background-image: url(../images/image_intro_mss.svg);
   background-repeat: no-repeat;

--- a/src/vues/index.pug
+++ b/src/vues/index.pug
@@ -14,7 +14,7 @@ block main
 
       p.
         La solution de cybersécurité de l'ANSSI <br/>
-        pour aider les entités publiques à sécuriser et à homologuer <br/>
+        pour aider les entités publiques à sécuriser et à homologuer
         rapidement leurs sites web, applications mobiles et API.
 
       nav


### PR DESCRIPTION
Pour que l'image fasse 50 % de la largeur.

En local :
![image](https://user-images.githubusercontent.com/24898521/207138042-3a48cd2c-e67d-4a03-8bde-c3d7b9d5c250.png)
