### PR TITLE
Conditionne les logs dans la console du « Journal MSS mémoire »

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -35,3 +35,4 @@ URL_SERVEUR_BASE_DONNEES_JOURNAL= # URL de la base de données du Journal MSS. e
 
 # interrupteurs de fonctionnalités (feature switches)
 AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire. Sinon le journal utilisera la base de données « URL_SERVEUR_BASE_DONNEES_JOURNAL »
+AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE = # `true` pour que le « Journal MSS » en mémoire logue les événements reçus dans la console

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -2,4 +2,8 @@ const sendinblue = () => ({
   clefAPI: () => process.env.SENDINBLUE_CLEF_API,
 });
 
-module.exports = { sendinblue };
+const journalMSS = () => ({
+  logEvenementDansConsole: () => process.env.AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE === 'true',
+});
+
+module.exports = { sendinblue, journalMSS };

--- a/src/adaptateurs/adaptateurJournalMSSMemoire.js
+++ b/src/adaptateurs/adaptateurJournalMSSMemoire.js
@@ -1,9 +1,13 @@
+const adaptateurEnvironnement = require('./adaptateurEnvironnement');
+
 const nouvelAdaptateur = () => {
   const consigneEvenement = (donneesEvenements) => {
     /* eslint-disable no-console */
-    console.log(`[JOURNAL MSS] Nouvel événement\n${JSON.stringify(donneesEvenements)}`);
-    return Promise.resolve();
+    const logDansConsole = adaptateurEnvironnement.journalMSS().logEvenementDansConsole();
+    if (logDansConsole) console.log(`[JOURNAL MSS] Nouvel événement\n${JSON.stringify(donneesEvenements)}`);
     /* eslint-enable no-console */
+
+    return Promise.resolve();
   };
 
   return {


### PR DESCRIPTION
… afin de ne pas avoir de logs polluants quand l'adaptateur est utilisé par les tests automatisés.

🧹 Pour vérifier que c'est clean, on peut regarder [les logs de la build](https://github.com/betagouv/mon-service-securise/actions/runs/4284218469/jobs/7460865905) qui ne montrent plus de `console.log` des événements du journal.