### PR TITLE
Modale de suppression de service

### DIFF
--- a/public/assets/styles/modaleSuppressionService.css
+++ b/public/assets/styles/modaleSuppressionService.css
@@ -1,0 +1,23 @@
+.modale-suppression-service .modale {
+  width: 400px;
+  padding: 3em 5em 1em 5em ;
+}
+
+.modale-suppression-service .modale h1 {
+  padding: 0;
+}
+
+.modale-suppression-service .modale .avertissement {
+  display: flex;
+  background-color: var(--fond-composant-secondaire);
+  border-radius: 0.3em;
+  margin-top: 2em;
+  padding: 1em;
+}
+
+.modale-suppression-service .modale .avertissement::before {
+  content: '👉';
+  display: block;
+  margin-right: 1em;
+  font-size: 1.1em;
+}

--- a/public/assets/styles/palette.css
+++ b/public/assets/styles/palette.css
@@ -8,6 +8,7 @@
   --rose-mise-en-avant: #f15172;
   --gris-fonce: #2f3a43;
   --gris-inactif: #929292;
+  --fond-composant-secondaire: #0f7ac71a;
 
   --texte-fonce: var(--gris-fonce);
   --texte-moyen-fonce: #5e5e5e;

--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -1,9 +1,24 @@
 import { $services, $modaleNouveauContributeur } from './modules/elementsDom/services.mjs';
-import { brancheModale } from './modules/interactions/modale.mjs';
+import { brancheModale, initialiseComportementModale } from './modules/interactions/modale.mjs';
 import brancheComportementPastilles from './modules/interactions/pastilles.js';
 import brancheComportementSaisieContributeur from './modules/interactions/saisieContributeur.js';
 
 $(() => {
+  const $modaleSuppression = $('.modale-suppression-service');
+  initialiseComportementModale($modaleSuppression);
+  $('.services').on('modaleSuppression', (_evenement, { idService, nomService }) => {
+    $('.nom-service', $modaleSuppression).text(nomService);
+
+    const $bouton = $('.bouton-suppression-service', $modaleSuppression);
+    $bouton.on('click', () => {
+      axios.delete(`/api/service/${idService}`).then(() => window.location.reload());
+    });
+    $modaleSuppression.on('fermeModale', () => {
+      $bouton.off();
+    });
+    $modaleSuppression.trigger('afficheModale');
+  });
+
   const peupleServicesDans = (placeholder, donneesServices, idUtilisateur) => {
     const $conteneurServices = $(placeholder);
     const nombreMaxContributeursDistincts = 2;

--- a/src/vues/espacePersonnel.pug
+++ b/src/vues/espacePersonnel.pug
@@ -1,11 +1,13 @@
 extends mssConnecte
 include fragments/modaleNouveauService
+include fragments/modales/modaleSuppressionService
 
 block append styles
   link(href = '/statique/assets/styles/espacePersonnel.css', rel = 'stylesheet')
 
 block main
   +modaleNouveauService
+  +modaleSuppressionService
 
   a(href = './nouvellesFonctionnalites').bandeau-nouveautes
     p.marges-fixes.

--- a/src/vues/fragments/modales/modaleSuppressionService.pug
+++ b/src/vues/fragments/modales/modaleSuppressionService.pug
@@ -1,0 +1,15 @@
+block append styles
+  link(href = '/statique/assets/styles/modaleSuppressionService.css', rel = 'stylesheet')
+
+mixin modaleSuppressionService()
+  .rideau.modale-suppression-service
+    .modale
+      .fermeture-modale
+      .contenu-modale
+        h1 Supprimer un service
+        p Souhaitez-vous définitivement supprimer le service #[span.nom-service] ?
+        .avertissement.
+          Toutes les données seront effacées.<br>
+          Aucun contributeur ne pourra accéder à ce service.
+
+        button(type = 'button').bouton.bouton-suppression-service Valider


### PR DESCRIPTION
Dans la feature de suppression de service,
dans la page espace personnel

Création d'une modale qui permettra d'appeler la suppression d'un service.

Note : Il n'y a aucun lien ou bouton pour afficher la modale, si vous voulez la voir et la tester une technique est de le faire depuis la console du navigateur

```js
$('.services').trigger('modaleSuppression', {nomService: 'Nom du service à supprimer', idService: '123-ou-un-id-a-supprimer'});
```