### PR TITLE
Renommage route `/api/homologations`

### DIFF
--- a/public/espacePersonnel.js
+++ b/public/espacePersonnel.js
@@ -33,8 +33,8 @@ $(() => {
   axios.get('/api/utilisateurCourant')
     .then(({ data }) => data.utilisateur)
     .then((utilisateur) => {
-      axios.get('/api/homologations')
-        .then(({ data }) => peupleServicesDans('.services', data.homologations, utilisateur.id));
+      axios.get('/api/services')
+        .then(({ data }) => peupleServicesDans('.services', data.services, utilisateur.id));
 
       if (!utilisateur.profilEstComplet) afficheBandeauMajProfil();
     });

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -77,10 +77,10 @@ const routesApi = (middleware, adaptateurMail, depotDonnees, referentiel) => {
 
   const routes = express.Router();
 
-  routes.get('/homologations', middleware.verificationAcceptationCGU, (requete, reponse) => {
+  routes.get('/services', middleware.verificationAcceptationCGU, (requete, reponse) => {
     depotDonnees.homologations(requete.idUtilisateurCourant)
       .then((services) => services.map((s) => s.toJSON()))
-      .then((services) => reponse.json({ homologations: services }));
+      .then((services) => reponse.json({ services }));
   });
 
   routes.use('/service', routesApiService(middleware, depotDonnees, referentiel));

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -23,10 +23,10 @@ describe('Le serveur MSS des routes /api/*', () => {
     it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
-      const homologation = { toJSON: () => ({ id: '456' }) };
+      const service = { toJSON: () => ({ id: '456' }) };
       testeur.depotDonnees().homologations = (idUtilisateur) => {
         expect(idUtilisateur).to.equal('123');
-        return Promise.resolve([homologation]);
+        return Promise.resolve([service]);
       };
 
       axios.get('http://localhost:1234/api/services')

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -12,15 +12,15 @@ describe('Le serveur MSS des routes /api/*', () => {
 
   afterEach(testeur.arrete);
 
-  describe('quand requête GET sur `/api/homologations`', () => {
+  describe('quand requête GET sur `/api/services`', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        'http://localhost:1234/api/homologations',
+        'http://localhost:1234/api/services',
         done,
       );
     });
 
-    it("interroge le dépôt de données pour récupérer les homologations de l'utilisateur", (done) => {
+    it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
       const homologation = { toJSON: () => ({ id: '456' }) };
@@ -29,13 +29,13 @@ describe('Le serveur MSS des routes /api/*', () => {
         return Promise.resolve([homologation]);
       };
 
-      axios.get('http://localhost:1234/api/homologations')
+      axios.get('http://localhost:1234/api/services')
         .then((reponse) => {
           expect(reponse.status).to.equal(200);
 
-          const { homologations } = reponse.data;
-          expect(homologations.length).to.equal(1);
-          expect(homologations[0].id).to.equal('456');
+          const { services } = reponse.data;
+          expect(services.length).to.equal(1);
+          expect(services[0].id).to.equal('456');
           done();
         })
         .catch(done);


### PR DESCRIPTION
Cette PR fait suite à #695 et poursuit une série de renommage des routes `homologation` en `service`.

On s'intéresse ici au renommage des routes `/homologation/*` en `/service/*`. On en profite pour renommer les dénominations « homologation » en « service » dans les fichiers changés, en s'en tenant aux noms avec une portée locale.

Prochaines étapes :
- [x] Routes `/api/homologation/*` -> `/api/service/*`
- [x] Routes `/homologation/*` -> `/service/*`
- [x] Routes `/api/homologations` -> `/api/services` <-- LA PR COURANTE
- [ ] Répertoires `src/vues/homologation/*` -> `src/vues/service/*`
- [ ] Répertoires `public/*/homologation/*` -> `public/*/service/*`
- [ ] Routes `/service/:id/dossier/*` -> `/service/:id/homologation/*`
- [ ] Routes `/service/:id/dossiers` -> `/service/:id/homologations`
- [ ] `Middleware.trouveHomologation` -> `Middleware.trouveService`
- [ ] `depotHomologation` -> `depotService`