### PR TITLE
Retrait l'astérisque de la modale de duplication

### DIFF
--- a/src/vues/fragments/modales/modaleDuplicationService.pug
+++ b/src/vues/fragments/modales/modaleDuplicationService.pug
@@ -11,7 +11,6 @@ mixin modaleDuplicationService()
       form.contenu-modale
         h1 Dupliquer un service
         p.description Sélectionnez le nombre de copies que vous souhaitez pour le service #[span.nom-service].
-        .requis
         label Nombre de copies
           br
           input(


### PR DESCRIPTION
Comme il y a 1 seul champ, nous n'avons pas besoin de l'astérisque
<img width="614" alt="Capture d’écran 2023-02-10 à 16 50 11" src="https://user-images.githubusercontent.com/39462397/218135461-c74bc39d-a33a-499c-a093-f2e7a02e06ad.png">
