### PR TITLE
Correction des camemberts des mesures non pleins

### DIFF
--- a/public/scripts/statistiquesMesures.js
+++ b/public/scripts/statistiquesMesures.js
@@ -14,6 +14,8 @@ const dessineCamembert = ($canevas, {
 }) => {
   const mesuresARemplir = totalMesures - mesuresEnCours - mesuresNonFaites - mesuresFaites;
   const donnees = [mesuresEnCours, mesuresNonFaites, mesuresARemplir, mesuresFaites];
+  const offsetMesuresFaites = mesuresARemplir ? 20 : 0;
+  const labelOffsetMesuresFaites = mesuresARemplir ? -20 : 15;
 
   /* eslint-disable no-new */
   new Chart(
@@ -46,7 +48,7 @@ const dessineCamembert = ($canevas, {
           },
           {
             data: donnees,
-            offset: [0, 0, 0, 20],
+            offset: [0, 0, 0, offsetMesuresFaites],
             radius: '180%',
             backgroundColor: [
               PALETTE.BLEU_MOYEN,
@@ -58,7 +60,7 @@ const dessineCamembert = ($canevas, {
               color: [PALETTE.BLANC, PALETTE.BLEU_FONCE, PALETTE.BLEU_FONCE, PALETTE.BLANC],
               font: { weight: 'bold' },
               align: 'start',
-              offset: [-15, -15, -15, -20],
+              offset: [-15, -15, -15, labelOffsetMesuresFaites],
               formatter: (valeur) => (valeur || ''),
             },
           },


### PR DESCRIPTION
Dans l'annexe de synthèse,
Quand toutes les mesures sont faites,
Les camemberts ne sont pas pleins.

- Les camemberts sont pleins
- Pendant que j'y étais j'ai centré le label au centre du camembert

<img width="1010" alt="Capture d’écran 2022-12-14 à 17 49 41" src="https://user-images.githubusercontent.com/39462397/207657159-9dfa76c2-2571-43b9-9144-e344e8da2338.png">
