### PR TITLE
[CONTOURNEMENT] Ne génère pas d'annexe « risques » s'il n'y a aucun risque

### DIFF
--- a/src/adaptateurs/adaptateurPdf.js
+++ b/src/adaptateurs/adaptateurPdf.js
@@ -54,13 +54,17 @@ const genereAnnexes = async ({
     pug.compileFile('src/pdf/modeles/annexe.piedpage.pug')({ nomService: donneesDescription.nomService })
   );
 
+  const risquesPresents = Object.keys(donneesRisques.risquesParNiveauGravite).length > 0;
+
   const [description, mesures, risques] = await Promise.all([
     genereAnnexe('annexeDescription', { donneesDescription }),
     genereAnnexe('annexeMesures', { donneesMesures, referentiel }),
-    genereAnnexe('annexeRisques', { donneesRisques, referentiel }),
+    risquesPresents ? genereAnnexe('annexeRisques', { donneesRisques, referentiel }) : null,
   ]);
 
-  return fusionnePdfs([description, mesures, risques]);
+  return fusionnePdfs(risquesPresents
+    ? [description, mesures, risques]
+    : [description, mesures]);
 };
 
 const ecrisLeChamp = (formulaire, idChamp, contenu) => {


### PR DESCRIPTION
… pour éviter une erreur de type :

```
mon-service-securise-web-1  | ProtocolError: Protocol error (Page.printToPDF): Printing failed
mon-service-securise-web-1  |     at /usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/Connection.js:329:24
mon-service-securise-web-1  |     at new Promise (<anonymous>)
mon-service-securise-web-1  |     at CDPSessionImpl.send (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/Connection.js:325:16)
mon-service-securise-web-1  |     at CDPPage.createPDFStream (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/Page.js:746:88)
mon-service-securise-web-1  |     at CDPPage.pdf (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/Page.js:772:37)
mon-service-securise-web-1  |     at generePdf (/usr/src/app/src/adaptateurs/adaptateurPdf.js:22:23)
mon-service-securise-web-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
mon-service-securise-web-1  |     at async Promise.all (index 0)
mon-service-securise-web-1  |     at async Object.genereAnnexes (/usr/src/app/src/adaptateurs/adaptateurPdf.js:61:7)
```

Nous ne comprenons pas encore comment résoudre mieux le problème.