### PR TITLE
Intégration Crisp

### DIFF
--- a/public/scripts/crisp.js
+++ b/public/scripts/crisp.js
@@ -1,0 +1,11 @@
+// Script obtenu sur https://app.crisp.chat/settings/websites/ > « Intégrations » > « HTML »
+window.$crisp = [];
+window.CRISP_WEBSITE_ID = '83715488-f261-43fe-806b-519f8611e146';
+function activeCrisp() {
+  const d = document;
+  const s = d.createElement('script');
+  s.src = 'https://client.crisp.chat/l.js';
+  s.async = 1;
+  d.getElementsByTagName('head')[0].appendChild(s);
+}
+activeCrisp();

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -14,14 +14,28 @@ const middleware = (configuration = {}) => {
 
   const positionneHeaders = (requete, reponse, suite) => {
     const { nonce } = requete;
-    const politiqueCommuneSecuriteContenus = "default-src 'self'; img-src 'self' data:;";
-    const politiqueSecuriteStyles = nonce
-      ? `style-src 'self' 'nonce-${nonce}';`
-      : '';
-    const politiqueSecuriteScripts = "script-src 'self'";
+
+    const csp = () => {
+      const fournisseursContenu = {
+        mss: {
+          defaultSrc: "'self'",
+          imgSrc: "'self' data:",
+          styleSrc: nonce ? `style-src 'self' 'nonce-${nonce}'` : '',
+          scriptsSrc: "'self'",
+        },
+      };
+      const { mss } = fournisseursContenu;
+      const politiques = [
+        ['default-src', `${mss.defaultSrc}`],
+        ['img-src', `${mss.imgSrc}`],
+        ['style-src', `${mss.styleSrc}`],
+        ['script-src', `${mss.scriptsSrc}`],
+      ];
+      return politiques.map(([nom, valeur]) => `${nom} ${valeur}`).join(';');
+    };
+
     reponse.set({
-      'content-security-policy':
-        `${politiqueCommuneSecuriteContenus} ${politiqueSecuriteStyles} ${politiqueSecuriteScripts}`,
+      'content-security-policy': csp(),
       'x-frame-options': 'deny',
       'x-content-type-options': 'nosniff',
       'referrer-policy': 'no-referrer',

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -18,18 +18,32 @@ const middleware = (configuration = {}) => {
     const csp = () => {
       const fournisseursContenu = {
         mss: {
+          connectSrc: "'self'",
           defaultSrc: "'self'",
+          fontSrc: "'self'",
           imgSrc: "'self' data:",
-          styleSrc: nonce ? `style-src 'self' 'nonce-${nonce}'` : '',
+          styleSrc: `'self' ${nonce ? `'nonce-${nonce}'` : ''}`,
           scriptsSrc: "'self'",
         },
+        crisp: {
+          // Liste obtenue de https://docs.crisp.chat/guides/others/whitelisting-our-systems/crisp-domain-names/
+          connectSrc: 'https://client.crisp.chat https://storage.crisp.chat wss://client.relay.crisp.chat wss://stream.relay.crisp.chat',
+          imgSrc: 'https://client.crisp.chat https://image.crisp.chat https://storage.crisp.chat',
+          fontSrc: 'https://client.crisp.chat',
+          mediaSrc: 'https://client.crisp.chat',
+          scriptSrc: 'https://client.crisp.chat https://settings.crisp.chat',
+          styleSrc: "'unsafe-inline' https://client.crisp.chat",
+        },
       };
-      const { mss } = fournisseursContenu;
+      const { mss, crisp } = fournisseursContenu;
       const politiques = [
+        ['connect-src', `${mss.connectSrc} ${crisp.connectSrc}`],
         ['default-src', `${mss.defaultSrc}`],
-        ['img-src', `${mss.imgSrc}`],
-        ['style-src', `${mss.styleSrc}`],
-        ['script-src', `${mss.scriptsSrc}`],
+        ['font-src', `${mss.fontSrc} ${crisp.fontSrc}`],
+        ['img-src', `${mss.imgSrc} ${crisp.imgSrc}`],
+        ['media-src', `${crisp.mediaSrc}`],
+        ['script-src', `${mss.scriptsSrc} ${crisp.scriptSrc}`],
+        ['style-src', `${mss.styleSrc} ${crisp.styleSrc}`],
       ];
       return politiques.map(([nom, valeur]) => `${nom} ${valeur}`).join(';');
     };

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -4,6 +4,7 @@ block page
   block scripts
     script(src='/bibliotheques/axios-1.0.0.min.js')
     script(src='/bibliotheques/jquery-3.6.0.min.js')
+    script(src='/statique/scripts/crisp.js')
 
   block styles
     link(href='/statique/assets/styles/palette.css', rel='stylesheet')

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -299,7 +299,7 @@ describe('Le middleware MSS', () => {
       verifieHeaderAvecNonce(
         '12345',
         'content-security-policy',
-        "style-src 'self' 'nonce-12345';",
+        "style-src 'self' 'nonce-12345' 'unsafe-inline' https://client.crisp.chat",
         done,
       );
     });
@@ -320,12 +320,24 @@ describe('Le middleware MSS', () => {
       verifiePositionnementHeader('content-security-policy', "default-src 'self'", done);
     });
 
-    it("autorise le chargement des images dont l'URL commence par `data:`", (done) => {
-      verifiePositionnementHeader('content-security-policy', "img-src 'self' data:;", done);
+    it("autorise l'utilisation d'APIs hébergées par les domaines « MSS » et « Crisp »", (done) => {
+      verifiePositionnementHeader('content-security-policy', "connect-src 'self' https://client.crisp.chat https://storage.crisp.chat wss://client.relay.crisp.chat wss://stream.relay.crisp.chat;", done);
     });
 
-    it('autorise le chargement de tous les scripts du domaine (et uniquement ceux-là)', (done) => {
-      verifiePositionnementHeader('content-security-policy', "script-src 'self'", done);
+    it('autorise le chargement de polices de caractères des domaines « MSS » et « Crisp »', (done) => {
+      verifiePositionnementHeader('content-security-policy', "font-src 'self' https://client.crisp.chat;", done);
+    });
+
+    it("autorise le chargement d'images des domaines « MSS » et « Crisp » ou dont l'URL commence par data:", (done) => {
+      verifiePositionnementHeader('content-security-policy', "img-src 'self' data: https://client.crisp.chat https://image.crisp.chat https://storage.crisp.chat;", done);
+    });
+
+    it('autorise le chargement de médias du domaine « Crisp »', (done) => {
+      verifiePositionnementHeader('content-security-policy', 'media-src https://client.crisp.chat;', done);
+    });
+
+    it('autorise le chargement de scripts des domaines « MSS » et « Crisp »', (done) => {
+      verifiePositionnementHeader('content-security-policy', "script-src 'self' https://client.crisp.chat https://settings.crisp.chat;", done);
     });
 
     it('interdit le chargement de la page dans une iFrame', (done) => {


### PR DESCRIPTION
### 🛑  En attente d'arbitrage sur `unsafe-inline`  🛑 

https://github.com/betagouv/mon-service-securise/pull/572#discussion_r1052341903



----------------------



J'ai voulu m'accorder un peu de temps pour voir comment intégrer le tchat Crisp chez nous pour outiller @henricasa.

### Résultat 

✅  Résultat après 1 h. 10 : le tchat est fonctionnel 👇 

![image](https://user-images.githubusercontent.com/24898521/208140812-f42d6bc7-3e74-4587-afc0-d3a5a7fad35d.png)

### Résumé
- J'ai choisi de mettre dans `crisp.js` le script donné par Crisp. Autrement dit : MSS ne fait pas du tout passe-plat.
- Le header `content-security-policy` est désormais calculé à partir d'un design plutôt déclaratif :
```js
const fournisseurs = {
  mss : { ... },
  crisp : { ... } 
} 
```

### Suite
L'intégration de Matomo, en suivant ce design, devrait se réaliser sans obstacle majeur.

🤝  Conversations bienvenues !