### PR TITLE
Bas de page accueil responsif

### DIFF
--- a/public/assets/styles/index.responsive.css
+++ b/public/assets/styles/index.responsive.css
@@ -28,7 +28,7 @@
 }
 
 @media screen and (max-width: 767px) {
-  header, header nav, footer .bandeau-mss, footer .infos-mss .liens, footer nav ul {
+  header, header nav {
     flex-wrap: wrap;
   }
 

--- a/public/assets/styles/piedPage.responsive.css
+++ b/public/assets/styles/piedPage.responsive.css
@@ -1,0 +1,52 @@
+@media screen and (max-width: 1247px) {
+  footer .marges-fixes {
+    width: 100vw;
+    max-width: 90%;
+  }
+  
+  footer .infos-mss {
+    flex-grow: 2;
+  }
+
+  footer .infos-mss .liens {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  footer nav ul {
+    flex-wrap: wrap;
+    row-gap: 1em;
+  }
+}
+
+@media screen and (max-width: 1247px) and (min-width: 768px) {
+  footer .infos-mss .liens {
+    width: fit-content;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  footer .bandeau-mss {
+    flex-direction: column;
+  }
+
+  footer .bandeau-mss .bloc-france {
+    align-self: flex-start;
+  }
+
+  footer .bandeau-mss .bloc-france .marianne {
+    height: 0.7em;
+  }
+
+  footer .infos-mss .liens {
+    padding-left: 0.7em;
+  }
+
+  footer .infos-mss .liens a {
+    padding: 0.15em 0;
+  }
+
+  footer .infos-mss .liens :nth-child(2n) {
+    padding-left: 0.2em;
+  }
+}

--- a/src/vues/index.pug
+++ b/src/vues/index.pug
@@ -3,6 +3,7 @@ extends mssDeconnecte
 block append styles
   link(href='/statique/assets/styles/index.css', rel='stylesheet')
   link(href='/statique/assets/styles/index.responsive.css', rel='stylesheet')
+  link(href='/statique/assets/styles/piedPage.responsive.css', rel='stylesheet')
 
 block main
   .introduction.marges-fixes


### PR DESCRIPTION
Afin de rendre le site plus responsif,
le pied de page prends en charge 3 niveaux de taille d'écran
<img width="433" alt="Capture d’écran 2023-01-04 à 15 53 20" src="https://user-images.githubusercontent.com/39462397/210582421-e4c29c90-584b-43cf-83ef-bbf8717358e0.png">
<img width="541" alt="Capture d’écran 2023-01-06 à 10 50 32" src="https://user-images.githubusercontent.com/39462397/210976047-79f92372-c2b8-4f5e-a9f3-02c84b27c851.png">


NOTES : 
- J'ai volontairement importé la feuille de style dans index.pug pour que seul la landing page reçoive le changement
- J'ai mis un commit de retrait de bouchonnage
- J'ai pas un bon résultat quand il y a le mélange liens, texte et ponctuation en mobile