### PR TITLE
[NETTOYAGE] Renommage routes homologation

### DIFF
--- a/public/assets/styles/espacePersonnel.css
+++ b/public/assets/styles/espacePersonnel.css
@@ -207,6 +207,8 @@
 }
 
 .nouveau.service {
+  cursor: pointer;
+
   color: var(--bleu-mise-en-avant);
   font-weight: bold;
   text-decoration: none;

--- a/public/homologation/avisExpertCyber.js
+++ b/public/homologation/avisExpertCyber.js
@@ -26,6 +26,6 @@ $(() => {
   $bouton.click(() => {
     const params = parametres('form#avis-expert-cyber');
     axios.post(`/api/service/${identifiantService}/avisExpertCyber`, params)
-      .then((reponse) => (window.location = `/homologation/${reponse.data.idService}`));
+      .then((reponse) => (window.location = `/service/${reponse.data.idService}`));
   });
 });

--- a/public/homologation/etapesDossier.js
+++ b/public/homologation/etapesDossier.js
@@ -33,8 +33,8 @@ const brancheComportemenFormulaire = (selecteur, idService, idEtape, idEtapeSuiv
       action(idEtape, idService)
         .then(() => (
           window.location = idEtapeSuivante
-            ? `/homologation/${idService}/dossier/edition/etape/${idEtapeSuivante}`
-            : `/homologation/${idService}/dossiers`
+            ? `/service/${idService}/dossier/edition/etape/${idEtapeSuivante}`
+            : `/service/${idService}/dossiers`
         ));
     }
   });

--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -131,6 +131,6 @@ ${statuts}
     arrangeParametresMesures(params);
 
     axios.post(`/api/service/${identifiantService}/mesures`, params)
-      .then((reponse) => (window.location = `/homologation/${reponse.data.idService}`));
+      .then((reponse) => (window.location = `/service/${reponse.data.idService}`));
   });
 });

--- a/public/homologation/risques.js
+++ b/public/homologation/risques.js
@@ -76,6 +76,6 @@ $(() => {
     );
 
     axios.post(`/api/service/${identifiantService}/risques`, params)
-      .then((reponse) => (window.location = `/homologation/${reponse.data.idService}`));
+      .then((reponse) => (window.location = `/service/${reponse.data.idService}`));
   });
 });

--- a/public/homologation/rolesResponsabilites.js
+++ b/public/homologation/rolesResponsabilites.js
@@ -33,6 +33,6 @@ $(() => {
     const params = tousLesParametres('form#roles-responsabilites');
 
     axios.post(`/api/service/${identifiantService}/rolesResponsabilites`, params)
-      .then((reponse) => (window.location = `/homologation/${reponse.data.idService}`));
+      .then((reponse) => (window.location = `/service/${reponse.data.idService}`));
   });
 });

