### PR TITLE
Utilisation de la page de changement de MDP pour l'initialisation du mot de passe

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -107,13 +107,12 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
       depotDonnees.utilisateurAFinaliser(idReset)
         .then((utilisateur) => {
           if (!utilisateur) {
-            reponse.status(404)
-              .send(`Identifiant d'initialisation de mot de passe "${idReset}" inconnu`);
-          } else {
-            const token = utilisateur.genereToken();
-            requete.session.token = token;
-            sersFormulaireEditionUtilisateur(requete, reponse);
+            reponse.status(404).send(`Identifiant d'initialisation de mot de passe "${idReset}" inconnu`);
+            return;
           }
+
+          requete.session.token = utilisateur.genereToken();
+          sersFormulaireEditionUtilisateur(requete, reponse);
         });
     });
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -14,15 +14,6 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
   avecCookieSecurise = (process.env.NODE_ENV === 'production')) => {
   let serveur;
 
-  const sersFormulaireEditionUtilisateur = (requete, reponse) => {
-    const departements = referentiel.departements();
-    middleware.verificationJWT(requete, reponse, () => {
-      const idUtilisateur = requete.idUtilisateurCourant;
-      depotDonnees.utilisateur(idUtilisateur)
-        .then((utilisateur) => reponse.render('utilisateur/edition', { utilisateur, departements }));
-    });
-  };
-
   const app = express();
 
   app.use(express.json());
@@ -112,7 +103,7 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
           }
 
           requete.session.token = utilisateur.genereToken();
-          sersFormulaireEditionUtilisateur(requete, reponse);
+          reponse.render('motDePasse/edition', { utilisateur });
         });
     });
 
@@ -133,8 +124,11 @@ const creeServeur = (depotDonnees, middleware, referentiel, moteurRegles,
 
   app.use('/pdf', routesPdf(middleware, adaptateurPdf));
 
-  app.get('/utilisateur/edition', (requete, reponse) => {
-    sersFormulaireEditionUtilisateur(requete, reponse);
+  app.get('/utilisateur/edition', middleware.verificationJWT, (requete, reponse) => {
+    const departements = referentiel.departements();
+    const idUtilisateur = requete.idUtilisateurCourant;
+    depotDonnees.utilisateur(idUtilisateur)
+      .then((utilisateur) => reponse.render('utilisateur/edition', { utilisateur, departements }));
   });
 
   app.use('/statique', express.static('public'));


### PR DESCRIPTION
Cette PR modifie la page utilisée pour l'initialisation du mot de passe.
Avant c'était la page de profil, désormais c'est la page dédiée au changement de mot de passe.

### 🗺 Feuille de route
- [x] #614 
- [x] #617 
- [x] #619
- [x] #628
- [x] #624 
- [ ] #647 👈 **Cette PR**
- [x] #643 
- [x] #645
- [ ] Décomissionnement saisie mot de passe depuis formulaire infos utilisateur