### PR TITLE
Correction d'un oubli de suite dans la route delete service

### DIFF
--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -224,7 +224,7 @@ const routesApiService = (middleware, depotDonnees, referentiel) => {
         });
     });
 
-  routes.delete('/:id', middleware.verificationAcceptationCGU, (requete, reponse) => {
+  routes.delete('/:id', middleware.verificationAcceptationCGU, (requete, reponse, suite) => {
     const verifiePermissionSuppressionService = (idUtilisateur, idService) => depotDonnees
       .autorisationPour(idUtilisateur, idService)
       .then((autorisation) => (


### PR DESCRIPTION
Le paramètre `suite` avait été oublié alors qu'il est utilisé dans la fonction