### PR TITLE
Champs requis pour les mesures spécifiques coté serveur

### DIFF
--- a/src/modeles/mesureSpecifique.js
+++ b/src/modeles/mesureSpecifique.js
@@ -5,7 +5,7 @@ const Referentiel = require('../referentiel');
 class MesureSpecifique extends Mesure {
   constructor(donneesMesure = {}, referentiel = Referentiel.creeReferentielVide()) {
     super({
-      proprietesAtomiquesRequises: ['description', 'categorie', 'statut'],
+      proprietesAtomiquesRequises: MesureSpecifique.proprietesObligatoires(),
       proprietesAtomiquesFacultatives: ['modalites'],
     });
 
@@ -21,6 +21,14 @@ class MesureSpecifique extends Mesure {
 
   statutRenseigne() {
     return Mesure.statutRenseigne(this.statut);
+  }
+
+  static proprietesObligatoires() {
+    return ['description', 'categorie', 'statut'];
+  }
+
+  static toutesProprietesObligatoiresRenseignees(mesure) {
+    return MesureSpecifique.proprietesObligatoires().every((propriete) => mesure?.[propriete]);
   }
 
   static valide({ categorie, statut }, referentiel) {

--- a/src/routes/routesApiHomologation.js
+++ b/src/routes/routesApiHomologation.js
@@ -8,6 +8,7 @@ const Dossier = require('../modeles/dossier');
 const FonctionnalitesSpecifiques = require('../modeles/fonctionnalitesSpecifiques');
 const DonneesSensiblesSpecifiques = require('../modeles/donneesSensiblesSpecifiques');
 const MesureGenerale = require('../modeles/mesureGenerale');
+const MesureSpecifique = require('../modeles/mesureSpecifique');
 const MesuresSpecifiques = require('../modeles/mesuresSpecifiques');
 const PartiesPrenantes = require('../modeles/partiesPrenantes/partiesPrenantes');
 const PointsAcces = require('../modeles/pointsAcces');
@@ -102,9 +103,8 @@ const routesApiHomologation = (middleware, depotDonnees, referentiel) => {
           return new MesureGenerale({ id: idMesure, statut, modalites }, referentiel);
         });
 
-      const aPersister = mesuresSpecifiques.filter(
-        (m) => m?.description || m?.categorie || m?.statut || m?.modalites
-      );
+      const aPersister = mesuresSpecifiques
+        .filter(MesureSpecifique.toutesProprietesObligatoiresRenseignees);
       const specifiques = new MesuresSpecifiques(
         { mesuresSpecifiques: aPersister },
         referentiel,

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -26,6 +26,17 @@ describe('Une mesure spécifique', () => {
     expect(mesure.modalites).to.equal('Des modalités de mise en œuvre');
   });
 
+  elle('connaît ses propriétés obligatoires', () => {
+    expect(MesureSpecifique.proprietesObligatoires()).to.eql(['description', 'categorie', 'statut']);
+  });
+
+  elle('peut dire si un objet a toutes les propriétés obligatoires renseignées', () => {
+    const mesure = { description: 'description', statut: 'fait', categorie: 'categorie' };
+    const mesureIncomplete = { statut: 'statut' };
+    expect(MesureSpecifique.toutesProprietesObligatoiresRenseignees(mesure)).to.be(true);
+    expect(MesureSpecifique.toutesProprietesObligatoiresRenseignees(mesureIncomplete)).to.be(false);
+  });
+
   elle('ne tient pas compte du champ `modalites` pour déterminer le statut de saisie', () => {
     const mesure = new MesureSpecifique({
       description: 'Une mesure spécifique',


### PR DESCRIPTION
On ne sauvegarde pas les mesures spécifiques qui n'ont pas tous les champs requis