### PR TITLE
Correction des camemberts des mesures non pleins

### DIFF
--- a/public/scripts/statistiquesMesures.js
+++ b/public/scripts/statistiquesMesures.js
@@ -14,6 +14,9 @@ const dessineCamembert = ($canevas, {
 }) => {
   const mesuresARemplir = totalMesures - mesuresEnCours - mesuresNonFaites - mesuresFaites;
   const donnees = [mesuresEnCours, mesuresNonFaites, mesuresARemplir, mesuresFaites];
+  const encoreMesuresAFaire = mesuresEnCours > 0 || mesuresNonFaites > 0 || mesuresARemplir > 0;
+  const decalageMesuresFaites = encoreMesuresAFaire ? 20 : 0;
+  const decalageLabelMesuresFaites = encoreMesuresAFaire ? -20 : 15;
 
   /* eslint-disable no-new */
   new Chart(
@@ -46,7 +49,7 @@ const dessineCamembert = ($canevas, {
           },
           {
             data: donnees,
-            offset: [0, 0, 0, 20],
+            offset: [0, 0, 0, decalageMesuresFaites],
             radius: '180%',
             backgroundColor: [
               PALETTE.BLEU_MOYEN,
@@ -58,7 +61,7 @@ const dessineCamembert = ($canevas, {
               color: [PALETTE.BLANC, PALETTE.BLEU_FONCE, PALETTE.BLEU_FONCE, PALETTE.BLANC],
               font: { weight: 'bold' },
               align: 'start',
-              offset: [-15, -15, -15, -20],
+              offset: [-15, -15, -15, decalageLabelMesuresFaites],
               formatter: (valeur) => (valeur || ''),
             },
           },


### PR DESCRIPTION
Dans l'annexe de synthèse,
Quand toutes les mesures sont faites,
Les camemberts ne sont pas pleins.

Les camemberts sont pleins
J'ai aussi centré le label au centre des camemberts

<img width="1010" alt="Capture d’écran 2022-12-14 à 17 49 41" src="https://user-images.githubusercontent.com/39462397/207879357-d02caea3-8d91-4efd-a979-184e333bc877.png">
