### PR TITLE
[REMANIEMENT] Utilise autorisations pour trouver homologations d'un créateur

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -152,9 +152,16 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
       .then((transferts) => Promise.all(transferts))
   );
 
-  const utilisateursCreesAvantLe = (date) => Promise.resolve(
-    donnees.utilisateurs.filter((u) => date - new Date(u.dateCreation) > 0)
-  );
+  const homologationsPourUtilisateursCreesAvantLe = (date) => {
+    const idsHomologationsPourCreateurs = donnees.utilisateurs
+      .filter((u) => date - new Date(u.dateCreation) > 0)
+      .map((u) => autorisationsCreation(u.id));
+
+    return Promise.all(idsHomologationsPourCreateurs)
+      .then((resultat) => resultat.flat())
+      .then((ids) => ids.map(homologation))
+      .then((hs) => Promise.all(hs));
+  };
 
   return {
     ajouteAutorisation,
@@ -184,7 +191,7 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     utilisateur,
     utilisateurAvecEmail,
     utilisateurAvecIdReset,
-    utilisateursCreesAvantLe,
+    homologationsPourUtilisateursCreesAvantLe,
   };
 };
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -173,8 +173,12 @@ const nouvelAdaptateur = (env) => {
       donnees: knex.raw("(jsonb_set(donnees::jsonb, '{ idUtilisateur }', '??'))::json", idUtilisateurCible),
     });
 
-  const utilisateursCreesAvantLe = (date) => knex('utilisateurs')
-    .whereRaw('date_creation < ?', date.toISOString())
+  const homologationsPourUtilisateursCreesAvantLe = (date) => knex('autorisations')
+    .join('utilisateurs', knex.raw("(autorisations.donnees->>'idUtilisateur')::uuid"), 'utilisateurs.id')
+    .join('homologations', knex.raw("(autorisations.donnees->>'idHomologation')::uuid"), 'homologations.id')
+    .whereRaw('utilisateurs.date_creation < ?', date.toISOString())
+    .whereRaw(knex.raw("autorisations.donnees->>'type' = 'createur'"))
+    .select('homologations.*')
     .then((lignes) => lignes.map(convertisLigneEnObjet));
 
   return {
@@ -207,7 +211,7 @@ const nouvelAdaptateur = (env) => {
     utilisateur,
     utilisateurAvecEmail,
     utilisateurAvecIdReset,
-    utilisateursCreesAvantLe,
+    homologationsPourUtilisateursCreesAvantLe,
   };
 };
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -143,15 +143,9 @@ const creeDepot = (config = {}) => {
       .map((h) => new Homologation(h, referentiel))
       .sort((h1, h2) => h1.nomService().localeCompare(h2.nomService())));
 
-  const homologationsCreeesAvantLe = (date) => {
-    const homologationsCreeesPar = (utilisateurs) => utilisateurs
-      .map((u) => homologations(u.id).then((hs) => hs.filter((h) => h.createur.id === u.id)));
-
-    return adaptateurPersistance
-      .utilisateursCreesAvantLe(date)
-      .then((utilisateurs) => Promise.all(homologationsCreeesPar(utilisateurs)))
-      .then((toutesHomologations) => toutesHomologations.flatMap((h) => h));
-  };
+  const homologationsCreeesAvantLe = (date) => adaptateurPersistance
+    .homologationsPourUtilisateursCreesAvantLe(date)
+    .then((hs) => hs.map((h) => new Homologation(h, referentiel)));
 
   const metsAJourDossierCourant = (idHomologation, dossier) => (
     ajouteDossierCourantSiNecessaire(idHomologation)

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -715,10 +715,7 @@ describe('Le dépôt de données des homologations', () => {
           { id: 'JANVIER', dateCreation: '2022-01-15 13:30:00', email: 'j@example.com' },
           { id: 'FEVRIER', dateCreation: '2022-02-15 13:30:00', email: 'f@example.com' },
         ],
-        homologations: [
-          { id: '123', idUtilisateur: 'JANVIER' },
-          { id: '789', idUtilisateur: 'FEVRIER' },
-        ],
+        homologations: [{ id: '123' }, { id: '789' }],
         autorisations: [
           { idUtilisateur: 'JANVIER', idHomologation: '123', type: 'createur' },
           { idUtilisateur: 'FEVRIER', idHomologation: '789', type: 'createur' },


### PR DESCRIPTION
Car `autorisations` est un meilleur socle pour répondre à la question « qui sont les créateurs des homologations ? ».