### PR TITLE
Correction date homologation

### DIFF
--- a/src/modeles/etapes/decision.js
+++ b/src/modeles/etapes/decision.js
@@ -53,8 +53,8 @@ class Decision extends Etape {
 
   periodeHomologationEstEnCours() {
     const maintenant = this.adaptateurHorloge.maintenant();
-    return new Date(this.dateHomologation) < maintenant
-      && maintenant < this.dateProchaineHomologation();
+    return new Date(this.dateHomologation) <= maintenant
+      && maintenant <= this.dateProchaineHomologation();
   }
 
   static valide({ dateHomologation, dureeValidite }, referentiel) {

--- a/test/constructeurs/constructeurDossier.js
+++ b/test/constructeurs/constructeurDossier.js
@@ -1,0 +1,57 @@
+const adaptateurHorlogeParDefaut = require('../../src/adaptateurs/adaptateurHorloge');
+const Dossier = require('../../src/modeles/dossier');
+const Referentiel = require('../../src/referentiel');
+
+class ConstructeurDossierFantaisie {
+  constructor(
+    id = '1',
+    referentiel = Referentiel.creeReferentielVide(),
+    adaptateurHorloge = adaptateurHorlogeParDefaut
+  ) {
+    this.donnees = { id };
+    this.referentiel = referentiel;
+    this.adaptateurHorloge = adaptateurHorloge;
+  }
+
+  sansDecision() {
+    this.donnees.decision = {};
+    return this;
+  }
+
+  avecDateHomologation(date) {
+    this.donnees.decision.dateHomologation = date.toISOString();
+    return this;
+  }
+
+  quiEstComplet() {
+    this.donnees.finalise = true;
+    this.donnees.decision = { dateHomologation: '2023-01-01', dureeValidite: 'unAn' };
+    this.donnees.datesTelechargements = this.referentiel
+      .tousDocumentsHomologation()
+      .reduce((acc, { id }) => ({ ...acc, [id]: new Date() }), {});
+    this.donnees.autorite = { nom: 'Jean Dupond', fonction: 'RSSI' };
+    return this;
+  }
+
+  quiEstActif(depuis = 1) {
+    const debutActif = new Date();
+    debutActif.setDate(debutActif.getDate() - depuis);
+    this.donnees.decision = { dateHomologation: debutActif.toISOString(), dureeValidite: 'unAn' };
+    return this;
+  }
+
+  quiEstExpire() {
+    const tresVieux = new Date();
+    tresVieux.setDate(tresVieux.getDate() - 400);
+    this.donnees.decision = { dateHomologation: tresVieux.toISOString(), dureeValidite: 'unAn' };
+    return this;
+  }
+
+  construit() {
+    return new Dossier(this.donnees, this.referentiel, this.adaptateurHorloge);
+  }
+}
+
+const unDossier = (referentiel, adaptateurHorloge) => new ConstructeurDossierFantaisie('1', referentiel, adaptateurHorloge);
+
+module.exports = { ConstructeurDossierFantaisie, unDossier };

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -92,11 +92,11 @@ describe("Un dossier d'homologation", () => {
 
     it("retourne `true` si la date du jour est la date d'homologation", () => {
       referentiel.recharge({ echeancesRenouvellement: { unAn: { nbMoisDecalage: 12 } } });
-      const aujourdhui = new Date(2023, 1, 1);
+      const aujourdhui = new Date();
       const adaptateurHorloge = { maintenant: () => aujourdhui };
       const dossierPremierJourActif = unDossier(referentiel, adaptateurHorloge)
         .quiEstComplet()
-        .avecDateHomologation(new Date('2023-01-01'))
+        .avecDateHomologation(aujourdhui)
         .construit();
       expect(dossierPremierJourActif.estActif()).to.equal(true);
     });
@@ -112,12 +112,12 @@ describe("Un dossier d'homologation", () => {
 
     it("retourne `true` si la date du jour est la date dernière date d'homologation", () => {
       referentiel.recharge({ echeancesRenouvellement: { unAn: { nbMoisDecalage: 12 } } });
-      const adaptateurHorloge = { maintenant: () => new Date(2024, 1, 1) };
+      const adaptateurHorloge = { maintenant: () => new Date('2024-01-01') };
       const dossierDernierJourActif = unDossier(referentiel, adaptateurHorloge)
         .quiEstComplet()
         .avecDateHomologation(new Date('2023-01-01'))
         .construit();
-      expect(dossierDernierJourActif.estActif()).to.equal(false);
+      expect(dossierDernierJourActif.estActif()).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
En introduisant le constructeur de dossier pour les tests, on s'est rendu compte d'un bug :

Les tests étaient faux car `new Date(2023, 1, 1)` *correspond à Février* : Les mois sont indéxés en base 0, alors que `new Date("2023-01-01")` correspond bien au 1er Janvier.

Cette PR corrige les tests et montre ainsi le défaut dans l'implémentation, en introduisant un constructeur de dossier.