### PR TITLE
Route pour duplication de service

### DIFF
--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -1,6 +1,11 @@
 const express = require('express');
 
-const { EchecAutorisation, ErreurModele, ErreurNomServiceDejaExistant } = require('../erreurs');
+const {
+  EchecAutorisation,
+  ErreurModele,
+  ErreurNomServiceDejaExistant,
+  ErreurDonneesObligatoiresManquantes,
+} = require('../erreurs');
 const ActeursHomologation = require('../modeles/acteursHomologation');
 const AutorisationCreateur = require('../modeles/autorisations/autorisationCreateur');
 const AvisExpertCyber = require('../modeles/avisExpertCyber');
@@ -268,7 +273,12 @@ const routesApiService = (middleware, depotDonnees, referentiel) => {
         if (e instanceof EchecAutorisation) {
           reponse.status(403).send('Droits insuffisants pour dupliquer le service');
         } else if (e instanceof ErreurNomServiceDejaExistant) {
-          reponse.status(424).send('La duplication a échouée');
+          reponse.status(424).send({ type: 'NOM_DEJA_EXISTANT', message: 'La duplication a échoué car le nom cible existe déjà' });
+        } else if (e instanceof ErreurDonneesObligatoiresManquantes) {
+          reponse.status(424).send({
+            type: 'DONNEES_OBLIGATOIRES_MANQUANTES',
+            message: 'La duplication a échoué car certaines données obligatoires ne sont pas renseignées',
+          });
         } else {
           suite(e);
         }

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -847,7 +847,24 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('retourne une erreur HTTP 424 si le nom cible du service existe déjà', (done) => {
       testeur.depotDonnees().dupliqueHomologation = () => Promise.reject(new ErreurNomServiceDejaExistant('Le nom existe déjà'));
 
-      testeur.verifieRequeteGenereErreurHTTP(424, 'La duplication a échouée', {
+      testeur.verifieRequeteGenereErreurHTTP(424, {
+        type: 'NOM_DEJA_EXISTANT',
+        message: 'La duplication a échoué car le nom cible existe déjà',
+      }, {
+        method: 'copy',
+        url: 'http://localhost:1234/api/service/123',
+      }, done);
+    });
+
+    it('retourne une erreur HTTP 424 si des données obligatoires ne sont pas renseignées', (done) => {
+      testeur.depotDonnees().dupliqueHomologation = () => Promise.reject(
+        new ErreurDonneesObligatoiresManquantes('Certaines données obligatoires ne sont pas renseignées')
+      );
+
+      testeur.verifieRequeteGenereErreurHTTP(424, {
+        type: 'DONNEES_OBLIGATOIRES_MANQUANTES',
+        message: 'La duplication a échoué car certaines données obligatoires ne sont pas renseignées',
+      }, {
         method: 'copy',
         url: 'http://localhost:1234/api/service/123',
       }, done);

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -28,7 +28,7 @@ const testeurMss = () => {
       .then(() => suite('Réponse OK inattendue'))
       .catch((erreur) => {
         expect(erreur.response.status).to.equal(status);
-        expect(erreur.response.data).to.equal(messageErreur);
+        expect(erreur.response.data).to.eql(messageErreur);
         suite();
       })
       .catch(suite);


### PR DESCRIPTION
Afin de dupliquer un service, nous avons une route COPY `/api/service/:id` qui duplique le service
quand : 
- l'utilisateur connecté est créateur du service
- le nom cible (* - Copie) n'existe pas déjà

Pour tester : curl fetch postman et tout le rest

Si le code vous est familier, c'est normal c'est quasi le même que la suppression. Si vous avez un refacto il sera le bienvenu