### PR TITLE
Génère un événement de complétude pour chaque service

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -4,6 +4,9 @@ const Referentiel = require('./src/referentiel');
 const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
 const AdaptateurPostgres = require('./src/adaptateurs/adaptateurPostgres');
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
+const fabriqueAdaptateurJournalMSS = require('./src/adaptateurs/fabriqueAdaptateurJournalMSS');
+const EvenementCompletudeServiceModifiee = require('./src/modeles/journalMSS/evenementCompletudeServiceModifiee');
+const { avecPMapPourChaqueElement } = require('./src/utilitaires/pMap');
 
 class ConsoleAdministration {
   constructor(environnementNode = (process.env.NODE_ENV || 'development')) {
@@ -12,6 +15,7 @@ class ConsoleAdministration {
     this.depotDonnees = DepotDonnees.creeDepot({
       adaptateurJWT, adaptateurPersistance, adaptateurUUID, referentiel,
     });
+    this.adaptateurJournalMSS = fabriqueAdaptateurJournalMSS();
   }
 
   transfereAutorisations(idUtilisateurSource, idUtilisateurCible) {
@@ -35,6 +39,28 @@ class ConsoleAdministration {
 
   supprimeUtilisateur(id) {
     return this.depotDonnees.supprimeUtilisateur(id);
+  }
+
+  genereTousEvenementsCompletude(persisteEvenements = false) {
+    const journalQuiLog = {
+      consigneEvenement: (evenement) => {
+        /* eslint-disable no-console */
+        console.log(evenement);
+        console.log('---------------');
+        return Promise.resolve();
+        /* eslint-enable no-console */
+      },
+    };
+
+    const persiste = (evenement) => (persisteEvenements
+      ? this.adaptateurJournalMSS.consigneEvenement(evenement)
+      : journalQuiLog.consigneEvenement(evenement));
+
+    const evenements = this.depotDonnees.toutesHomologations()
+      .then((hs) => hs.map((h) => ({ idService: h.id, ...h.completudeMesures() })))
+      .then((stats) => stats.map((s) => new EvenementCompletudeServiceModifiee(s).toJSON()));
+
+    return avecPMapPourChaqueElement(evenements, persiste);
   }
 }
 

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -159,6 +159,17 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     return Promise.resolve();
   };
 
+  const toutesHomologations = () => {
+    const toutes = donnees.homologations.map((h) => {
+      const intervenants = intervenantsHomologation(h.id);
+      [h.createur] = intervenants.createurs;
+      h.contributeurs = intervenants.contributeurs;
+      return h;
+    });
+
+    return Promise.resolve(toutes);
+  };
+
   const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => (
     autorisations(idUtilisateurSource)
       .then((as) => as.map((a) => Promise.resolve(a.idUtilisateur = idUtilisateurCible)))
@@ -191,6 +202,7 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     supprimeService,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    toutesHomologations,
     transfereAutorisations,
     utilisateur,
     utilisateurAvecEmail,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -177,6 +177,24 @@ const nouvelAdaptateur = (env) => {
     .whereRaw("donnees->>'idHomologation'=?", idHomologation)
     .del();
 
+  const toutesHomologations = () => knex('homologations as h')
+    .join('autorisations as a1', knex.raw("(a1.donnees->>'idHomologation')::uuid"), 'h.id')
+    .join(
+      'autorisations as a2',
+      knex.raw("a1.donnees->>'idHomologation'"),
+      knex.raw("a2.donnees->>'idHomologation'"),
+    )
+    .join('utilisateurs as u', knex.raw("(a2.donnees->>'idUtilisateur')::uuid"), 'u.id')
+    .select({
+      idHomologation: 'h.id',
+      donneesHomologation: 'h.donnees',
+      idUtilisateur: 'u.id',
+      dateCreationUtilisateur: 'u.date_creation',
+      donneesUtilisateur: 'u.donnees',
+      type: knex.raw("a2.donnees->>'type'"),
+    })
+    .then(ajouteIntervenantsAHomologations);
+
   const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => knex('autorisations')
     .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateurSource)
     .update({
@@ -210,6 +228,7 @@ const nouvelAdaptateur = (env) => {
     supprimeHomologations,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    toutesHomologations,
     transfereAutorisations,
     utilisateur,
     utilisateurAvecEmail,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -43,6 +43,7 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeHomologation,
     supprimeHomologationsCreeesPar,
+    toutesHomologations,
   } = depotHomologations;
 
   const {
@@ -99,6 +100,7 @@ const creeDepot = (config = {}) => {
     supprimeHomologationsCreeesPar,
     supprimeIdResetMotDePassePourUtilisateur,
     supprimeUtilisateur,
+    toutesHomologations,
     transfereAutorisations,
     utilisateur,
     utilisateurAFinaliser,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -235,6 +235,11 @@ const creeDepot = (config = {}) => {
     )
   );
 
+  const toutesHomologations = () => (
+    adaptateurPersistance.toutesHomologations()
+      .then((hs) => hs.map((h) => new Homologation(h, referentiel)))
+  );
+
   return {
     ajouteAvisExpertCyberAHomologation,
     ajouteDescriptionServiceAHomologation,
@@ -250,6 +255,7 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeHomologation,
     supprimeHomologationsCreeesPar,
+    toutesHomologations,
   };
 };
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -63,6 +63,45 @@ describe('Le dépôt de données des homologations', () => {
       .catch(done);
   });
 
+  it('connaît toutes les homologations enregistrées dans MSS', (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      homologations: [
+        { id: '123', descriptionService: { nomService: 'Super Service' } },
+        { id: '789', descriptionService: { nomService: 'Autre service' } },
+      ],
+      utilisateurs: [
+        { id: '456', prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' },
+        { id: '999', prenom: 'Karine', nom: 'Durand', email: 'k.d@mail.fr' },
+      ],
+      autorisations: [
+        { idUtilisateur: '456', idHomologation: '123', type: 'createur' },
+        { idUtilisateur: '999', idHomologation: '789', type: 'createur' },
+      ],
+    });
+
+    const referentiel = Referentiel.creeReferentielVide();
+    const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance, referentiel });
+
+    depot.toutesHomologations()
+      .then((homologations) => {
+        expect(homologations.length).to.equal(2);
+
+        const verifieHomologation = (h, idAttendu, idCreateurAttendu) => {
+          expect(h).to.be.a(Homologation);
+          expect(h.id).to.equal(idAttendu);
+          expect(h.referentiel).to.equal(referentiel);
+          expect(h.createur).to.be.ok();
+          expect(h.createur.id).to.equal(idCreateurAttendu);
+        };
+
+        const [a, b] = homologations;
+        verifieHomologation(a, '123', '456');
+        verifieHomologation(b, '789', '999');
+        done();
+      })
+      .catch(done);
+  });
+
   it('trie les homologations par ordre alphabétique du nom du service', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [


### PR DESCRIPTION
L'objectif est d'alimenter le journal MSS en événements de complétude afin d'avoir une vision sur tous les services référencés.

Note pour le relecteur : `toutesHomologations()` est une duplication assumée et non élégante de `homologations(idUtilisateur)`. Ce code est voué à être utilisé une seule fois via la consoleAdministration pour nourrir la PROD. Il sera ensuite « git reverted ». Ce ne devrait pas être une source d'inspiration.

Un chemin de design plus souhaitable serait de réutiliser `homologations(idUtilisateur)` qui saurait gérer le cas où on ne lui passe aucun id en retournant toutes les homologations.