### PR TITLE
Remplace le champ `prenomNom` par une collection

### DIFF
--- a/src/modeles/avis.js
+++ b/src/modeles/avis.js
@@ -7,6 +7,7 @@ class Avis extends InformationsHomologation {
     super({
       proprietesAtomiquesRequises: Avis.proprietesAtomiquesRequises(),
       proprietesAtomiquesFacultatives: Avis.proprietesAtomiquesFacultatives(),
+      proprietesListes: Avis.proprietesListes(),
     });
 
     Avis.valide(donnees, referentiel);
@@ -14,15 +15,15 @@ class Avis extends InformationsHomologation {
   }
 
   static proprietesAtomiquesRequises() {
-    return ['prenomNom', 'statut', 'dureeValidite'];
+    return ['statut', 'dureeValidite'];
   }
 
   static proprietesAtomiquesFacultatives() {
     return ['commentaires'];
   }
 
-  static proprietes() {
-    return [...Avis.proprietesAtomiquesRequises(), ...Avis.proprietesAtomiquesFacultatives()];
+  static proprietesListes() {
+    return ['collaborateurs'];
   }
 
   static valide({ dureeValidite, statut }, referentiel) {
@@ -31,6 +32,24 @@ class Avis extends InformationsHomologation {
     }
     if (!referentiel.estIdentifiantStatutAvisDossierHomologationConnu(statut)) {
       throw new ErreurAvisInvalide(`L'avis "${statut}" est invalide`);
+    }
+  }
+
+  statutSaisie() {
+    const statutSaisieProprietesAtomiques = super.statutSaisie();
+    const collaborateursSaisis = this.collaborateurs.length > 0
+      && this.collaborateurs.every((c) => !!c);
+    switch (statutSaisieProprietesAtomiques) {
+      case InformationsHomologation.COMPLETES:
+        return collaborateursSaisis
+          ? InformationsHomologation.COMPLETES
+          : InformationsHomologation.A_COMPLETER;
+      case InformationsHomologation.A_SAISIR:
+        return collaborateursSaisis
+          ? InformationsHomologation.A_COMPLETER
+          : InformationsHomologation.A_SAISIR;
+      default:
+        return InformationsHomologation.A_COMPLETER;
     }
   }
 }

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -248,7 +248,8 @@ const routesApiService = (
 
   routes.put('/:id/dossier/avis',
     middleware.trouveHomologation,
-    middleware.aseptiseListes([{ nom: 'avis', proprietes: Avis.proprietes() }]),
+    middleware.aseptiseListes([{ nom: 'avis', proprietes: [...Avis.proprietesAtomiquesRequises(), ...Avis.proprietesAtomiquesFacultatives()] }]),
+    middleware.aseptise('avis.*.collaborateurs.*'),
     (requete, reponse, suite) => {
       const { body: { avis } } = requete;
       if (!avis) {

--- a/test/constructeurs/constructeurDossier.js
+++ b/test/constructeurs/constructeurDossier.js
@@ -35,7 +35,7 @@ class ConstructeurDossierFantaisie {
 
   quiEstComplet() {
     this.donnees.finalise = true;
-    this.donnees.avis = [{ prenomNom: 'Jean Dupond', dureeValidite: 'unAn', statut: 'favorable' }];
+    this.donnees.avis = [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }];
     this.donnees.decision = { dateHomologation: '2023-01-01', dureeValidite: 'unAn' };
     this.donnees.datesTelechargements = this.referentiel
       .tousDocumentsHomologation()

--- a/test/modeles/avis.spec.js
+++ b/test/modeles/avis.spec.js
@@ -11,10 +11,23 @@ describe("Un avis sur un dossier d'homologation", () => {
     echeancesRenouvellement: { unAn: {} },
   });
 
-  it('est complet si tous les champs requis sont remplis', () => {
-    const avis = new Avis({ prenomNom: 'Jean Dupond', statut: 'favorable', dureeValidite: 'unAn' }, referentiel);
+  it('est complet si toutes les informations sont remplies', () => {
+    const avis = new Avis({ statut: 'favorable', dureeValidite: 'unAn', collaborateurs: ['Jean Dupond'] }, referentiel);
 
     expect(avis.statutSaisie()).to.be(InformationsHomologation.COMPLETES);
+  });
+
+  it("est incomplet si la liste des collaborateurs n'est pas remplie", () => {
+    const verifieAvecCollaborateurs = (collaborateurs) => {
+      const avis = new Avis({ statut: 'favorable', dureeValidite: 'unAn', collaborateurs }, referentiel);
+      expect(avis.statutSaisie()).to.be(InformationsHomologation.A_COMPLETER);
+    };
+
+    verifieAvecCollaborateurs([null]);
+    verifieAvecCollaborateurs(['']);
+    verifieAvecCollaborateurs([]);
+    verifieAvecCollaborateurs([undefined]);
+    verifieAvecCollaborateurs(undefined);
   });
 
   it('est invalide si la durée de validité est inconnue dans le référentiel', () => {

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -20,7 +20,7 @@ describe("Un dossier d'homologation", () => {
       decision: { dateHomologation: '2022-12-01', dureeValidite: 'unAn' },
       autorite: { nom: 'Jean Courage', fonction: 'Responsable' },
       datesTelechargements: { decision: '2023-01-01T00:00:00.000Z' },
-      avis: [{ prenomNom: 'Jean Dupond', dureeValidite: 'unAn', statut: 'favorable' }],
+      avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
       finalise: true,
     },
     referentiel);
@@ -30,7 +30,7 @@ describe("Un dossier d'homologation", () => {
       decision: { dateHomologation: '2022-12-01', dureeValidite: 'unAn' },
       autorite: { nom: 'Jean Courage', fonction: 'Responsable' },
       datesTelechargements: { decision: '2023-01-01T00:00:00.000Z' },
-      avis: [{ prenomNom: 'Jean Dupond', dureeValidite: 'unAn', statut: 'favorable' }],
+      avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
       finalise: true,
     });
   });
@@ -86,7 +86,7 @@ describe("Un dossier d'homologation", () => {
 
     it('remplace les avis par ceux fournis', () => {
       const dossier = new Dossier({}, referentiel);
-      const avisComplet = { prenomNom: 'Jean Dupond', statut: 'favorable', dureeValidite: 'unAn' };
+      const avisComplet = { collaborateurs: ['Jean Dupond'], statut: 'favorable', dureeValidite: 'unAn' };
 
       dossier.enregistreAvis([avisComplet]);
 

--- a/test/modeles/etapes/etapeAvis.spec.js
+++ b/test/modeles/etapes/etapeAvis.spec.js
@@ -12,13 +12,13 @@ describe('Une étape « Avis »', () => {
 
     const etape = new EtapeAvis({
       avis: [
-        { prenomNom: 'Jean Durand', statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' },
+        { collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' },
       ],
     }, referentiel);
 
     expect(etape.toJSON()).to.eql({
       avis: [
-        { prenomNom: 'Jean Durand', statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' },
+        { collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' },
       ],
     });
   });
@@ -52,7 +52,7 @@ describe('Une étape « Avis »', () => {
         statutAvisDossierHomologation: { favorable: { } },
       });
       const avecAvisSaisis = new EtapeAvis(
-        { avis: [{ prenomNom: 'Jean Durand', statut: 'favorable', dureeValidite: 'unAn' }] },
+        { avis: [{ collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn' }] },
         referentiel
       );
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -496,7 +496,7 @@ describe('Une homologation', () => {
         },
         dossiers: [{
           id: '1',
-          avis: [{ prenomNom: 'Jean Dupond', dureeValidite: 'unAn', statut: 'favorable' }],
+          avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
           autorite: { nom: 'Jean Dupond', fonction: 'RSSI' },
           decision: { dateHomologation: aujourdhui.toISOString(), dureeValidite: 'unAn' },
           datesTelechargements: { decision: aujourdhui.toISOString() },

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -739,10 +739,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('aseptise la liste des avis', (done) => {
       axios.put('http://localhost:1234/api/service/456/dossier/avis', { avis: [] })
         .then(() => {
-          testeur.middleware().verifieAseptisationListe('avis', ['prenomNom', 'statut', 'dureeValidite', 'commentaires']);
+          testeur.middleware().verifieAseptisationListe('avis', ['statut', 'dureeValidite', 'commentaires']);
           done();
         })
         .catch(done);
+    });
+
+    it('aseptise les collaborateurs mentionnés dans les avis', (done) => {
+      testeur.middleware().verifieAseptisationParametres(
+        ['avis.*.collaborateurs.*'], { url: 'http://localhost:1234/api/service/456/dossier/avis', method: 'put' }, done
+      );
     });
 
     it("renvoie une 400 si aucun avis n'est envoyé", (done) => {
@@ -763,11 +769,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         depotAppele = true;
         expect(idHomologation).to.equal('456');
         expect(dossier.avis.avis.length).to.equal(1);
-        expect(dossier.avis.avis[0].donneesSerialisees()).to.eql({ prenomNom: 'Jean Dupond', statut: 'favorable', dureeValidite: 'unAn', commentaires: 'Ok' });
+        expect(dossier.avis.avis[0].donneesSerialisees()).to.eql({ collaborateurs: ['Jean Dupond'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'Ok' });
         return Promise.resolve();
       };
 
-      axios.put('http://localhost:1234/api/service/456/dossier/avis', { avis: [{ prenomNom: 'Jean Dupond', statut: 'favorable', dureeValidite: 'unAn', commentaires: 'Ok' }] })
+      axios.put('http://localhost:1234/api/service/456/dossier/avis', { avis: [{ collaborateurs: ['Jean Dupond'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'Ok' }] })
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));


### PR DESCRIPTION
Le champ `prenomNom` d'un avis de dossier n'est pas une chaine de caractères, mais un tableau de nom de collaborateurs.