### PR TITLE
Double saisie du mot de passe

### DIFF
--- a/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
+++ b/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
@@ -23,6 +23,7 @@ const brancheSoumissionFormulaireUtilisateur = (selecteurFormulaire, action) => 
   $(`${selecteurFormulaire} button[type = 'submit']`).on('click', () => {
     declencheValidation(selecteurFormulaire);
   });
+
   $(selecteurFormulaire).on('submit', (evenement) => {
     evenement.preventDefault();
 
@@ -35,6 +36,7 @@ const brancheSoumissionFormulaireUtilisateur = (selecteurFormulaire, action) => 
         }
         return { ...acc, [clef]: obtentionDonnees[clef]() };
       }, {});
+
     action(donnees);
   });
 };

--- a/public/modules/interactions/brancheValidationMotDePasse.js
+++ b/public/modules/interactions/brancheValidationMotDePasse.js
@@ -1,0 +1,14 @@
+$(() => {
+  const $champMdp = () => $('#mot-de-passe');
+  const $confirmationMdp = () => $('#mot-de-passe-confirmation');
+
+  const verifieMotDePasse = () => {
+    const erreur = $champMdp().val() !== $confirmationMdp().val()
+      ? 'erreurDoubleSaisieAvecDifference'
+      : '';
+    $confirmationMdp().get(0).setCustomValidity(erreur);
+  };
+
+  $champMdp().on('input', verifieMotDePasse);
+  $confirmationMdp().on('input', verifieMotDePasse);
+});

--- a/src/vues/fragments/utilisateur/nouveauMotDePasse.pug
+++ b/src/vues/fragments/utilisateur/nouveauMotDePasse.pug
@@ -3,3 +3,9 @@ mixin nouveauMotDePasse
   label Nouveau mot de passe
     .infos-complementaires (Si vous laissez ce champ vide, le mot de passe ne sera pas modifié.)
     input(id='mot-de-passe', name = 'motDePasse', type='password')
+
+  label Confirmez mot de passe
+    input(id='mot-de-passe-confirmation', name = 'motDePasseConfirmation', type='password')
+    .message-erreur Les deux mots de passe sont différents
+
+  script(type = 'module', src = '/statique/modules/interactions/brancheValidationMotDePasse.js')


### PR DESCRIPTION
Cette PR met en place une double saisie du mot de passe côté client.

Le champ de confirmation [est invalide](https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation#complex_constraints_using_the_constraint_validation_api) si les 2 saisies diffèrent.

J'ai bien aimé pouvoir faire porter le JS de validation directement dans le mixin de mot de passe.
J'ai l'intuition que ça nous facilitera la tâche au moment de transition où on aura la saisie de mot de passe sur 2 pages distinctes.

#### Arrivée sur la page

![image](https://user-images.githubusercontent.com/24898521/212068600-062b02e5-a677-4b15-927f-5848114e1bab.png)

#### Cas d'erreur

![image](https://user-images.githubusercontent.com/24898521/212068705-5128952d-7d33-4e87-b7cb-3f607f7f7cd2.png)


#### 🗺️  Feuille de route
- [x] #614 
- [ ] #617 
- [ ] **#619** 👈 **Cette PR**
- [ ] Ajout validation règles robustesse (client + serveur)
- [ ] Duplication saisie mot de passe (+ éventuellement CGU) dans formulaire à part
- [ ] Service du nouveau formulaire depuis l'API réinitialisation mot de passe
- [ ] Ajout option « Changer mon mot de passe » dans menu utilisateur
- [ ] Ajout bandeau « Mettez à jour votre profil » si nom utilisateur non renseigné
- [ ] Décommissionnement saisie mot de passe depuis formulaire infos utilisateur