### PR TITLE
Propriétés obligatoires

### DIFF
--- a/src/modeles/base.js
+++ b/src/modeles/base.js
@@ -1,3 +1,18 @@
+const proprietePresente = (valeur) => {
+  if (Array.isArray(valeur)) {
+    return valeur.length && valeur.every((item) => proprietePresente(item));
+  }
+
+  switch (typeof valeur) {
+    case 'undefined': return false;
+    case 'boolean': return true;
+    case 'string': return valeur.length > 0;
+    case 'number': return !Number.isNaN(valeur);
+    case 'object': return valeur !== null && Object.keys(valeur).length !== 0;
+    default: return false;
+  }
+};
+
 class Base {
   constructor(proprietes = {}) {
     const {
@@ -49,6 +64,15 @@ class Base {
     });
 
     return resultat;
+  }
+
+  static proprietesObligatoires() {
+    return [];
+  }
+
+  static proprietesObligatoiresRenseignees(donnees) {
+    return this.proprietesObligatoires()
+      .every((propriete) => proprietePresente(donnees?.[propriete]));
   }
 }
 

--- a/test/modeles/base.spec.js
+++ b/test/modeles/base.spec.js
@@ -2,6 +2,12 @@ const expect = require('expect.js');
 
 const Base = require('../../src/modeles/base');
 
+class ExtensionBase extends Base {
+  static proprietesObligatoires() {
+    return ['propriete1', 'propriete2'];
+  }
+}
+
 describe('Un objet métier', () => {
   it('sait si une de ses propriétés a été saisie', () => {
     const objetMetier = new Base({ proprietesAtomiquesRequises: ['propriete'] });
@@ -28,5 +34,54 @@ describe('Un objet métier', () => {
     const objetMetier = new Base({ proprietesAtomiquesFacultatives: ['propriete'] });
     objetMetier.renseigneProprietes({ propriete: 'valeur' });
     expect(objetMetier.toJSON()).to.eql({ propriete: 'valeur' });
+  });
+
+  it('a des propriétés obligatoires vide par défaut', () => {
+    expect(Base.proprietesObligatoires()).to.eql([]);
+  });
+
+  describe('sur vérification du renseignement des propriétés obligatoires', () => {
+    it('sait répondre quand les propriétés sont de type texte', () => {
+      const donnees = { propriete1: 'texte', propriete2: 'texte' };
+      const donneesSansPropriete2 = { propriete1: 'texte' };
+
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donnees)).to.be(true);
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donneesSansPropriete2)).to.be(false);
+    });
+
+    it('sait répondre quand les propriétés sont de type booléen', () => {
+      const donnees = { propriete1: true, propriete2: false };
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donnees)).to.be(true);
+    });
+
+    it('sait répondre quand les propriétés sont de type numérique', () => {
+      const donnees = { propriete1: 1, propriete2: 0 };
+
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donnees)).to.be(true);
+    });
+
+    it('refuse la valeur `NaN`', () => {
+      const donnees = { propriete1: 1, propriete2: NaN };
+
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donnees)).to.be(false);
+    });
+
+    it('sait répondre quand les propriétés sont des listes', () => {
+      const donnees = { propriete1: ['valeur1'], propriete2: ['valeur2'] };
+      const donneesAvecListeVide = { propriete1: ['valeur1'], propriete2: [] };
+      const avecListeTexteVide = { propriete1: ['valeur1'], propriete2: [''] };
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donnees)).to.be(true);
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donneesAvecListeVide)).to.be(false);
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(avecListeTexteVide)).to.be(false);
+    });
+
+    it("sait répondre quand les propriétés sont des listes d'agrégats", () => {
+      const donnees = { propriete1: [{ description: 'texte' }], propriete2: [{ description: 'texte' }] };
+      expect(ExtensionBase.proprietesObligatoiresRenseignees(donnees)).to.be(true);
+    });
+
+    it("reste robuste quand il n'y a pas de propriétés obligatoires", () => {
+      expect(Base.proprietesObligatoiresRenseignees({})).to.be(true);
+    });
   });
 });


### PR DESCRIPTION
Tous les objets du modèle fils de Base auront la possibilité de savoir si toutes les propriétés obligatoires sont renseignées
