### PR TITLE
Champs requis dan la page Décrire

### DIFF
--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -4,6 +4,11 @@
   margin: 0 0 1em;
 }
 
+.titre ~ .description {
+  font-weight: normal;
+  font-size: 0.9em;
+}
+
 #risqueJuridiqueFinancierReputationnel :is(.exemple, .exemple + br) {
   display: none;
 }

--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -1,3 +1,9 @@
+.mention {
+  display: flex;
+  justify-content: end;
+  margin: 0 0 1em;
+}
+
 #risqueJuridiqueFinancierReputationnel :is(.exemple, .exemple + br) {
   display: none;
 }

--- a/public/modules/soumetsHomologation.mjs
+++ b/public/modules/soumetsHomologation.mjs
@@ -1,4 +1,5 @@
 import adaptateurAjaxAxios from './adaptateurAjaxAxios.mjs';
+import { brancheValidation, declencheValidation } from './interactions/validation.mjs';
 
 const initialiseComportementFormulaire = (
   selecteurFormulaire,
@@ -13,6 +14,7 @@ const initialiseComportementFormulaire = (
     : { method: 'post', url: '/api/homologation' };
   const $form = $(selecteurFormulaire);
 
+  brancheValidation(selecteurFormulaire);
   $form.on('submit', ((evenement) => {
     evenement.preventDefault();
     requete.data = fonctionExtractionParametres(selecteurFormulaire);
@@ -25,7 +27,9 @@ const initialiseComportementFormulaire = (
       .then(redirigeVersSynthese);
   }));
 
-  $bouton.on('click', () => $form.trigger('submit'));
+  $bouton.on('click', () => {
+    declencheValidation(selecteurFormulaire);
+  });
 };
 
 export default initialiseComportementFormulaire;

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -10,38 +10,51 @@ mixin formulaireDescriptionService(idHomologation)
     p.
       Précisez les caractéristiques de votre service pour obtenir des recommandations personnalisées de l'ANSSI.
     section
-      label Nom du service numérique à homologuer
-        br
-        input(
-          id = 'nom-service',
-          name = 'nomService',
-          type = 'text',
-          value != homologation.nomService(),
-        )
+      .mention champ obligatoire
+      .requis
+        label Nom du service numérique à homologuer
+          br
+          input(
+            id = 'nom-service',
+            name = 'nomService',
+            type = 'text',
+            value != homologation.nomService(),
+            required
+          )
+          .message-erreur Le nom est obligatoire. Veuillez le renseigner.
 
-      +inputChoix({
-        type: 'checkbox',
-        nom: 'typeService',
-        titre: 'Type(s)',
-        items: referentiel.typesService(),
-        objetDonnees: homologation.descriptionService,
-      })
+      .requis
+        +inputChoix({
+          type: 'checkbox',
+          nom: 'typeService',
+          titre: 'Type(s)',
+          items: referentiel.typesService(),
+          objetDonnees: homologation.descriptionService,
+          messageErreur: 'Ce champ est obligatoire. Veuillez sélectionner une ou plusieurs options.',
+          requis: true,
+        })
 
-      +inputChoix({
-        type: 'radio',
-        nom: 'provenanceService',
-        titre: 'Provenance',
-        items: referentiel.provenancesService(),
-        objetDonnees: homologation.descriptionService,
-      })
+      .requis
+        +inputChoix({
+          type: 'radio',
+          nom: 'provenanceService',
+          titre: 'Provenance',
+          items: referentiel.provenancesService(),
+          objetDonnees: homologation.descriptionService,
+          messageErreur: 'La provenance est obligatoire. Veuillez cocher une option.',
+          requis: true,
+        })
 
-      +inputChoix({
-        type: 'radio',
-        nom: 'statutDeploiement',
-        titre: 'Statut',
-        items: referentiel.statutsDeploiement(),
-        objetDonnees: homologation.descriptionService,
-      })
+      .requis
+        +inputChoix({
+          type: 'radio',
+          nom: 'statutDeploiement',
+          titre: 'Statut',
+          items: referentiel.statutsDeploiement(),
+          objetDonnees: homologation.descriptionService,
+          messageErreur: 'Le statut est obligatoire. Veuillez cocher une option.',
+          requis: true,
+        })
 
       label Présentation
         textarea(
@@ -94,28 +107,36 @@ mixin formulaireDescriptionService(idHomologation)
       })
 
     section
-      +inputChoix({
-        type: 'radio',
-        nom: 'localisationDonnees',
-        titre: 'Localisation des données',
-        items: referentiel.localisationsDonnees(),
-        objetDonnees: homologation.descriptionService,
-      })
+      .requis
+        +inputChoix({
+          type: 'radio',
+          nom: 'localisationDonnees',
+          titre: 'Localisation des données',
+          items: referentiel.localisationsDonnees(),
+          objetDonnees: homologation.descriptionService,
+          messageErreur: 'La localisation des données est obligatoire. Veuillez cocher une option.',
+          requis: true,
+        })
 
-      +inputChoix({
-        type: 'radio',
-        nom: 'delaiAvantImpactCritique',
-        titre: 'Estimation de la durée maximale acceptable de dysfonctionnement grave du service',
-        items: referentiel.delaisAvantImpactCritique(),
-        objetDonnees: homologation.descriptionService,
-      })
-
-      +inputOuiNon({
-        nom: 'risqueJuridiqueFinancierReputationnel',
-        titre: 'Une atteinte à la sécurité ou au bon fonctionnement du service pourrait entraîner un impact critique sur les plans juridique, financier ou réputationnel',
-        objetDonnees: homologation.descriptionService,
-        exempleOui: "Les mesures de sécurité à mettre en œuvre, proposées dans l'étape suivante « Sécuriser », seront renforcées (ex : réaliser un audit de sécurité, une analyse Ebios, …).",
-      })
+      .requis
+        +inputChoix({
+          type: 'radio',
+          nom: 'delaiAvantImpactCritique',
+          titre: 'Estimation de la durée maximale acceptable de dysfonctionnement grave du service',
+          items: referentiel.delaisAvantImpactCritique(),
+          objetDonnees: homologation.descriptionService,
+          messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
+          requis: true,
+        })
+      .requis
+        +inputOuiNon({
+          nom: 'risqueJuridiqueFinancierReputationnel',
+          titre: 'Une atteinte à la sécurité ou au bon fonctionnement du service pourrait entraîner un impact critique sur les plans juridique, financier ou réputationnel',
+          objetDonnees: homologation.descriptionService,
+          exempleOui: "Les mesures de sécurité à mettre en œuvre, proposées dans l'étape suivante « Sécuriser », seront renforcées (ex : réaliser un audit de sécurité, une analyse Ebios, …).",
+          messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
+          requis: true,
+        })
 
     if idHomologation
       button.bouton#diagnostic(idHomologation = idHomologation) Enregistrer

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -79,6 +79,7 @@ mixin formulaireDescriptionService(idHomologation)
         type: 'checkbox',
         nom: 'fonctionnalites',
         titre: 'Fonctionnalité(s) offerte(s)',
+        description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
         items: referentiel.fonctionnalites(),
         objetDonnees: homologation.descriptionService,
       })
