### PR TITLE
Génère un événement de complétude pour chaque service

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -4,6 +4,9 @@ const Referentiel = require('./src/referentiel');
 const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
 const AdaptateurPostgres = require('./src/adaptateurs/adaptateurPostgres');
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
+const fabriqueAdaptateurJournalMSS = require('./src/adaptateurs/fabriqueAdaptateurJournalMSS');
+const EvenementCompletudeServiceModifiee = require('./src/modeles/journalMSS/evenementCompletudeServiceModifiee');
+const { avecPMapPourChaqueElement } = require('./src/utilitaires/pMap');
 
 class ConsoleAdministration {
   constructor(environnementNode = (process.env.NODE_ENV || 'development')) {
@@ -12,6 +15,7 @@ class ConsoleAdministration {
     this.depotDonnees = DepotDonnees.creeDepot({
       adaptateurJWT, adaptateurPersistance, adaptateurUUID, referentiel,
     });
+    this.adaptateurJournalMSS = fabriqueAdaptateurJournalMSS();
   }
 
   dupliqueHomologation(idHomologation) {
@@ -39,6 +43,25 @@ class ConsoleAdministration {
 
   supprimeUtilisateur(id) {
     return this.depotDonnees.supprimeUtilisateur(id);
+  }
+
+  genereTousEvenementsCompletude(persisteEvenements = false) {
+    const journalConsole = {
+      consigneEvenement: (evenement) => {
+        /* eslint-disable no-console */
+        console.log(`${JSON.stringify(evenement)}\n---------------`);
+        return Promise.resolve();
+        /* eslint-enable no-console */
+      },
+    };
+
+    const journal = (persisteEvenements ? this.adaptateurJournalMSS : journalConsole);
+
+    const evenements = this.depotDonnees.toutesHomologations()
+      .then((hs) => hs.map((h) => ({ idService: h.id, ...h.completudeMesures() })))
+      .then((stats) => stats.map((s) => new EvenementCompletudeServiceModifiee(s).toJSON()));
+
+    return avecPMapPourChaqueElement(evenements, journal.consigneEvenement);
   }
 }
 

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -35,7 +35,7 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
   };
 
   const autorisations = (idUtilisateur) => Promise.resolve(
-    donnees.autorisations.filter((a) => a.idUtilisateur === idUtilisateur)
+    donnees.autorisations.filter((a) => (typeof idUtilisateur !== 'undefined' ? a.idUtilisateur === idUtilisateur : true))
   );
 
   const intervenantsHomologation = (idHomologation) => donnees.autorisations

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -97,8 +97,13 @@ const nouvelAdaptateur = (env) => {
   );
 
   const homologations = (idUtilisateur) => {
-    const idsHomologations = knex('autorisations')
-      .whereRaw("(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur)
+    let autorisations = knex('autorisations');
+
+    if (typeof idUtilisateur !== 'undefined') {
+      autorisations = autorisations.whereRaw("(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur);
+    }
+
+    const idsHomologations = autorisations
       .select({ idHomologation: knex.raw("(donnees->>'idHomologation')") })
       .then((lignes) => lignes.map(({ idHomologation }) => idHomologation));
 

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -44,6 +44,7 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeHomologation,
     supprimeHomologationsCreeesPar,
+    toutesHomologations,
   } = depotHomologations;
 
   const {
@@ -101,6 +102,7 @@ const creeDepot = (config = {}) => {
     supprimeHomologationsCreeesPar,
     supprimeIdResetMotDePassePourUtilisateur,
     supprimeUtilisateur,
+    toutesHomologations,
     transfereAutorisations,
     utilisateur,
     utilisateurAFinaliser,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -180,6 +180,8 @@ const creeDepot = (config = {}) => {
       .map((h) => new Homologation(h, referentiel))
       .sort((h1, h2) => h1.nomService().localeCompare(h2.nomService())));
 
+  const toutesHomologations = () => homologations();
+
   const metsAJourDossierCourant = (idHomologation, dossier) => (
     ajouteDossierCourantSiNecessaire(idHomologation)
       .then((d) => {
@@ -290,6 +292,7 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesPourHomologation,
     supprimeHomologation,
     supprimeHomologationsCreeesPar,
+    toutesHomologations,
     trouveIndexDisponible,
   };
 };

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -64,6 +64,18 @@ describe('Le dépôt de données des homologations', () => {
       .catch(done);
   });
 
+  it("utilise l'adaptateur de persistance sans `idUtilisateur` pour récupérer toutes les homologations du système", (done) => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur();
+    adaptateurPersistance.homologations = (idUtilisateur) => {
+      expect(idUtilisateur).to.be(undefined);
+      done();
+    };
+
+    const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance });
+
+    depot.toutesHomologations();
+  });
+
   it('trie les homologations par ordre alphabétique du nom du service', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
       homologations: [


### PR DESCRIPTION
Cette fois-ci le commit ne sera pas « git reverted » comme il l'avait été par le passé en 249eb38ff9ca79e2458ec880973a5489289e1a0c et 1850435e5d9911d3ad06f727b08fc5cfc0e73168.

Pour une bonne raison : cette fois-ci, il est possible de coder la fonctionnalité correctement sans compromis de qualité de design grâce au remaniement introduit par caa0521533a63e5dae325663bb93bf84ad8c9ab9.
