### PR TITLE
Duplication test présence homologation

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -273,7 +273,11 @@ const creeDepot = (config = {}) => {
         .then((donnees) => nouvelleHomologation(idCreateur, donnees));
     };
 
-    return homologation(idHomologation).then(duplique);
+    return homologation(idHomologation)
+      .then((h) => (typeof h === 'undefined' ? Promise.reject(new ErreurHomologationInexistante(
+        `Homologation "${idHomologation}" non trouvée`
+      )) : h))
+      .then(duplique);
   };
 
   return {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -1077,6 +1077,17 @@ describe('Le dépôt de données des homologations', () => {
       });
     });
 
+    it("reste robuste quand l'homologation n'est pas trouvée", (done) => {
+      depot.dupliqueHomologation('id-invalide')
+        .then(() => done('La tentative de duplication aurait dû lever une exception'))
+        .catch((e) => {
+          expect(e).to.be.an(ErreurHomologationInexistante);
+          expect(e.message).to.equal('Homologation "id-invalide" non trouvée');
+          done();
+        })
+        .catch(done);
+    });
+
     it('peut dupliquer une homologation à partir de son identifiant', (done) => {
       depot.dupliqueHomologation('123-1')
         .then(() => depot.homologations('123'))


### PR DESCRIPTION
Pendant la duplication, si l'id de l'homologation ne correspond à rien en base l'application reste robuste