### PR TITLE
[CORRECTION] Utilise un tableau pour le type du service « Démo »

### DIFF
--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -11,7 +11,7 @@ const descriptionService = new DescriptionService({
   provenanceService: 'developpement',
   risqueJuridiqueFinancierReputationnel: false,
   statutDeploiement: 'enLigne',
-  typeService: 'siteInternet',
+  typeService: ['siteInternet'],
 }, referentiel);
 
 const creeDonnees = (depotDonnees) => depotDonnees


### PR DESCRIPTION
a8a7074d4dc8e40b4c8224c585851119c4f12f99 a ajouté une `DescriptionService` au service de Démo, car celle-ci est désormais obligatoire.

Par contre le `typeService` doit être un tableau (et non une chaîne) car il peut être multiple. Il est d'ailleurs rendu par des checkboxes sur la page `Décrire`.