### PR TITLE
Ajout de la page dédiée au changement de mot de passe

### DIFF
--- a/public/motDePasse/edition.js
+++ b/public/motDePasse/edition.js
@@ -1,0 +1,23 @@
+import { brancheValidation, declencheValidation } from '../modules/interactions/validation.mjs';
+
+$(() => {
+  const reponseAcceptee = (nom) => ($(`#${nom}:checked`).val() ? true : undefined);
+
+  const selecteurFormulaire = 'form.mot-de-passe#edition';
+
+  brancheValidation(selecteurFormulaire);
+  const $boutonValider = $("button[type = 'submit']", $(selecteurFormulaire));
+  $boutonValider.on('click', () => declencheValidation(selecteurFormulaire));
+
+  $(selecteurFormulaire).on('submit', (e) => {
+    e.preventDefault();
+
+    const donnees = {
+      motDePasse: $('#mot-de-passe').val(),
+      cguAcceptees: reponseAcceptee('cguAcceptees'),
+    };
+
+    axios.put('/api/motDePasse', donnees)
+      .then(() => (window.location = '/espacePersonnel'));
+  });
+});

--- a/src/mss.js
+++ b/src/mss.js
@@ -64,6 +64,12 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
     reponse.render('connexion');
   });
 
+  app.get('/motDePasse/edition', middleware.verificationJWT, (requete, reponse) => {
+    const idUtilisateur = requete.idUtilisateurCourant;
+    depotDonnees.utilisateur(idUtilisateur)
+      .then((utilisateur) => reponse.render('motDePasse/edition', { utilisateur }));
+  });
+
   app.get('/questionsFrequentes', (_requete, reponse) => {
     adaptateurEquations.indiceCyber()
       .then((svg) => reponse.render('questionsFrequentes', { formuleIndiceCyber: svg }));

--- a/src/vues/fragments/utilisateur/nouveauMotDePasse.pug
+++ b/src/vues/fragments/utilisateur/nouveauMotDePasse.pug
@@ -1,5 +1,4 @@
 mixin nouveauMotDePasse
-  h2 Changer de mot de passe
   label Nouveau mot de passe
     .infos-complementaires (Si vous laissez ce champ vide, le mot de passe ne sera pas modifié.)
     input(id='mot-de-passe', name = 'motDePasse', type='password')

--- a/src/vues/motDePasse/edition.pug
+++ b/src/vues/motDePasse/edition.pug
@@ -1,0 +1,21 @@
+extends ../mssConnecte
+
+include ../fragments/utilisateur/nouveauMotDePasse
+include ../fragments/utilisateur/questionCgu
+
+block append styles
+  link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
+
+block main
+  form.etroit.mot-de-passe#edition
+    h1 Changez votre mot de passe
+
+    section
+      +nouveauMotDePasse
+      if !utilisateur.accepteCGU()
+        +questionCgu
+
+    button(type = 'submit').bouton Valider
+
+  script(type = 'module', src = '/statique/motDePasse/edition.js')

--- a/src/vues/utilisateur/edition.pug
+++ b/src/vues/utilisateur/edition.pug
@@ -14,6 +14,7 @@ block main
     })
 
     section
+      h2 Changer de mot de passe
       +nouveauMotDePasse
       if !utilisateur.accepteCGU()
         +questionCgu

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -55,9 +55,19 @@ describe('Le serveur MSS', () => {
         .catch((e) => done(e.response?.data || e));
     });
   });
+
   describe('quand requête GET sur `/connexion`', () => {
     it("déconnecte l'utilisateur courant", (done) => {
       testeur.middleware().verifieRequeteExigeSuppressionCookie('http://localhost:1234/connexion', done);
+    });
+  });
+
+  describe('quand GET sur /motDePasse/edition', () => {
+    it("vérifie que l'utilisateur est authentifié", (done) => {
+      const utilisateur = { accepteCGU: () => true };
+      testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
+
+      testeur.middleware().verifieRequeteExigeJWT('http://localhost:1234/motDePasse/edition', done);
     });
   });
 


### PR DESCRIPTION
Sur l'URL `/motDePasse/edition` on affiche le formulaire qui est – pour le moment – également présent sur la page d'édition du profil utilisateur.

![image](https://user-images.githubusercontent.com/24898521/212349180-5da64d3d-089e-430f-a762-13701862ead2.png)

🗺️  Feuille de route :
- [x] #614 
- [x] #617 
- [x] **#619
- [ ] Ajout validation règles robustesse (client + serveur)
- [x] Duplication saisie mot de passe (+ éventuellement CGU) dans formulaire à part #624 👈 **Cette PR**
- [ ] Service du nouveau formulaire depuis l'API réinitialisation mot de passe
- [ ] Ajout option « Changer mon mot de passe » dans menu utilisateur
- [ ] Ajout bandeau « Mettez à jour votre profil » si nom utilisateur non renseigné
- [ ] Décommissionnement saisie mot de passe depuis formulaire infos utilisateur