### PR TITLE
Sous-titre informatif au champ téléphone

### DIFF
--- a/public/assets/styles/utilisateur.css
+++ b/public/assets/styles/utilisateur.css
@@ -26,3 +26,9 @@ section:first-of-type {
 .affichage-simple {
   margin-bottom: 2em;
 }
+
+label .information {
+  margin-top: 0.2em;
+  font-size: 0.9em;
+  font-weight: normal;
+}

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -65,7 +65,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
             .message-erreur L'e-mail est obligatoire. Veuillez respecter le format jean.dupont@domaine.fr.
 
       label Téléphone
-        br
+        .information Pour bénéficier d’un accompagnement personnalisé
         input(
           id = 'telephone',
           name = 'telephone',


### PR DESCRIPTION
Dans les page /utilisateur/edition et /inscription,
nous ajoutons une information au champ téléphone
<img width="536" alt="Capture d’écran 2023-03-02 à 09 25 09" src="https://user-images.githubusercontent.com/39462397/222385892-3873a71b-ffd8-40e4-ab19-757e18d77eb3.png">
