### PR TITLE
Ajout route `PUT /api/motDePasse`

### DIFF
--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -29,6 +29,7 @@ const verifieRequeteChangeEtat = (donneesEtat, requete, done) => {
 };
 
 let authentificationBasiqueMenee = false;
+let cguAcceptees;
 let expirationCookieRepoussee = false;
 let headersAvecNoncePositionnes = false;
 let headersPositionnes = false;
@@ -41,8 +42,9 @@ let verificationJWTMenee = false;
 let verificationCGUMenee = false;
 
 const middlewareFantaisie = {
-  reinitialise: (idUtilisateur) => {
+  reinitialise: (idUtilisateur, acceptationCGU = true) => {
     authentificationBasiqueMenee = false;
+    cguAcceptees = acceptationCGU;
     expirationCookieRepoussee = false;
     headersAvecNoncePositionnes = false;
     headersPositionnes = false;
@@ -98,6 +100,7 @@ const middlewareFantaisie = {
 
   trouveHomologation: (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
+    requete.cguAcceptees = cguAcceptees;
     requete.homologation = new Homologation({
       id: '456',
       descriptionService: { nomService: 'un service' },
@@ -108,12 +111,14 @@ const middlewareFantaisie = {
 
   verificationJWT: (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
+    requete.cguAcceptees = cguAcceptees;
     verificationJWTMenee = true;
     suite();
   },
 
   verificationAcceptationCGU: (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
+    requete.cguAcceptees = cguAcceptees;
     verificationCGUMenee = true;
     suite();
   },


### PR DESCRIPTION
Il s'agit d'une première étape sur le chemin vers une page à part pour changer le mot de passe.

Tâches à venir par la suite :
- [x] Ajout route `PUT /api/motDePasse`
- [ ] Appel à cette route depuis formulaire mise à jour existant
- [ ] Ajout champ confirmation (+validation double saisie) dans formulaire existant
- [ ] Ajout validation règles robustesse (client + serveur)
- [ ] Duplication saisie mot de passe (+ éventuellement CGU) dans formulaire à part
- [ ] Service du nouveau formulaire depuis l'API réinitialisation mot de passe
- [ ] Ajout option « Changer mon mot de passe » dans menu utilisateur
- [ ] Ajout bandeau « Mettez à jour votre profil » si nom utilisateur non renseigné
- [ ] Décommissionnement saisie mot de passe depuis formulaire infos utilisateur