### PR TITLE
Affiche un fil d'Ariane pour les pages privées

### DIFF
--- a/public/assets/styles/filAriane.css
+++ b/public/assets/styles/filAriane.css
@@ -1,0 +1,11 @@
+nav.fil-ariane {
+  display: flex;
+  column-gap: 0.4em;
+
+  color: var(--bleu-mise-en-avant);
+}
+
+.fil-ariane a {
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}

--- a/public/assets/styles/homologation/synthese.css
+++ b/public/assets/styles/homologation/synthese.css
@@ -160,25 +160,6 @@
   margin-top: 1em;
 }
 
-.vers-complements {
-  margin-right: 0.18em;
-}
-
-.vers-complements::after {
-  content: '';
-  display: inline-block;
-
-  width: 0.4em;
-  height: 0.4em;
-  margin-left: 0.2em;
-
-  border: 2px var(--bleu-mise-en-avant) solid;
-  border-left: 0;
-  border-bottom: 0;
-
-  transform: rotate(0.12turn) translateY(-0.05em);
-}
-
 .liens {
   display: flex;
   flex-direction: column;

--- a/public/assets/styles/lien.css
+++ b/public/assets/styles/lien.css
@@ -17,3 +17,22 @@ a.nouvel-onglet::after {
 a.nouvel-onglet {
   display: inline-block;
 }
+
+a.avec-chevron {
+  margin-right: 0.18em;
+}
+
+a.avec-chevron::after {
+  content: '';
+  display: inline-block;
+
+  width: 0.4em;
+  height: 0.4em;
+  margin-left: 0.2em;
+
+  border: 2px var(--bleu-mise-en-avant) solid;
+  border-left: 0;
+  border-bottom: 0;
+
+  transform: rotate(0.12turn) translateY(-0.05em);
+}

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -1,13 +1,20 @@
 extends mssConnecte
+include ./fragments/texteTronque
 
 block append styles
   link(href = '/statique/assets/styles/deuxColonnes.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/filAriane.css', rel = 'stylesheet')
 
 block retour
-  - let lienRetour = '/';
-  - if (homologation) lienRetour = '/espacePersonnel';
-  - if (homologation && homologation.id) lienRetour = `/homologation/${homologation.id}`;
-  a(href = lienRetour) ‹&nbsp;&nbsp;Retour
+  - const s = homologation || service
+  if s
+    nav.fil-ariane
+      a.avec-chevron(href = '/espacePersonnel') Espace personnel
+      if s.id
+        a.avec-chevron(href = `/homologation/${s.id}`)
+          +texteTronque({ texte: s.nomService() })
+
+      block filArianeNoeudFinal
 
 block main
   .corps.marges-fixes

--- a/src/vues/fragments/texteTronque.pug
+++ b/src/vues/fragments/texteTronque.pug
@@ -1,0 +1,6 @@
+mixin texteTronque({ tailleLimite = 40, texte })
+  -
+    const longueurInitiale = texte.length;
+    let resultat = texte.substring(0, tailleLimite);
+    if (resultat.length < longueurInitiale) resultat += '…';
+  span!= resultat

--- a/src/vues/homologation/avisExpertCyber.pug
+++ b/src/vues/homologation/avisExpertCyber.pug
@@ -1,6 +1,9 @@
 extends ./formulaire
 include ../fragments/inputChoix
 
+block filArianeNoeudFinal
+  div Avis sur le dossier
+
 block formulaire
   form.homologation#avis-expert-cyber
     h1.action Avis sur le dossier

--- a/src/vues/homologation/decrire.pug
+++ b/src/vues/homologation/decrire.pug
@@ -2,3 +2,6 @@ extends ./formulaire
 
 block append styles
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
+
+block filArianeNoeudFinal
+  div Décrire

--- a/src/vues/homologation/formulaireEtapier.pug
+++ b/src/vues/homologation/formulaireEtapier.pug
@@ -22,6 +22,9 @@ mixin barre-progression({ idEtape })
 block append styles
   link(href='/statique/assets/styles/etapesDossier.css', rel='stylesheet')
 
+block filArianeNoeudFinal
+  div Homologuer
+
 block zone-principale
   form.homologation
     h1.action Homologuer

--- a/src/vues/homologation/mesures.pug
+++ b/src/vues/homologation/mesures.pug
@@ -14,6 +14,9 @@ block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
 
+block filArianeNoeudFinal
+  div Sécuriser
+
 block formulaire
   form.homologation#mesures
     h1.action Sécuriser

--- a/src/vues/homologation/risques.pug
+++ b/src/vues/homologation/risques.pug
@@ -4,6 +4,9 @@ include ../carteInformations
 block append styles
   link(href = '/statique/assets/styles/homologation/risques.css', rel = 'stylesheet')
 
+block filArianeNoeudFinal
+  div Risques de sécurité
+
 block formulaire
   form.homologation#risques
     h1.action Risques de sécurité

--- a/src/vues/homologation/rolesResponsabilites.pug
+++ b/src/vues/homologation/rolesResponsabilites.pug
@@ -7,6 +7,9 @@ include ../fragments/elementsAjoutables/elementsAjoutablesPartiePrenante
 block append styles
   link(href = '/statique/assets/styles/homologation/rolesResponsabilites.css', rel = 'stylesheet')
 
+block filArianeNoeudFinal
+  div Contacts utiles
+
 block formulaire
   form.homologation#roles-responsabilites
     h1.action Rôles et responsabilités

--- a/src/vues/homologation/synthese.pug
+++ b/src/vues/homologation/synthese.pug
@@ -1,5 +1,6 @@
 extends ../deuxColonnes
 include ../cartes/indiceCyber
+include ../fragments/texteTronque
 
 mixin action({ id, description, indisponible, sousTitre, url, statut })
   a(
@@ -23,7 +24,9 @@ block append styles
   link(href = '/statique/assets/styles/homologation/synthese.css', rel = 'stylesheet')
 
 block retour
-  a(href = '/espacePersonnel') ‹&nbsp;&nbsp;Mon espace personnel
+  nav.fil-ariane
+    a.avec-chevron(href = '/espacePersonnel') Espace personnel
+    div: +texteTronque({ texte: service.nomService() })
 
 block zone-principale
   .details-service

--- a/src/vues/homologation/synthese.pug
+++ b/src/vues/homologation/synthese.pug
@@ -17,7 +17,7 @@ mixin outilComplementaire({ id, nom, description, lien })
     .titre-outil
       .icone-outil
       h3= nom
-    .description #{description} #[a.vers-complements(href = lien.url)= lien.texte]
+    .description #{description} #[a.avec-chevron(href = lien.url)= lien.texte]
 
 block append styles
   link(href = '/statique/assets/styles/homologation/synthese.css', rel = 'stylesheet')
@@ -67,5 +67,5 @@ block cartes-informations
 
   +carteInformations({ titre: 'Pour les services référencés avant le 12/10/2022' })
     .liens
-      a.vers-complements(href = `/homologation/${service.id}/avisExpertCyber`) Accéder à « Avis sur le dossier »
-      a.vers-complements(href = `/homologation/${service.id}/decision`) Télécharger les annexes 1ère version
+      a.avec-chevron(href = `/homologation/${service.id}/avisExpertCyber`) Accéder à « Avis sur le dossier »
+      a.avec-chevron(href = `/homologation/${service.id}/decision`) Télécharger les annexes 1ère version

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -9,7 +9,7 @@ block page
     link(href='/statique/assets/styles/palette.css', rel='stylesheet')
     link(href='/statique/assets/styles/fonts.css', rel='stylesheet')
     link(href='/statique/assets/styles/bouton.css', rel='stylesheet')
-    link(href='/statique/assets/styles/modules/lienNouvelOnglet.css', rel='stylesheet')
+    link(href='/statique/assets/styles/lien.css', rel='stylesheet')
     link(href='/statique/assets/styles/mss.css', rel='stylesheet')
     link(href='/statique/assets/styles/entete.css', rel='stylesheet')
     link(href='/statique/assets/styles/piedPage.css', rel='stylesheet')


### PR DESCRIPTION
<img width="708" alt="Screenshot 2023-01-03 at 19 06 15" src="https://user-images.githubusercontent.com/105624/210415632-6d86980a-0f7f-44a2-8c1e-5c99917bb049.png">

J'ai fait quelques choix qui nous écartent potentiellement de la maquette – à valider avec l'équipe design :
- Quand on crée un nouveau service, on affiche dans le fil d'Ariane `Espace personnel > Décrire`
- Quand on est dans la page de synthèse, on affiche dans le fil d'Ariane `Espace personnel > Service XXX > Synthèse`