### PR TITLE
Regroupe les différentes requêtes pour transfert dans une même transaction

### DIFF
--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -104,10 +104,7 @@ const creeDepot = (config = {}) => {
       .then(() => verifieUtilisateurExiste(idUtilisateurCible))
       .then(() => verifieUtilisateursSourceDestinationDifferents())
       .then(() => adaptateurPersistance
-        .supprimeAutorisationsContributionDejaPresentes(idUtilisateurSource, idUtilisateurCible))
-      .then(() => adaptateurPersistance
-        .transfereAutorisations(idUtilisateurSource, idUtilisateurCible))
-      .then(() => adaptateurPersistance.supprimeDoublonsCreationContribution(idUtilisateurCible));
+        .transfereAutorisations(idUtilisateurSource, idUtilisateurCible));
   };
 
   return {


### PR DESCRIPTION
Note : le mécanisme de transaction existe seulement pour l'adaptateur Postgres. Peut-être que si on voulait réutiliser un jour l'adaptateur mémoire en prod, il faudrait l'y implémenter ? Le débat semble prématuré pour l'instant.