### PR TITLE
Ne pas mentionner les PDFs dans la duplication

### DIFF
--- a/public/assets/styles/modale.css
+++ b/public/assets/styles/modale.css
@@ -107,8 +107,9 @@ body.recouvert {
 .rideau .modale .avertissement .resume::before {
   content: '👉';
   display: block;
-  margin-right: 1em;
+  margin-right: 0.6em;
   font-size: 1.1em;
+  transform: translateY(-0.1em);
 }
 
 .modale.deconnexion {

--- a/src/vues/fragments/modales/modaleDuplicationService.pug
+++ b/src/vues/fragments/modales/modaleDuplicationService.pug
@@ -33,12 +33,9 @@ mixin modaleDuplicationService()
               li Sécuriser
               li Risques
               li Contacts utiles
-              li PDF Synthèse de la sécurité du service
-              li PDF Annexes
 
             ul.sans
               li Homologuer
-              li PDF Décision d'homologation de sécurité
 
         .message-erreur.message-erreur-serveur
 


### PR DESCRIPTION
Cette PR modifie la modale de duplication, pour qu'elle ressemble à 👇 

![image](https://user-images.githubusercontent.com/24898521/218104531-3e824fea-7c67-4bce-b435-78625058d762.png)

Au passage l'icône 👉 est un peu déplacé pour être bien aligné.