### PR TITLE
Conditionne le rendu de la page d'erreur

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -18,6 +18,7 @@ const creeServeur = (
   adaptateurHorloge,
   adaptateurGestionErreur,
   avecCookieSecurise = (process.env.NODE_ENV === 'production'),
+  avecPageErreur = (process.env.NODE_ENV === 'production'),
 ) => {
   let serveur;
 
@@ -143,9 +144,11 @@ const creeServeur = (
 
   app.use(adaptateurGestionErreur.controleurErreurs());
 
-  app.use((_erreur, _requete, reponse, _suite) => {
-    reponse.render('erreur');
-  });
+  if (avecPageErreur) {
+    app.use((_erreur, _requete, reponse, _suite) => {
+      reponse.render('erreur');
+    });
+  }
 
   const ecoute = (port, succes) => {
     serveur = app.listen(port, succes);


### PR DESCRIPTION
En local, on ne souhaite pas rendre une "belle" page d'erreur en dernier recours, pour 2 raisons :
- Les erreurs remontées nous permettent souvent dans les phases de développement de comprendre où sont les problèmes
- Certains tests se basent sur le fait que le serveur crash