### PR TITLE
Affichage centré du label dans les camemberts

### DIFF
--- a/public/scripts/statistiquesMesures.js
+++ b/public/scripts/statistiquesMesures.js
@@ -14,9 +14,12 @@ const dessineCamembert = ($canevas, {
 }) => {
   const mesuresARemplir = totalMesures - mesuresEnCours - mesuresNonFaites - mesuresFaites;
   const donnees = [mesuresEnCours, mesuresNonFaites, mesuresARemplir, mesuresFaites];
-  const encoreMesuresAFaire = mesuresEnCours > 0 || mesuresNonFaites > 0 || mesuresARemplir > 0;
-  const decalageMesuresFaites = encoreMesuresAFaire ? 20 : 0;
-  const decalageLabelMesuresFaites = encoreMesuresAFaire ? -20 : 15;
+
+  const toutesMesures = (nombreDuStatut) => totalMesures > 0 && totalMesures === nombreDuStatut;
+  const decalageLabel = (statutUnique) => (statutUnique ? 10 : -15);
+
+  const decalageMesuresFaites = toutesMesures(mesuresFaites) ? 0 : 20;
+  const decalageLabelMesuresFaites = toutesMesures(mesuresFaites) ? 15 : -20;
 
   /* eslint-disable no-new */
   new Chart(
@@ -61,7 +64,12 @@ const dessineCamembert = ($canevas, {
               color: [PALETTE.BLANC, PALETTE.BLEU_FONCE, PALETTE.BLEU_FONCE, PALETTE.BLANC],
               font: { weight: 'bold' },
               align: 'start',
-              offset: [-15, -15, -15, decalageLabelMesuresFaites],
+              offset: [
+                decalageLabel(toutesMesures(mesuresEnCours)),
+                decalageLabel(toutesMesures(mesuresNonFaites)),
+                decalageLabel(toutesMesures(mesuresARemplir)),
+                decalageLabelMesuresFaites,
+              ],
               formatter: (valeur) => (valeur || ''),
             },
           },


### PR DESCRIPTION
Dans la synthèse de sécurité,
Dans les camemberts,
Quand on a qu'un seul type présent (en cours OU non fait OU fait OU à remplir),
L'affichage du label doit être centré

<img width="927" alt="Capture d’écran 2023-01-10 à 12 10 37" src="https://user-images.githubusercontent.com/39462397/211536742-196a1b0f-58a2-495b-a12c-a034ad82c4de.png">
<img width="931" alt="Capture d’écran 2023-01-10 à 12 10 54" src="https://user-images.githubusercontent.com/39462397/211536747-23ba760b-ccc1-488e-a2a7-43ae7bb04813.png">
<img width="929" alt="Capture d’écran 2023-01-10 à 12 16 12" src="https://user-images.githubusercontent.com/39462397/211537252-cc99c8dd-86d1-475d-9f14-18f4d69631d9.png">

