### PR TITLE
Journalisation événement suppression service

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -9,6 +9,7 @@ const Dossier = require('../modeles/dossier');
 const Homologation = require('../modeles/homologation');
 const EvenementCompletudeServiceModifiee = require('../modeles/journalMSS/evenementCompletudeServiceModifiee');
 const EvenementNouveauServiceCree = require('../modeles/journalMSS/evenementNouveauServiceCree');
+const EvenementServiceSupprime = require('../modeles/journalMSS/evenementServiceSupprime');
 const { avecPMapPourChaqueElement } = require('../utilitaires/pMap');
 
 const creeDepot = (config = {}) => {
@@ -223,7 +224,11 @@ const creeDepot = (config = {}) => {
     .then(() => Promise.all([
       adaptateurPersistance.supprimeHomologation(idHomologation),
       adaptateurPersistance.supprimeService(idHomologation),
-    ]));
+    ]))
+    .then(() => adaptateurJournalMSS.consigneEvenement(
+      new EvenementServiceSupprime({ idService: idHomologation })
+        .toJSON()
+    ));
 
   const supprimeHomologationsCreeesPar = (idUtilisateur, idsHomologationsAConserver = []) => (
     avecPMapPourChaqueElement(

--- a/src/modeles/journalMSS/evenementServiceSupprime.js
+++ b/src/modeles/journalMSS/evenementServiceSupprime.js
@@ -1,0 +1,23 @@
+const { ErreurIdentifiantServiceManquant } = require('./erreurs');
+const Evenement = require('./evenement');
+
+class EvenementServiceSupprime extends Evenement {
+  constructor(donnees, options = {}) {
+    const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
+
+    const valide = () => {
+      const manque = (donnee) => typeof donnee === 'undefined';
+      if (manque(donnees.idService)) throw new ErreurIdentifiantServiceManquant();
+    };
+
+    valide();
+
+    super(
+      'SERVICE_SUPPRIME',
+      { idService: adaptateurChiffrement.hacheSha256(donnees.idService) },
+      date
+    );
+  }
+}
+
+module.exports = EvenementServiceSupprime;

--- a/test/modeles/journalMSS/evenementServiceSupprime.spec.js
+++ b/test/modeles/journalMSS/evenementServiceSupprime.spec.js
@@ -1,0 +1,41 @@
+const expect = require('expect.js');
+const { ErreurIdentifiantServiceManquant } = require('../../../src/modeles/journalMSS/erreurs');
+const EvenementServiceSupprime = require('../../../src/modeles/journalMSS/evenementServiceSupprime');
+
+describe('Un événement de service supprimé', () => {
+  const hacheEnMajuscules = { hacheSha256: (valeur) => valeur?.toUpperCase() };
+
+  it("chiffre l'identifiant du service qui lui est donné", () => {
+    const evenement = new EvenementServiceSupprime(
+      { idService: 'abc' },
+      { adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+    expect(evenement.toJSON().donnees.idService).to.be('ABC');
+  });
+
+  it('sait se convertir en JSON', () => {
+    const evenement = new EvenementServiceSupprime(
+      { idService: 'abc' },
+      { date: 'Une date', adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+    expect(evenement.toJSON()).to.eql({
+      type: 'SERVICE_SUPPRIME',
+      donnees: {
+        idService: 'ABC',
+      },
+      date: 'Une date',
+    });
+  });
+
+  it("exige que l'identifiant du service soit renseigné", (done) => {
+    try {
+      new EvenementServiceSupprime({}, { adaptateurChiffrement: hacheEnMajuscules });
+      done("L'instanciation de l'événement aurait dû lever une exception");
+    } catch (e) {
+      expect(e).to.be.an(ErreurIdentifiantServiceManquant);
+      done();
+    }
+  });
+});


### PR DESCRIPTION
Maintenant qu'on génère nos statistiques sur la base d'événements de création / modification de service, il est important de consigner aussi les événements de suppression – sinon, on continue de comptabiliser des services supprimés, ce qui fausse les métriques.

Ainsi, avec cette PR, on consigne un événement de suppression de service quand on supprime un service.