### PR TITLE
Utilise nom d'homologation disponible pour la duplication

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -243,8 +243,23 @@ const creeDepot = (config = {}) => {
     )
   );
 
-  const dupliqueHomologation = (idHomologation) => homologation(idHomologation)
-    .then((h) => nouvelleHomologation(h.createur.id, h.donneesADupliquer()));
+  const trouveNomDisponible = (idCreateur, nomHomologation) => (
+    homologations(idCreateur).then((hs) => {
+      const noms = hs.map((h) => h.nomService());
+      const nomExiste = (nom) => noms.some((n) => n === nom);
+
+      let index = 1;
+      while (nomExiste(`${nomHomologation} - Copie ${index}`)) index += 1;
+
+      return `${nomHomologation} - Copie ${index}`;
+    })
+  );
+
+  const dupliqueHomologation = (idHomologation) => (
+    homologation(idHomologation)
+      .then((h) => trouveNomDisponible(h.createur.id, h.nomService())
+        .then((nom) => nouvelleHomologation(h.createur.id, h.donneesADupliquer(nom))))
+  );
 
   return {
     ajouteAvisExpertCyberAHomologation,
@@ -262,6 +277,7 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeHomologation,
     supprimeHomologationsCreeesPar,
+    trouveNomDisponible,
   };
 };
 

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -216,9 +216,9 @@ class Homologation {
     };
   }
 
-  donneesADupliquer() {
+  donneesADupliquer(nomService) {
     const donnees = this.donneesAPersister().sauf('dossiers', 'id');
-    donnees.descriptionService.nomService += ' - Copie';
+    donnees.descriptionService.nomService = nomService;
     return donnees;
   }
 

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -3,7 +3,6 @@ const express = require('express');
 const {
   EchecAutorisation,
   ErreurModele,
-  ErreurNomServiceDejaExistant,
   ErreurDonneesObligatoiresManquantes,
 } = require('../erreurs');
 const ActeursHomologation = require('../modeles/acteursHomologation');
@@ -272,8 +271,6 @@ const routesApiService = (middleware, depotDonnees, referentiel) => {
       .catch((e) => {
         if (e instanceof EchecAutorisation) {
           reponse.status(403).send('Droits insuffisants pour dupliquer le service');
-        } else if (e instanceof ErreurNomServiceDejaExistant) {
-          reponse.status(424).send({ type: 'NOM_DEJA_EXISTANT', message: 'La duplication a échoué car le nom cible existe déjà' });
         } else if (e instanceof ErreurDonneesObligatoiresManquantes) {
           reponse.status(424).send({
             type: 'DONNEES_OBLIGATOIRES_MANQUANTES',

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -492,38 +492,28 @@ describe('Une homologation', () => {
 
   describe('sur une demande des données à dupliquer', () => {
     const referentiel = Referentiel.creeReferentielVide();
-    const descriptionService = (nomService, presentation = '') => uneDescriptionValide(referentiel)
-      .avecNomService(nomService)
-      .avecPresentation(presentation)
-      .construis()
-      .toJSON();
+    const descriptionService = uneDescriptionValide(referentiel).construis().toJSON();
 
     it('retourne les données sans identifiant', () => {
-      const homologation = new Homologation({
-        id: 'id-homologation',
-        descriptionService: descriptionService('nom-service'),
-      }, referentiel);
+      const homologation = new Homologation({ id: 'id-homologation', descriptionService }, referentiel);
 
       const duplicata = homologation.donneesADupliquer();
 
       expect(duplicata.id).to.be(undefined);
     });
 
-    it("suffixe le nom de l'homologation dupliquée par « - Copie »", () => {
-      const homologation = new Homologation({
-        id: 'id-homologation',
-        descriptionService: descriptionService('nom-service'),
-      }, referentiel);
+    it("utilise le nom d'homologation passé en paramètre", () => {
+      const homologation = new Homologation({ id: 'id-homologation', descriptionService }, referentiel);
 
-      const duplicata = homologation.donneesADupliquer();
+      const duplicata = homologation.donneesADupliquer('Nouveau service');
 
-      expect(duplicata.descriptionService.nomService).to.equal('nom-service - Copie');
+      expect(duplicata.descriptionService.nomService).to.equal('Nouveau service');
     });
 
     it("ne duplique pas les dossiers de l'homologation", () => {
       const homologation = new Homologation({
         id: 'id-homologation',
-        descriptionService: descriptionService('nom-service'),
+        descriptionService,
         dossiers: [{ id: '999' }],
       }, referentiel);
 

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -844,18 +844,6 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       }, done);
     });
 
-    it('retourne une erreur HTTP 424 si le nom cible du service existe déjà', (done) => {
-      testeur.depotDonnees().dupliqueHomologation = () => Promise.reject(new ErreurNomServiceDejaExistant('Le nom existe déjà'));
-
-      testeur.verifieRequeteGenereErreurHTTP(424, {
-        type: 'NOM_DEJA_EXISTANT',
-        message: 'La duplication a échoué car le nom cible existe déjà',
-      }, {
-        method: 'copy',
-        url: 'http://localhost:1234/api/service/123',
-      }, done);
-    });
-
     it('retourne une erreur HTTP 424 si des données obligatoires ne sont pas renseignées', (done) => {
       testeur.depotDonnees().dupliqueHomologation = () => Promise.reject(
         new ErreurDonneesObligatoiresManquantes('Certaines données obligatoires ne sont pas renseignées')


### PR DESCRIPTION
Cette PR permet de dupliquer plusieurs fois un même service, sans avoir d'erreur de « nom déjà pris ».