@@ -95,6 +96,7 @@ mixin formulaireDescriptionService(idHomologation)
         type: 'checkbox',
         nom: 'donneesCaracterePersonnel',
         titre: 'Données à caractère personnel et autres données sensibles stockées par le service',
+        description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
         items: referentiel.donneesCaracterePersonnel(),
         objetDonnees: homologation.descriptionService,
       })

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -118,8 +118,8 @@ mixin formulaireDescriptionService(idHomologation)
       })
 
     if idHomologation
-      .bouton#diagnostic(idHomologation = idHomologation) Enregistrer
+      button.bouton#diagnostic(idHomologation = idHomologation) Enregistrer
     else
-      .bouton#diagnostic Valider
+      button.bouton#diagnostic Valider
 
   script(type = 'module', src = '/statique/homologation/descriptionService.js')

--- a/src/vues/fragments/inputChoix.pug
+++ b/src/vues/fragments/inputChoix.pug
@@ -1,4 +1,4 @@
-mixin inputChoix({ type, nom, titre, items, objetDonnees = homologation, messageErreur, decoration, requis = false })
+mixin inputChoix({ type, nom, titre, description, items, objetDonnees = homologation, messageErreur, decoration, requis = false })
   - let valeursSelectionnees = objetDonnees[nom]
   - if (typeof valeursSelectionnees === 'boolean') valeursSelectionnees = (valeursSelectionnees ? 'oui' : 'non')
   - const requisGroupe = requis && type === 'checkbox' && Object.keys(items).length > 1
