### PR TITLE
Suppression utilisateur depuis console administrateur

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -32,6 +32,10 @@ class ConsoleAdministration {
       idsHomologationsAConserver
     );
   }
+
+  supprimeUtilisateur(id) {
+    return this.depotDonnees.supprimeUtilisateur(id);
+  }
 }
 
 module.exports = ConsoleAdministration;

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -133,6 +133,12 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     return Promise.resolve();
   };
 
+  const nbAutorisationsCreateur = (idUtilisateur) => Promise.resolve(
+    donnees.autorisations
+      .filter((a) => a.idUtilisateur === idUtilisateur && a.type === 'createur')
+      .length
+  );
+
   const supprimeAutorisation = (idUtilisateur, idHomologation) => {
     donnees.autorisations = donnees.autorisations
       .filter((a) => a.idUtilisateur !== idUtilisateur && a.idHomologation !== idHomologation);
@@ -140,6 +146,12 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
   };
 
   const supprimeAutorisations = () => Promise.resolve(donnees.autorisations = []);
+
+  const supprimeAutorisationsContribution = (idUtilisateur) => {
+    donnees.autorisations = donnees.autorisations
+      .filter((a) => a.idUtilisateur !== idUtilisateur && a.type !== 'contributeur');
+    return Promise.resolve();
+  };
 
   const supprimeAutorisationsHomologation = (idHomologation) => {
     donnees.autorisations = donnees.autorisations
@@ -168,9 +180,11 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     metsAJourHomologation,
     metsAJourService,
     metsAJourUtilisateur,
+    nbAutorisationsCreateur,
     service,
     supprimeAutorisation,
     supprimeAutorisations,
+    supprimeAutorisationsContribution,
     supprimeAutorisationsHomologation,
     supprimeHomologation,
     supprimeHomologations,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -156,6 +156,12 @@ const nouvelAdaptateur = (env) => {
 
   const ajouteAutorisation = (...params) => ajouteLigneDansTable('autorisations', ...params);
 
+  const nbAutorisationsCreateur = (idUtilisateur) => knex('autorisations')
+    .count('id')
+    .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
+    .whereRaw("donnees->>'type'='createur'")
+    .then(([{ count }]) => parseInt(count, 10));
+
   const supprimeAutorisation = (idUtilisateur, idHomologation) => knex('autorisations')
     .whereRaw(
       "donnees->>'idUtilisateur'=? and donnees->>'idHomologation'=?",
@@ -164,6 +170,11 @@ const nouvelAdaptateur = (env) => {
     .del();
 
   const supprimeAutorisations = () => knex('autorisations').del();
+
+  const supprimeAutorisationsContribution = (idUtilisateur) => knex('autorisations')
+    .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
+    .whereRaw("donnees->>'type'='contributeur'")
+    .del();
 
   const supprimeAutorisationsHomologation = (idHomologation) => knex('autorisations')
     .whereRaw("donnees->>'idHomologation'=?", idHomologation)
@@ -191,10 +202,12 @@ const nouvelAdaptateur = (env) => {
     metsAJourHomologation,
     metsAJourService,
     metsAJourUtilisateur,
+    nbAutorisationsCreateur,
     nbUtilisateurs,
     service,
     supprimeAutorisation,
     supprimeAutorisations,
+    supprimeAutorisationsContribution,
     supprimeAutorisationsHomologation,
     supprimeHomologation,
     supprimeService,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -115,9 +115,6 @@ const nouvelAdaptateur = (env) => {
   const metsAJourService = (...params) => metsAJourTable('services', ...params);
   const metsAJourUtilisateur = (...params) => metsAJourTable('utilisateurs', ...params);
 
-  const nbUtilisateurs = () => knex('utilisateurs').count()
-    .then((rows) => rows[0]['count(*)']);
-
   const supprimeHomologation = (...params) => supprimeEnregistrement('homologations', ...params);
   const supprimeService = (...params) => supprimeEnregistrement('services', ...params);
   const supprimeUtilisateur = (...params) => supprimeEnregistrement('utilisateurs', ...params);
@@ -203,7 +200,6 @@ const nouvelAdaptateur = (env) => {
     metsAJourService,
     metsAJourUtilisateur,
     nbAutorisationsCreateur,
-    nbUtilisateurs,
     service,
     supprimeAutorisation,
     supprimeAutorisations,

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -27,6 +27,7 @@ class ErreurProprieteManquante extends ErreurModele {}
 class ErreurRisqueInconnu extends ErreurModele {}
 class ErreurStatutDeploiementInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
+class ErreurSuppressionImpossible extends Error {}
 class ErreurTentativeSuppressionCreateur extends ErreurModele {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
@@ -68,6 +69,7 @@ module.exports = {
   ErreurRisqueInconnu,
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,
+  ErreurSuppressionImpossible,
   ErreurTentativeSuppressionCreateur,
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,


### PR DESCRIPTION
On peut supprimer uniquement les utilisateurs qui ne sont pas créateurs.
Les utilisateurs contributeurs sont supprimés avec leurs autorisations de contribution.

À utiliser avec la console Admin.