### PR TITLE
Route annexe description

### DIFF
--- a/src/adaptateurs/adaptateurPdfLatex.js
+++ b/src/adaptateurs/adaptateurPdfLatex.js
@@ -16,6 +16,8 @@ const generationPdfLatex = (cheminFichierTex, donnees = {}) => fsPromises
     return pdflatex(texConfectionne);
   });
 
+const genereAnnexeDescription = () => generationPdfLatex('src/vuesTex/annexeDescription.template.tex');
+
 const genereAnnexeMesures = (donnees) => generationPdfLatex('src/vuesTex/annexeMesures.template.tex', donnees);
 
 const genereAnnexeRisques = (donnees) => generationPdfLatex('src/vuesTex/annexeRisques.template.tex', donnees);
@@ -41,4 +43,4 @@ const genereAnnexes = (donneesMesures, donneesRisques) => {
     .then((pdf) => Buffer.from(pdf.buffer, 'binary'));
 };
 
-module.exports = { genereAnnexes };
+module.exports = { genereAnnexes, genereAnnexeDescription };

--- a/src/routes/routesPdf.js
+++ b/src/routes/routesPdf.js
@@ -16,6 +16,15 @@ const routesPdf = (middleware, adaptateurPdf) => {
       .catch(suite);
   });
 
+  routes.get('/:id/annexeDescription.pdf', (_requete, reponse, suite) => {
+    adaptateurPdf.genereAnnexeDescription()
+      .then((pdf) => {
+        reponse.contentType('application/pdf');
+        reponse.send(pdf);
+      })
+      .catch(suite);
+  });
+
   return routes;
 };
 

--- a/src/vuesTex/annexeDescription.template.tex
+++ b/src/vuesTex/annexeDescription.template.tex
@@ -1,0 +1,8 @@
+\documentclass[9pt, a4paper]{article}
+
+\newcommand{\vuesTex}[1]{__=donnees.CHEMIN_BASE_ABSOLU__/src/vuesTex/#1}
+\input{\vuesTex{fragments/definitionDocument}}
+
+\begin{document}
+  \MakeUppercase{Annexe description}
+\end{document}

--- a/test/routes/routesPdf.spec.js
+++ b/test/routes/routesPdf.spec.js
@@ -46,4 +46,28 @@ describe('Le serveur MSS des routes /pdf/*', () => {
         .catch(done);
     });
   });
+  describe('quand requête GET sur `/pdf/:id/annexeDescription.pdf`', () => {
+    beforeEach(() => {
+      testeur.adaptateurPdf().genereAnnexeDescription = () => Promise.resolve('Pdf annexe description');
+    });
+
+    it('sert un fichier de type pdf', (done) => {
+      verifieTypeFichierServiEstPDF('http://localhost:1234/pdf/456/annexeDescription.pdf', done);
+    });
+
+    it('utilise un adaptateur de pdf pour la génération', (done) => {
+      let adaptateurPdfAppele = false;
+      testeur.adaptateurPdf().genereAnnexeDescription = () => {
+        adaptateurPdfAppele = true;
+        return Promise.resolve('Pdf annexe description');
+      };
+
+      axios.get('http://localhost:1234/pdf/456/annexeDescription.pdf')
+        .then(() => {
+          expect(adaptateurPdfAppele).to.be(true);
+          done();
+        })
+        .catch(done);
+    });
+  });
 });


### PR DESCRIPTION
Dans le but d'ajouter une page **Description** aux annexes

- [x] Route provisoire `/pdf/:id/annexeDescription.pdf`
- [ ] Nouvelle page latex
  - [ ] Titre entête
  - [ ] Nom service en bas de page
  - [ ] Numéro de page
  - [ ] Bloc Fonctionnalités offertes
  - [ ] Bloc Données stockées
  - [ ] Bloc Durée maximale acceptable de dysfonctionnement grave du service
  - [ ] Quoi faire dans le cas où il y a plusieurs pages ?
- [ ] Ajouter au pdf annexes.pdf
- [ ] Supprimer la route provisoire

J'ai créé une route provisoire `/pdf/:id/annexeDescription.pdf` avec une page quasi vide