### PR TITLE
Mesures et risques avec commentaires indivisible

### DIFF
--- a/src/pdf/modeles/annexeMesures.pug
+++ b/src/pdf/modeles/annexeMesures.pug
@@ -6,7 +6,7 @@ mixin bloc-mesure(mesuresParCategorie, legende)
         p.categorie= donneesMesures.categories[categorie]
         ul.liste-puce
           each mesure in mesuresParCategorie[categorie]
-            li(class=mesure.indispensable ? "etoile" : "")
+            li.bloc-indivisible(class = mesure.indispensable ? "etoile" : "")
               .mesure-contenu
                 .mesure-description!= mesure.description
                 if mesure.modalites

--- a/src/pdf/modeles/annexeRisques.pug
+++ b/src/pdf/modeles/annexeRisques.pug
@@ -11,7 +11,7 @@ mixin niveau-criticite(idNiveau)
     each niveau in donneesRisques.niveauxGravite
       if donneesRisques.risquesParNiveauGravite[niveau.identifiant]
         each risque in donneesRisques.risquesParNiveauGravite[niveau.identifiant]
-          li.bloc-risque
+          li.bloc-risque.bloc-indivisible
             .contenu-niveau
               +niveau-criticite(niveau.identifiant)
               p.niveau= niveau.description


### PR DESCRIPTION
Dans le pdf HTML les sauts de page évite de diviser les descriptions des commentaires