@@ -9,6 +9,8 @@ mixin inputChoix({ type, nom, titre, items, objetDonnees = homologation, message
     .titre= titre
       if decoration
         .decoration !{decoration}
+    if description
+      .description= description
     each donnees, identifiant in items
       - const { description, exemple } = donnees
       - const identifiantInput = `${nom}-${identifiant}`

--- a/src/vues/fragments/inputChoix.pug
+++ b/src/vues/fragments/inputChoix.pug
@@ -1,7 +1,11 @@
 mixin inputChoix({ type, nom, titre, items, objetDonnees = homologation, messageErreur, decoration, requis = false })
   - let valeursSelectionnees = objetDonnees[nom]
   - if (typeof valeursSelectionnees === 'boolean') valeursSelectionnees = (valeursSelectionnees ? 'oui' : 'non')
-  fieldset(id = nom)
+  - const requisGroupe = requis && type === 'checkbox' && Object.keys(items).length > 1
+  - const requisChamp = requis && (type === 'radio' || Object.keys(items).length === 1)
+  - const classeGroupe = type === 'checkbox' ? 'casesACocher' : ''
+
+  fieldset(id = nom, class = classeGroupe, required = requisGroupe)
     .titre= titre
       if decoration
         .decoration !{decoration}
@@ -18,7 +22,7 @@ mixin inputChoix({ type, nom, titre, items, objetDonnees = homologation, message
             ? valeursSelectionnees.includes(identifiant)
             : identifiant === valeursSelectionnees
         ),
-        required = requis,
+        required = requisChamp,
         title = ''
       )
       label(for = identifiantInput)= description

--- a/src/vues/homologation/creation.pug
+++ b/src/vues/homologation/creation.pug
@@ -1,4 +1,4 @@
-extends ./formulaire
+extends ./decrire
 include ../fragments/formulaireDescriptionService
 
 block formulaire

--- a/src/vues/homologation/decrire.pug
+++ b/src/vues/homologation/decrire.pug
@@ -1,0 +1,4 @@
+extends ./formulaire
+
+block append styles
+  link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')

--- a/src/vues/homologation/descriptionService.pug
+++ b/src/vues/homologation/descriptionService.pug
@@ -1,4 +1,4 @@
-extends ./formulaire
+extends ./decrire
 include ../fragments/formulaireDescriptionService
 
 block formulaire

--- a/test_public/modules/soumetsHomologation.spec.mjs
+++ b/test_public/modules/soumetsHomologation.spec.mjs
@@ -13,7 +13,7 @@ describe("L'initialisation du comportement du formulaire", () => {
       const dom = new JSDOM(`
         <form class="formulaire">
           <input name="champ-1" value="valeur 1">
-          <div class="bouton"></div>
+          <button class="bouton"></button>
         </form>
       `);
       global.$ = jquery(dom.window);


### PR DESCRIPTION
Dans la page Décrire,
Il y a des validateurs de présence sur les champs voulus obligatoires.

Notes :
- La maquette est disponible dans Figma
- ~~J'ai pour le moment inventé les messages d'erreurs (à valider / ré-écrire)~~
- Il n'y a pas de validateurs pour `Données à caractère personnel et autres données sensibles stockées par le service` et `Fonctionnalité(s) offerte(s)` à la place il y a une phrase indiquant qu'il est bon de remplir

<img width="844" alt="Capture d’écran 2022-12-22 à 10 34 21" src="https://user-images.githubusercontent.com/39462397/209104181-97582205-eee3-4d6f-bcdb-ebd7e72570df.png">

