### PR TITLE
Supprime un test qui logue une exception dans la console

### DIFF
--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -707,18 +707,6 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .catch(done);
     });
 
-    it("reste robuste en cas d'erreur inattendue", (done) => {
-      testeur.depotDonnees().metsAJourDossierCourant = () => Promise.reject(new Error('Boom'));
-
-      axios.put('http://localhost:1234/api/service/456/dossier/document/decision')
-        .then(() => done('Le serveur aurait dû lever une exception'))
-        .catch((e) => {
-          expect(e.response.status).to.be(500);
-          done();
-        })
-        .catch(done);
-    });
-
     it("reste robuste si l'id de document ne correspond pas à un document connu", (done) => {
       axios.put('http://localhost:1234/api/service/456/dossier/document/mauvaisId')
         .catch(({ response }) => {


### PR DESCRIPTION
C'est [ce log](https://github.com/betagouv/mon-service-securise/actions/runs/4314569761/jobs/7527775395#step:5:1123) que cette PR vient supprimer.

Avoir une stack trace dans les logs de nos tests : 👎👎👎  

Le prix à payer pour ne pas loguer l'exception semble trop élevé : bouchonner la console le temps du test, puis la remettre en place après le test.

Il faudrait plutôt que nos routes soient, par construction, robustes aux erreurs inattendues. Pourquoi pas un wrapper qui ajouterait lui-même ce `.catch()` qui devrait être systématique sur les routes d'API.