### PR TITLE
Nouvelle route de suppression de service

### DIFF
--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -7,6 +7,7 @@ class AutorisationBase extends Base {
 
     this.permissionAjoutContributeur = false;
     this.permissionSuppressionContributeur = false;
+    this.permissionSuppressionService = false;
   }
 }
 

--- a/src/modeles/autorisations/autorisationCreateur.js
+++ b/src/modeles/autorisations/autorisationCreateur.js
@@ -6,6 +6,7 @@ class AutorisationCreateur extends AutorisationBase {
 
     this.permissionAjoutContributeur = true;
     this.permissionSuppressionContributeur = true;
+    this.permissionSuppressionService = true;
   }
 }
 

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -12,4 +12,9 @@ describe('Une autorisation de base', () => {
     const autorisation = new AutorisationBase();
     expect(autorisation.permissionSuppressionContributeur).to.be(false);
   });
+
+  it('ne permet pas de supprimer un service', () => {
+    const autorisation = new AutorisationBase();
+    expect(autorisation.permissionSuppressionService).to.be(false);
+  });
 });

--- a/test/modeles/autorisations/autorisationCreateur.spec.js
+++ b/test/modeles/autorisations/autorisationCreateur.spec.js
@@ -12,4 +12,9 @@ describe("Une autorisation d'accès en tant que créateur", () => {
     const autorisation = new AutorisationCreateur();
     expect(autorisation.permissionSuppressionContributeur).to.be(true);
   });
+
+  it('permet de supprimer un service', () => {
+    const autorisation = new AutorisationCreateur();
+    expect(autorisation.permissionSuppressionService).to.be(true);
+  });
 });


### PR DESCRIPTION
Dans la feature de suppression de service,

Je propose d'ajouter une nouvelle route DELETE qui permet de supprimer un service quand on est connecté, cgu acceptées et créateur du service.

La suppression utilise les mécanismes déjà implémentés et utilisés dans la console admin.