### PR TITLE
Couleurs d'interactions pour l'étapier

### DIFF
--- a/public/assets/styles/etapesDossier.css
+++ b/public/assets/styles/etapesDossier.css
@@ -59,15 +59,18 @@ section {
 }
 
 form .numero-etape {
-  width: 2em;
-  height: 2em;
-
   margin-right: 0.5em;
-  border-radius: 50%;
   border: solid var(--taille-bordure-etape);
 
   text-align: center;
   line-height: 1.9;
+}
+
+.etape .numero-etape, .etape.passee .coche {
+  width: 2em;
+  height: 2em;
+
+  border-radius: 50%;
 }
 
 .etape.passee .numero-etape {
@@ -77,9 +80,23 @@ form .numero-etape {
 }
 
 .etape.passee .coche {
-  width: 2em;
-  height: 2em;
+  display: block;
   background: url(../images/icone_coche_blanche.svg) no-repeat center;
+}
+
+.etape.passee .numero-etape:hover {
+  background-color: var(--bleu-survol);
+  border-color: var(--bleu-survol);
+}
+
+.etape.passee .numero-etape:active {
+  background-color: var(--bleu-anssi);
+  border-color: var(--bleu-anssi);
+}
+
+.etape.passee .coche:focus {
+  outline: 0.17em solid var(--systeme-design-etat-bleu-bordure-focus);
+  outline-offset: 0.3em;
 }
 
 .etape.passee .numero-etape::after, .etape:is(.passee, .courante) .numero-etape::before {

--- a/public/assets/styles/palette.css
+++ b/public/assets/styles/palette.css
@@ -2,6 +2,7 @@
   --bleu-anssi: #08416a;
   --bleu-ciel: #a3c6ee;
   --bleu-mise-en-avant: #0079d0;
+  --bleu-survol: #0c5c98;
   --bleu-mise-en-avant-03-pc: #0f7ac708;
   --bleu-mise-en-avant-20-pc: #0f7ac730;
   --rose-anssi: #ff6584;
@@ -46,6 +47,7 @@
 
   /* https://www.systeme-de-design.gouv.fr */
   --systeme-design-etat-bleu: #000091;
+  --systeme-design-etat-bleu-bordure-focus: #0a76f6;
   --systeme-design-etat-gris-survol: #f6f6f6;
   --systeme-design-etat-gris-actif: #ededed;
   --systeme-design-etat-contour-champs: #dddddd;

--- a/src/vues/homologation/formulaireEtapier.pug
+++ b/src/vues/homologation/formulaireEtapier.pug
@@ -14,10 +14,9 @@ mixin barre-progression({ idEtape })
 
       .etape(class = classeEtape)
         if classeEtape === 'passee'
-          a(href = `/homologation/${homologation.id}/dossier/edition/etape/${etape.numero}`)
-            .numero-etape
-              .coche
-            .libelle-etape= etape.libelle
+          .numero-etape
+            a(href = `/homologation/${homologation.id}/dossier/edition/etape/${etape.numero}`).coche
+          .libelle-etape= etape.libelle
         else
           +descriptionEtape({ etape })
 


### PR DESCRIPTION
Dans le parcours homologuer,
les étapes complètes sont cliquables.

Ce dev ajoute des styles d'intéeactions et rend uniquement le rond cliquable

Normal
<img width="353" alt="Capture d’écran 2023-02-20 à 10 54 30" src="https://user-images.githubusercontent.com/39462397/220072546-2321e3eb-7b75-4790-80d6-8da099602080.png">
Survol
<img width="364" alt="Capture d’écran 2023-02-20 à 10 54 38" src="https://user-images.githubusercontent.com/39462397/220072552-ab15aa44-074f-4124-9724-17e2fb908004.png">
Clic
<img width="368" alt="Capture d’écran 2023-02-20 à 10 54 46" src="https://user-images.githubusercontent.com/39462397/220072553-e62ae299-4d6b-43b7-aca5-99cd3aac100a.png">
Focus
<img width="372" alt="Capture d’écran 2023-02-20 à 10 55 01" src="https://user-images.githubusercontent.com/39462397/220072557-960dba4f-a156-4c82-bd55-a887262d4f05.png">
