### PR TITLE
Utilisation d'un objet de persistance homologation

### DIFF
--- a/src/modeles/base.js
+++ b/src/modeles/base.js
@@ -31,6 +31,10 @@ class Base {
     return this.proprietesAtomiquesRequises.length === 0;
   }
 
+  donneesSerialisees() {
+    return this.toJSON();
+  }
+
   renseigneProprietes(donnees, referentiel) {
     [...this.proprietesAtomiquesRequises, ...this.proprietesAtomiquesFacultatives]
       .forEach((p) => (this[p] = donnees[p]));

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -6,6 +6,7 @@ const DescriptionService = require('./descriptionService');
 const Dossiers = require('./dossiers');
 const Mesure = require('./mesure');
 const Mesures = require('./mesures');
+const DonneesPersistanceHomologation = require('./objetsDonnees/donneesPersistanceHomologation');
 const Risques = require('./risques');
 const RolesResponsabilites = require('./rolesResponsabilites');
 const Utilisateur = require('./utilisateur');
@@ -112,6 +113,20 @@ class Homologation {
     }, {});
   }
 
+  donneesAPersister() {
+    return new DonneesPersistanceHomologation({
+      id: this.id,
+      avisExpertCyber: this.avisExpertCyber.donneesSerialisees(),
+      descriptionService: this.descriptionService.donneesSerialisees(),
+      dossiers: this.dossiers.donneesSerialisees(),
+      mesuresGenerales: this.mesuresGenerales().donneesSerialisees(),
+      mesuresSpecifiques: this.mesuresSpecifiques().donneesSerialisees(),
+      risquesGeneraux: this.risquesGeneraux().donneesSerialisees(),
+      risquesSpecifiques: this.risquesSpecifiques().donneesSerialisees(),
+      rolesResponsabilites: this.rolesResponsabilites.donneesSerialisees(),
+    });
+  }
+
   dossierCourant() {
     return this.dossiers.dossierCourant();
   }
