### PR TITLE
Utilisation l'objet étape date pour le dossier d'homologation

### DIFF
--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -11,15 +11,17 @@ class Dossier extends InformationsHomologation {
   ) {
     donneesDossier.finalise = !!donneesDossier.finalise;
 
-    super({ proprietesAtomiquesFacultatives: ['id', 'dateHomologation', 'dureeValidite', 'finalise'] });
+    super({ proprietesAtomiquesFacultatives: ['id', 'finalise'] });
     this.renseigneProprietes(donneesDossier);
 
     this.etapeDate = new EtapeDate(
-      { dateHomologation: this.dateHomologation, dureeValidite: this.dureeValidite },
-      referentiel
+      {
+        dateHomologation: donneesDossier.dateHomologation,
+        dureeValidite: donneesDossier.dureeValidite,
+      },
+      referentiel,
+      adaptateurHorloge
     );
-
-    this.adaptateurHorloge = adaptateurHorloge;
   }
 
   descriptionDateHomologation() {
@@ -44,9 +46,14 @@ class Dossier extends InformationsHomologation {
 
   estActif() {
     if (!this.estComplet()) return false;
-    const maintenant = this.adaptateurHorloge.maintenant();
-    return new Date(this.dateHomologation) < maintenant
-      && maintenant < this.dateProchaineHomologation();
+    return this.etapeDate.periodeHomologationEstEnCours();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      ...this.etapeDate.toJSON(),
+    };
   }
 }
 

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -43,6 +43,7 @@ class Dossier extends InformationsHomologation {
   }
 
   estActif() {
+    if (!this.estComplet()) return false;
     const maintenant = this.adaptateurHorloge.maintenant();
     return new Date(this.dateHomologation) < maintenant
       && maintenant < this.dateProchaineHomologation();

--- a/src/modeles/etapeDate.js
+++ b/src/modeles/etapeDate.js
@@ -1,4 +1,5 @@
 const { ErreurDateHomologationInvalide, ErreurDureeValiditeInvalide } = require('../erreurs');
+const adaptateurHorlogeParDefaut = require('../adaptateurs/adaptateurHorloge');
 const Etape = require('./etape');
 const { ajouteMoisADate, dateEnFrancais, dateInvalide } = require('../utilitaires/date');
 const Referentiel = require('../referentiel');
@@ -6,11 +7,13 @@ const Referentiel = require('../referentiel');
 class EtapeDate extends Etape {
   constructor(
     { dateHomologation, dureeValidite } = {},
-    referentiel = Referentiel.creeReferentielVide()
+    referentiel = Referentiel.creeReferentielVide(),
+    adaptateurHorloge = adaptateurHorlogeParDefaut
   ) {
     super({ proprietesAtomiquesFacultatives: ['dateHomologation', 'dureeValidite'] }, referentiel);
     EtapeDate.valide({ dateHomologation, dureeValidite }, referentiel);
     this.renseigneProprietes({ dateHomologation, dureeValidite });
+    this.adaptateurHorloge = adaptateurHorloge;
   }
 
   descriptionDateHomologation() {
@@ -46,6 +49,12 @@ class EtapeDate extends Etape {
 
   estComplete() {
     return !!this.dateHomologation && !!this.dureeValidite;
+  }
+
+  periodeHomologationEstEnCours() {
+    const maintenant = this.adaptateurHorloge.maintenant();
+    return new Date(this.dateHomologation) < maintenant
+      && maintenant < this.dateProchaineHomologation();
   }
 
   static valide({ dateHomologation, dureeValidite }, referentiel) {

--- a/src/vues/homologation/etapeDossier/2.pug
+++ b/src/vues/homologation/etapeDossier/2.pug
@@ -19,7 +19,7 @@ block formulaire
     .requis
       label Date d'homologation
         .infos-complementaires Cette date correspond à la date de signature de l'autorité d'homologation.
-        input(id = 'date-homologation' nom = 'dateHomologation', type = 'date', required, value = dossierCourant.dateHomologation)
+        input(id = 'date-homologation' nom = 'dateHomologation', type = 'date', required, value = dossierCourant.etapeDate.dateHomologation)
         .message-erreur Ce champ est obligatoire. Veuillez saisir une date.
 
     .requis
@@ -28,7 +28,7 @@ block formulaire
         nom: 'dureeValidite',
         items: referentiel.echeancesRenouvellement(),
         titre: "Durée de validité de l'homologation",
-        objetDonnees: dossierCourant,
+        objetDonnees: dossierCourant.etapeDate,
         messageErreur: 'Ce champ est obligatoire. Veuillez choisir une option.',
         requis: true,
       })

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -940,8 +940,8 @@ describe('Le dépôt de données des homologations', () => {
         .then((h) => {
           expect(h.nombreDossiers()).to.equal(2);
           const dossierCourant = h.dossierCourant();
-          expect(dossierCourant.dateHomologation).to.equal('2022-12-01');
-          expect(dossierCourant.dureeValidite).to.equal('unAn');
+          expect(dossierCourant.etapeDate.dateHomologation).to.equal('2022-12-01');
+          expect(dossierCourant.etapeDate.dureeValidite).to.equal('unAn');
           done();
         })
         .catch(done);
@@ -969,8 +969,8 @@ describe('Le dépôt de données des homologations', () => {
         .then((h) => {
           expect(h.nombreDossiers()).to.equal(1);
           const dossierCourant = h.dossierCourant();
-          expect(dossierCourant.dateHomologation).to.equal('2022-11-30');
-          expect(dossierCourant.dureeValidite).to.equal('sixMois');
+          expect(dossierCourant.etapeDate.dateHomologation).to.equal('2022-11-30');
+          expect(dossierCourant.etapeDate.dureeValidite).to.equal('sixMois');
           done();
         })
         .catch(done);

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -32,7 +32,8 @@ describe("Un dossier d'homologation", () => {
 
   describe('sur demande du caractère actif du dossier', () => {
     it("retourne `false` si le dossier n'est pas complet", () => {
-      const dossier = new Dossier({ estComplet: () => (false) }, referentiel);
+      const adaptateurHorloge = { maintenant: () => new Date(2023, 1, 1) };
+      const dossier = new Dossier({ id: '2', finalise: true, dateHomologation: '2023-01-01' }, referentiel, adaptateurHorloge);
       expect(dossier.estActif()).to.equal(false);
     });
 

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -545,8 +545,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().metsAJourDossierCourant = (idService, dossier) => {
         try {
           expect(idService).to.equal('456');
-          expect(dossier.dateHomologation).to.equal('2022-12-01');
-          expect(dossier.dureeValidite).to.equal('unAn');
+          expect(dossier.etapeDate.dateHomologation).to.equal('2022-12-01');
+          expect(dossier.etapeDate.dureeValidite).to.equal('unAn');
           dossierSauve = true;
 
           return Promise.resolve();


### PR DESCRIPTION
Fait suite à la PR #689,

- Utilisation de EtapeDate pour persister
- Utilisation de EtapeDate dans les templates