### PR TITLE
Affiche un bandeau « Mettez à jour vos informations » si le nom n'est pas renseigné

### DIFF
--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -145,11 +145,13 @@
   background-repeat: no-repeat;
 }
 
-.bandeau-nouveautes {
+.bandeau-nouveautes, .bandeau-maj-profil {
   display: flex;
   height: 2.7em;
   align-items: center;
+}
 
+.bandeau-nouveautes {
   background-color: var(--rose-anssi);
 }
 
@@ -157,7 +159,19 @@
   background-color: var(--rose-mise-en-avant);
 }
 
-.bandeau-nouveautes p {
+.bandeau-maj-profil {
+  background-color: var(--bleu-mise-en-avant);
+}
+
+.bandeau-maj-profil:hover {
+  background-color: var(--bleu-anssi);
+}
+
+.bandeau-maj-profil.invisible {
+  display: none;
+}
+
+:is(.bandeau-nouveautes, .bandeau-maj-profil) p {
   color: #fff;
   font-weight: bold;
   font-size: .95em;

--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -39,8 +39,16 @@ $(() => {
     brancheModale('#nouveau-service', '#modale-nouveau-service');
   };
 
+  const afficheBandeauMajProfil = () => {
+    $('.bandeau-maj-profil').removeClass('invisible');
+  };
+
   axios.get('/api/utilisateurCourant')
-    .then((reponse) => reponse.data.utilisateur.id)
-    .then((idUtilisateur) => axios.get('/api/homologations')
-      .then((reponse) => peupleServicesDans('.services', reponse.data.homologations, idUtilisateur)));
+    .then(({ data }) => data.utilisateur)
+    .then((utilisateur) => {
+      axios.get('/api/homologations')
+        .then(({ data }) => peupleServicesDans('.services', data.homologations, utilisateur.id));
+
+      if (!utilisateur.profilEstComplet) afficheBandeauMajProfil();
+    });
 });

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -113,6 +113,10 @@ class Utilisateur extends Base {
     return [this.prenom, this.nom].join(' ').trim() || this.email;
   }
 
+  profilEstComplet() {
+    return (this.nom?.trim() ?? '') !== '';
+  }
+
   toJSON() {
     return {
       id: this.id,
@@ -125,6 +129,7 @@ class Utilisateur extends Base {
       delegueProtectionDonnees: this.estDelegueProtectionDonnees(),
       nomEntitePublique: this.nomEntitePublique || '',
       departementEntitePublique: this.departementEntitePublique || '',
+      profilEstComplet: this.profilEstComplet(),
     };
   }
 }

--- a/src/vues/espacePersonnel.pug
+++ b/src/vues/espacePersonnel.pug
@@ -12,6 +12,11 @@ block main
   a(href = './nouvellesFonctionnalites').bandeau-nouveautes
     p.marges-fixes.
       Découvrez les nouvelles fonctionnalités  ›
+
+  a(href = './utilisateur/edition').bandeau-maj-profil.invisible
+    p.marges-fixes.
+      Mettez à jour vos informations  ›
+
   .suivi-services.marges-fixes
     h1 Mon espace personnel
     .services

--- a/src/vues/utilisateur/edition.pug
+++ b/src/vues/utilisateur/edition.pug
@@ -4,6 +4,14 @@ include ../fragments/formulaireUtilisateur
 include ../fragments/utilisateur/nouveauMotDePasse
 include ../fragments/utilisateur/questionCgu
 
+block append styles
+  link(href = '/statique/assets/styles/filAriane.css', rel = 'stylesheet')
+
+block retour
+  nav.fil-ariane
+    a.avec-chevron(href = '/espacePersonnel') Espace personnel
+    div Profil
+
 block main
   form.etroit.utilisateur#edition
     h1 Profil

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -64,6 +64,7 @@ describe('Une homologation', () => {
         delegueProtectionDonnees: false,
         nomEntitePublique: '',
         departementEntitePublique: '',
+        profilEstComplet: true,
       },
       contributeurs: [{
         id: '999',
@@ -76,6 +77,7 @@ describe('Une homologation', () => {
         delegueProtectionDonnees: false,
         nomEntitePublique: '',
         departementEntitePublique: '',
+        profilEstComplet: true,
       }],
     });
   });

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -5,6 +5,18 @@ const Referentiel = require('../../src/referentiel');
 const Utilisateur = require('../../src/modeles/utilisateur');
 
 describe('Un utilisateur', () => {
+  describe("sur demande d'un profil complet ou non", () => {
+    it('considère le profil « complet » dès lors que le nom est renseigné', () => {
+      const utilisateur = new Utilisateur({ nom: 'Dupont', email: 'jean.dupont@mail.fr' });
+      expect(utilisateur.profilEstComplet()).to.be(true);
+    });
+
+    it("considère le profil « incomplet » si le nom n'est pas renseigné", () => {
+      const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
+      expect(utilisateur.profilEstComplet()).to.be(false);
+    });
+  });
+
   describe('sur demande de ses initiales', () => {
     it('renvoie les initiales du prénom et du nom', () => {
       const utilisateur = new Utilisateur({ prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' });
@@ -60,6 +72,7 @@ describe('Un utilisateur', () => {
       delegueProtectionDonnees: false,
       nomEntitePublique: 'Ville de Paris',
       departementEntitePublique: '75',
+      profilEstComplet: true,
     });
   });
 


### PR DESCRIPTION
### 🗺 Feuille de route
- [x] #614 
- [x] #617 
- [x] #619
- [x] #628
- [x] #624 
- [ ] Service du nouveau formulaire depuis l'API réinitialisation mot de passe
- [ ] #643 
- [ ] **Ajout bandeau « Mettez à jour votre profil » si nom utilisateur non renseigné 👈 Cette PR**
- [ ] Décomissionnement saisie mot de passe depuis formulaire infos utilisateur

### Contexte
Désormais le changement de MDP se fait sur une page dédiée.
Cette page dédiée sera également utilisée comme page d'arrivée pour les utilisateurs invités à s'inscrire.

Autrement dit :
 * A est inscrit
 * Il invite B à contribuer
 * B clique sur le lien d'inscription qu'il reçoit par e-mail
 * B arrivera sur la page « Changer votre mot de passe »

Avant, B arrivait sur la page « Profil » où il était obligé de saisir à la fois son mot de passe **ET** ses informations de profil.

Désormais il faut donc inciter le nouvel inscrit à aller remplir ses infos de profil. 
C'est ce que fait ce bandeau.

### Pour tester en local

Le scenario est :
 - partir d'un compte complet
 - inviter un collaborateur
 - regarder dans la console l'ID de reset MDP du collaborateur
 - naviguer sur `http://mss-local/initialisationMotDePasse/:uuid` pour être connecté avec le nouveau collaborateur
 - naviguer sur `http://mss-local/motDePasse/edition` pour choisir un MDP et accepter les CGU
 - naviguer sur l'espace personnel

C'est une fois l'espace personnel affiché qu'on voit le bandeau :

![image](https://user-images.githubusercontent.com/24898521/214292990-581bdc49-dd49-4e01-8667-7d686dabaf9d.png)
 
⚠️ Le bandeau n'est pas en dégradé de couleur comme sur la maquette. Car je ne savais pas quel comportement ajouter au `:hover` et Mari n'est pas dispo cet après-midi.