### PR TITLE
[CORRECTION] Retourne à espacement vertical connu

### DIFF
--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -38,7 +38,7 @@ main a {
 }
 
 section {
-  padding: 0.5em 0;
+  padding: 2em 0;
   border-top: solid 1px var(--liseres);
 
   text-align: left;
@@ -88,7 +88,6 @@ section:last-of-type {
 
 .etroit .sous-titre {
   margin: 0;
-  padding-bottom: 2em;
 }
 
 .etroit .description {

--- a/src/vues/connexion.pug
+++ b/src/vues/connexion.pug
@@ -11,9 +11,8 @@ block main
       span ou&nbsp;
       a(href='/inscription') créez votre compte
 
-    .mention champ obligatoire
-
     section
+      .mention champ obligatoire
       .requis
         label E-mail
           br


### PR DESCRIPTION
a20b37a16351e8003cc2abb4e4f1fb232733e4c4 a changé les espaces verticaux de règles très larges de `mss.css`. Cela cause des régressions sur la page « Décrire » où les labels « Ajouter une fonctionnalité » et « Ajouter des données » se retrouvent collés aux sections inférieures.

Ce commit conserve le placement correct de `.mention champ obligatoire` dans la page de connexion en modifiant la structure de `connexion.pug` plutôt que le CSS de `mss.css`.

La correction du bug : 

![image](https://user-images.githubusercontent.com/24898521/212920037-b7426698-b02f-4469-b461-1228fed45996.png)
