### PR TITLE
Données stockées à l'annexe description

### DIFF
--- a/src/modeles/objetsVues/vueAnnexePDFDescription.js
+++ b/src/modeles/objetsVues/vueAnnexePDFDescription.js
@@ -15,11 +15,23 @@ class VueAnnexePDFDescription {
       .fonctionnalitesSpecifiques
       .descriptions();
 
+    const donneesStockees = this.referentiel.descriptionsDonneesCaracterePersonnel(
+      this.homologation.descriptionService.donneesCaracterePersonnel
+    );
+    const donneesStockeesSpecifiques = this.homologation
+      .descriptionService
+      .donneesSensiblesSpecifiques
+      .descriptions();
+
     return {
       nomService: this.homologation.nomService(),
       fonctionnalites: [
         ...fonctionnalites,
         ...fonctionnalitesSpecifiques,
+      ],
+      donneesStockees: [
+        ...donneesStockees,
+        ...donneesStockeesSpecifiques,
       ],
     };
   }

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -37,6 +37,10 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const descriptionEcheanceRenouvellement = (id) => echeancesRenouvellement()[id]?.description;
   const delaisAvantImpactCritique = () => donnees.delaisAvantImpactCritique;
   const donneesCaracterePersonnel = () => donnees.donneesCaracterePersonnel;
+  const descriptionDonneesCaracterePersonnel = (id) => donneesCaracterePersonnel()[id]?.description;
+  const descriptionsDonneesCaracterePersonnel = (ids) => ids
+    ?.map((id) => descriptionDonneesCaracterePersonnel(id))
+    .filter((id) => id !== undefined);
   const etapesParcoursHomologation = () => donnees.etapesParcoursHomologation || [];
   const identifiantsEcheancesRenouvellement = () => Object.keys(echeancesRenouvellement());
   const fonctionnalites = () => donnees.fonctionnalites;
@@ -193,11 +197,13 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     departements,
     descriptionActionSaisie,
     descriptionCategorie,
+    descriptionDonneesCaracterePersonnel,
     descriptionEcheanceRenouvellement,
     descriptionExpiration,
     descriptionFonctionnalite,
     descriptionRisque,
     descriptionStatutMesure,
+    descriptionsDonneesCaracterePersonnel,
     descriptionsFonctionnalites,
     donneesCaracterePersonnel,
     echeancesRenouvellement,

--- a/src/vuesTex/annexeDescription.template.tex
+++ b/src/vuesTex/annexeDescription.template.tex
@@ -25,7 +25,22 @@
       __~__%
     \end{itemize}
   }
+  \vskip 10mm
   __?__
+
+  __? donnees.donneesStockees && donnees.donneesStockees.length __
+  \boitegriseespacee{Données Stockées}{
+    \begin{itemize}[labelsep=1.5em, leftmargin=3em]
+      __~ donnees.donneesStockees :lesDonnees __%
+        \item[\textcolor{bleu_mss}{\textbullet}]
+          \vskip 2mm
+          __= lesDonnees __
+      __~__%
+    \end{itemize}
+  }
+  \vskip 10mm
+  __?__
+
   % L'espace insécable ~ est présent pour éviter le cas d'un document sans contenu
   ~
 \end{document}

--- a/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
+++ b/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
@@ -11,6 +11,11 @@ describe("L'objet de vue de l'annexe de description", () => {
         description: 'Une fonctionnalité',
       },
     },
+    donneesCaracterePersonnel: {
+      desDonnees: {
+        description: 'Des données',
+      },
+    },
   };
   const referentiel = Referentiel.creeReferentiel(donneesReferentiel);
   const homologation = new Homologation({
@@ -20,6 +25,8 @@ describe("L'objet de vue de l'annexe de description", () => {
       nomService: 'Nom Service',
       fonctionnalites: ['uneFonctionnalite'],
       fonctionnalitesSpecifiques: [{ description: 'Une fonctionnalité spécifique' }],
+      donneesCaracterePersonnel: ['desDonnees'],
+      donneesSensiblesSpecifiques: [{ description: 'Des données spécifiques' }],
     },
   }, referentiel);
 
@@ -48,5 +55,23 @@ describe("L'objet de vue de l'annexe de description", () => {
 
     expect(donnees).to.have.key('fonctionnalites');
     expect(donnees.fonctionnalites).to.contain('Une fonctionnalité spécifique');
+  });
+
+  it('fournit la liste des données stockées', () => {
+    const vueAnnexePDFDescription = new VueAnnexePDFDescription(homologation, referentiel);
+
+    const donnees = vueAnnexePDFDescription.donnees();
+
+    expect(donnees).to.have.key('donneesStockees');
+    expect(donnees.donneesStockees[0]).to.equal('Des données');
+  });
+
+  it('ajoute les données spécifiques à la liste des données stockées', () => {
+    const vueAnnexePDFDescription = new VueAnnexePDFDescription(homologation, referentiel);
+
+    const donnees = vueAnnexePDFDescription.donnees();
+
+    expect(donnees).to.have.key('donneesStockees');
+    expect(donnees.donneesStockees).to.contain('Des données spécifiques');
   });
 });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -136,6 +136,31 @@ describe('Le référentiel', () => {
     expect(referentiel.donneesCaracterePersonnel()).to.eql({ uneClef: 'une valeur' });
   });
 
+  it('sait décrire un type de données à caractère personnel', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      donneesCaracterePersonnel: { uneClef: { description: 'Une description' } },
+    });
+
+    expect(referentiel.descriptionDonneesCaracterePersonnel('uneClef')).to.equal('Une description');
+  });
+
+  it('sait décrire des types de données à caractère personnel', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      donneesCaracterePersonnel: {
+        clef1: { description: 'Description 1' },
+        clef2: { description: 'Description 2' },
+      },
+    });
+
+    expect(referentiel.descriptionsDonneesCaracterePersonnel(['clef1', 'clef2'])).to.eql(['Description 1', 'Description 2']);
+  });
+
+  it("sait décrire des types de données à caractère personnel en restant robuste quand un type n'est pas dans le référentiel", () => {
+    const referentiel = Referentiel.creeReferentielVide();
+
+    expect(referentiel.descriptionsDonneesCaracterePersonnel(['clef'])).to.eql([]);
+  });
+
   it('connaît la liste des délais avant impact critique', () => {
     const referentiel = Referentiel.creeReferentiel({
       delaisAvantImpactCritique: { uneClef: 'une valeur' },


### PR DESCRIPTION
Dans le but d'ajouter une page **Description** aux annexes

- [x] Route provisoire `/pdf/:id/annexeDescription.pdf`
- [ ] Nouvelle page latex
  - [x] Titre entête
  - [x] Nom service en bas de page
  - [x] Numéro de page
  - [x] Bloc Fonctionnalités offertes
  - [x] Bloc Données stockées
  - [ ] Bloc Durée maximale acceptable de dysfonctionnement grave du service
  - [ ] Quoi faire dans le cas où il y a plusieurs pages ?
- [ ] Ajouter au pdf annexes.pdf
- [ ] Supprimer la route provisoire

J'ai ajouté le bloc Données stockées au pdf `/pdf/:id/annexeDescription.pdf`

Notes :
- Les données stockées spécifiques sont ajoutées à la suite des données stockées
- Le bloc disparait quand il n'y a pas d'élément