### PR TITLE
Affichage des caractères spéciaux dans l'annexe html des mesures

### DIFF
--- a/src/pdf/modeles/annexeMesures.pug
+++ b/src/pdf/modeles/annexeMesures.pug
@@ -9,9 +9,9 @@ mixin bloc-mesure(mesuresParCategorie, legende)
           each mesure in mesuresParCategorie[categorie]
             li(class=mesure.indispensable ? "etoile" : "")
               .mesure-contenu
-                .mesure-description= mesure.description
+                .mesure-description!= mesure.description
                 if mesure.modalites
-                  .mesure-modalite= mesure.modalites
+                  .mesure-modalite!= mesure.modalites
     .saut-page
 
 +bloc-mesure(donneesMesures.mesuresParStatut.enCours, donneesMesures.statuts.enCours)


### PR DESCRIPTION
Dans l'annexe HTML des mesures, les caractères spéciaux venants de l'utilisateurs (modalités et description mesure spécifique) ont des caractères spéciaux échappés coté back.
