### PR TITLE
Correction position bouton collant des mesures

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -118,12 +118,18 @@ form#mesures .specifiques input[type='radio'] {
 }
 
 .enregistrement {
-  bottom: 8em;
+  bottom: 3em;
   display: flex;
-  width: 100%;
+  width: calc(100% + 7em);
+  margin-left: -7em;
+  padding-right: 7em;
   border-top-width: 2px;
   border-top-style: solid;
   border-image: linear-gradient(-45deg, #5cc7ff33, #3788d733, #2c57aa33, #6b24dd33, #a826b333) 1;
+}
+
+.enregistrement .bouton {
+  margin: 1em 0 1em auto;
 }
 
 footer {


### PR DESCRIPTION
Dans la page Sécurisé,
le bouton collant n'était pas bien positionné.
<img width="1062" alt="Capture d’écran 2023-03-01 à 12 35 55" src="https://user-images.githubusercontent.com/39462397/222129065-454cc909-2cf7-4f06-a4b4-a93cf824c9b8.png">
