### PR TITLE
Creation nouveau service complet

### DIFF
--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -24,7 +24,10 @@ const creeDonnees = (depotDonnees) => depotDonnees
   .then((u) => (
     depotDonnees.metsAJourMotDePasse(u.id, process.env.MOT_DE_PASSE_UTILISATEUR_DEMO)
   ))
-  .then((u) => depotDonnees.nouvelleHomologation(u.id, descriptionService.toJSON()));
+  .then((u) => depotDonnees.nouvelleHomologation(
+    u.id,
+    { descriptionService: descriptionService.toJSON() }
+  ));
 
 if (process.env.CREATION_UTILISATEUR_DEMO) {
   const adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV);

--- a/migrations/20221129194103_duplicationAutorisationsHomologationsEnAutorisationsServices.js
+++ b/migrations/20221129194103_duplicationAutorisationsHomologationsEnAutorisationsServices.js
@@ -1,9 +1,4 @@
-const pourChaqueLigne = (requete, miseAJour) => import('p-map')
-  .then((module) => {
-    const pMap = module.default;
-
-    return requete.then((lignes) => pMap(lignes, miseAJour, { concurrency: 2 }));
-  });
+const pourChaqueLigne = require('./utilitaires/pourChaqueLigne');
 
 exports.up = (knex) => pourChaqueLigne(
   knex('autorisations'),

--- a/migrations/20230207141258_suppressionDonneesIdUtilisateurDansServices.js
+++ b/migrations/20230207141258_suppressionDonneesIdUtilisateurDansServices.js
@@ -1,0 +1,14 @@
+const pourChaqueLigne = require('./utilitaires/pourChaqueLigne');
+
+const supprimeIdUtilisateur = (knex, table) => pourChaqueLigne(
+  knex(table).whereRaw("donnees->>'idUtilisateur' IS NOT NULL"),
+  ({ id, donnees: { idUtilisateur, ...autresDonnees } }) => knex(table)
+    .where({ id })
+    .update({ donnees: autresDonnees }),
+);
+
+exports.up = (knex) => Promise.all(
+  ['homologations', 'services'].map((table) => supprimeIdUtilisateur(knex, table))
+);
+
+exports.down = () => Promise.resolve();

--- a/migrations/utilitaires/pourChaqueLigne.js
+++ b/migrations/utilitaires/pourChaqueLigne.js
@@ -1,0 +1,8 @@
+const pourChaqueLigne = (requete, miseAJour) => import('p-map')
+  .then((module) => {
+    const pMap = module.default;
+
+    return requete.then((lignes) => pMap(lignes, miseAJour, { concurrency: 2 }));
+  });
+
+module.exports = pourChaqueLigne;

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -192,18 +192,14 @@ const creeDepot = (config = {}) => {
       })
   );
 
