### PR TITLE
Modification de l'intitulé du rattachement à l'entité

### DIFF
--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -105,7 +105,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
         )
 
       .requis(data-nom = 'nomEntitePublique')
-        label Nom de votre entité publique
+        label Nom de l'entité publique publique de rattachement principal
           br
           input(
             id = 'nomEntitePublique',


### PR DESCRIPTION
Cette modification permet à un prestataire agissant pour le compte d'une entité en matière de SSI de cette dernière (ou de plusieurs entités) de s'inscrire, conformément aux CGU.