### PR TITLE
Durée maximale acceptable dans l'annexe description

### DIFF
--- a/src/modeles/objetsVues/vueAnnexePDFDescription.js
+++ b/src/modeles/objetsVues/vueAnnexePDFDescription.js
@@ -23,6 +23,11 @@ class VueAnnexePDFDescription {
       .donneesSensiblesSpecifiques
       .descriptions();
 
+    const dureeDysfonctionnementMaximumAcceptable = this.referentiel
+      .descriptionDelaiAvantImpactCritique(
+        this.homologation.descriptionService.delaiAvantImpactCritique
+      );
+
     return {
       nomService: this.homologation.nomService(),
       fonctionnalites: [
@@ -33,6 +38,7 @@ class VueAnnexePDFDescription {
         ...donneesStockees,
         ...donneesStockeesSpecifiques,
       ],
+      dureeDysfonctionnementMaximumAcceptable,
     };
   }
 }

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -36,6 +36,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const echeancesRenouvellement = () => donnees.echeancesRenouvellement || [];
   const descriptionEcheanceRenouvellement = (id) => echeancesRenouvellement()[id]?.description;
   const delaisAvantImpactCritique = () => donnees.delaisAvantImpactCritique;
+  const descriptionDelaiAvantImpactCritique = (id) => delaisAvantImpactCritique()[id]?.description;
   const donneesCaracterePersonnel = () => donnees.donneesCaracterePersonnel;
   const descriptionDonneesCaracterePersonnel = (id) => donneesCaracterePersonnel()[id]?.description;
   const descriptionsDonneesCaracterePersonnel = (ids) => ids
@@ -197,6 +198,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     departements,
     descriptionActionSaisie,
     descriptionCategorie,
+    descriptionDelaiAvantImpactCritique,
     descriptionDonneesCaracterePersonnel,
     descriptionEcheanceRenouvellement,
     descriptionExpiration,

--- a/src/vuesTex/annexeDescription.template.tex
+++ b/src/vuesTex/annexeDescription.template.tex
@@ -41,6 +41,16 @@
   \vskip 10mm
   __?__
 
-  % L'espace insécable ~ est présent pour éviter le cas d'un document sans contenu
-  ~
+  \boitegriseespacee{Durée maximale acceptable de dysfonctionnement grave du service}{
+    \begin{itemize}[labelsep=1.5em, leftmargin=3em]
+      \item[\textcolor{bleu_mss}{\textbullet}]
+        \vskip 2mm
+        __? donnees.dureeDysfonctionnementMaximumAcceptable !== undefined __
+          __= donnees.dureeDysfonctionnementMaximumAcceptable __
+        __??__
+          Non renseignée
+        __?__
+    \end{itemize}
+  }
+  \vskip 10mm
 \end{document}

--- a/src/vuesTex/macros/boiteGrise.tex
+++ b/src/vuesTex/macros/boiteGrise.tex
@@ -12,4 +12,4 @@
 
 \newcommand{\boitegrisenormale}[2]{\boitegrise{20pt}{0pt}{#1}{#2}}
 \newcommand{\boitegriseespacee}[2]{\boitegrise{20pt}{10pt}{#1}{#2}}
-\newcommand{\boitegrisevide}[2]{\boitegrise{10pt}{20pt}{#1}{#2}}
+\newcommand{\boitegrisevide}[1]{\boitegrise{10pt}{20pt}{#1}}

--- a/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
+++ b/test/modeles/objetsVues/vueAnnexePDFDescription.spec.js
@@ -16,6 +16,9 @@ describe("L'objet de vue de l'annexe de description", () => {
         description: 'Des données',
       },
     },
+    delaisAvantImpactCritique: {
+      unJour: { description: 'Un jour' },
+    },
   };
   const referentiel = Referentiel.creeReferentiel(donneesReferentiel);
   const homologation = new Homologation({
@@ -27,6 +30,7 @@ describe("L'objet de vue de l'annexe de description", () => {
       fonctionnalitesSpecifiques: [{ description: 'Une fonctionnalité spécifique' }],
       donneesCaracterePersonnel: ['desDonnees'],
       donneesSensiblesSpecifiques: [{ description: 'Des données spécifiques' }],
+      delaiAvantImpactCritique: 'unJour',
     },
   }, referentiel);
 
@@ -73,5 +77,14 @@ describe("L'objet de vue de l'annexe de description", () => {
 
     expect(donnees).to.have.key('donneesStockees');
     expect(donnees.donneesStockees).to.contain('Des données spécifiques');
+  });
+
+  it('fournit la durée maximale acceptable de dysfonctionnement grave', () => {
+    const vueAnnexePDFDescription = new VueAnnexePDFDescription(homologation, referentiel);
+
+    const donnees = vueAnnexePDFDescription.donnees();
+
+    expect(donnees).to.have.key('dureeDysfonctionnementMaximumAcceptable');
+    expect(donnees.dureeDysfonctionnementMaximumAcceptable).to.equal('Un jour');
   });
 });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -169,6 +169,20 @@ describe('Le référentiel', () => {
     expect(referentiel.delaisAvantImpactCritique()).to.eql({ uneClef: 'une valeur' });
   });
 
+  it('sait décrire un délai avant impact critique', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      delaisAvantImpactCritique: { uneClef: { description: 'une valeur' } },
+    });
+
+    expect(referentiel.descriptionDelaiAvantImpactCritique('uneClef')).to.equal('une valeur');
+  });
+
+  it("reste robuste quand le délai avant impact critique n'est pas dans le référentiel", () => {
+    const referentiel = Referentiel.creeReferentielVide();
+
+    expect(referentiel.descriptionDelaiAvantImpactCritique('uneClef')).to.equal(undefined);
+  });
+
   describe('sur demande de la liste des mesures', () => {
     it('retourne la liste', () => {
       const referentiel = Referentiel.creeReferentiel({


### PR DESCRIPTION
Dans le but d'ajouter une page **Description** aux annexes

- [x] Route provisoire `/pdf/:id/annexeDescription.pdf`
- [X] Nouvelle page latex
  - [x] Titre entête
  - [x] Nom service en bas de page
  - [x] Numéro de page
  - [x] Bloc Fonctionnalités offertes
  - [x] Bloc Données stockées
  - [x] Bloc Durée maximale acceptable de dysfonctionnement grave du service
- [ ] Ajouter au pdf annexes.pdf
- [ ] Supprimer la route provisoire

J'ai ajouté le bloc Durée maximale acceptable de dysfonctionnement grave du service au pdf `/pdf/:id/annexeDescription.pdf`

Notes :
- Le texte `Non renseignée` apparait si la durée n'est pas définie