### PR TITLE
Corps de la page d'accueil responsive

### DIFF
--- a/public/assets/styles/index.responsive.css
+++ b/public/assets/styles/index.responsive.css
@@ -3,6 +3,10 @@
     min-width: unset;
   }
 
+  .marges-fixes {
+    width: 100vw;
+  }
+
   .introduction {
     width: unset;
     max-width: 90%;
@@ -24,6 +28,18 @@
 }
 
 @media screen and (max-width: 767px) {
+  header, header nav, footer .bandeau-mss, footer .infos-mss .liens, footer nav ul {
+    flex-wrap: wrap;
+  }
+
+  header > :not(nav) {
+    font-size: 0.7em;
+  }
+
+  header nav {
+    flex-direction: column;
+  }
+
   .introduction {
     margin: 4em auto 7em;
   }

--- a/public/assets/styles/index.responsive.css
+++ b/public/assets/styles/index.responsive.css
@@ -1,0 +1,49 @@
+@media screen and (max-width: 1247px) {
+  body {
+    min-width: unset;
+  }
+
+  .introduction {
+    width: unset;
+    max-width: 90%;
+  }
+
+  .image-intro-mss {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 1247px) and (min-width: 768px) {
+  .introduction {
+    margin: 8em auto 12em;
+  }
+
+  .presentation p br {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .introduction {
+    margin: 4em auto 7em;
+  }
+
+  .introduction h1 {
+    font-size: 2em;
+  }
+
+  .introduction :is(h2, .etiquette, p, nav) {
+    font-size: 1em;
+  }
+
+  .introduction h3 {
+    font-size: 1.15em;
+  }
+
+  .introduction nav {
+    flex-direction: column;
+    row-gap: 1em;
+
+    text-align: center;
+  }
+}

--- a/src/vues/base.pug
+++ b/src/vues/base.pug
@@ -1,5 +1,6 @@
 doctype html
 meta(charset='utf-8')
+meta(name = 'viewport', content = 'width=device-width')
 link(rel='icon', href='/statique/assets/images/favicons/favicon.ico')
 script(src = '/statique/scripts/matomo.js')
 

--- a/src/vues/index.pug
+++ b/src/vues/index.pug
@@ -2,6 +2,7 @@ extends mssDeconnecte
 
 block append styles
   link(href='/statique/assets/styles/index.css', rel='stylesheet')
+  link(href='/statique/assets/styles/index.responsive.css', rel='stylesheet')
 
 block main
   .introduction.marges-fixes


### PR DESCRIPTION
Nouveau style responsif pour la page d'accueil,
Les points de rupture sont 768px et 1247px.
Les maquettes sont sur Figma

Pour ce dev j'ai utilisé un fichier css supplémentaire qui surcharge les propriétés

<img width="450" alt="Capture d’écran 2023-01-05 à 18 11 37" src="https://user-images.githubusercontent.com/39462397/210840115-0fbf7b84-386d-42ba-9831-863cf9a5fa3d.png">
<img width="245" alt="Capture d’écran 2023-01-05 à 18 15 40" src="https://user-images.githubusercontent.com/39462397/210840865-4c6f168c-b21c-42a4-90bd-2d15e45b40c7.png">



NOTE : les prochains devs seront pour le footer et le header