### PR TITLE
Annexe description - entête et pied de page

### DIFF
--- a/src/adaptateurs/adaptateurPdfLatex.js
+++ b/src/adaptateurs/adaptateurPdfLatex.js
@@ -16,7 +16,7 @@ const generationPdfLatex = (cheminFichierTex, donnees = {}) => fsPromises
     return pdflatex(texConfectionne);
   });
 
-const genereAnnexeDescription = () => generationPdfLatex('src/vuesTex/annexeDescription.template.tex');
+const genereAnnexeDescription = (donnees) => generationPdfLatex('src/vuesTex/annexeDescription.template.tex', donnees);
 
 const genereAnnexeMesures = (donnees) => generationPdfLatex('src/vuesTex/annexeMesures.template.tex', donnees);
 

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -9,6 +9,7 @@ const Mesures = require('./mesures');
 const Risques = require('./risques');
 const RolesResponsabilites = require('./rolesResponsabilites');
 const Utilisateur = require('./utilisateur');
+const VueAnnexePDFDescription = require('./objetsVues/vueAnnexePDFDescription');
 const VueAnnexePDFMesures = require('./objetsVues/vueAnnexePDFMesures');
 const VueAnnexePDFRisques = require('./objetsVues/vueAnnexePDFRisques');
 
@@ -189,6 +190,10 @@ class Homologation {
       contributeurs: this.contributeurs.map((c) => c.toJSON()),
       nomService: this.nomService(),
     };
+  }
+
+  vueAnnexePDFDescription() {
+    return new VueAnnexePDFDescription(this);
   }
 
   vueAnnexePDFMesures() {

--- a/src/modeles/objetsVues/vueAnnexePDFDescription.js
+++ b/src/modeles/objetsVues/vueAnnexePDFDescription.js
@@ -1,0 +1,11 @@
+class VueAnnexePDFDescription {
+  constructor(homologation) {
+    this.homologation = homologation;
+  }
+
+  donnees() {
+    return { nomService: this.homologation.nomService() };
+  }
+}
+
+module.exports = VueAnnexePDFDescription;

--- a/src/routes/routesPdf.js
+++ b/src/routes/routesPdf.js
@@ -16,8 +16,11 @@ const routesPdf = (middleware, adaptateurPdf) => {
       .catch(suite);
   });
 
-  routes.get('/:id/annexeDescription.pdf', (_requete, reponse, suite) => {
-    adaptateurPdf.genereAnnexeDescription()
+  routes.get('/:id/annexeDescription.pdf', middleware.trouveHomologation, (requete, reponse, suite) => {
+    const { homologation } = requete;
+    const donneesDescription = homologation.vueAnnexePDFDescription().donnees();
+
+    adaptateurPdf.genereAnnexeDescription(donneesDescription)
       .then((pdf) => {
         reponse.contentType('application/pdf');
         reponse.send(pdf);

--- a/src/vuesTex/annexeDescription.template.tex
+++ b/src/vuesTex/annexeDescription.template.tex
@@ -2,6 +2,16 @@
 
 \newcommand{\vuesTex}[1]{__=donnees.CHEMIN_BASE_ABSOLU__/src/vuesTex/#1}
 \input{\vuesTex{fragments/definitionDocument}}
+\input{\vuesTex{fragments/couleurs}}
+\input{\vuesTex{macros/entetePiedPage}}
+
+
+\entete{\MakeUppercase{Description détaillée}}{
+  \textcolor{gris}{Toutes les caractéristiques du service numérique et ses besoins de sécurité.}
+  }
+  \piedpage{\small{\textcolor{bleu}{\textbf{MonServiceSécurisé -}} __= donnees.nomService __}}
+  
+\renewcommand{\headrulewidth}{0pt}
 
 \begin{document}
   \MakeUppercase{Annexe description}

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -5,8 +5,9 @@ const InformationsHomologation = require('../../src/modeles/informationsHomologa
 const Homologation = require('../../src/modeles/homologation');
 const MesureGenerale = require('../../src/modeles/mesureGenerale');
 const Utilisateur = require('../../src/modeles/utilisateur');
-const VueAnnexePDFRisques = require('../../src/modeles/objetsVues/vueAnnexePDFRisques');
+const VueAnnexePDFDescription = require('../../src/modeles/objetsVues/vueAnnexePDFDescription');
 const VueAnnexePDFMesures = require('../../src/modeles/objetsVues/vueAnnexePDFMesures');
+const VueAnnexePDFRisques = require('../../src/modeles/objetsVues/vueAnnexePDFRisques');
 
 describe('Une homologation', () => {
   it('connaît le nom du service', () => {
@@ -389,6 +390,16 @@ describe('Une homologation', () => {
     }, referentiel);
 
     expect(homologation.descriptionLocalisationDonnees()).to.equal('France');
+  });
+
+  it("récupère un objet de vue pour le pdf de l'annexe de la description", () => {
+    const homologation = new Homologation({
+      id: '123',
+      idUtilisateur: '456',
+      descriptionService: { nomService: 'nom' },
+    });
+
+    expect(homologation.vueAnnexePDFDescription()).to.be.a(VueAnnexePDFDescription);
   });
 
   it("récupère un objet de vue pour le pdf de l'annexe des risques", () => {

--- a/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
+++ b/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
@@ -1,0 +1,21 @@
+const expect = require('expect.js');
+
+const Homologation = require('../../../src/modeles/homologation');
+const VueAnnexePDFDescription = require('../../../src/modeles/objetsVues/vueAnnexePDFDescription');
+
+describe("L'objet de vue de l'annexe de description", () => {
+  const homologation = new Homologation({
+    id: '123',
+    idUtilisateur: '456',
+    descriptionService: { nomService: 'Nom Service' },
+  });
+
+  it('fournit le nom du service', () => {
+    const vueAnnexePDFDescription = new VueAnnexePDFDescription(homologation);
+
+    const donnees = vueAnnexePDFDescription.donnees();
+
+    expect(donnees).to.have.key('nomService');
+    expect(donnees.nomService).to.equal('Nom Service');
+  });
+});

--- a/test/routes/routesPdf.spec.js
+++ b/test/routes/routesPdf.spec.js
@@ -51,6 +51,13 @@ describe('Le serveur MSS des routes /pdf/*', () => {
       testeur.adaptateurPdf().genereAnnexeDescription = () => Promise.resolve('Pdf annexe description');
     });
 
+    it("recherche l'homologation correspondante", (done) => {
+      testeur.middleware().verifieRechercheHomologation(
+        'http://localhost:1234/pdf/456/annexeDescription.pdf',
+        done,
+      );
+    });
+
     it('sert un fichier de type pdf', (done) => {
       verifieTypeFichierServiEstPDF('http://localhost:1234/pdf/456/annexeDescription.pdf', done);
     });


### PR DESCRIPTION
Dans le but d'ajouter une page **Description** aux annexes

- [x] Route provisoire `/pdf/:id/annexeDescription.pdf`
- [ ] Nouvelle page latex
  - [x] Titre entête
  - [x] Nom service en bas de page
  - [x] Numéro de page
  - [ ] Bloc Fonctionnalités offertes
  - [ ] Bloc Données stockées
  - [ ] Bloc Durée maximale acceptable de dysfonctionnement grave du service
  - [ ] Quoi faire dans le cas où il y a plusieurs pages ?
- [ ] Ajouter au pdf annexes.pdf
- [ ] Supprimer la route provisoire

J'ai ajouté les entête et pied de page au pdf `/pdf/:id/annexeDescription.pdf`