### PR TITLE
[CORRECTION] Ramène seulement une fois chaque service à la récupération de tous les services

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -34,9 +34,15 @@ const nouvelAdaptateur = (donnees = {}, adaptateurHorloge = adaptateurHorlogePar
     return Promise.resolve();
   };
 
-  const autorisations = (idUtilisateur) => Promise.resolve(
-    donnees.autorisations.filter((a) => (typeof idUtilisateur !== 'undefined' ? a.idUtilisateur === idUtilisateur : true))
-  );
+  const autorisations = (idUtilisateur) => {
+    const seulementUnUtilisateur = typeof idUtilisateur !== 'undefined';
+
+    const filtre = seulementUnUtilisateur
+      ? (a) => a.idUtilisateur === idUtilisateur
+      : (a) => a.type === 'createur';
+
+    return Promise.resolve(donnees.autorisations.filter(filtre));
+  };
 
   const intervenantsHomologation = (idHomologation) => donnees.autorisations
     .filter((a) => a.idHomologation === idHomologation)

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -97,13 +97,14 @@ const nouvelAdaptateur = (env) => {
   );
 
   const homologations = (idUtilisateur) => {
-    let autorisations = knex('autorisations');
+    const seulementUnUtilisateur = typeof idUtilisateur !== 'undefined';
 
-    if (typeof idUtilisateur !== 'undefined') {
-      autorisations = autorisations.whereRaw("(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur);
-    }
+    const filtre = seulementUnUtilisateur
+      ? ["(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur]
+      : ["(donnees->>'type') = 'createur'"];
 
-    const idsHomologations = autorisations
+    const idsHomologations = knex('autorisations')
+      .whereRaw(...filtre)
       .select({ idHomologation: knex.raw("(donnees->>'idHomologation')") })
       .then((lignes) => lignes.map(({ idHomologation }) => idHomologation));
 


### PR DESCRIPTION
Sans ce commit, les services avec contributeurs étaient ramenés « contributeurs + 1 » fois.