### PR TITLE
Factorisation appels changements mot de passe

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -15,7 +15,6 @@ class ErreurDossierNonFinalisable extends ErreurModele {}
 class ErreurDossiersInvalides extends ErreurModele {}
 class ErreurDureeValiditeInvalide extends ErreurModele {}
 class ErreurEmailManquant extends ErreurModele {}
-class ErreurCGUNonAcceptees extends Error {}
 class ErreurHomologationInexistante extends ErreurModele {}
 class ErreurIdentifiantActionSaisieInvalide extends ErreurModele {}
 class ErreurIdentifiantActionSaisieManquant extends ErreurModele {}
@@ -56,7 +55,6 @@ module.exports = {
   ErreurDossiersInvalides,
   ErreurDureeValiditeInvalide,
   ErreurEmailManquant,
-  ErreurCGUNonAcceptees,
   ErreurHomologationInexistante,
   ErreurIdentifiantActionSaisieInvalide,
   ErreurIdentifiantActionSaisieManquant,

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -147,7 +147,7 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
       .catch(suite);
   });
 
-  routes.put('/motDePasse', middleware.verificationJWT, (requete, reponse, suite) => {
+  const metsAJourMotDePasse = (requete, reponse, suite) => {
     const idUtilisateur = requete.idUtilisateurCourant;
     const cguDejaAcceptees = requete.cguAcceptees;
     const cguEnCoursDAcceptation = valeurBooleenne(requete.body.cguAcceptees);
@@ -155,7 +155,7 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
     const motDePasseInvalide = !(typeof motDePasse === 'string' && motDePasse);
 
     if (motDePasseInvalide) {
-      reponse.status(204).end();
+      suite();
       return;
     }
 
@@ -169,9 +169,14 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
       .then(depotDonnees.supprimeIdResetMotDePassePourUtilisateur)
       .then((utilisateur) => {
         requete.session.token = utilisateur.genereToken();
-        reponse.json({ idUtilisateur });
+        suite();
       })
       .catch(suite);
+  };
+
+  routes.put('/motDePasse', middleware.verificationJWT, metsAJourMotDePasse, (requete, reponse) => {
+    const idUtilisateur = requete.idUtilisateurCourant;
+    reponse.json({ idUtilisateur });
   });
 
   routes.put('/utilisateur',

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -182,6 +182,7 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
       const donnees = obtentionDonneesDeBaseUtilisateur(requete.body);
       const cguAcceptees = valeurBooleenne(requete.body.cguAcceptees);
       const { motDePasse } = requete.body;
+      const motDePasseValide = (typeof motDePasse === 'string' && motDePasse);
 
       const { donneesInvalides, messageErreur } = messageErreurDonneesUtilisateur(donnees, true);
       if (donneesInvalides) {
@@ -191,7 +192,6 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
         return;
       }
 
-      const motDePasseValide = (valeur) => (typeof valeur === 'string' && valeur);
       depotDonnees.utilisateur(idUtilisateur)
         .then((utilisateur) => {
           if (utilisateur.accepteCGU() || cguAcceptees) {
@@ -200,7 +200,7 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
           throw new ErreurCGUNonAcceptees();
         })
         .then((utilisateur) => {
-          if (motDePasseValide(motDePasse)) {
+          if (motDePasseValide) {
             return depotDonnees.metsAJourMotDePasse(utilisateur.id, motDePasse);
           }
           return utilisateur;

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -726,7 +726,10 @@ describe('Le serveur MSS des routes /api/*', () => {
     });
 
     describe("lorsque utilisateur n'a pas encore accepté les CGU", () => {
-      beforeEach(() => (utilisateur.accepteCGU = () => false));
+      beforeEach(() => {
+        const cguNonAcceptees = false;
+        testeur.middleware().reinitialise(utilisateur.id, cguNonAcceptees);
+      });
 
       it('met à jour le mot de passe si case CGU cochée dans formulaire', (done) => {
         let motDePasseMisAJour = false;

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -414,7 +414,6 @@ describe('Le serveur MSS des routes /api/*', () => {
       };
 
       axios.put('http://localhost:1234/api/motDePasse', { motDePasse: '' })
-        .then((reponse) => expect(reponse.status).to.equal(204))
         .then(() => expect(motDePasseMisAJour).to.be(false))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));


### PR DESCRIPTION
Cette PR fait suite à #614. Il s'agit d'une étape suivante sur le chemin vers une page à part pour changer le mot de passe.

Tâches à venir par la suite :
- [x] Ajout route `PUT /api/motDePasse`
- [x] Appel à cette route depuis formulaire mise à jour existant
- [ ] Ajout champ confirmation (+validation double saisie) dans formulaire existant
- [ ] Ajout validation règles robustesse (client + serveur)
- [ ] Duplication saisie mot de passe (+ éventuellement CGU) dans formulaire à part
- [ ] Service du nouveau formulaire depuis l'API réinitialisation mot de passe
- [ ] Ajout option « Changer mon mot de passe » dans menu utilisateur
- [ ] Ajout bandeau « Mettez à jour votre profil » si nom utilisateur non renseigné
- [ ] Décommissionnement saisie mot de passe depuis formulaire infos utilisateur