### PR TITLE
Suppression étoile dans la modale de création de nouveau service

### DIFF
--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -7,14 +7,18 @@
   margin-right: .4em;
 }
 
+.requis::before {
+  position: absolute;
+  left: -1em;
+}
+
 .mention::before, .requis::before {
   content: "*";
   color: var(--rose-anssi);
 }
 
-.requis::before {
-  position: absolute;
-  left: -1em;
+form.champ-unique .requis::before {
+  content: "";
 }
 
 .requis {

--- a/src/vues/fragments/modaleNouveauService.pug
+++ b/src/vues/fragments/modaleNouveauService.pug
@@ -10,7 +10,7 @@ mixin modaleNouveauService
       .fermeture-modale
       .contenu-modale
         h1 Nouveau service
-        form(action = "/homologation/creation", method = "GET")
+        form.champ-unique(action = "/homologation/creation", method = "GET")
           .case-a-cocher.requis
             input(id = 'attestation', name = 'attestation', type = 'checkbox', required, title = '')
             label(for = 'attestation')


### PR DESCRIPTION
On ne souhaite plus afficher l'étoile avant la case à cocher, contrairement aux autres formulaires.

<img width="475" alt="Screenshot 2022-12-31 at 15 28 39" src="https://user-images.githubusercontent.com/105624/210140108-3b5ebf79-b8ca-4e42-8a20-ae60bd0e44a4.png">