--- a/public/modules/elementsDom/services.mjs
+++ b/public/modules/elementsDom/services.mjs
@@ -58,7 +58,7 @@ const $serviceExistant = (
   const $element = $(`
 <a
   class="service"
-  href="/homologation/${donneesService.id}"
+  href="/service/${donneesService.id}"
   data-id="${donneesService.id}"
   data-nom="${donneesService.nomService}"
 >

--- a/public/modules/elementsDom/services.mjs
+++ b/public/modules/elementsDom/services.mjs
@@ -112,10 +112,10 @@ const $serviceExistant = (
 };
 
 const $nouveauService = () => $(`
-<a class="nouveau service" href="/homologation/creation" id="nouveau-service">
+<div class="nouveau service" id="nouveau-service">
   <div class="icone-ajout"></div>
   <div>Nouveau service</div>
-</a>
+</div>
 `);
 
 const $services = (donneesServices, ...params) => (

--- a/public/modules/soumetsHomologation.mjs
+++ b/public/modules/soumetsHomologation.mjs
@@ -20,7 +20,7 @@ const initialiseComportementFormulaire = (
     requete.data = fonctionExtractionParametres(selecteurFormulaire);
 
     const redirigeVersSynthese = ({ data: { idService } }) => (
-      window.location = `/homologation/${idService}`
+      window.location = `/service/${idService}`
     );
 
     adaptateurAjax.execute(requete)

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -34,7 +34,7 @@ const envoieMessageInvitationContribution = (
   {
     PRENOM: prenomNomEmetteur,
     NOM_SERVICE: nomService,
-    URL: `${process.env.URL_BASE_MSS}/homologation/${idHomologation}`,
+    URL: `${process.env.URL_BASE_MSS}/service/${idHomologation}`,
   }
 );
 

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -27,14 +27,14 @@ const envoieMessageFinalisationInscription = (
 );
 
 const envoieMessageInvitationContribution = (
-  destinataire, prenomNomEmetteur, nomService, idHomologation
+  destinataire, prenomNomEmetteur, nomService, idService
 ) => envoieEmail(
   destinataire,
   parseInt(process.env.SENDINBLUE_TEMPLATE_INVITATION_CONTRIBUTION, 10),
   {
     PRENOM: prenomNomEmetteur,
     NOM_SERVICE: nomService,
-    URL: `${process.env.URL_BASE_MSS}/service/${idHomologation}`,
+    URL: `${process.env.URL_BASE_MSS}/service/${idService}`,
   }
 );
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -4,7 +4,7 @@ const express = require('express');
 const { DUREE_SESSION } = require('./http/configurationServeur');
 const routesApi = require('./routes/routesApi');
 const routesBibliotheques = require('./routes/routesBibliotheques');
-const routesHomologation = require('./routes/routesHomologation');
+const routesService = require('./routes/routesService');
 const routesPdf = require('./routes/routesPdf');
 
 require('dotenv').config();
@@ -126,7 +126,7 @@ const creeServeur = (
 
   app.use('/bibliotheques', routesBibliotheques());
 
-  app.use('/homologation', routesHomologation(middleware, referentiel, depotDonnees, moteurRegles));
+  app.use('/service', routesService(middleware, referentiel, depotDonnees, moteurRegles));
 
   app.use('/pdf', routesPdf(middleware, adaptateurPdf));
 

--- a/src/routes/routesService.js
+++ b/src/routes/routesService.js
@@ -4,7 +4,7 @@ const ActionsSaisie = require('../modeles/actionsSaisie');
 const Homologation = require('../modeles/homologation');
 const InformationsHomologation = require('../modeles/informationsHomologation');
 
-const routesHomologation = (
+const routesService = (
   middleware,
   referentiel,
   depotDonnees,
@@ -104,4 +104,4 @@ const routesHomologation = (
   return routes;
 };
 
-module.exports = routesHomologation;
+module.exports = routesService;

--- a/src/routes/routesService.js
+++ b/src/routes/routesService.js
@@ -23,7 +23,7 @@ const routesHomologation = (
     const actionsSaisie = new ActionsSaisie(referentiel, homologation)
       .toJSON()
       .map(({ id, ...autresDonnees }) => (
-        { url: `/homologation/${homologation.id}/${id}`, id, ...autresDonnees }
+        { url: `/service/${homologation.id}/${id}`, id, ...autresDonnees }
       ));
 
     reponse.render('homologation/synthese', {

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -11,7 +11,7 @@ block retour
     nav.fil-ariane
       a.avec-chevron(href = '/espacePersonnel') Espace personnel
       if s.id
-        a.avec-chevron(href = `/homologation/${s.id}`)
+        a.avec-chevron(href = `/service/${s.id}`)
           +texteTronque({ texte: s.nomService() })
 
       block filArianeNoeudFinal

--- a/src/vues/documentImprimable.pug
+++ b/src/vues/documentImprimable.pug
@@ -14,5 +14,5 @@ block page
     link(href='/statique/assets/styles/documentImprimable.css', rel='stylesheet')
 
   nav.ne-pas-imprimer
-    a(href = `/homologation/${homologation.id}`) ‹&nbsp;&nbsp;Retour
+    a(href = `/service/${homologation.id}`) ‹&nbsp;&nbsp;Retour
     .bouton#telecharger Télécharger le document

--- a/src/vues/fragments/modaleNouveauService.pug
+++ b/src/vues/fragments/modaleNouveauService.pug
@@ -10,7 +10,7 @@ mixin modaleNouveauService
       .fermeture-modale
       .contenu-modale
         h1 Nouveau service
-        form.champ-unique(action = "/homologation/creation", method = "GET")
+        form.champ-unique(action = "/service/creation", method = "GET")
           .case-a-cocher.requis
             input(id = 'attestation', name = 'attestation', type = 'checkbox', required, title = '')
             label(for = 'attestation')

--- a/src/vues/homologation/dossiers.pug
+++ b/src/vues/homologation/dossiers.pug
@@ -12,7 +12,7 @@ mixin dossier({ statut, dossier, idHomologation })
       div= `Prochaine homologation : ${prochaineHomologation}`
     if idHomologation
       nav
-        a(href = `/homologation/${idHomologation}/dossier/edition/etape/1`) Consulter
+        a(href = `/service/${idHomologation}/dossier/edition/etape/1`) Consulter
 
 mixin dossierFinalise({ dossier })
   +dossier({ statut: 'Homologation finalisée', dossier })

--- a/src/vues/homologation/dossiers.pug
+++ b/src/vues/homologation/dossiers.pug
@@ -1,6 +1,6 @@
 extends ./formulaireEtapier
 
-mixin dossier({ statut, dossier, idHomologation })
+mixin dossier({ statut, dossier, idService })
   -
     const duree = dossier.descriptionDureeValidite()
     const prochaineHomologation = dossier.descriptionProchaineDateHomologation()
@@ -10,9 +10,9 @@ mixin dossier({ statut, dossier, idHomologation })
       .statut= statut
       div= `Durée : ${duree}`
       div= `Prochaine homologation : ${prochaineHomologation}`
-    if idHomologation
+    if idService
       nav
-        a(href = `/service/${idHomologation}/dossier/edition/etape/1`) Consulter
+        a(href = `/service/${idService}/dossier/edition/etape/1`) Consulter
 
 mixin dossierFinalise({ dossier })
   +dossier({ statut: 'Homologation finalisée', dossier })
@@ -28,7 +28,7 @@ block formulaire
 
   .dossiers
     if dossierCourant
-      +dossierCourant({ dossier: dossierCourant, idHomologation: homologation.id })
+      +dossierCourant({ dossier: dossierCourant, idService: homologation.id })
 
     each dossier in dossiersFinalises
       +dossierFinalise({ dossier })

--- a/src/vues/homologation/etapeDossier/1.pug
+++ b/src/vues/homologation/etapeDossier/1.pug
@@ -8,7 +8,7 @@ block formulaire
     li Télécharger les documents ci-dessous :
       ul.documents
         li: +document({ url: '/statique/assets/pdf/dossierDecision.pdf', description: "Décision d'homologation de sécurité (modèle)" })
-        li: +document({ url: `/homologation/${homologation.id}/syntheseSecurite`, description: "Synthèse de l'état de sécurité du service" })
+        li: +document({ url: `/service/${homologation.id}/syntheseSecurite`, description: "Synthèse de l'état de sécurité du service" })
         li: +document({ url: `/pdf/${homologation.id}/annexes.pdf`, description: 'Annexes' })
     li.
       Remplir la décision d'homologation de sécurité avec l'ensemble des

--- a/src/vues/homologation/formulaireEtapier.pug
+++ b/src/vues/homologation/formulaireEtapier.pug
@@ -15,7 +15,7 @@ mixin barre-progression({ idEtape })
       .etape(class = classeEtape)
         if classeEtape === 'passee'
           .numero-etape
-            a(href = `/homologation/${homologation.id}/dossier/edition/etape/${etape.numero}`).coche
+            a(href = `/service/${homologation.id}/dossier/edition/etape/${etape.numero}`).coche
           .libelle-etape= etape.libelle
         else
           +descriptionEtape({ etape })
@@ -40,7 +40,7 @@ block zone-principale
     block formulaire
 
     .boutons
-      a(href = `/homologation/${homologation.id}`): .bouton.blanc Revenir à la synthèse
+      a(href = `/service/${homologation.id}`): .bouton.blanc Revenir à la synthèse
       block bouton-etape
 
   script(type = 'module', src = '/statique/homologation/etapesDossier.js')

--- a/src/vues/homologation/synthese.pug
+++ b/src/vues/homologation/synthese.pug
@@ -40,18 +40,18 @@ block zone-principale
           id: 'risques',
           nom: 'Risques',
           description: 'Cartographiez les impacts potentiels des risques de sécurité les plus courants.',
-          lien: { url: `/homologation/${service.id}/risques`, texte: 'Remplir'}
+          lien: { url: `/service/${service.id}/risques`, texte: 'Remplir'}
         })
         +outilComplementaire({
           id: 'contactsUtiles',
           nom: 'Contacts utiles',
           description: 'Créez la liste des personne contribuant au fonctionnement du service à contacter en cas de besoin.',
-          lien: { url: `/homologation/${service.id}/rolesResponsabilites`, texte: 'Compléter' }
+          lien: { url: `/service/${service.id}/rolesResponsabilites`, texte: 'Compléter' }
         })
 
     .telechargement-pdfs
       a.bouton.nouvel-onglet(
-        href = `/homologation/${service.id}/syntheseSecurite`,
+        href = `/service/${service.id}/syntheseSecurite`,
         target = `blank`,
         rel = ``
       ) Télécharger la synthèse
@@ -90,5 +90,5 @@ block cartes-informations
 
   +carteInformations({ titre: 'Pour les services référencés avant le 12/10/2022' })
     .liens
-      a.avec-chevron(href = `/homologation/${service.id}/avisExpertCyber`) Accéder à « Avis sur le dossier »
-      a.avec-chevron(href = `/homologation/${service.id}/decision`) Télécharger les annexes 1ère version
+      a.avec-chevron(href = `/service/${service.id}/avisExpertCyber`) Accéder à « Avis sur le dossier »
+      a.avec-chevron(href = `/service/${service.id}/decision`) Télécharger les annexes 1ère version

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -36,7 +36,7 @@ let headersPositionnes = false;
 let idUtilisateurCourant;
 let listesAseptisees = [];
 let parametresAseptises = [];
-let rechercheHomologationEffectuee = false;
+let rechercheServiceEffectuee = false;
 let suppressionCookieEffectuee = false;
 let verificationJWTMenee = false;
 let verificationCGUMenee = false;
@@ -51,7 +51,7 @@ const middlewareFantaisie = {
     idUtilisateurCourant = idUtilisateur;
     listesAseptisees = [];
     parametresAseptises = [];
-    rechercheHomologationEffectuee = false;
+    rechercheServiceEffectuee = false;
     suppressionCookieEffectuee = false;
     verificationJWTMenee = false;
     verificationCGUMenee = false;
@@ -105,7 +105,7 @@ const middlewareFantaisie = {
       id: '456',
       descriptionService: { nomService: 'un service' },
     });
-    rechercheHomologationEffectuee = true;
+    rechercheServiceEffectuee = true;
     suite();
   },
 
@@ -138,7 +138,7 @@ const middlewareFantaisie = {
   },
 
   verifieRechercheService: (...params) => {
-    verifieRequeteChangeEtat({ lectureEtat: () => rechercheHomologationEffectuee }, ...params);
+    verifieRequeteChangeEtat({ lectureEtat: () => rechercheServiceEffectuee }, ...params);
   },
 
   verifieRequeteExigeAcceptationCGU: (...params) => {

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -137,7 +137,7 @@ const middlewareFantaisie = {
     }, ...params);
   },
 
-  verifieRechercheHomologation: (...params) => {
+  verifieRechercheService: (...params) => {
     verifieRequeteChangeEtat({ lectureEtat: () => rechercheHomologationEffectuee }, ...params);
   },
 

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -117,7 +117,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         { method: 'put', url: 'http://localhost:1234/api/service/456' }, done
       );
     });
@@ -210,7 +210,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation({
+      testeur.middleware().verifieRechercheService({
         method: 'post',
         url: 'http://localhost:1234/api/service/456/mesures',
       }, done);
@@ -321,7 +321,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation({
+      testeur.middleware().verifieRechercheService({
         method: 'post',
         url: 'http://localhost:1234/api/service/456/rolesResponsabilites',
       }, done);
@@ -374,7 +374,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation({
+      testeur.middleware().verifieRechercheService({
         method: 'post',
         url: 'http://localhost:1234/api/service/456/risques',
       }, done);
@@ -482,7 +482,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     ));
 
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation({
+      testeur.middleware().verifieRechercheService({
         method: 'post',
         url: 'http://localhost:1234/api/service/456/avisExpertCyber',
       }, done);
@@ -534,7 +534,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation({
+      testeur.middleware().verifieRechercheService({
         method: 'put',
         url: 'http://localhost:1234/api/service/456/dossier',
       }, done);

--- a/test/routes/routesPdf.spec.js
+++ b/test/routes/routesPdf.spec.js
@@ -20,8 +20,8 @@ describe('Le serveur MSS des routes /pdf/*', () => {
       testeur.adaptateurPdf().genereAnnexes = () => Promise.resolve('Pdf annexes');
     });
 
-    it("recherche l'homologation correspondante", (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+    it('recherche le service correspondant', (done) => {
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/pdf/456/annexes.pdf',
         done,
       );

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -103,7 +103,7 @@ describe('Le serveur MSS des routes /service/*', () => {
   });
 
   describe('quand requête GET sur `/service/:id/risques`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/risques',
         done,
@@ -112,7 +112,7 @@ describe('Le serveur MSS des routes /service/*', () => {
   });
 
   describe('quand requête GET sur `/service/:id/avisExpertCyber`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/avisExpertCyber',
         done,
@@ -121,7 +121,7 @@ describe('Le serveur MSS des routes /service/*', () => {
   });
 
   describe('quand requête GET sur `/service/:id/dossiers`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/dossiers',
         done,
@@ -138,7 +138,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       );
     });
 
-    it("recherche l'homologation correspondante", (done) => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/dossier/edition/etape/1',
         done,
@@ -152,11 +152,11 @@ describe('Le serveur MSS des routes /service/*', () => {
       }, done);
     });
 
-    it("ajoute un dossier courant à l'homologation si nécessaire", (done) => {
+    it('ajoute un dossier courant au service si nécessaire', (done) => {
       let dossierAjoute = false;
-      testeur.depotDonnees().ajouteDossierCourantSiNecessaire = (idHomologation) => {
+      testeur.depotDonnees().ajouteDossierCourantSiNecessaire = (idService) => {
         try {
-          expect(idHomologation).to.equal('456');
+          expect(idService).to.equal('456');
           dossierAjoute = true;
           return Promise.resolve();
         } catch (e) {
@@ -170,11 +170,11 @@ describe('Le serveur MSS des routes /service/*', () => {
         .catch((e) => done(e.response?.data || e));
     });
 
-    it("recharge l'homologation avant de servir la vue", (done) => {
-      let chargementsHomologation = 0;
+    it('recharge le service avant de servir la vue', (done) => {
+      let chargementsService = 0;
       testeur.depotDonnees().homologation = () => {
         try {
-          chargementsHomologation += 1;
+          chargementsService += 1;
           return Promise.resolve(new Homologation({ id: '456', descriptionService: { nomService: 'un service' } }));
         } catch (e) {
           return Promise.reject(e);
@@ -182,7 +182,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       };
 
       axios('http://localhost:1234/service/456/dossier/edition/etape/1')
-        .then(() => expect(chargementsHomologation).to.equal(1))
+        .then(() => expect(chargementsService).to.equal(1))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
     });

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -4,69 +4,69 @@ const expect = require('expect.js');
 const testeurMSS = require('./testeurMSS');
 const Homologation = require('../../src/modeles/homologation');
 
-describe('Le serveur MSS des routes /homologation/*', () => {
+describe('Le serveur MSS des routes /service/*', () => {
   const testeur = testeurMSS();
 
   beforeEach(testeur.initialise);
 
   afterEach(testeur.arrete);
 
-  describe('quand requête GET sur `/homologation/:id`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+  describe('quand requête GET sur `/service/:id`', () => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456',
+        'http://localhost:1234/service/456',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/descriptionService`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+  describe('quand requête GET sur `/service/:id/descriptionService`', () => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/descriptionService',
+        'http://localhost:1234/service/456/descriptionService',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/decision`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+  describe('quand requête GET sur `/service/:id/decision`', () => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/decision',
+        'http://localhost:1234/service/456/decision',
         done,
       );
     });
 
     it('sert la page avec un nonce', (done) => {
       testeur.middleware().verifieRequetePositionneHeadersAvecNonce(
-        'http://localhost:1234/homologation/456/decision',
+        'http://localhost:1234/service/456/decision',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/syntheseSecurite`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+  describe('quand requête GET sur `/service/:id/syntheseSecurite`', () => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/syntheseSecurite',
+        'http://localhost:1234/service/456/syntheseSecurite',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/syntheseSecurite/annexes/mesures`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+  describe('quand requête GET sur `/service/:id/syntheseSecurite/annexes/mesures`', () => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/syntheseSecurite/annexes/mesures',
+        'http://localhost:1234/service/456/syntheseSecurite/annexes/mesures',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/mesures`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+  describe('quand requête GET sur `/service/:id/mesures`', () => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/mesures',
+        'http://localhost:1234/service/456/mesures',
         done
       );
     });
@@ -86,50 +86,50 @@ describe('Le serveur MSS des routes /homologation/*', () => {
         return {};
       };
 
-      axios('http://localhost:1234/homologation/456/mesures')
+      axios('http://localhost:1234/service/456/mesures')
         .then(() => expect(moteurInterroge).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
     });
   });
 
