### PR TITLE
Correction bords bouton inactif

### DIFF
--- a/public/assets/styles/bouton.css
+++ b/public/assets/styles/bouton.css
@@ -27,4 +27,5 @@ button {
 
 .bouton:disabled {
   background-color: var(--gris-inactif);
+  border-color: var(--gris-inactif);
 }

--- a/src/vues/fragments/modaleNouveauService.pug
+++ b/src/vues/fragments/modaleNouveauService.pug
@@ -3,7 +3,6 @@ include lienNouvelOnglet
 block append styles
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/formulaire.css', rel='stylesheet')
-  link(href = '/statique/assets/styles/bouton.css', rel='stylesheet')
 
 mixin modaleNouveauService
   .rideau#modale-nouveau-service


### PR DESCRIPTION
Avant :
<img width="262" alt="Screenshot 2022-12-23 at 14 34 29" src="https://user-images.githubusercontent.com/105624/209344586-7d35d53f-7ad3-41b9-9947-64c837c1d5b5.png">

Après correction :
<img width="270" alt="Screenshot 2022-12-23 at 14 35 06" src="https://user-images.githubusercontent.com/105624/209344682-1f7f6dc0-e16c-4c62-b166-517dc3359920.png">

(Au passage, on en a profité pour supprimer une inclusion CSS en doublon.)