### PR TITLE
Entête de l'accueil responsif

### DIFF
--- a/public/assets/images/icone_sandwich.svg
+++ b/public/assets/images/icone_sandwich.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="22" viewBox="0 0 24 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd"
+    d="M0 0.333008H24V2.99967H0V0.333008ZM0 9.66634H24V12.333H0V9.66634ZM0 18.9997H24V21.6663H0V18.9997Z"
+    fill="#000091"/>
+</svg>

--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -22,6 +22,10 @@ header nav {
   font-size: 0.9em;
 }
 
+header nav :is(.sandwich, .bouton-fermer) {
+  display: none;
+}
+
 header nav a, .nom-utilisateur-courant {
   padding: 0.3em 0.85em;
 

--- a/public/assets/styles/entete.responsive.css
+++ b/public/assets/styles/entete.responsive.css
@@ -1,0 +1,121 @@
+@media screen and (max-width: 1247px) {
+  header.marges-fixes {
+    width: 100vw;
+    max-width: 90%;
+    column-gap: unset;
+  }
+
+  header nav:not(.visible) {
+    display: none;
+  }
+
+  header .sandwich {
+    background-image: url('../images/icone_sandwich.svg');
+    background-repeat: no-repeat;
+    background-size: contain;
+    width: 1.5em;
+    height: 1.5em;
+    cursor: pointer;
+  }
+
+  header nav.visible {
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: 1;
+    background-color: #fff;
+    height: 100vh;
+    width: 100vw;
+    flex-direction: column-reverse;
+    justify-content: flex-end;
+    row-gap: 1em;
+  }
+
+  header nav.visible .bouton-fermer {
+    display: block;
+    align-self: flex-end;
+    margin: 1em 5% 1em 0;
+    width: fit-content;
+    border: 0;
+    color: var(--systeme-design-etat-bleu);
+    cursor: pointer;
+  }
+
+  header nav.visible .bouton-fermer::after {
+    content: '';
+    display: inline-block;
+    width: 1.1em;
+    height: 1.2em;
+    margin-left: 0.3em;
+  
+    background-color: var(--systeme-design-etat-bleu);
+    -webkit-mask: url(../images/icone_fermer.svg) no-repeat center;
+    mask: url(../images/icone_fermer.svg) no-repeat center;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+
+    transform: translateY(0.3em);
+  }
+
+  header nav.visible :is(a, .nom-utilisateur-courant) {
+    padding: 0.3em 0 0.6em;
+    border-bottom: 1px var(--liseres) solid;
+  }
+
+  header nav.visible > :is(a, .utilisateur-courant) {
+    width: 90%;
+  }
+
+  header nav.visible .utilisateur-courant {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+  
+  header nav.visible .utilisateur-courant .connexion {
+    border-top: 0;
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+    width: 100%;
+    margin: 1em 0;
+  }
+
+  header nav.visible .utilisateur-courant .inscription {
+    width: 100%;
+  }
+
+  header nav.visible .nom-utilisateur-courant {
+    align-self: flex-start;
+    width: 100%;
+  }
+
+  header nav.visible .nom-utilisateur-courant + .menu {
+    box-sizing: border-box;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header nav.visible .nom-utilisateur-courant + .menu a {
+    font-size: 1em;
+    line-height: 2em;
+    border: 0;
+  }
+}
+
+@media screen and (max-width: 1247px) and (min-width: 768px) {
+  header nav.visible .bouton-fermer {
+    margin-top: 3em;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  header {
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  header :is(.logo-anssi, .logo-mss) {
+    display: none;
+  }
+}

--- a/public/assets/styles/index.responsive.css
+++ b/public/assets/styles/index.responsive.css
@@ -3,6 +3,10 @@
     min-width: unset;
   }
 
+  .sans-ascenseur {
+    overflow: hidden;
+  }
+
   .introduction {
     width: unset;
     max-width: 90%;

--- a/public/assets/styles/index.responsive.css
+++ b/public/assets/styles/index.responsive.css
@@ -3,10 +3,6 @@
     min-width: unset;
   }
 
-  .marges-fixes {
-    width: 100vw;
-  }
-
   .introduction {
     width: unset;
     max-width: 90%;
@@ -28,18 +24,6 @@
 }
 
 @media screen and (max-width: 767px) {
-  header, header nav {
-    flex-wrap: wrap;
-  }
-
-  header > :not(nav) {
-    font-size: 0.7em;
-  }
-
-  header nav {
-    flex-direction: column;
-  }
-
   .introduction {
     margin: 4em auto 7em;
   }

--- a/public/entete.js
+++ b/public/entete.js
@@ -1,3 +1,5 @@
+import brancheMenuSandwich from './modules/interactions/brancheMenuSandwich.js';
+
 $(() => {
   const creeBoutonConnexion = () => $(`
 <a href="/inscription" class="inscription">Inscription</a>
@@ -34,6 +36,8 @@ $(() => {
     const $bouton = creeBoutonConnexion();
     $conteneur.append($bouton);
   };
+
+  brancheMenuSandwich();
 
   axios.get('/api/utilisateurCourant')
     .then((reponse) => ajouteUtilisateurCourantDans('.utilisateur-courant', reponse.data.utilisateur))

--- a/public/modules/interactions/brancheMenuSandwich.js
+++ b/public/modules/interactions/brancheMenuSandwich.js
@@ -1,0 +1,16 @@
+const brancheMenuSandwich = () => {
+  const $menu = $('header nav');
+  const $sandwich = $('.sandwich');
+  const $boutonFermer = $('.bouton-fermer', $menu);
+
+  const interrupteurVisible = (visible) => {
+    $menu.toggleClass('visible', visible);
+    $('body').toggleClass('sans-ascenseur', visible);
+  };
+
+  $sandwich.on('click', () => interrupteurVisible(true));
+
+  $boutonFermer.on('click', () => interrupteurVisible(false));
+};
+
+export default brancheMenuSandwich;

--- a/src/vues/index.pug
+++ b/src/vues/index.pug
@@ -3,6 +3,7 @@ extends mssDeconnecte
 block append styles
   link(href='/statique/assets/styles/index.css', rel='stylesheet')
   link(href='/statique/assets/styles/index.responsive.css', rel='stylesheet')
+  link(href='/statique/assets/styles/entete.responsive.css', rel='stylesheet')
   link(href='/statique/assets/styles/piedPage.responsive.css', rel='stylesheet')
 
 block main

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -23,8 +23,10 @@ block page
       .devise
     a.logo-anssi(href='https://www.ssi.gouv.fr')
     a.logo-mss(href='/')
+    .sandwich
     nav
       block navigation
+      .bouton-fermer Fermer
 
   main
     .retour.marges-fixes


### PR DESCRIPTION
Afin de rendre le site plus responsif,
L'entête a des styles différents pour 3 niveaux d'écran et un menu sandwich 🍔
<img width="374" alt="Capture d’écran 2023-01-06 à 15 44 51" src="https://user-images.githubusercontent.com/39462397/211035143-606190c4-822e-4800-92d4-11cf90a16e62.png">
<img width="367" alt="Capture d’écran 2023-01-06 à 15 44 56" src="https://user-images.githubusercontent.com/39462397/211035146-3c4682d8-c17e-4a88-976a-d8daddb66241.png">
<img width="448" alt="Capture d’écran 2023-01-06 à 15 45 06" src="https://user-images.githubusercontent.com/39462397/211035149-9a6fe4cf-b2c3-423c-bcac-f33493506534.png">
<img width="438" alt="Capture d’écran 2023-01-06 à 15 45 13" src="https://user-images.githubusercontent.com/39462397/211035156-3fef9d95-2086-4237-8dc3-430e81b3e959.png">

Notes :
- Cette PR contient un commit de débouchonnage du style de l'entête
- Pour le sandwich j'ai du faire des modifications dans l'entête desktop
- La version connecté n'est pas optimale