### PR TITLE
[CORRECTION] Affichage icône nouvel onglet en bleu

### DIFF
--- a/public/assets/styles/homologation/synthese.css
+++ b/public/assets/styles/homologation/synthese.css
@@ -184,6 +184,10 @@
   padding-right: 1.85em;
 }
 
-a.nouvel-onglet::after {
+.cartes-informations a.nouvel-onglet::after {
+  background-color: var(--bleu-mise-en-avant);
+}
+
+.zone-principale a.nouvel-onglet::after {
   background-color: white;
 }


### PR DESCRIPTION
<img width="196" alt="Screenshot 2023-01-16 at 15 54 58" src="https://user-images.githubusercontent.com/105624/212707344-5b43f981-6c71-4381-83a8-be44bf40206a.png">

L'icône s'affichait en blanc sur fond blanc, ce qui la rendait invisible.