### PR TITLE
Déplace le bouton « Ajouter une mesure spécifique » à côté de « Enregistrer »

### DIFF
--- a/public/assets/styles/bouton.css
+++ b/public/assets/styles/bouton.css
@@ -34,3 +34,9 @@ button {
   background-color: var(--bleu-anssi);
   cursor: wait;
 }
+
+.bouton.bouton-secondaire {
+  color: var(--bleu-mise-en-avant);
+  border-color: var(--bleu-mise-en-avant);
+  background-color: #fff;
+}

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -122,14 +122,15 @@ form#mesures .specifiques input[type='radio'] {
   display: flex;
   width: calc(100% + 7em);
   margin-left: -7em;
-  padding-right: 7em;
+  padding: 1.4em 7em 1.4em 0;
   border-top-width: 2px;
   border-top-style: solid;
   border-image: linear-gradient(-45deg, #5cc7ff33, #3788d733, #2c57aa33, #6b24dd33, #a826b333) 1;
 }
 
-.enregistrement .bouton {
-  margin: 1em 0 1em auto;
+.enregistrement button {
+  margin: 0 0 0 auto;
+  padding: 0.7em 1.2em;
 }
 
 footer {

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -120,6 +120,8 @@ form#mesures .specifiques input[type='radio'] {
 .enregistrement {
   bottom: 3em;
   display: flex;
+  justify-content: flex-end;
+  column-gap: 1.7em;
   width: calc(100% + 7em);
   margin-left: -7em;
   padding: 1.4em 7em 1.4em 0;
@@ -128,10 +130,26 @@ form#mesures .specifiques input[type='radio'] {
   border-image: linear-gradient(-45deg, #5cc7ff33, #3788d733, #2c57aa33, #6b24dd33, #a826b333) 1;
 }
 
-.enregistrement button {
-  margin: 0 0 0 auto;
+.enregistrement .bouton {
+  margin: 0;
   padding: 0.7em 1.2em;
 }
+
+.enregistrement .nouvel-item {
+  display: flex;
+  align-items: center;
+  padding-left: 0.8em;
+}
+
+.enregistrement .nouvel-item::before {
+  content: '';
+  display: block;
+  width: 1.4em;
+  height: 1.4em;
+  margin-right: 0.4em;
+  background: url(../../images/icone_plus_pastille_bleue.svg) center/contain;
+}
+
 
 footer {
   bottom: 0;

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -34,7 +34,6 @@ block formulaire
 
       .mention champ obligatoire
       .specifiques
-        a.nouvel-item Ajouter une mesure spécifique
         #mesures-specifiques
 
       .mesures
@@ -53,6 +52,7 @@ block formulaire
                   h1= donnees.description
                   p!= donnees.descriptionLongue
     .enregistrement
+      button.bouton.bouton-secondaire.nouvel-item(type = 'button') Ajouter une mesure spécifique
       button.bouton(idHomologation = service.id) Enregistrer
 
   script(id = 'donnees-mesures-generales', type = 'application/json').

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -53,7 +53,7 @@ block formulaire
                   h1= donnees.description
                   p!= donnees.descriptionLongue
     .enregistrement
-      button.bouton(idHomologation = service.id) Enregistrer &nbsp;&nbsp;›
+      button.bouton(idHomologation = service.id) Enregistrer
 
   script(id = 'donnees-mesures-generales', type = 'application/json').
     !{JSON.stringify(service.mesures.toJSON().mesuresGenerales || [])}


### PR DESCRIPTION
Cette PR pousse un cran plus loin l'intégration du footer d'enregistrement.

🎨 C'est seulement du CSS. Aucun JS modifié.

**AVANT**
![image](https://user-images.githubusercontent.com/24898521/222493785-e530053b-d241-4cfc-a3fc-d6106b0b0785.png)


**APRÈS**
![image](https://user-images.githubusercontent.com/24898521/222493820-396822f5-921b-4ac0-9ef8-64076575cd65.png)

L'inspiration vient des Figma existants où le footer est plus étoffé : 

![image](https://user-images.githubusercontent.com/24898521/222493957-27750cbc-1923-4950-b26c-08036996ee4c.png)
