### PR TITLE
Montée de version de node en 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 RUN apt-get update && \
     apt-get install --yes texlive-latex-extra texlive-lang-european texlive-lang-french

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "engines": {
-    "node": "16",
-    "npm": "8"
+    "node": "18",
+    "npm": "9"
   },
   "scripts": {
     "build": "knex migrate:latest && npm test && npm run cree-utilisateur-demo",


### PR DESCRIPTION
On passe de node 16 - npm 8 à node 18 - npm 9 car node 18 est la version lts en cours
<img width="476" alt="Capture d’écran 2023-02-10 à 15 21 51" src="https://user-images.githubusercontent.com/39462397/218115119-3b7f63d3-9541-4e57-b9c2-a68f36f23728.png">
