### PR TITLE
Exige présence identifiant service

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -43,7 +43,7 @@ class ConsoleAdministration {
     };
 
     const evenementPourHomologation = (h) => new EvenementNouveauServiceCree(
-      { idUtilisateur: h.createur.id },
+      { idService: h.id, idUtilisateur: h.createur.id },
       { date: jourSuivant(h.createur.dateCreation) }
     ).toJSON();
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -176,7 +176,7 @@ const creeDepot = (config = {}) => {
         idUtilisateur, idHomologation, type: 'createur',
       }))
       .then(() => adaptateurJournalMSS.consigneEvenement(
-        new EvenementNouveauServiceCree({ idUtilisateur }).toJSON()
+        new EvenementNouveauServiceCree({ idService: idHomologation, idUtilisateur }).toJSON()
       ))
       .then(() => idHomologation);
   };

--- a/src/modeles/journalMSS/erreurs.js
+++ b/src/modeles/journalMSS/erreurs.js
@@ -1,6 +1,8 @@
 class ErreurJournal extends Error {}
+class ErreurIdentifiantServiceManquant extends ErreurJournal {}
 class ErreurIdentifiantUtilisateurManquant extends ErreurJournal {}
 
 module.exports = {
+  ErreurIdentifiantServiceManquant,
   ErreurIdentifiantUtilisateurManquant,
 };

--- a/src/modeles/journalMSS/evenements.js
+++ b/src/modeles/journalMSS/evenements.js
@@ -1,6 +1,6 @@
 const AdaptateurChiffrement = require('../../adaptateurs/adaptateurChiffrement');
 
-const { ErreurIdentifiantUtilisateurManquant } = require('./erreurs');
+const { ErreurIdentifiantServiceManquant, ErreurIdentifiantUtilisateurManquant } = require('./erreurs');
 
 class Evenements {
   constructor(type, donnees, date) {
@@ -26,6 +26,7 @@ class EvenementNouveauServiceCree extends Evenements {
     } = options;
 
     const valide = () => {
+      if (!donnees.idService) throw new ErreurIdentifiantServiceManquant();
       if (!donnees.idUtilisateur) throw new ErreurIdentifiantUtilisateurManquant();
     };
 
@@ -33,7 +34,10 @@ class EvenementNouveauServiceCree extends Evenements {
 
     super(
       'NOUVEAU_SERVICE_CREE',
-      { idUtilisateur: adaptateurChiffrement.hacheSha256(donnees.idUtilisateur) },
+      {
+        idService: adaptateurChiffrement.hacheSha256(donnees.idService),
+        idUtilisateur: adaptateurChiffrement.hacheSha256(donnees.idUtilisateur),
+      },
       date
     );
   }

--- a/test/modeles/journalMSS/evenements.spec.js
+++ b/test/modeles/journalMSS/evenements.spec.js
@@ -1,38 +1,64 @@
 const expect = require('expect.js');
 const { EvenementNouveauServiceCree } = require('../../../src/modeles/journalMSS/evenements');
-const { ErreurIdentifiantUtilisateurManquant } = require('../../../src/modeles/journalMSS/erreurs');
+const { ErreurIdentifiantServiceManquant, ErreurIdentifiantUtilisateurManquant } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de nouveau service créé', () => {
-  const hacheEnMajuscules = { hacheSha256: (valeur) => valeur.toUpperCase() };
+  const hacheEnMajuscules = { hacheSha256: (valeur) => valeur?.toUpperCase() };
 
-  it("chiffre l'identifiant utilisateur qui lui est donné", () => {
+  it("chiffre l'identifiant du service qui lui est donné", () => {
     const evenement = new EvenementNouveauServiceCree(
-      { idUtilisateur: 'abc' },
+      { idService: 'abc', idUtilisateur: 'def' },
       { adaptateurChiffrement: hacheEnMajuscules }
     );
 
-    expect(evenement.toJSON().donnees.idUtilisateur).to.be('ABC');
+    expect(evenement.toJSON().donnees.idService).to.be('ABC');
+  });
+
+  it("chiffre l'identifiant utilisateur qui lui est donné", () => {
+    const evenement = new EvenementNouveauServiceCree(
+      { idService: 'abc', idUtilisateur: 'def' },
+      { adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+    expect(evenement.toJSON().donnees.idUtilisateur).to.be('DEF');
   });
 
   it('sait se convertir en JSON', () => {
     const evenement = new EvenementNouveauServiceCree(
-      { idUtilisateur: 'abc' },
+      { idService: 'abc', idUtilisateur: 'def' },
       { date: '17/11/2022', adaptateurChiffrement: hacheEnMajuscules }
     );
 
     expect(evenement.toJSON()).to.eql({
       type: 'NOUVEAU_SERVICE_CREE',
-      donnees: { idUtilisateur: 'ABC' },
+      donnees: { idService: 'ABC', idUtilisateur: 'DEF' },
       date: '17/11/2022',
     });
   });
 
   it("exige que l'identifiant utilisateur associé au service soit renseigné", (done) => {
     try {
-      new EvenementNouveauServiceCree({});
+      new EvenementNouveauServiceCree(
+        { idService: 'ABC' },
+        { adaptateurChiffrement: hacheEnMajuscules }
+      );
+
       done(Error("L'instanciation de l'événement aurait dû lever une exception"));
     } catch (e) {
       expect(e).to.be.an(ErreurIdentifiantUtilisateurManquant);
+      done();
+    }
+  });
+
+  it("exige que l'identifiant du service créé soit renseigné", (done) => {
+    try {
+      new EvenementNouveauServiceCree(
+        { idUtilisateur: 'DEF' },
+        { adaptateurChiffrement: hacheEnMajuscules }
+      );
+      done(Error("L'instanciation de l'événement aurait dû lever une exception"));
+    } catch (e) {
+      expect(e).to.be.an(ErreurIdentifiantServiceManquant);
       done();
     }
   });


### PR DESCRIPTION
Désormais les événements de création de service embarquent un SHA-1 de l'identifiant du service.

Ça nous laisse la porte grande ouverte pour l'exploitation des données.
Ce serait très compliqué à rattraper plus tard, sur les événements déjà enregistrés.