### PR TITLE
[CORRECTION] Évite les multiples duplications non désirées

### DIFF
--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -3,9 +3,6 @@ import { brancheModale, initialiseComportementModale } from './modules/interacti
 import brancheComportementPastilles from './modules/interactions/pastilles.js';
 import brancheComportementSaisieContributeur from './modules/interactions/saisieContributeur.js';
 import brancheMenuContextuelService from './modules/interactions/brancheMenuContextuelService.js';
-import { brancheValidation, declencheValidation } from './modules/interactions/validation.mjs';
-
-const tableauDeLongueur = (longueur) => [...Array(longueur).keys()];
 
 $(() => {
   const $modaleSuppression = $('.modale-suppression-service');
@@ -17,41 +14,6 @@ $(() => {
     $bouton.on('click', () => axios.delete(`/api/service/${idService}`).then(() => window.location.reload()));
     $modaleSuppression.on('fermeModale', () => $bouton.off());
     $modaleSuppression.trigger('afficheModale');
-  });
-
-  const $modaleDuplication = $('.modale-duplication-service');
-  initialiseComportementModale($modaleDuplication);
-  $('.services').on('modaleDuplication', (_e, { idService, nomService }) => {
-    $('.nom-service', $modaleDuplication).text(nomService);
-
-    const selecteurFormulaire = '.modale-duplication-service form';
-    const $valider = $('.bouton-duplication-service', $modaleDuplication);
-    const $erreurServeur = $('.message-erreur-serveur', $modaleDuplication);
-
-    $(selecteurFormulaire).on('submit', (e) => {
-      e.preventDefault();
-      $erreurServeur.hide();
-      const nombreCopies = parseInt($('#nombre-copie').val(), 10) || 1;
-
-      tableauDeLongueur(nombreCopies).reduce((acc) => acc.then(
-        () => axios({ method: 'copy', url: `/api/service/${idService}` })
-      ), Promise.resolve())
-        .then(() => window.location.reload())
-        .catch((exc) => {
-          if (exc.response.status !== 424) return;
-
-          $erreurServeur.text(exc.response.data.message).show();
-        });
-    });
-
-    brancheValidation(selecteurFormulaire);
-    $(`${selecteurFormulaire} button[type = 'submit']`).on('click', () => declencheValidation(selecteurFormulaire));
-
-    $modaleDuplication.on('fermeModale', () => {
-      $erreurServeur.hide();
-      $valider.off();
-    });
-    $modaleDuplication.trigger('afficheModale');
   });
 
   const peupleServicesDans = (placeholder, donneesServices, idUtilisateur) => {

--- a/public/scripts/modaleDuplicationService.js
+++ b/public/scripts/modaleDuplicationService.js
@@ -1,0 +1,41 @@
+import { brancheValidation, declencheValidation } from '../modules/interactions/validation.mjs';
+import { initialiseComportementModale } from '../modules/interactions/modale.mjs';
+
+const tableauDeLongueur = (longueur) => [...Array(longueur).keys()];
+
+$(() => {
+  const $modaleDuplication = $('.modale-duplication-service');
+  initialiseComportementModale($modaleDuplication);
+
+  const selecteurFormulaire = '.modale-duplication-service form';
+  const $erreurServeur = $('.message-erreur-serveur', $modaleDuplication);
+
+  brancheValidation(selecteurFormulaire);
+  $(`${selecteurFormulaire} button[type = 'submit']`).on('click', () => declencheValidation(selecteurFormulaire));
+
+  $modaleDuplication.on('fermeModale', () => $erreurServeur.hide());
+
+  let idServiceCourant;
+
+  $(selecteurFormulaire).on('submit', (e) => {
+    e.preventDefault();
+    $erreurServeur.hide();
+    const nombreCopies = parseInt($('#nombre-copie').val(), 10) || 1;
+
+    tableauDeLongueur(nombreCopies).reduce((acc) => acc.then(
+      () => axios({ method: 'copy', url: `/api/service/${idServiceCourant}` })
+    ), Promise.resolve())
+      .then(() => window.location.reload())
+      .catch((exc) => {
+        if (exc.response.status !== 424) return;
+
+        $erreurServeur.text(exc.response.data.message).show();
+      });
+  });
+
+  $('.services').on('modaleDuplication', (_e, { idService, nomService }) => {
+    idServiceCourant = idService;
+    $('.nom-service', $modaleDuplication).text(nomService);
+    $modaleDuplication.trigger('afficheModale');
+  });
+});

--- a/src/vues/fragments/modales/modaleDuplicationService.pug
+++ b/src/vues/fragments/modales/modaleDuplicationService.pug
@@ -1,6 +1,9 @@
 block append styles
   link(href = '/statique/assets/styles/modaleDuplicationService.css', rel = 'stylesheet')
 
+block append scripts
+  script(type = "module", src = "/statique/scripts/modaleDuplicationService.js")
+
 mixin modaleDuplicationService()
   .rideau.modale-duplication-service
     .modale


### PR DESCRIPTION
… qui arrivaient en « ouvrant » puis « fermant » plusieurs fois de suite une modale de duplication.

Le souci était que le handler `.on('submit')` était déclaré **dans** le handler `.on('modaleDuplication')`. Autrement dit : chaque ouverture de modale enregistrait un nouveau handler de soumission du formulaire.

Ce commit corrige le bug, et au passage introduit un fichier JS dédié à la modale pour mieux s'y retrouver.

Co-authored-by: Jacques Raguin <jacques.raguin@beta.gouv.fr>