### PR TITLE
[CORRECTION] Vérifie que le dossier est finalisé pour être actif

### DIFF
--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -64,8 +64,7 @@ class Dossier extends InformationsHomologation {
   }
 
   estActif() {
-    if (!this.estComplet()) return false;
-    return this.decision.periodeHomologationEstEnCours();
+    return this.finalise && this.decision.periodeHomologationEstEnCours();
   }
 
   toJSON() {

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -96,8 +96,8 @@ describe("Un dossier d'homologation", () => {
   });
 
   describe('sur demande du caractère actif du dossier', () => {
-    it("retourne `false` si le dossier n'est pas complet", () => {
-      const dossier = unDossier().sansDecision().construit();
+    it("retourne `false` si le dossier n'est pas finalise", () => {
+      const dossier = unDossier(referentiel).quiEstActif().construit();
       expect(dossier.estActif()).to.equal(false);
     });
 


### PR DESCRIPTION
On a trouvé un bug, lors de l'ajout de l'étape Autorité, les homologations qui étaient finalisées n'ont plus la coche verte car le dossier n'est plus `estComplet()`