### PR TITLE
Suppression du sous titre

### DIFF
--- a/src/vues/cartes/indiceCyber.pug
+++ b/src/vues/cartes/indiceCyber.pug
@@ -20,6 +20,6 @@ mixin indiceCyber({ referentiel, indiceCyber })
     p: +descriptionIndiceCyber()
     p: +lienNouvelOnglet('/questionsFrequentes#indice-cyber', 'En savoir plus')
 
-  +carteInformations({ titre: 'Indice cyber', sousTitre: "Évalué par l'ANSSI", details: 'detailsIndiceCyber' })
+  +carteInformations({ titre: 'Indice cyber', details: 'detailsIndiceCyber' })
     .score-indice-cyber
       +scoreIndiceCyber(formatIndiceCyber, indiceCyber.total, noteMax)


### PR DESCRIPTION
Vu avec Mari, il faut supprimer le terme "Évalué par l'Anssi", sous titre de l'indice cyber