### PR TITLE
[CORRECTION] Ignore les mesures dont le statut n'est pas renseigné

### DIFF
--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -62,9 +62,11 @@ class Mesures extends InformationsHomologation {
     const personnalisees = ({ id: idMesure }) => (
       Object.keys(this.mesuresPersonnalisees).includes(idMesure)
     );
-    return this.mesuresGenerales.items
+
+    return this.mesuresGenerales.toutes()
       .filter(personnalisees)
-      .map((i) => ({ idMesure: i.id, statut: i.statut }));
+      .filter((m) => m.statut !== '')
+      .map((m) => ({ idMesure: m.id, statut: m.statut }));
   }
 }
 

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -159,24 +159,40 @@ describe('Les mesures liées à une homologation', () => {
     });
 
     elles('donnent les statuts des mesures personnalisées', () => {
-      const mesure = new Mesures(
+      const mesures = new Mesures(
         { mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] },
         referentiel,
         { mesure1: {} }
       );
 
-      expect(mesure.statutsMesuresPersonnalisees()).to.eql([{ idMesure: 'mesure1', statut: 'fait' }]);
+      expect(mesures.statutsMesuresPersonnalisees()).to.eql([{ idMesure: 'mesure1', statut: 'fait' }]);
     });
 
     elles('ignorent les mesures générales qui ne sont pas des mesures personnalisées', () => {
       const seulementMesure1 = { mesure1: {} };
-      const mesure = new Mesures(
+      const mesures = new Mesures(
         { mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }, { id: 'mesure2', statut: 'fait' }] },
         referentiel,
         seulementMesure1
       );
 
-      expect(mesure.statutsMesuresPersonnalisees()).to.eql([{ idMesure: 'mesure1', statut: 'fait' }]);
+      expect(mesures.statutsMesuresPersonnalisees()).to.eql([{ idMesure: 'mesure1', statut: 'fait' }]);
+    });
+
+    elles("ignorent les mesures dont le statut n'est pas renseigné", () => {
+      const mesures = new Mesures(
+        {
+          mesuresGenerales: [{
+            id: 'mesure1',
+            statut: '',
+            modalites: 'Un commentaire laissé sans valoriser le statut',
+          }],
+        },
+        referentiel,
+        { mesure1: {} }
+      );
+
+      expect(mesures.statutsMesuresPersonnalisees()).to.be.empty();
     });
   });
 });


### PR DESCRIPTION
… car on ne veut pas qu'elles polluent les statistiques calculées dans Metabase.

Sans cette correction, on se retrouve avec une visualisation Metabase qui montre des mesures sans statut 👇 

![image](https://user-images.githubusercontent.com/24898521/217211384-712fe763-11a4-4a17-9999-5ced392f278d.png)