-  const nouvelleHomologation = (idUtilisateur, donneesDescriptionService) => {
+  const nouvelleHomologation = (idUtilisateur, donneesHomologation) => {
     const idHomologation = adaptateurUUID.genereUUID();
     const idAutorisation = adaptateurUUID.genereUUID();
-    const donnees = {
-      idUtilisateur,
-      descriptionService: donneesDescriptionService,
-    };
 
-    return valideDescriptionService(idUtilisateur, donneesDescriptionService)
+    return valideDescriptionService(idUtilisateur, donneesHomologation.descriptionService)
       .then(() => Promise.all([
-        adaptateurPersistance.ajouteHomologation(idHomologation, donnees),
-        adaptateurPersistance.ajouteService(idHomologation, donnees),
+        adaptateurPersistance.ajouteHomologation(idHomologation, donneesHomologation),
+        adaptateurPersistance.ajouteService(idHomologation, donneesHomologation),
       ]))
       .then(() => adaptateurPersistance.ajouteAutorisation(idAutorisation, {
         idUtilisateur, idHomologation, idService: idHomologation, type: 'createur',

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -29,7 +29,7 @@ const routesApiService = (middleware, depotDonnees, referentiel) => {
       .then(() => new DescriptionService(requete.body, referentiel))
       .then((description) => depotDonnees.nouvelleHomologation(
         requete.idUtilisateurCourant,
-        description.toJSON(),
+        { descriptionService: description.toJSON() },
       ))
       .then((idService) => reponse.json({ idService }))
       .catch((e) => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -520,14 +520,14 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     it('ajoute la nouvelle homologation au dépôt', (done) => {
-      const donneesDescriptionService = uneDescriptionValide(referentiel)
+      const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Super Service')
         .construis()
         .toJSON();
 
       depot.homologations('123')
         .then((homologations) => expect(homologations.length).to.equal(0))
-        .then(() => depot.nouvelleHomologation('123', donneesDescriptionService))
+        .then(() => depot.nouvelleHomologation('123', { descriptionService }))
         .then(() => depot.homologations('123'))
         .then((homologations) => {
           expect(homologations.length).to.equal(1);
@@ -540,12 +540,12 @@ describe('Le dépôt de données des homologations', () => {
     it("génère un UUID pour l'homologation créée", (done) => {
       adaptateurUUID.genereUUID = () => '11111111-1111-1111-1111-111111111111';
 
-      const donneesDescriptionService = uneDescriptionValide(referentiel)
+      const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Super Service')
         .construis()
         .toJSON();
 
-      depot.nouvelleHomologation('123', donneesDescriptionService)
+      depot.nouvelleHomologation('123', { descriptionService })
         .then((idHomologation) => expect(idHomologation).to.equal(
           '11111111-1111-1111-1111-111111111111'
         ))
@@ -563,12 +563,12 @@ describe('Le dépôt de données des homologations', () => {
         referentiel,
       });
 
-      const donneesDescriptionService = uneDescriptionValide(referentiel)
+      const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Super Service')
         .construis()
         .toJSON();
 
-      depot.nouvelleHomologation('123', donneesDescriptionService)
+      depot.nouvelleHomologation('123', { descriptionService })
         .then((idHomologation) => depotDonneesServices.service(idHomologation))
         .then((service) => {
           expect(service.nomService()).to.equal('Super Service');
@@ -579,13 +579,13 @@ describe('Le dépôt de données des homologations', () => {
 
     it("déclare un accès entre l'utilisateur et l'homologation", (done) => {
       const depotAutorisations = DepotDonneesAutorisations.creeDepot({ adaptateurPersistance });
-      const donneesDescriptionService = uneDescriptionValide(referentiel)
+      const descriptionService = uneDescriptionValide(referentiel)
         .construis()
         .toJSON();
 
       depotAutorisations.autorisations('123')
         .then((as) => expect(as.length).to.equal(0))
-        .then(() => depot.nouvelleHomologation('123', donneesDescriptionService))
+        .then(() => depot.nouvelleHomologation('123', { descriptionService }))
         .then(() => depotAutorisations.autorisations('123'))
         .then((as) => {
           expect(as.length).to.equal(1);
@@ -600,14 +600,14 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     describe("le journal MSS est utilisé pour consigner l'enregistrement", () => {
-      let donneesDescriptionService;
+      let descriptionService;
 
       const verifieRecuEvenementDeType = (typeAttendu, evenements) => (
         expect(evenements.map((e) => e.type)).to.contain(typeAttendu)
       );
 
       beforeEach(() => (
-        donneesDescriptionService = uneDescriptionValide(referentiel)
+        descriptionService = uneDescriptionValide(referentiel)
           .construis()
           .toJSON()
       ));
@@ -618,7 +618,7 @@ describe('Le dépôt de données des homologations', () => {
           evenements.push(evenement);
         };
 
-        depot.nouvelleHomologation('123', donneesDescriptionService)
+        depot.nouvelleHomologation('123', { descriptionService })
           .then(() => verifieRecuEvenementDeType('NOUVEAU_SERVICE_CREE', evenements))
           .then(() => done())
           .catch(done);
@@ -630,7 +630,7 @@ describe('Le dépôt de données des homologations', () => {
           evenements.push(evenement);
         };
 
-        depot.nouvelleHomologation('123', donneesDescriptionService)
+        depot.nouvelleHomologation('123', { descriptionService })
           .then(() => verifieRecuEvenementDeType('COMPLETUDE_SERVICE_MODIFIEE', evenements))
           .then(() => done())
           .catch(done);
@@ -643,7 +643,7 @@ describe('Le dépôt de données des homologations', () => {
         .construis()
         .toJSON();
 
-      depot.nouvelleHomologation('123', donneesDescriptionServiceIncompletes)
+      depot.nouvelleHomologation('123', { descriptionService: donneesDescriptionServiceIncompletes })
         .then(() => done("La création de l'homologation aurait dû lever une exception"))
         .catch((e) => expect(e).to.be.an(ErreurDonneesObligatoiresManquantes))
         .then(() => done())
@@ -651,13 +651,13 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     it('lève une exception si le nom du service existe déjà pour une autre homologation', (done) => {
-      const donneesDescriptionService = uneDescriptionValide(referentiel)
+      const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Nom service')
         .construis()
         .toJSON();
 
-      depot.nouvelleHomologation('123', donneesDescriptionService)
-        .then(() => depot.nouvelleHomologation('123', donneesDescriptionService))
+      depot.nouvelleHomologation('123', { descriptionService })
+        .then(() => depot.nouvelleHomologation('123', { descriptionService }))
         .then(() => done("La création de l'homologation aurait dû lever une exception"))
         .catch((e) => {
           expect(e).to.be.an(ErreurNomServiceDejaExistant);

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -95,9 +95,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .construis()
         .toJSON();
 
-      testeur.depotDonnees().nouvelleHomologation = (idUtilisateur, donneesService) => {
+      testeur.depotDonnees().nouvelleHomologation = (idUtilisateur, { descriptionService }) => {
         expect(idUtilisateur).to.equal('123');
-        expect(donneesService).to.eql(donneesDescriptionService);
+        expect(descriptionService).to.eql(donneesDescriptionService);
         return Promise.resolve('456');
       };
 
@@ -110,6 +110,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .catch((e) => done(e.response?.data || e));
     });
   });
+
   describe('quand requête PUT sur `/api/service/:id`', () => {
     beforeEach(() => {
       testeur.depotDonnees().ajouteDescriptionServiceAHomologation = () => Promise.resolve();


### PR DESCRIPTION
On utilise maintenant _toutes_ les données du service (y compris mesures, risques, etc.) pour créer la nouvelle homologation. Ceci en préparation de la fonctionnalité de duplication de service.

Au passage, on corrige le fait que la base de données persistait encore (à tort) `idUtilisateur` dans la table `homologations`. Et on fait une migration pour nettoyer les données existantes.