### PR TITLE
Nouvelles routes pour des PDFs HTML

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
 const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPI()
   ? require('./src/adaptateurs/adaptateurMailSendinblue')
   : require('./src/adaptateurs/adaptateurMailSurConsole');
+const adaptateurPdfHtml = require('./src/adaptateurs/adaptateurPdfHtml');
 const adaptateurPdfLatex = require('./src/adaptateurs/adaptateurPdfLatex');
 
 const port = process.env.PORT || 3000;
@@ -30,6 +31,7 @@ const serveur = MSS.creeServeur(
   referentiel,
   moteurRegles,
   adaptateurMail,
+  adaptateurPdfHtml,
   adaptateurPdfLatex,
   adaptateurHorloge
 );

--- a/src/adaptateurs/adaptateurPdfHtml.js
+++ b/src/adaptateurs/adaptateurPdfHtml.js
@@ -1,0 +1,5 @@
+const genereAnnexes = () => Promise.resolve('<h1>Annexe du service</h1>');
+
+const genereDossierDecision = () => Promise.resolve('<h1>Dossier de décision</h1>');
+
+module.exports = { genereAnnexes, genereDossierDecision };

--- a/src/mss.js
+++ b/src/mss.js
@@ -14,6 +14,7 @@ const creeServeur = (
   referentiel,
   moteurRegles,
   adaptateurMail,
+  adaptateurPdfHtml,
   adaptateurPdf,
   adaptateurHorloge,
   avecCookieSecurise = (process.env.NODE_ENV === 'production'),
@@ -122,7 +123,7 @@ const creeServeur = (
     reponse.render('espacePersonnel');
   });
 
-  app.use('/api', routesApi(middleware, adaptateurMail, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf));
+  app.use('/api', routesApi(middleware, adaptateurMail, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf, adaptateurPdfHtml));
 
   app.use('/bibliotheques', routesBibliotheques());
 

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -18,7 +18,8 @@ const routesApi = (
   depotDonnees,
   referentiel,
   adaptateurHorloge,
-  adaptateurPdf
+  adaptateurPdf,
+  adaptateurPdfHtml
 ) => {
   const verifieSuccesEnvoiMessage = (promesseEnvoiMessage, utilisateur) => promesseEnvoiMessage
     .then(() => utilisateur)
@@ -90,7 +91,7 @@ const routesApi = (
       .then((services) => reponse.json({ services }));
   });
 
-  routes.use('/service', routesApiService(middleware, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf));
+  routes.use('/service', routesApiService(middleware, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf, adaptateurPdfHtml));
 
   routes.get('/seuilCriticite', middleware.verificationAcceptationCGU, (requete, reponse) => {
     const {

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -29,11 +29,12 @@ const routesApiService = (
   depotDonnees,
   referentiel,
   adaptateurHorloge,
-  adaptateurPdf
+  adaptateurPdf,
+  adaptateurPdfHtml
 ) => {
   const routes = express.Router();
 
-  routes.use(routesApiServicePdf(middleware, adaptateurPdf));
+  routes.use(routesApiServicePdf(middleware, adaptateurPdf, adaptateurPdfHtml));
 
   routes.post('/', middleware.verificationAcceptationCGU, middleware.aseptise('nomService'), middleware.aseptiseListes([
     { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },

--- a/src/routes/routesApiServicePdf.js
+++ b/src/routes/routesApiServicePdf.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const routesApiServicePdf = (middleware, adaptateurPdf) => {
+const routesApiServicePdf = (middleware, adaptateurPdf, adaptateurPdfHtml) => {
   const routes = express.Router();
 
   routes.get('/:id/pdf/annexes.pdf', middleware.trouveHomologation, (requete, reponse, suite) => {
@@ -17,6 +17,15 @@ const routesApiServicePdf = (middleware, adaptateurPdf) => {
       .catch(suite);
   });
 
+  routes.get('/:id/pdf/annexes', (_requete, reponse, suite) => {
+    adaptateurPdfHtml.genereAnnexes()
+      .then((html) => {
+        reponse.contentType('text/html');
+        reponse.send(html);
+      })
+      .catch(suite);
+  });
+
   routes.get('/:id/pdf/dossierDecision.pdf', middleware.trouveHomologation, (requete, reponse) => {
     const { homologation } = requete;
     const donnees = {
@@ -29,6 +38,17 @@ const routesApiServicePdf = (middleware, adaptateurPdf) => {
       .then((pdf) => {
         reponse.contentType('application/pdf');
         reponse.send(pdf);
+      })
+      .catch(() => {
+        reponse.sendStatus(424);
+      });
+  });
+
+  routes.get('/:id/pdf/dossierDecision', (_requete, reponse) => {
+    adaptateurPdfHtml.genereDossierDecision()
+      .then((html) => {
+        reponse.contentType('text/html');
+        reponse.send(html);
       })
       .catch(() => {
         reponse.sendStatus(424);

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -13,6 +13,7 @@ const testeurMss = () => {
   let adaptateurHorloge;
   let adaptateurMail;
   let adaptateurPdf;
+  let adaptateurPdfHtml;
   let depotDonnees;
   let moteurRegles;
   let referentiel;
@@ -38,6 +39,7 @@ const testeurMss = () => {
   const initialise = (done) => {
     adaptateurHorloge = adaptateurHorlogeParDefaut;
     adaptateurMail = {};
+    adaptateurPdfHtml = {};
     adaptateurPdf = {};
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();
@@ -51,6 +53,7 @@ const testeurMss = () => {
           referentiel,
           moteurRegles,
           adaptateurMail,
+          adaptateurPdfHtml,
           adaptateurPdf,
           adaptateurHorloge,
           false,
@@ -66,6 +69,7 @@ const testeurMss = () => {
     adaptateurHorloge: () => adaptateurHorloge,
     adaptateurMail: () => adaptateurMail,
     adaptateurPdf: () => adaptateurPdf,
+    adaptateurPdfHtml: () => adaptateurPdfHtml,
     depotDonnees: () => depotDonnees,
     middleware: () => middleware,
     moteurRegles: () => moteurRegles,


### PR DESCRIPTION
Dans le grand projet de générer des PDFs en HTML coté serveur,
l'étape 1 est de créer des routes provisoires pour afficher des pages html, ainsi qu'un adaptateur.
routes : `/:id/api/service/456/pdf/annexes` et `/:id/api/service/456/pdf/dossierDecision`