### PR TITLE
[CORRECTION] Supprime le « s » en trop

### DIFF
--- a/src/vues/fragments/modaleNouveauService.pug
+++ b/src/vues/fragments/modaleNouveauService.pug
@@ -19,7 +19,7 @@ mixin modaleNouveauService
               | aux besoins de sécurité élevés.
               |
               +lienNouvelOnglet('https://aide.monservicesecurise.beta.gouv.fr/fr/article/quels-services-ne-peuvent-pas-etre-references-sur-monservicesecurise-ey6mt1', 'En savoir plus')
-            .message.message-erreur Ce champs est obligatoire. Veuillez le cocher.
+            .message.message-erreur Ce champ est obligatoire. Veuillez le cocher.
           button.bouton.confirmation Continuer
 
   script(type = 'module', src = '/statique/scripts/modaleNouveauService.js')


### PR DESCRIPTION
Cette PR supprime un `s` en trop 👇 

![image](https://user-images.githubusercontent.com/24898521/224722878-6abe4b98-a984-4863-88b4-240702b2858d.png)