@@ -133,6 +148,8 @@ class Homologation {
   mesuresParStatutEtCategorie() {
     return this.mesures.parStatutEtCategorie();
   }
+
+  mesuresGenerales() { return this.mesures.mesuresGenerales; }
 
   mesuresSpecifiques() { return this.mesures.mesuresSpecifiques; }
 
@@ -157,6 +174,10 @@ class Homologation {
   piloteProjet() { return this.rolesResponsabilites.piloteProjet; }
 
   presentation() { return this.descriptionService.presentation; }
+
+  risquesGeneraux() {
+    return this.risques.risquesGeneraux;
+  }
 
   risquesPrincipaux() {
     return this.risques.principaux();

--- a/src/modeles/listeItems.js
+++ b/src/modeles/listeItems.js
@@ -28,6 +28,10 @@ class ListeItems extends InformationsHomologation {
     return this.items.map((i) => i.toJSON());
   }
 
+  donneesSerialisees() {
+    return this.items.map((i) => i.donneesSerialisees());
+  }
+
   tous() {
     return this.items;
   }

--- a/src/modeles/objetsDonnees/donneesPersistanceHomologation.js
+++ b/src/modeles/objetsDonnees/donneesPersistanceHomologation.js
@@ -1,0 +1,11 @@
+class DonneesPersistanceHomologation {
+  constructor(donneesHomologation) {
+    this.donnees = donneesHomologation;
+  }
+
+  toutes() {
+    return this.donnees;
+  }
+}
+
+module.exports = DonneesPersistanceHomologation;

--- a/src/modeles/risqueGeneral.js
+++ b/src/modeles/risqueGeneral.js
@@ -23,6 +23,10 @@ class RisqueGeneral extends Risque {
     };
   }
 
+  donneesSerialisees() {
+    return super.toJSON();
+  }
+
   static valide(donnees, referentiel) {
     const { id } = donnees;
     const identifiantsRisquesRepertories = referentiel.identifiantsRisques();

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -1,5 +1,7 @@
 const expect = require('expect.js');
 
+const uneDescriptionValide = require('../constructeurs/constructeurDescriptionService');
+
 const Referentiel = require('../../src/referentiel');
 const InformationsHomologation = require('../../src/modeles/informationsHomologation');
 const Homologation = require('../../src/modeles/homologation');
@@ -424,5 +426,67 @@ describe('Une homologation', () => {
     });
 
     expect(homologation.vueAnnexePDFMesures()).to.be.a(VueAnnexePDFMesures);
+  });
+
+  describe('sur requête des données à persister', () => {
+    it("retourne une représentation correcte de l'ensemble de l'Homologation", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        categoriesMesures: {},
+        localisationsDonnees: { uneLocalisation: {} },
+        mesures: { uneMesure: {} },
+        reglesPersonnalisation: { mesuresBase: ['uneMesure'] },
+        risques: { unRisque: {} },
+        statutsDeploiement: { unStatutDeploiement: {} },
+      });
+
+      const homologation = new Homologation({
+        id: 'id-homologation',
+        avisExpertCyber: { avis: 'defavorable' },
+        descriptionService: uneDescriptionValide(Referentiel.creeReferentielVide())
+          .avecNomService('nom-service')
+          .construis()
+          .toJSON(),
+        dossiers: [{ id: '999' }],
+        mesuresGenerales: [{ id: 'uneMesure', statut: 'fait' }],
+        mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
+        risquesGeneraux: [{ id: 'unRisque' }],
+        risquesSpecifiques: [{ description: 'Un risque' }],
+        rolesResponsabilites: {
+          autoriteHomologation: 'Jean Dupont',
+          partiesPrenantes: [{ nom: 'Un hébergeur', type: 'Hebergement' }],
+        },
+      },
+      referentiel);
+
+      expect(homologation.donneesAPersister().toutes()).to.eql({
+        id: 'id-homologation',
+        avisExpertCyber: { avis: 'defavorable' },
+        descriptionService: {
+          delaiAvantImpactCritique: 'unDelai',
+          localisationDonnees: 'uneLocalisation',
+          nomService: 'nom-service',
+          presentation: 'Une présentation',
+          provenanceService: 'uneProvenance',
+          risqueJuridiqueFinancierReputationnel: false,
+          statutDeploiement: 'unStatutDeploiement',
+          donneesCaracterePersonnel: [],
+          fonctionnalites: [],
+          typeService: 'unType',
+          donneesSensiblesSpecifiques: [],
+          fonctionnalitesSpecifiques: [],
+          pointsAcces: [],
+        },
+        dossiers: [{ id: '999', finalise: false }],
+        mesuresGenerales: [{ id: 'uneMesure', statut: 'fait' }],
+        mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
+        risquesGeneraux: [{ id: 'unRisque' }],
+        risquesSpecifiques: [{ description: 'Un risque' }],
+        rolesResponsabilites: {
+          acteursHomologation: [],
+          autoriteHomologation: 'Jean Dupont',
+          partiesPrenantes: [{ nom: 'Un hébergeur', type: 'Hebergement' }],
+        },
+      });
+    });
   });
 });

--- a/test/modeles/risqueGeneral.spec.js
+++ b/test/modeles/risqueGeneral.spec.js
@@ -60,4 +60,18 @@ describe('Un risque général', () => {
       done();
     }
   });
+
+  it('sait se sérialiser', () => {
+    const risque = new RisqueGeneral({
+      id: 'unRisque',
+      commentaire: 'Un commentaire',
+      niveauGravite: 'unNiveau',
+    }, referentiel);
+
+    expect(risque.donneesSerialisees()).to.eql({
+      id: 'unRisque',
+      commentaire: 'Un commentaire',
+      niveauGravite: 'unNiveau',
+    });
+  });
 });


### PR DESCRIPTION
Nettoyage, aligne comportement postgres avec comportement adaptateur mémoire (créateur et collaborateurs toujours dans homologation depuis la base).
Pour éviter de sauvegarder créateur et collaborateurs dans les mises à jour des services,
on introduit un objet intermédiaire (donneesPersistanceHomologation) qui exclut explicitement ces données (créateur et collaborateurs) des données à sauvegarder.

Au passage, on corrige aussi une anomalie : on embarquait dans la base de données la description du risque général persisté, maintenant ce n'est plus le cas.

NOTE : Modifie l'adaptateur postgres