### PR TITLE
Améliore le middleware de test

### DIFF
--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -33,6 +33,7 @@ let cguAcceptees;
 let expirationCookieRepoussee = false;
 let headersAvecNoncePositionnes = false;
 let headersPositionnes = false;
+let homologationTrouvee;
 let idUtilisateurCourant;
 let listesAseptisees = [];
 let parametresAseptises = [];
@@ -42,12 +43,17 @@ let verificationJWTMenee = false;
 let verificationCGUMenee = false;
 
 const middlewareFantaisie = {
-  reinitialise: (idUtilisateur, acceptationCGU = true) => {
+  reinitialise: ({
+    idUtilisateur,
+    acceptationCGU = true,
+    homologationARenvoyer = new Homologation({ id: '456', descriptionService: { nomService: 'un service' } }),
+  }) => {
     authentificationBasiqueMenee = false;
     cguAcceptees = acceptationCGU;
     expirationCookieRepoussee = false;
     headersAvecNoncePositionnes = false;
     headersPositionnes = false;
+    homologationTrouvee = homologationARenvoyer;
     idUtilisateurCourant = idUtilisateur;
     listesAseptisees = [];
     parametresAseptises = [];
@@ -101,10 +107,7 @@ const middlewareFantaisie = {
   trouveHomologation: (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
     requete.cguAcceptees = cguAcceptees;
-    requete.homologation = new Homologation({
-      id: '456',
-      descriptionService: { nomService: 'un service' },
-    });
+    requete.homologation = homologationTrouvee;
     rechercheServiceEffectuee = true;
     suite();
   },

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -21,7 +21,7 @@ describe('Le serveur MSS des routes /api/*', () => {
     });
 
     it("interroge le dépôt de données pour récupérer les homologations de l'utilisateur", (done) => {
-      testeur.middleware().reinitialise('123');
+      testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
       const homologation = { toJSON: () => ({ id: '456' }) };
       testeur.depotDonnees().homologations = (idUtilisateur) => {
@@ -391,7 +391,7 @@ describe('Le serveur MSS des routes /api/*', () => {
       let motDePasseMisAJour = false;
 
       expect(utilisateur.id).to.equal('123');
-      testeur.middleware().reinitialise(utilisateur.id);
+      testeur.middleware().reinitialise({ idUtilisateur: utilisateur.id });
       testeur.depotDonnees().metsAJourMotDePasse = (idUtilisateur, motDePasse) => {
         try {
           expect(idUtilisateur).to.equal('123');
@@ -473,7 +473,10 @@ describe('Le serveur MSS des routes /api/*', () => {
     describe("si les CGU n'ont pas déjà été acceptées", () => {
       beforeEach(() => {
         const cguNonAcceptees = false;
-        testeur.middleware().reinitialise(utilisateur.id, cguNonAcceptees);
+        testeur.middleware().reinitialise({
+          idUtilisateur: utilisateur.id,
+          acceptationCGU: cguNonAcceptees,
+        });
       });
 
       describe("et que l'utilisateur n'est pas en train de les accepter", () => {
@@ -600,7 +603,7 @@ describe('Le serveur MSS des routes /api/*', () => {
     });
 
     it('convertit le RSSI en booléen', (done) => {
-      testeur.middleware().reinitialise(utilisateur.id);
+      testeur.middleware().reinitialise({ idUtilisateur: utilisateur.id });
 
       testeur.depotDonnees().metsAJourUtilisateur = (id, { rssi }) => {
         try {
@@ -624,7 +627,7 @@ describe('Le serveur MSS des routes /api/*', () => {
     });
 
     it('convertit le délégué à la protection des données en booléen', (done) => {
-      testeur.middleware().reinitialise(utilisateur.id);
+      testeur.middleware().reinitialise({ idUtilisateur: utilisateur.id });
 
       testeur.depotDonnees().metsAJourUtilisateur = (id, { delegueProtectionDonnees }) => {
         try {
@@ -650,7 +653,7 @@ describe('Le serveur MSS des routes /api/*', () => {
     it("met à jour les autres informations de l'utilisateur", (done) => {
       let infosMisesAJour = false;
 
-      testeur.middleware().reinitialise(utilisateur.id);
+      testeur.middleware().reinitialise({ idUtilisateur: utilisateur.id });
 
       testeur.depotDonnees().metsAJourUtilisateur = (id, donnees) => {
         try {
@@ -687,7 +690,7 @@ describe('Le serveur MSS des routes /api/*', () => {
     });
 
     it("renvoie l'utilisateur correspondant à l'identifiant", (done) => {
-      testeur.middleware().reinitialise('123');
+      testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
       const depotDonnees = testeur.depotDonnees();
       depotDonnees.utilisateur = (idUtilisateur) => {
@@ -711,7 +714,7 @@ describe('Le serveur MSS des routes /api/*', () => {
     });
 
     it("répond avec un code 401 quand il n'y a pas d'identifiant", (done) => {
-      testeur.middleware().reinitialise('');
+      testeur.middleware().reinitialise({ idUtilisateur: '' });
 
       axios.get('http://localhost:1234/api/utilisateurCourant')
         .then(() => {
@@ -797,7 +800,7 @@ describe('Le serveur MSS des routes /api/*', () => {
     const utilisateur = { id: '999', genereToken: () => 'un token', accepteCGU: () => true };
 
     beforeEach(() => {
-      testeur.middleware().reinitialise('456');
+      testeur.middleware().reinitialise({ idUtilisateur: '456' });
       autorisation.permissionAjoutContributeur = true;
 
       testeur.depotDonnees().autorisationExiste = () => Promise.resolve(false);
@@ -1035,7 +1038,7 @@ describe('Le serveur MSS des routes /api/*', () => {
 
       it("envoie un mail d'invitation au contributeur créé", (done) => {
         let messageEnvoye = false;
-        testeur.middleware().reinitialise('456');
+        testeur.middleware().reinitialise({ idUtilisateur: '456' });
 
         testeur.depotDonnees().utilisateur = (id) => {
           try {

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -90,7 +90,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("demande au dépôt de données d'enregistrer les nouveaux service", (done) => {
-      testeur.middleware().reinitialise('123');
+      testeur.middleware().reinitialise({ idUtilisateur: '123' });
       const donneesDescriptionService = uneDescriptionValide(testeur.referentiel())
         .construis()
         .toJSON();
@@ -158,7 +158,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('demande au dépôt de données de mettre à jour le service', (done) => {
-      testeur.middleware().reinitialise('123');
+      testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
       testeur.depotDonnees().ajouteDescriptionServiceAHomologation = (
         (idUtilisateur, idService, infosGenerales) => {
@@ -622,7 +622,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it("demande au dépôt de vérifier l'autorisation d'accès au service pour l'utilisateur courant", (done) => {
       let autorisationVerifiee = false;
 
-      testeur.middleware().reinitialise('999');
+      testeur.middleware().reinitialise({ idUtilisateur: '999' });
       testeur.depotDonnees().autorisationPour = (idUtilisateur, idService) => {
         try {
           expect(idUtilisateur).to.equal('999');
@@ -717,7 +717,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it("demande au dépôt de vérifier l'autorisation d'accès au service pour l'utilisateur courant", (done) => {
       let autorisationVerifiee = false;
 
-      testeur.middleware().reinitialise('999');
+      testeur.middleware().reinitialise({ idUtilisateur: '999' });
       testeur.depotDonnees().autorisationPour = (idUtilisateur, idService) => {
         try {
           expect(idUtilisateur).to.equal('999');
@@ -801,7 +801,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it("demande au dépôt de vérifier que l'utilisateur courant a le droit de dupliquer le service", (done) => {
       let autorisationVerifiee = false;
 
-      testeur.middleware().reinitialise('999');
+      testeur.middleware().reinitialise({ idUtilisateur: '999' });
       testeur.depotDonnees().autorisationPour = (idUtilisateur, idService) => {
         try {
           expect(idUtilisateur).to.equal('999');
@@ -861,7 +861,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('demande au dépôt de dupliquer le service', (done) => {
       let serviceDuplique = false;
 
-      testeur.middleware().reinitialise('999');
+      testeur.middleware().reinitialise({ idUtilisateur: '999' });
       testeur.depotDonnees().dupliqueHomologation = (idService) => {
         try {
           expect(idService).to.equal('123');

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -36,7 +36,7 @@ const testeurMss = () => {
   const initialise = (done) => {
     adaptateurMail = {};
     adaptateurPdf = {};
-    middleware.reinitialise();
+    middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();
     moteurRegles = new MoteurRegles(referentiel);
     depotVide()


### PR DESCRIPTION
On utilise désormais un objet dans la méthode `reinitialise` pour faciliter l'utilisation d'objet personnalisé.

Cela permet aussi d'utiliser une homologation personnalisée lorsqu'on appele la fonction `trouveHomologation` dans le middleware de test.

Prémaniement du travail de l'étape décision.