### PR TITLE
Champs requis pour les mesures spécifiques

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -152,7 +152,32 @@ textarea {
 
 select {
   display: block;
-  margin: 1em 0;
+  box-sizing: border-box;
+  margin: 0.3em 0 1em 0;
+  padding: 0.8em;
+  border: solid 1px var(--liseres);
+  border-radius: 5px;
+  width: 100%;
+  background: var(--fond-pale);
+  font-family: Marianne;
+
+  appearance: none;
+}
+
+.selecteur-options {
+  position: relative;
+}
+
+.selecteur-options::after {
+  content: "";
+  top: 0.98em;
+  right: 1.05em;
+  position: absolute;
+  border-bottom: 1.5px black solid;
+  border-right: 1.5px black solid;
+  width: 0.5em;
+  height: 0.5em;
+  transform: rotate(45deg);
 }
 
 .case-a-cocher {

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -91,18 +91,21 @@ form#mesures .decoration {
   margin-bottom: 2em;
 }
 
-.specifiques .requis {
-  position: relative;
+.specifiques .propriete-specifique {
+  margin-bottom: 1em;
 }
 
 .specifiques .item-ajoute {
-  padding-left: 2em;
+  padding: 1em 2em;
 }
 
-.specifiques .selecteur-options {
-  min-width: 25%;
-  width: -moz-fit-content;
-  width: fit-content;
+.specifiques .nom-champ {
+  display: block;
+  font-weight: bold;
+}
+
+form#mesures .specifiques input[type='radio'] {
+  margin-left: 0;
 }
 
 #mesures-specifiques {

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -91,6 +91,12 @@ form#mesures .decoration {
   margin-bottom: 2em;
 }
 
+.specifiques .selecteur-options {
+  min-width: 25%;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
 #mesures-specifiques {
   margin-top: 2em;
 }

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -91,6 +91,14 @@ form#mesures .decoration {
   margin-bottom: 2em;
 }
 
+.specifiques .requis {
+  position: relative;
+}
+
+.specifiques .item-ajoute {
+  padding-left: 2em;
+}
+
 .specifiques .selecteur-options {
   min-width: 25%;
   width: -moz-fit-content;

--- a/public/assets/styles/utilisateur.css
+++ b/public/assets/styles/utilisateur.css
@@ -24,35 +24,6 @@
   margin-bottom: -1em;
 }
 
-select {
-  box-sizing: border-box;
-  width: 100%;
-  margin-top: 0.3em;
-  padding: 0.8em;
-  border: solid 1px var(--liseres);
-  border-radius: 5px;
-  background: var(--fond-pale);
-  font-family: Marianne;
-
-  appearance: none;
-}
-
-.departements {
-  position: relative;
-}
-
-.departements::after {
-  content: "";
-  top: 14px;
-  right: 15px;
-  position: absolute;
-  border-bottom: 1.5px black solid;
-  border-right: 1.5px black solid;
-  width: 0.5em;
-  height: 0.5em;
-  transform: rotate(45deg);
-}
-
 .affichage-simple {
   margin-bottom: 2em;
 }

