### PR TITLE
Enregistrement sticky des mesures

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -111,3 +111,26 @@ form#mesures .specifiques input[type='radio'] {
 #mesures-specifiques {
   margin-top: 2em;
 }
+
+.enregistrement, footer {
+  position: sticky;
+  background-color: #fff;
+}
+
+.enregistrement {
+  bottom: 8em;
+  display: flex;
+  width: 100%;
+  border-top-width: 2px;
+  border-top-style: solid;
+  border-image: linear-gradient(-45deg, #5cc7ff33, #3788d733, #2c57aa33, #6b24dd33, #a826b333) 1;
+}
+
+footer {
+  bottom: 0;
+  border-top: solid 2px var(--systeme-design-etat-bleu);
+}
+
+main {
+  border-bottom: 0;
+}

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -52,8 +52,8 @@ block formulaire
                   .fermeture-modale
                   h1= donnees.description
                   p!= donnees.descriptionLongue
-
-    button.bouton(idHomologation = service.id) Enregistrer &nbsp;&nbsp;›
+    .enregistrement
+      button.bouton(idHomologation = service.id) Enregistrer &nbsp;&nbsp;›
 
   script(id = 'donnees-mesures-generales', type = 'application/json').
     !{JSON.stringify(service.mesures.toJSON().mesuresGenerales || [])}


### PR DESCRIPTION
Dans la page Sécurisé,
Le bouton Enregistrer et le footer deviennent sticky.
<img width="956" alt="Capture d’écran 2023-03-01 à 11 30 23" src="https://user-images.githubusercontent.com/39462397/222113820-6a4f1521-d10c-44a1-9f18-c874ad3a8e58.png">
