### PR TITLE
Interroge `datesTelechargements` pour savoir si dossier est complet

### DIFF
--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -52,7 +52,7 @@ class Dossier extends InformationsHomologation {
   }
 
   estComplet() {
-    return this.decision.estComplete();
+    return this.decision.estComplete() && this.datesTelechargements.estComplete();
   }
 
   estActif() {

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -55,10 +55,22 @@ describe("Un dossier d'homologation", () => {
   });
 
   describe('sur vérification que ce dossier est complet', () => {
-    it("retourne le caractère de l'étape date", () => {
-      referentiel.recharge({ echeancesRenouvellement: { unAn: {} } });
-      const dossierComplet = new Dossier({ decision: { dateHomologation: '2022-11-27', dureeValidite: 'unAn' } }, referentiel);
-      expect(dossierComplet.estComplet()).to.be(true);
+    it('demande à chaque étape si elle est complète', () => {
+      const etapesInterrogees = [];
+      const bouchonneEtape = (etape) => ({
+        estComplete: () => {
+          etapesInterrogees.push(etape);
+          return true;
+        },
+      });
+
+      const dossier = new Dossier();
+      dossier.decision = { ...bouchonneEtape('decision') };
+      dossier.datesTelechargements = { ...bouchonneEtape('datesTelechargements') };
+
+      dossier.estComplet();
+
+      expect(etapesInterrogees).to.eql(['decision', 'datesTelechargements']);
     });
   });
 


### PR DESCRIPTION
Cette PR répare un oubli.

Il faut bien interroger `datesTelechargements` pour savoir si un dossier est complet.

Exemple de problème qui peut arriver sans cette PR :
 - créer une homologation
 - télécharger seulement **un** document sur les 3
 - en changeant l'URL du navigateur, aller à l'étape `date` de l'homologation
 - remplir cette étape
 - arriver ensuite sur l'étape « Récapitulatif » et cliquer « Enregistrer la décision »
 - sans cette PR : on peut finaliser le dossier sans avoir téléchargé les 3 PDF à la première étape.