### PR TITLE
Redirige vers page « Mot de passe » pour accepter les CGU

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -65,7 +65,7 @@ const middleware = (configuration = {}) => {
 
   const verificationAcceptationCGU = (requete, reponse, suite) => {
     verificationJWT(requete, reponse, () => {
-      if (!requete.cguAcceptees) reponse.redirect('/utilisateur/edition');
+      if (!requete.cguAcceptees) reponse.redirect('/motDePasse/edition');
       else suite();
     });
   };

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -109,7 +109,7 @@ describe('Le middleware MSS', () => {
     const middleware = Middleware({ adaptateurJWT, depotDonnees });
 
     reponse.redirect = (url) => {
-      expect(url).to.equal('/utilisateur/edition');
+      expect(url).to.equal('/motDePasse/edition');
       done();
     };
 


### PR DESCRIPTION
… car désormais c'est sur cette page que se fait l'acceptation des CGU.
Le formulaire de changement de MDP + acceptation des CGU va disparaître de la page « Profil utilisateur ».