### PR TITLE
Ajoute la validation des cases à cocher et zone de texte

### DIFF
--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -50,15 +50,15 @@
   margin-bottom: 2em;
 }
 
-:is(input, select):not(.intouche):valid{
+:is(input, select, textarea):not(.intouche):valid{
   border-color: var(--bleu-mise-en-avant);
 }
 
-input[type="radio"]:valid {
+input[type="radio"]:not(.intouche):valid {
   background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="45" style="fill: white; stroke: %230f7ac7; stroke-width: 0.50em" /></svg>')
 }
 
-:is(input, select):not(.intouche):invalid {
+:is(input, select, textarea):not(.intouche):invalid {
   border-color: var(--rose-anssi);
 }
 
@@ -66,10 +66,10 @@ input[type="radio"]:not(.intouche):invalid {
   background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="45" style="fill: white; stroke: %23ff6584; stroke-width: 0.50em" /></svg>')
 }
 
-:is(input, select):not(.intouche):invalid:focus {
+:is(input, select, textarea):not(.intouche):invalid:focus {
   outline-color: var(--rose-anssi);
 }
 
-:is(input, select):not(.intouche):invalid ~ .message-erreur {
+:is(input, select, textarea):not(.intouche):invalid ~ .message-erreur {
   display: block;
 }

--- a/public/homologation/etapesDossier.js
+++ b/public/homologation/etapesDossier.js
@@ -1,4 +1,4 @@
-import { brancheValidation, declencheValidation } from '../modules/interactions/validation.js';
+import { brancheValidation, declencheValidation } from '../modules/interactions/validation.mjs';
 
 let formulaireDejaSoumis = false;
 

--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -1,6 +1,6 @@
 import arrangeParametresMesures from '../modules/arrangeParametresMesures.mjs';
 import brancheFiltresMesures from '../modules/interactions/brancheFiltresMesures.mjs';
-import { brancheConteneur, brancheValidation, declencheValidation } from '../modules/interactions/validation.js';
+import { brancheConteneur, brancheValidation, declencheValidation } from '../modules/interactions/validation.mjs';
 import parametres from '../modules/parametres.mjs';
 import { brancheAjoutItem, peupleListeItems } from '../modules/saisieListeItems.js';
 import texteHTML from '../modules/texteHTML.js';

--- a/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
+++ b/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
@@ -1,4 +1,4 @@
-import { brancheValidation, declencheValidation } from './validation.js';
+import { brancheValidation, declencheValidation } from './validation.mjs';
 import convertisReponseOuiNon from '../convertisReponseOuiNon.mjs';
 
 const brancheSoumissionFormulaireUtilisateur = (selecteurFormulaire, action) => {

--- a/public/modules/interactions/validation.mjs
+++ b/public/modules/interactions/validation.mjs
@@ -1,12 +1,14 @@
+import brancheValidationCasesACocher from './brancheValidationCasesACocher.mjs';
+
 const EVENEMENT_AFFICHE_ERREURS_SI_NECESSAIRE = 'afficheErreursSiNecessaire';
 
 const brancheConteneur = (selecteurConteneur) => {
-  $('input, select', selecteurConteneur).each((_index, champ) => {
+  $('input, select, textarea', selecteurConteneur).each((_index, champ) => {
     $(champ).addClass('intouche');
     $(champ).on('input', () => {
       $(champ).removeClass('intouche');
     });
-    if (champ.type === 'radio') {
+    if (champ.type === 'radio' || champ.type === 'checkbox') {
       $(champ).on('change', (evenement) => $(evenement.target).siblings().removeClass('intouche'));
     }
     $(champ).on('invalid', (evenement) => {
@@ -23,6 +25,7 @@ const brancheValidation = (selecteurFormulaire) => {
   });
 
   brancheConteneur(selecteurFormulaire);
+  brancheValidationCasesACocher();
 };
 
 const declencheValidation = (selecteurFormulaire) => {


### PR DESCRIPTION
Dans la grande aventure qui est la validation des formulaires coté client,
je propose d'ajouter aux systèmes de validation déjà en place la validation des checkbox et textarea

Notes :
- Pages concernées :
  - /inscription
  - /utilisateur/edition
  - /homologation/:id/mesures
  - /homologation/:id/dossier/edition/etape/*
  - /espacePersonnel -> popin de création
- J'ai renommé le fichier avec mjs en extension pour l'utiliser plus tard dans les fichiers de description du service
- Les textarea apparaissent avec une bordure bleue au moment du submit ou de la modification