### PR TITLE
[REMANIEMENT] Organise la suppression de la même manière que la duplication

### DIFF
--- a/public/assets/styles/modaleSuppressionService.css
+++ b/public/assets/styles/modaleSuppressionService.css
@@ -6,3 +6,7 @@
 .modale-suppression-service .modale h1 {
   padding: 0;
 }
+
+.modale-suppression-service .nom-service {
+  font-weight: bold;
+}

--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -1,21 +1,10 @@
 import { $services, $modaleNouveauContributeur } from './modules/elementsDom/services.mjs';
-import { brancheModale, initialiseComportementModale } from './modules/interactions/modale.mjs';
+import { brancheModale } from './modules/interactions/modale.mjs';
 import brancheComportementPastilles from './modules/interactions/pastilles.js';
 import brancheComportementSaisieContributeur from './modules/interactions/saisieContributeur.js';
 import brancheMenuContextuelService from './modules/interactions/brancheMenuContextuelService.js';
 
 $(() => {
-  const $modaleSuppression = $('.modale-suppression-service');
-  initialiseComportementModale($modaleSuppression);
-  $('.services').on('modaleSuppression', (_evenement, { idService, nomService }) => {
-    $('.nom-service', $modaleSuppression).text(nomService);
-
-    const $bouton = $('.bouton-suppression-service', $modaleSuppression);
-    $bouton.on('click', () => axios.delete(`/api/service/${idService}`).then(() => window.location.reload()));
-    $modaleSuppression.on('fermeModale', () => $bouton.off());
-    $modaleSuppression.trigger('afficheModale');
-  });
-
   const peupleServicesDans = (placeholder, donneesServices, idUtilisateur) => {
     const $conteneurServices = $(placeholder);
     const nombreMaxContributeursDistincts = 2;

--- a/public/scripts/modaleDescriptionService.js
+++ b/public/scripts/modaleDescriptionService.js
@@ -1,3 +1,0 @@
-import { initialiseComportementModale } from '../modules/interactions/modale.mjs';
-
-$(() => initialiseComportementModale($('.rideau#descriptionService')));

--- a/public/scripts/modaleSuppressionService.js
+++ b/public/scripts/modaleSuppressionService.js
@@ -1,0 +1,18 @@
+import { initialiseComportementModale } from '../modules/interactions/modale.mjs';
+
+$(() => {
+  const $modaleSuppression = $('.modale-suppression-service');
+  initialiseComportementModale($modaleSuppression);
+
+  let idServiceCourant;
+
+  const $bouton = $('.bouton-suppression-service', $modaleSuppression);
+  $bouton.on('click', () => axios.delete(`/api/service/${idServiceCourant}`)
+    .then(() => window.location.reload()));
+
+  $('.services').on('modaleSuppression', (_evenement, { idService, nomService }) => {
+    idServiceCourant = idService;
+    $('.nom-service', $modaleSuppression).text(nomService);
+    $modaleSuppression.trigger('afficheModale');
+  });
+});

--- a/src/vues/fragments/modales/modaleSuppressionService.pug
+++ b/src/vues/fragments/modales/modaleSuppressionService.pug
@@ -1,6 +1,9 @@
 block append styles
   link(href = '/statique/assets/styles/modaleSuppressionService.css', rel = 'stylesheet')
 
+block append scripts
+  script(type = "module", src = "/statique/scripts/modaleSuppressionService.js")
+
 mixin modaleSuppressionService()
   .rideau.modale-suppression-service
     .modale


### PR DESCRIPTION
Ce commit applique l'architecture utilisée par #671 à la suppression du service.

Au passage on supprime un fichier JS non utilisé, et on corrige une régression sur un nom de service qui doit être en gras 👇 

![image](https://user-images.githubusercontent.com/24898521/218078899-02839fd3-e5da-4d5c-a645-8e3f451b804d.png)
