### PR TITLE
[CORRECTION] gestion des transferts

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -153,9 +153,43 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     return Promise.resolve();
   };
 
+  const supprimeAutorisationsContributionDejaPresentes = (
+    idUtilisateurSource,
+    idUtilisateurCible
+  ) => {
+    const autorisationContributionExistante = (idUtilisateur, idHomologation) => (
+      !!donnees.autorisations.find(
+        (a) => a.idUtilisateur === idUtilisateur && a.idHomologation === idHomologation && a.type === 'contributeur'
+      )
+    );
+
+    donnees.autorisations = donnees.autorisations.filter((a) => (
+      a.idUtilisateur !== idUtilisateurSource
+        || a.type !== 'contributeur'
+        || !autorisationContributionExistante(idUtilisateurCible, a.idHomologation)
+    ));
+
+    return Promise.resolve();
+  };
+
   const supprimeAutorisationsHomologation = (idHomologation) => {
     donnees.autorisations = donnees.autorisations
       .filter((a) => a.idHomologation !== idHomologation);
+    return Promise.resolve();
+  };
+
+  const supprimeDoublonsCreationContribution = (idUtilisateur) => {
+    const idsHomologationsCreees = donnees.autorisations
+      .filter((a) => a.idUtilisateur === idUtilisateur && a.type === 'createur')
+      .map((a) => a.idHomologation);
+
+    donnees.autorisations = donnees.autorisations
+      .filter((a) => (
+        a.idUtilisateur !== idUtilisateur
+        || a.type !== 'contributeur'
+        || !idsHomologationsCreees.includes(a.idHomologation)
+      ));
+
     return Promise.resolve();
   };
 
@@ -185,7 +219,9 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     supprimeAutorisation,
     supprimeAutorisations,
     supprimeAutorisationsContribution,
+    supprimeAutorisationsContributionDejaPresentes,
     supprimeAutorisationsHomologation,
+    supprimeDoublonsCreationContribution,
     supprimeHomologation,
     supprimeHomologations,
     supprimeService,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -173,8 +173,30 @@ const nouvelAdaptateur = (env) => {
     .whereRaw("donnees->>'type'='contributeur'")
     .del();
 
+  const supprimeAutorisationsContributionDejaPresentes = (idUtilisateurSource, idUtilisateurCible) => knex('autorisations as a1')
+    .join(
+      'autorisations as a2',
+      knex.raw("a1.donnees->>'idHomologation'"),
+      knex.raw("a2.donnees->>'idHomologation'"),
+    )
+    .whereRaw("a1.donnees->>'idUtilisateur'=?", idUtilisateurSource)
+    .whereRaw("a2.donnees->>'idUtilisateur'=?", idUtilisateurCible)
+    .whereRaw("a1.donnees->>'type'='contributeur'")
+    .whereRaw("a2.donnees->>'type'='contributeur'")
+    .del();
+
   const supprimeAutorisationsHomologation = (idHomologation) => knex('autorisations')
     .whereRaw("donnees->>'idHomologation'=?", idHomologation)
+    .del();
+
+  const supprimeDoublonsCreationContribution = (idUtilisateur) => knex('autorisations as a1')
+    .join('autorisations as a2', function jointure() {
+      this.on(knex.raw("a1.donnees->>'idHomologation'"), knex.raw("a2.donnees->>'idHomologation'"))
+        .andOn(knex.raw("a1.donnees->>'idUtilisateur'"), knex.raw("a2.donnees->>'idUtilisateur'"));
+    })
+    .whereRaw("a1.donnees->>'idUtilisateur'=?", idUtilisateur)
+    .whereRaw("a1.donnees->>'type'='contributeur'")
+    .whereRaw("a2.donnees->>'type'='createur'")
     .del();
 
   const transfereAutorisations = (idUtilisateurSource, idUtilisateurCible) => knex('autorisations')
@@ -204,7 +226,9 @@ const nouvelAdaptateur = (env) => {
     supprimeAutorisation,
     supprimeAutorisations,
     supprimeAutorisationsContribution,
+    supprimeAutorisationsContributionDejaPresentes,
     supprimeAutorisationsHomologation,
+    supprimeDoublonsCreationContribution,
     supprimeHomologation,
     supprimeService,
     supprimeHomologations,

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -28,6 +28,7 @@ class ErreurStatutDeploiementInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
 class ErreurSuppressionImpossible extends Error {}
 class ErreurTentativeSuppressionCreateur extends ErreurModele {}
+class ErreurTranfertVersUtilisateurSource extends Error {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
 
@@ -69,6 +70,7 @@ module.exports = {
   ErreurStatutMesureInvalide,
   ErreurSuppressionImpossible,
   ErreurTentativeSuppressionCreateur,
+  ErreurTranfertVersUtilisateurSource,
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,
   ErreurUtilisateurInexistant,


### PR DESCRIPTION
Cette PR corrige le comportement du transfert de tous les dossiers d'un utilisateur source vers un utilisateur cible. Spéciquement :
- Si l'utilisateur cible est déjà contributeur sur un service dont l'utilisateur source est aussi contributeur, on ne doit pas dupliquer les droits de contribution sur ce service.
- Si l'utilisateur cible est contributeur sur un service dont l'utilisateur source est le créateur, on doit mettre à jour les droits pour l'utilisateur cible.