--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -42,49 +42,55 @@ $(() => {
   const zoneSaisieMesureSpecifique = (index, donnees = {}) => {
     const { description = '', categorie = '', statut = '', modalites = '' } = donnees;
 
-    const referentielCategoriesMesures = JSON.parse($('#referentiel-categories-mesures').text());
-    const options = Object.keys(referentielCategoriesMesures).map((c) => (`
-<option value="${c}"${c === categorie ? ' selected' : ''}>
-  ${referentielCategoriesMesures[c]}
-</option>
-    `)).join('');
-
-    const referentielStatutsMesures = JSON.parse($('#referentiel-statuts-mesures').text());
-    let statuts = Object.keys(referentielStatutsMesures).map((s) => `
-<input id="statut-${s}-mesure-specifique-${index}"
-       name="statut-mesure-specifique-${index}"
-       value="${s}"
-       ${s === statut ? 'checked' : ''}
+    const choixParBoutonsRadios = (referentielChamp, nomChamp, label, valeur) => {
+      let boutonsRadios = Object.keys(referentielChamp).map((champ) => `
+<input id="${nomChamp}-${champ}-mesure-specifique-${index}"
+       name="${nomChamp}-mesure-specifique-${index}"
+       value="${champ}"
+       ${champ === valeur ? 'checked' : ''}
        type="radio"
        required>
-<label for="statut-${s}-mesure-specifique-${index}">${referentielStatutsMesures[s]}</label>
+<label for="${nomChamp}-${champ}-mesure-specifique-${index}">${referentielChamp[champ]}</label>
 <br>
     `).join('');
-    statuts = `<div class="requis">${statuts}<div class="message-erreur">Ce champ est obligatoire. Veuillez le renseigner.</div></div>`;
+      boutonsRadios = `
+<div class="requis propriete-specifique">
+  <span class="nom-champ">${label}</span>
+  ${boutonsRadios}
+  <div class="message-erreur">Ce champ est obligatoire. Veuillez le renseigner.</div>
+</div>
+      `;
+      return boutonsRadios;
+    };
+    const referentielCategoriesMesures = JSON.parse($('#referentiel-categories-mesures').text());
+    const categories = choixParBoutonsRadios(referentielCategoriesMesures, 'categorie', 'Catégorie', categorie);
+
+    const referentielStatutsMesures = JSON.parse($('#referentiel-statuts-mesures').text());
+    const statuts = choixParBoutonsRadios(referentielStatutsMesures, 'statut', 'Niveau de mise en œuvre', statut);
 
     return `
-<div class="requis">
-  <input id="description-mesure-specifique-${index}"
-        name="description-mesure-specifique-${index}"
-        placeholder="Description de la mesure"
-        value="${description}"
-        required>
-  <div class="message-erreur">L'intitulé est obligatoire. Veuillez le renseigner.</div>
+<div class="requis propriete-specifique">
+  <label for="description-mesure-specifique-${index}" class="nom-champ">
+    Intitulé
+    <input id="description-mesure-specifique-${index}"
+          name="description-mesure-specifique-${index}"
+          placeholder="Description de la mesure"
+          value="${description}"
+          required>
+    <div class="message-erreur">L'intitulé est obligatoire. Veuillez le renseigner.</div>
+  </label>
 </div>
 
-<div class="requis selecteur-options">
-  <select id="categorie-mesure-specifique-${index}" name="categorie-mesure-specifique-${index}" required>
-    <option value="">--Catégorie--</option>
-    ${options}
-  </select>
-  <div class="message-erreur">Ce champ est obligatoire. Veuillez sélectionner une entrée.</div>
-</div>
+${categories}
 
 ${statuts}
 
-<textarea id="modalites-mesure-specifique-${index}"
-          name="modalites-mesure-specifique-${index}"
-          placeholder="Modalités de mise en œuvre (facultatif)">${modalites}</textarea>
+<label for="modalites-mesure-specifique-${index}" class="nom-champ propriete-specifique">
+  Précisions sur la mesure dans le cadre de votre organisation
+  <textarea id="modalites-mesure-specifique-${index}"
+            name="modalites-mesure-specifique-${index}"
+            placeholder="Modalités de mise en œuvre (facultatif)">${modalites}</textarea>
+</label>
       `;
   };
 
@@ -118,7 +124,7 @@ ${statuts}
   $bouton.on('click', () => {
     declencheValidation('form#mesures');
   });
-  
+
   $('form#mesures').on('submit', (evenement) => {
     evenement.preventDefault();
     const params = parametres('form#mesures');

--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -64,11 +64,12 @@ $(() => {
        name="description-mesure-specifique-${index}"
        placeholder="Description de la mesure"
        value="${description}">
-
-<select id="categorie-mesure-specifique-${index}" name="categorie-mesure-specifique-${index}">
-  <option value="">--Catégorie--</option>
-  ${options}
-</select>
+<div class="selecteur-options">
+  <select id="categorie-mesure-specifique-${index}" name="categorie-mesure-specifique-${index}">
+    <option value="">--Catégorie--</option>
+    ${options}
+  </select>
+</div>
 
 ${statuts}
 

--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -1,5 +1,6 @@
 import arrangeParametresMesures from '../modules/arrangeParametresMesures.mjs';
 import brancheFiltresMesures from '../modules/interactions/brancheFiltresMesures.mjs';
+import { brancheConteneur, brancheValidation, declencheValidation } from '../modules/interactions/validation.js';
 import parametres from '../modules/parametres.mjs';
 import { brancheAjoutItem, peupleListeItems } from '../modules/saisieListeItems.js';
 import texteHTML from '../modules/texteHTML.js';
@@ -49,26 +50,34 @@ $(() => {
     `)).join('');
 
     const referentielStatutsMesures = JSON.parse($('#referentiel-statuts-mesures').text());
-    const statuts = Object.keys(referentielStatutsMesures).map((s) => `
+    let statuts = Object.keys(referentielStatutsMesures).map((s) => `
 <input id="statut-${s}-mesure-specifique-${index}"
        name="statut-mesure-specifique-${index}"
        value="${s}"
        ${s === statut ? 'checked' : ''}
-       type="radio">
+       type="radio"
+       required>
 <label for="statut-${s}-mesure-specifique-${index}">${referentielStatutsMesures[s]}</label>
 <br>
     `).join('');
+    statuts = `<div class="requis">${statuts}<div class="message-erreur">Ce champ est obligatoire. Veuillez le renseigner.</div></div>`;
 
     return `
-<input id="description-mesure-specifique-${index}"
-       name="description-mesure-specifique-${index}"
-       placeholder="Description de la mesure"
-       value="${description}">
-<div class="selecteur-options">
-  <select id="categorie-mesure-specifique-${index}" name="categorie-mesure-specifique-${index}">
+<div class="requis">
+  <input id="description-mesure-specifique-${index}"
+        name="description-mesure-specifique-${index}"
+        placeholder="Description de la mesure"
+        value="${description}"
+        required>
+  <div class="message-erreur">L'intitulé est obligatoire. Veuillez le renseigner.</div>
+</div>
+
+<div class="requis selecteur-options">
+  <select id="categorie-mesure-specifique-${index}" name="categorie-mesure-specifique-${index}" required>
     <option value="">--Catégorie--</option>
     ${options}
   </select>
+  <div class="message-erreur">Ce champ est obligatoire. Veuillez sélectionner une entrée.</div>
 </div>
 
 ${statuts}
@@ -84,6 +93,7 @@ ${statuts}
     zoneSaisieMesureSpecifique,
     () => (indexMaxMesuresSpecifiques += 1),
     { ordreInverse: true },
+    brancheConteneur,
   );
 
   const peupleMesuresSpecifiques = (...params) => (
@@ -100,10 +110,17 @@ ${statuts}
   indexMaxMesuresSpecifiques = peupleMesuresSpecifiques('#mesures-specifiques', '#donnees-mesures-specifiques');
   brancheAjoutMesureSpecifique('.nouvel-item', '#mesures-specifiques');
 
+  brancheValidation('form#mesures');
+
   const $bouton = $('.bouton[idHomologation]');
   const identifiantHomologation = $bouton.attr('idHomologation');
 
   $bouton.on('click', () => {
+    declencheValidation('form#mesures');
+  });
+  
+  $('form#mesures').on('submit', (evenement) => {
+    evenement.preventDefault();
     const params = parametres('form#mesures');
     arrangeParametresMesures(params);
 

--- a/public/modules/interactions/validation.js
+++ b/public/modules/interactions/validation.js
@@ -1,13 +1,7 @@
 const EVENEMENT_AFFICHE_ERREURS_SI_NECESSAIRE = 'afficheErreursSiNecessaire';
 
-const brancheValidation = (selecteurFormulaire) => {
-  $(selecteurFormulaire).on(EVENEMENT_AFFICHE_ERREURS_SI_NECESSAIRE, (evenement) => {
-    if (!evenement.target.reportValidity()) {
-      $('.intouche', selecteurFormulaire).removeClass('intouche');
-    }
-  });
-
-  $('input, select', selecteurFormulaire).each((_index, champ) => {
+const brancheConteneur = (selecteurConteneur) => {
+  $('input, select', selecteurConteneur).each((_index, champ) => {
     $(champ).addClass('intouche');
     $(champ).on('input', () => {
       $(champ).removeClass('intouche');
@@ -21,8 +15,18 @@ const brancheValidation = (selecteurFormulaire) => {
   });
 };
 
+const brancheValidation = (selecteurFormulaire) => {
+  $(selecteurFormulaire).on(EVENEMENT_AFFICHE_ERREURS_SI_NECESSAIRE, (evenement) => {
+    if (!evenement.target.reportValidity()) {
+      $('.intouche', selecteurFormulaire).removeClass('intouche');
+    }
+  });
+
+  brancheConteneur(selecteurFormulaire);
+};
+
 const declencheValidation = (selecteurFormulaire) => {
   $(selecteurFormulaire).trigger(EVENEMENT_AFFICHE_ERREURS_SI_NECESSAIRE);
 };
 
-export { brancheValidation, declencheValidation };
+export { brancheConteneur, brancheValidation, declencheValidation };

--- a/public/modules/saisieListeItems.js
+++ b/public/modules/saisieListeItems.js
@@ -5,7 +5,9 @@ const brancheSuppressionElement = () => {
   });
 };
 
-const afficheZoneSaisieItem = (selecteur, zoneSaisie, ordreInverse) => {
+const afficheZoneSaisieItem = (
+  selecteur, zoneSaisie, ordreInverse, actionSurZoneSaisieApresAjout = () => {}
+) => {
   const $conteneurSaisieItem = $(`
 <label class="item-ajoute">
   <div class="icone-suppression"></div>
@@ -17,16 +19,23 @@ const afficheZoneSaisieItem = (selecteur, zoneSaisie, ordreInverse) => {
   brancheSuppressionElement();
 
   $conteneurSaisieItem.append(zoneSaisie);
+
+  actionSurZoneSaisieApresAjout($conteneurSaisieItem);
 };
 
 const brancheAjoutItem = (
   selecteurAction, selecteurConteneur, cbZoneSaisie, cbIncrementeIndex,
-  options = { ordreInverse: false },
+  options = { ordreInverse: false }, actionSurZoneSaisieApresAjout
 ) => {
-  $(selecteurAction).click((e) => {
+  $(selecteurAction).on('click', (e) => {
     e.preventDefault();
     const index = cbIncrementeIndex();
-    afficheZoneSaisieItem(selecteurConteneur, cbZoneSaisie(index, {}), options.ordreInverse);
+    afficheZoneSaisieItem(
+      selecteurConteneur,
+      cbZoneSaisie(index, {}),
+      options.ordreInverse,
+      actionSurZoneSaisieApresAjout
+    );
   });
 };
 

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -121,7 +121,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
       .requis(data-nom = 'departementEntitePublique')
         label Département où est localisée cette entité
           br
-          .departements
+          .selecteur-options
             select(id = 'departementEntitePublique', name = 'departementEntitePublique', required, title = '')
               option(value = '') - Sélectionnez un département -
               each departement in departements

--- a/src/vues/homologation/mesures.pug
+++ b/src/vues/homologation/mesures.pug
@@ -12,6 +12,7 @@ mixin inputMesure({ nom, titre, indispensable })
 
 block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
 
 block formulaire
   form.homologation#mesures
@@ -48,7 +49,7 @@ block formulaire
                   h1= donnees.description
                   p!= donnees.descriptionLongue
 
-    .bouton(idHomologation = homologation.id) Enregistrer &nbsp;&nbsp;›
+    button.bouton(idHomologation = homologation.id) Enregistrer &nbsp;&nbsp;›
 
   script(id = 'donnees-mesures-generales', type = 'application/json').
     !{JSON.stringify(homologation.mesures.toJSON().mesuresGenerales || [])}


### PR DESCRIPTION
Dans la page des mesures
les mesures spécifiques sont munies de système de validation pour les champs description, statut et catégorie

- Style des select commun à tous les formulaires
- Branchement des validateur sur un conteneur
- Nouveau style du bloc

<img width="804" alt="Capture d’écran 2022-12-13 à 17 32 21" src="https://user-images.githubusercontent.com/39462397/207390131-f7b5c16d-1d65-499c-abdc-4d1ebd864a66.png">
