### PR TITLE
Mention champ obligatoire dans les mesures

### DIFF
--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -1,9 +1,3 @@
-.mention {
-  display: flex;
-  justify-content: end;
-  margin: 0 0 1em;
-}
-
 .titre ~ .description {
   font-weight: normal;
   font-size: 0.9em;

--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -1,6 +1,11 @@
 .mention {
-  align-self: end;
-  margin-top: 2em;
+  display: flex;
+  justify-content: end;
+  margin-bottom: 1em;
+}
+
+:is(h1, hr) + .mention {
+  margin: 2em 0 0;
 }
 
 .mention::before {

--- a/public/assets/styles/utilisateur.css
+++ b/public/assets/styles/utilisateur.css
@@ -20,8 +20,8 @@
   padding: 1em 1em 1em 0.8em;
 }
 
-.mention {
-  margin-bottom: -1em;
+section:first-of-type {
+  padding-top: 1em;
 }
 
 .affichage-simple {

--- a/src/vues/homologation/mesures.pug
+++ b/src/vues/homologation/mesures.pug
@@ -29,6 +29,7 @@ block formulaire
         each categorie, identifiant in referentiel.categoriesMesures()
           a(id = identifiant)= categorie
 
+      .mention champ obligatoire
       .specifiques
         a.nouvel-item Ajouter une mesure spécifique
         #mesures-specifiques


### PR DESCRIPTION
Dans la page des mesures, nous souhaitons avoir la mention champ obligatoire
<img width="902" alt="Capture d’écran 2023-01-03 à 12 11 23" src="https://user-images.githubusercontent.com/39462397/210346357-3995730f-a057-488b-9c47-030563e65ac3.png">

NOTE : pendant que je passais par là, j'en ai profité pour mettre les propriétés de styles de `.mention` uniquement dans validation.css
Les pages impactées par cela sont :
- Décrire
- Profil / Inscription
- Homologation - étape 2