### PR TITLE
Enlève le saut d'affichage lors de l'apparition d'une modale

### DIFF
--- a/public/assets/styles/modale.css
+++ b/public/assets/styles/modale.css
@@ -1,7 +1,3 @@
-body.recouvert {
-  overflow: hidden;
-}
-
 .puce-information {
   cursor: pointer;
 


### PR DESCRIPTION
Ce comportement n'est reproductible que sur Chrome.
Lors de l'affichage d'une modale, si la page comporte un slider de défilement, il disparait, entrainant un saut d'affichage de toute la page.