### PR TITLE
Bouton du menu contextuel gris quand le menu est ouvert

### DIFF
--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -56,7 +56,7 @@
   background-position: center;
 }
 
-.service .menu-contextuel-titre:hover {
+.service .menu-contextuel-ouvert .menu-contextuel-titre, .service .menu-contextuel-titre:hover {
   background-color: var(--systeme-design-etat-gris-survol);
 }
 
@@ -65,6 +65,7 @@
 }
 
 .service .menu-contextuel-options {
+  display: none;
   position: absolute;
   right: 0;
   margin-top: 0.5em;
@@ -73,8 +74,8 @@
   color: var(--bleu-mise-en-avant);
 }
 
-.service .menu-contextuel-options.invisible {
-  display: none;
+.service .menu-contextuel-ouvert .menu-contextuel-options {
+  display: block;
 }
 
 .service .option {

--- a/public/modules/interactions/brancheMenuContextuelService.js
+++ b/public/modules/interactions/brancheMenuContextuelService.js
@@ -2,12 +2,13 @@ const brancheMenuContextuelService = ($service) => {
   $('.menu-contextuel-titre', $service).on('click', (evenement) => {
     evenement.preventDefault();
 
-    const $optionsLocales = $('.menu-contextuel-options', $service);
     const $masqueLocal = $('.masque', $service);
-    $('.menu-contextuel-options').not($optionsLocales).addClass('invisible');
+    const $menuContextuelLocal = $('.menu-contextuel', $service);
     $('.masque').not($masqueLocal).addClass('invisible');
-    $optionsLocales.toggleClass('invisible');
+    $('.menu-contextuel').not($menuContextuelLocal).removeClass('menu-contextuel-ouvert');
+
     $masqueLocal.toggleClass('invisible');
+    $menuContextuelLocal.toggleClass('menu-contextuel-ouvert');
 
     $('.masque', $service).on('click', (e) => {
       e.preventDefault();


### PR DESCRIPTION
Dans l'espace personnel,
quand le menu contextuel est ouvert,
le bouton … doit être gris clair
<img width="312" alt="Capture d’écran 2023-02-10 à 17 16 20" src="https://user-images.githubusercontent.com/39462397/218141637-5f0bd2dc-be7d-498e-b87b-92e92db91850.png">
