### PR TITLE
Ajoute les fonctionnalités à l'annexe description

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -193,7 +193,7 @@ class Homologation {
   }
 
   vueAnnexePDFDescription() {
-    return new VueAnnexePDFDescription(this);
+    return new VueAnnexePDFDescription(this, this.referentiel);
   }
 
   vueAnnexePDFMesures() {

--- a/src/modeles/itemsAvecDescription.js
+++ b/src/modeles/itemsAvecDescription.js
@@ -6,6 +6,10 @@ class ItemsAvecDescription extends ElementsConstructibles {
     super(ItemAvecDescription, items);
   }
 
+  descriptions() {
+    return this.tous().map((item) => item.description);
+  }
+
   static proprietesItem() {
     return ItemAvecDescription.proprietes();
   }

--- a/src/modeles/objetsVues/vueAnnexePDFDescription.js
+++ b/src/modeles/objetsVues/vueAnnexePDFDescription.js
@@ -1,10 +1,27 @@
+const Referentiel = require('../../referentiel');
+
 class VueAnnexePDFDescription {
-  constructor(homologation) {
+  constructor(homologation, referentiel = Referentiel.creeReferentielVide()) {
+    this.referentiel = referentiel;
     this.homologation = homologation;
   }
 
   donnees() {
-    return { nomService: this.homologation.nomService() };
+    const fonctionnalites = this.referentiel.descriptionsFonctionnalites(
+      this.homologation.descriptionService.fonctionnalites
+    );
+    const fonctionnalitesSpecifiques = this.homologation
+      .descriptionService
+      .fonctionnalitesSpecifiques
+      .descriptions();
+
+    return {
+      nomService: this.homologation.nomService(),
+      fonctionnalites: [
+        ...fonctionnalites,
+        ...fonctionnalitesSpecifiques,
+      ],
+    };
   }
 }
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -40,6 +40,10 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const etapesParcoursHomologation = () => donnees.etapesParcoursHomologation || [];
   const identifiantsEcheancesRenouvellement = () => Object.keys(echeancesRenouvellement());
   const fonctionnalites = () => donnees.fonctionnalites;
+  const descriptionFonctionnalite = (id) => fonctionnalites()[id]?.description;
+  const descriptionsFonctionnalites = (ids) => ids
+    ?.map((id) => descriptionFonctionnalite(id))
+    .filter((id) => id !== undefined);
   const localisationsDonnees = () => donnees.localisationsDonnees;
   const identifiantsLocalisationsDonnees = () => Object.keys(localisationsDonnees());
   const mesureIndispensable = (idMesure) => !!donnees.mesures[idMesure].indispensable;
@@ -191,8 +195,10 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     descriptionCategorie,
     descriptionEcheanceRenouvellement,
     descriptionExpiration,
+    descriptionFonctionnalite,
     descriptionRisque,
     descriptionStatutMesure,
+    descriptionsFonctionnalites,
     donneesCaracterePersonnel,
     echeancesRenouvellement,
     etapeExiste,

--- a/src/vuesTex/annexeDescription.template.tex
+++ b/src/vuesTex/annexeDescription.template.tex
@@ -3,6 +3,7 @@
 \newcommand{\vuesTex}[1]{__=donnees.CHEMIN_BASE_ABSOLU__/src/vuesTex/#1}
 \input{\vuesTex{fragments/definitionDocument}}
 \input{\vuesTex{fragments/couleurs}}
+\input{\vuesTex{macros/boiteGrise}}
 \input{\vuesTex{macros/entetePiedPage}}
 
 
@@ -14,5 +15,17 @@
 \renewcommand{\headrulewidth}{0pt}
 
 \begin{document}
-  \MakeUppercase{Annexe description}
+  __? donnees.fonctionnalites && donnees.fonctionnalites.length __
+  \boitegriseespacee{Fonctionnalités offertes}{
+    \begin{itemize}[labelsep=1.5em, leftmargin=3em]
+      __~ donnees.fonctionnalites :fonctionnalite __%
+        \item[\textcolor{bleu_mss}{\textbullet}]
+          \vskip 2mm
+          __= fonctionnalite __
+      __~__%
+    \end{itemize}
+  }
+  __?__
+  % L'espace insécable ~ est présent pour éviter le cas d'un document sans contenu
+  ~
 \end{document}

--- a/src/vuesTex/fragments/couleurs.tex
+++ b/src/vuesTex/fragments/couleurs.tex
@@ -5,6 +5,7 @@
 \definecolor{gris}{rgb}{0.37, 0.37, 0.37}
 \definecolor{gris_clair}{rgb}{0.96, 0.96, 0.96}
 \definecolor{lisere}{rgb}{0.71, 0.76, 0.82}
+\definecolor{bleu_mss}{HTML}{0F7AC7}
 \definecolor{rouge}{HTML}{e32630}
 \definecolor{orange}{HTML}{ff9940}
 \definecolor{jaune}{HTML}{fcdf41}

--- a/test/modeles/itemsAvecDescriptions.spec.js
+++ b/test/modeles/itemsAvecDescriptions.spec.js
@@ -15,6 +15,16 @@ describe('Les items avec descriptions', () => {
     expect(itemsAvecDescription.nombre()).to.equal(2);
   });
 
+  ils('savent transmettre leurs descriptions', () => {
+    const itemsAvecDescription = new ItemsAvecDescription(
+      { items: [
+        { description: 'Une description' },
+        { description: 'Une autre description' },
+      ] }
+    );
+    expect(itemsAvecDescription.descriptions()).to.eql(['Une description', 'Une autre description']);
+  });
+
   ils("donnent la liste des propriétés de l'item", () => {
     expect(ItemsAvecDescription.proprietesItem()).to.eql(['description']);
   });

--- a/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
+++ b/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
@@ -1,14 +1,27 @@
 const expect = require('expect.js');
 
 const Homologation = require('../../../src/modeles/homologation');
+const Referentiel = require('../../../src/referentiel');
 const VueAnnexePDFDescription = require('../../../src/modeles/objetsVues/vueAnnexePDFDescription');
 
 describe("L'objet de vue de l'annexe de description", () => {
+  const donneesReferentiel = {
+    fonctionnalites: {
+      uneFonctionnalite: {
+        description: 'Une fonctionnalité',
+      },
+    },
+  };
+  const referentiel = Referentiel.creeReferentiel(donneesReferentiel);
   const homologation = new Homologation({
     id: '123',
     idUtilisateur: '456',
-    descriptionService: { nomService: 'Nom Service' },
-  });
+    descriptionService: {
+      nomService: 'Nom Service',
+      fonctionnalites: ['uneFonctionnalite'],
+      fonctionnalitesSpecifiques: [{ description: 'Une fonctionnalité spécifique' }],
+    },
+  }, referentiel);
 
   it('fournit le nom du service', () => {
     const vueAnnexePDFDescription = new VueAnnexePDFDescription(homologation);
@@ -17,5 +30,23 @@ describe("L'objet de vue de l'annexe de description", () => {
 
     expect(donnees).to.have.key('nomService');
     expect(donnees.nomService).to.equal('Nom Service');
+  });
+
+  it('fournit la liste des fonctionnalités', () => {
+    const vueAnnexePDFDescription = new VueAnnexePDFDescription(homologation, referentiel);
+
+    const donnees = vueAnnexePDFDescription.donnees();
+
+    expect(donnees).to.have.key('fonctionnalites');
+    expect(donnees.fonctionnalites[0]).to.equal('Une fonctionnalité');
+  });
+
+  it('ajoute à la liste des fonctionnalités les spécifiques', () => {
+    const vueAnnexePDFDescription = new VueAnnexePDFDescription(homologation, referentiel);
+
+    const donnees = vueAnnexePDFDescription.donnees();
+
+    expect(donnees).to.have.key('fonctionnalites');
+    expect(donnees.fonctionnalites).to.contain('Une fonctionnalité spécifique');
   });
 });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -103,6 +103,31 @@ describe('Le référentiel', () => {
     expect(referentiel.fonctionnalites()).to.eql({ uneClef: 'une valeur' });
   });
 
+  it('sait décrire une fonctionnalité', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      fonctionnalites: { uneClef: { description: 'Une description' } },
+    });
+
+    expect(referentiel.descriptionFonctionnalite('uneClef')).to.equal('Une description');
+  });
+
+  it('sait décrire des fonctionnalités', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      fonctionnalites: {
+        clef1: { description: 'Description 1' },
+        clef2: { description: 'Description 2' },
+      },
+    });
+
+    expect(referentiel.descriptionsFonctionnalites(['clef1', 'clef2'])).to.eql(['Description 1', 'Description 2']);
+  });
+
+  it("sait décrire des fonctionnalités en restant robuste quand une fonctionnalité n'est pas dans le référentiel", () => {
+    const referentiel = Referentiel.creeReferentielVide();
+
+    expect(referentiel.descriptionsFonctionnalites(['clef'])).to.eql([]);
+  });
+
   it('connaît la liste des données à caractère personnel', () => {
     const referentiel = Referentiel.creeReferentiel({
       donneesCaracterePersonnel: { uneClef: 'une valeur' },


### PR DESCRIPTION
Dans le but d'ajouter une page **Description** aux annexes

- [x] Route provisoire `/pdf/:id/annexeDescription.pdf`
- [ ] Nouvelle page latex
  - [x] Titre entête
  - [x] Nom service en bas de page
  - [x] Numéro de page
  - [x] Bloc Fonctionnalités offertes
  - [ ] Bloc Données stockées
  - [ ] Bloc Durée maximale acceptable de dysfonctionnement grave du service
  - [ ] Quoi faire dans le cas où il y a plusieurs pages ?
- [ ] Ajouter au pdf annexes.pdf
- [ ] Supprimer la route provisoire

J'ai ajouté le bloc Fonctionnalités au pdf `/pdf/:id/annexeDescription.pdf`

Notes :
- Les fonctionnalités spécifiques sont ajoutées à la suite des fonctionnalités
- Le bloc disparait quand il n'y a pas de fonctionnalité