### PR TITLE
Affichage des mesures spécifiques dans les onglets

### DIFF
--- a/public/modules/interactions/brancheFiltresMesures.mjs
+++ b/public/modules/interactions/brancheFiltresMesures.mjs
@@ -1,7 +1,11 @@
 const CLASSE_ELEMENT_INVISIBLE = 'invisible';
 
-const mesureSpecifiqueDeCategorie = (elementMesureSpecifique, categorieFiltre) => !categorieFiltre
-  || $(`option[value="${categorieFiltre}"]:selected, option[value=""]:selected`, elementMesureSpecifique).length === 1;
+const mesureSpecifiqueDeCategorie = (elementMesureSpecifique, categorieFiltre) => {
+  const $categories = $("input:radio[name^='categorie-']", elementMesureSpecifique);
+  return !categorieFiltre
+    || $categories.filter(`[value="${categorieFiltre}"]:checked`).length === 1
+    || $categories.length === $categories.not(':checked').length;
+};
 
 const mesureGeneraleDeCategorie = (elementMesure, categorieFiltre) => !categorieFiltre
   || $(elementMesure).hasClass(categorieFiltre);

--- a/test_public/modules/interactions/brancheFiltresMesures.spec.mjs
+++ b/test_public/modules/interactions/brancheFiltresMesures.spec.mjs
@@ -19,14 +19,17 @@ describe('Le branchement des filtres dans la page des mesures', () => {
       </div>
 
       <div class="mesures-specifiques">
-        <div id= "mesure-specifique-defaut" class="mesure-specifique">
-          <select><option value="" selected>Catégorie non spécifiée</option></select>
+        <div id="mesure-specifique-defaut" class="mesure-specifique">
+          <input type="radio" id="categorie-A" name="categorie-mesure-specifique-defaut" value="A">Catégorie A
+          <input type="radio" id="categorie-B" name="categorie-mesure-specifique-defaut" value="B">Catégorie B
         </div>
-        <div id= "mesure-specifique-A" class="mesure-specifique">
-          <select><option value="A" selected>Catégorie A</option></select>
+        <div id="mesure-specifique-A" class="mesure-specifique">
+          <input type="radio" id="categorie-A" name="categorie-mesure-specifique-A" value="A" checked>Catégorie A
+          <input type="radio" id="categorie-B" name="categorie-mesure-specifique-A" value="B">Catégorie B
         </div>
-        <div id= "mesure-specifique-B" class="mesure-specifique">
-          <select><option value="B" selected>Catégorie B</option></select>
+        <div id="mesure-specifique-B" class="mesure-specifique">
+          <input type="radio" id="categorie-A" name="categorie-mesure-specifique-B" value="A">Catégorie A
+          <input type="radio" id="categorie-B" name="categorie-mesure-specifique-B" value="B" checked>Catégorie B
         </div>
       </div>
     `;


### PR DESCRIPTION
Dans la page des mesures,
les mesures spécifiques disparaissent quand on utilise les onglets.

Le comportement attendu est :
- Une mesure spécifique apparait quand l'onglet toutes est sélectionné
- Une mesure spécifique n'ayant pas encore de catégorie apparait dans tous les onglets
- Une mesure spécifique avec une catégorie apparait dans l'onglet de sa catégorie et pas dans les onglets des autres catégories

NOTE : bug causé par le passage du bouton select à des boutons radio