### PR TITLE
Utilisation de la route `/api/motDePasse` pour MAJ du mot de passe

### DIFF
--- a/public/utilisateur/edition.js
+++ b/public/utilisateur/edition.js
@@ -2,8 +2,12 @@ import brancheSoumissionFormulaireUtilisateur from '../modules/interactions/bran
 
 $(() => {
   const selecteurFormulaire = 'form.utilisateur#edition';
-  const action = (donnees) => axios.put('/api/utilisateur', donnees)
-    .then(() => (window.location = '/espacePersonnel'));
+  const action = (donnees) => {
+    const { motDePasse, cguAcceptees, ...resteDuProfil } = donnees;
+    return axios.put('/api/motDePasse', { motDePasse, cguAcceptees })
+      .then(() => axios.put('/api/utilisateur', resteDuProfil))
+      .then(() => (window.location = '/espacePersonnel'));
+  };
 
   brancheSoumissionFormulaireUtilisateur(selecteurFormulaire, action);
 });


### PR DESCRIPTION
Pour assurer une transition douce vers la création d'une page dédiée au changement du MDP.

**[EDIT après être de nouveau en non-Draft]**
Ça aurait été un sacré bug d'oublier `cguAcceptees` dans le payload qui part vers `PUT /api/motDePasse`.
Je m'en suis rendu compte en supprimant la gestion du mot de passe dans `PUT /api/utilisateur` : en lisant les tests que je supprimais j'ai compris qu'il manquait quelque chose côté front avec les CGU…

La PR est grosse car j'ai supprimé tous les tests devenus obsolètes sur `PUT /api/utilisateur`.
**[/EDIT]**

🗺️  Feuille de route :
- [x] #614 
- [ ] #617  👈 **Cette PR**
- [x] **#619
- [ ] Ajout validation règles robustesse (client + serveur)
- [ ] Duplication saisie mot de passe (+ éventuellement CGU) dans formulaire à part
- [ ] Service du nouveau formulaire depuis l'API réinitialisation mot de passe
- [ ] Ajout option « Changer mon mot de passe » dans menu utilisateur
- [ ] Ajout bandeau « Mettez à jour votre profil » si nom utilisateur non renseigné
- [ ] Décommissionnement saisie mot de passe depuis formulaire infos utilisateur