-  describe('quand requete GET sur `/homologation/:id/rolesResponsabilites`', () => {
-    it("recherche l'homologation correspondante", (done) => {
+  describe('quand requete GET sur `/service/:id/rolesResponsabilites`', () => {
+    it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/rolesResponsabilites',
+        'http://localhost:1234/service/456/rolesResponsabilites',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/risques`', () => {
+  describe('quand requête GET sur `/service/:id/risques`', () => {
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/risques',
+        'http://localhost:1234/service/456/risques',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/avisExpertCyber`', () => {
+  describe('quand requête GET sur `/service/:id/avisExpertCyber`', () => {
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/avisExpertCyber',
+        'http://localhost:1234/service/456/avisExpertCyber',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/dossiers`', () => {
+  describe('quand requête GET sur `/service/:id/dossiers`', () => {
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/dossiers',
+        'http://localhost:1234/service/456/dossiers',
         done,
       );
     });
   });
 
-  describe('quand requête GET sur `/homologation/:id/dossier/edition/etape/:idEtape`', () => {
+  describe('quand requête GET sur `/service/:id/dossier/edition/etape/:idEtape`', () => {
     beforeEach(() => {
       testeur.referentiel().recharge({ etapesParcoursHomologation: [{ numero: 1 }] });
       testeur.depotDonnees().ajouteDossierCourantSiNecessaire = () => Promise.resolve();
@@ -140,7 +140,7 @@ describe('Le serveur MSS des routes /homologation/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheHomologation(
-        'http://localhost:1234/homologation/456/dossier/edition/etape/1',
+        'http://localhost:1234/service/456/dossier/edition/etape/1',
         done,
       );
     });
@@ -148,7 +148,7 @@ describe('Le serveur MSS des routes /homologation/*', () => {
     it("répond avec une erreur HTTP 404 si l'identifiant d'étape n'est pas connu du référentiel", (done) => {
       testeur.verifieRequeteGenereErreurHTTP(404, 'Étape inconnue', {
         method: 'get',
-        url: 'http://localhost:1234/homologation/456/dossier/edition/etape/2',
+        url: 'http://localhost:1234/service/456/dossier/edition/etape/2',
       }, done);
     });
 
@@ -164,7 +164,7 @@ describe('Le serveur MSS des routes /homologation/*', () => {
         }
       };
 
-      axios('http://localhost:1234/homologation/456/dossier/edition/etape/1')
+      axios('http://localhost:1234/service/456/dossier/edition/etape/1')
         .then(() => expect(dossierAjoute).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
@@ -181,7 +181,7 @@ describe('Le serveur MSS des routes /homologation/*', () => {
         }
       };
 
-      axios('http://localhost:1234/homologation/456/dossier/edition/etape/1')
+      axios('http://localhost:1234/service/456/dossier/edition/etape/1')
         .then(() => expect(chargementsHomologation).to.equal(1))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -13,7 +13,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456',
         done,
       );
@@ -22,7 +22,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/descriptionService`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/descriptionService',
         done,
       );
@@ -31,7 +31,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/decision`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/decision',
         done,
       );
@@ -47,7 +47,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/syntheseSecurite`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/syntheseSecurite',
         done,
       );
@@ -56,7 +56,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/syntheseSecurite/annexes/mesures`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/syntheseSecurite/annexes/mesures',
         done,
       );
@@ -65,7 +65,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/mesures`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/mesures',
         done
       );
@@ -95,7 +95,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requete GET sur `/service/:id/rolesResponsabilites`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/rolesResponsabilites',
         done,
       );
@@ -104,7 +104,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/risques`', () => {
     it("recherche l'homologation correspondante", (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/risques',
         done,
       );
@@ -113,7 +113,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/avisExpertCyber`', () => {
     it("recherche l'homologation correspondante", (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/avisExpertCyber',
         done,
       );
@@ -122,7 +122,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/dossiers`', () => {
     it("recherche l'homologation correspondante", (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/dossiers',
         done,
       );
@@ -139,7 +139,7 @@ describe('Le serveur MSS des routes /service/*', () => {
     });
 
     it("recherche l'homologation correspondante", (done) => {
-      testeur.middleware().verifieRechercheHomologation(
+      testeur.middleware().verifieRechercheService(
         'http://localhost:1234/service/456/dossier/edition/etape/1',
         done,
       );

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -52,7 +52,8 @@ const testeurMss = () => {
           false,
         );
         serveur.ecoute(1234, done);
-      });
+      })
+      .catch(done);
   };
 
   const arrete = () => (serveur.arreteEcoute());

--- a/test_public/modules/soumetsHomologation.spec.mjs
+++ b/test_public/modules/soumetsHomologation.spec.mjs
@@ -66,7 +66,7 @@ describe("L'initialisation du comportement du formulaire", () => {
       initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, adaptateurAjax);
 
       evenementsDifferes.resolveWith($('.bouton').trigger('click'))
-        .then(() => expect(window.location).to.equal('/homologation/123'))
+        .then(() => expect(window.location).to.equal('/service/123'))
         .then(() => done())
         .catch(done);
     });


### PR DESCRIPTION
Cette PR fait suite à #593 et démarre une série de renommage des routes `homologation` en `service`.

On s'intéresse ici au renommage des routes `/homologation/*` en `/service/*`. On en profite pour renommer les dénominations « homologation » en « service » dans les fichiers changés, en s'en tenant aux noms avec une portée locale.

Prochaines étapes :
- [x] Routes `/api/homologation/*` -> `/api/service/*`
- [x] Routes `/homologation/*` -> `/service/*` <-- LA PR COURANTE
- [ ] Routes `/homologations` -> `/services`
- [ ] Répertoires `src/vues/homologation/*` -> `src/vues/service/*`
- [ ] Répertoires `public/*/homologation/*` -> `public/*/service/*`
- [ ] Répertoires `src/vues/homologation/*` -> `src/vues/service/*`
- [ ] Routes `/service/:id/dossier/*` -> `/service/:id/homologation/*`
- [ ] Routes `/service/:id/dossiers` -> `/service/:id/homologations`
- [ ] `Middleware.trouveHomologation` -> `Middleware.trouveService`
- [ ] `depotHomologation` -> `depotService`