### PR TITLE
Correction du bug des mesures générales indispensables

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -47,7 +47,12 @@ class Homologation {
     let { mesuresGenerales = [] } = donnees;
     const mesuresPersonnalisees = moteurRegles.mesures(this.descriptionService);
     const idMesuresPersonnalisees = Object.keys(mesuresPersonnalisees);
-    mesuresGenerales = mesuresGenerales.filter((m) => idMesuresPersonnalisees.includes(m.id));
+    mesuresGenerales = mesuresGenerales
+      .filter((mesure) => idMesuresPersonnalisees.includes(mesure.id))
+      .map((mesure) => ({
+        ...mesure,
+        rendueIndispensable: !!mesuresPersonnalisees[mesure.id]?.indispensable,
+      }));
     this.mesures = new Mesures(
       { mesuresGenerales, mesuresSpecifiques },
       referentiel,

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -2,7 +2,7 @@ const Mesure = require('./mesure');
 const { ErreurMesureInconnue } = require('../erreurs');
 
 class MesureGenerale extends Mesure {
-  constructor(donneesMesure, referentiel, rendueIndispensable = false) {
+  constructor(donneesMesure, referentiel) {
     super({
       proprietesAtomiquesRequises: ['id', 'statut'],
       proprietesAtomiquesFacultatives: ['modalites'],
@@ -11,7 +11,7 @@ class MesureGenerale extends Mesure {
     MesureGenerale.valide(donneesMesure, referentiel);
     this.renseigneProprietes(donneesMesure);
 
-    this.rendueIndispensable = rendueIndispensable;
+    this.rendueIndispensable = !!donneesMesure.rendueIndispensable;
     this.referentiel = referentiel;
   }
 

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -42,7 +42,6 @@ class MesuresGenerales extends ElementsConstructibles {
     this.items.forEach((mesure) => {
       const { id, statut } = mesure;
       const { categorie } = this.referentiel.mesure(id);
-      mesure.rendueIndispensable = mesuresPersonnalisees[id].indispensable;
 
       if (statut === MesureGenerale.STATUT_FAIT) {
         stats[categorie].misesEnOeuvre += 1;
@@ -60,9 +59,8 @@ class MesuresGenerales extends ElementsConstructibles {
 
     Object.keys(mesuresPersonnalisees)
       .map((id) => new MesureGenerale(
-        { id },
+        { id, rendueIndispensable: mesuresPersonnalisees[id].indispensable },
         this.referentiel,
-        mesuresPersonnalisees[id].indispensable,
       ))
       .reduce((acc, mesure) => {
         const { categorie } = this.referentiel.mesure(mesure.id);

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -150,6 +150,18 @@ describe('Une homologation', () => {
     expect(homologation.risquesSpecifiques().nombre()).to.equal(1);
   });
 
+  it('se construit en renseignant le caractère indispensable des mesures générales grâce aux mesures personnalisées', () => {
+    const moteur = { mesures: () => ({ m1: { indispensable: true } }) };
+    const referentiel = Referentiel.creeReferentiel({ mesures: { m1: {} } });
+
+    const homologation = new Homologation({
+      id: '123',
+      mesuresGenerales: [{ id: 'm1' }],
+    }, referentiel, moteur);
+
+    expect(homologation.mesures.mesuresGenerales.toutes().find((mesure) => mesure.id === 'm1').rendueIndispensable).to.be(true);
+  });
+
   it('connaît ses mesures spécifiques', () => {
     const homologation = new Homologation({
       id: '123',

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -82,8 +82,7 @@ describe('Une mesure de sécurité', () => {
   it('peut être rendue indispensable, même si le référentiel dit le contraire', () => {
     expect(referentiel.mesureIndispensable('identifiantMesure')).to.be(false);
 
-    const mesureRendueIndispensable = true;
-    const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait' }, referentiel, mesureRendueIndispensable);
+    const mesure = new MesureGenerale({ id: 'identifiantMesure', statut: 'fait', rendueIndispensable: true }, referentiel);
     expect(mesure.estIndispensable()).to.be(true);
   });
 

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -124,13 +124,6 @@ describe('La liste des mesures générales', () => {
       expect(stats.deux.indispensables.fait).to.equal(0);
     });
 
-    it('tient compte des mesures faites rendues indispensables', () => {
-      const mesuresGenerales = creeMesuresGenerales([{ id: 'id2', statut: 'fait' }]);
-
-      const stats = mesuresGenerales.statistiques({ id2: { indispensable: true } }).toJSON();
-      expect(stats.une.indispensables.fait).to.equal(1);
-    });
-
     it('calcule le nombre de mesures indispensables en cours', () => {
       const mesuresGenerales = creeMesuresGenerales([{ id: 'id1', statut: 'enCours' }]);
 


### PR DESCRIPTION
Dans les annexes,
Les mesures rendues indispensables apparaissent comme recommandées (sans l'étoile)

La cause est l'instanciation dans les listeItems des objets MesureGenerale sans le paramètre `renduIndispensable`
