### PR TITLE
Page étape avis sans possibilité d'ajouter des éléments

### DIFF
--- a/public/assets/styles/etapesDossier/avis.css
+++ b/public/assets/styles/etapesDossier/avis.css
@@ -1,0 +1,57 @@
+section.description {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+section.description p {
+  margin-bottom: 2em;
+}
+
+.elements-ajoutables .item-ajoute {
+  padding: 0;
+}
+
+.elements-ajoutables .cartouche {
+  border-bottom: 1px var(--liseres) solid;
+  width: 100%;
+  padding: 2em;
+  box-sizing: border-box;
+}
+
+.elements-ajoutables .cartouche h3 {
+  color: var(--bleu-anssi);
+  font-weight: bold;
+  margin: 0;
+}
+
+.elements-ajoutables .contenu {
+  padding: 2em;
+}
+
+.elements-ajoutables .contenu label {
+  font-weight: bold;
+}
+
+.elements-ajoutables .contenu .requis:first-of-type {
+  margin-bottom: 2em;
+}
+
+.elements-ajoutables .contenu label.champ-texte {
+  width: 100%;
+}
+
+.elements-ajoutables .contenu fieldset label {
+  font-weight: normal;
+}
+
+.elements-ajoutables .contenu fieldset {
+  margin: 0;
+}
+
+.elements-ajoutables .contenu label.texte-libre {
+  width: 100%;
+}
+
+.elements-ajoutables .contenu textarea {
+  height: 6em;
+}

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -286,6 +286,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     seuilsCriticites,
     descriptionStatutDeploiement,
     sousTitreActionSaisie,
+    statutsAvisDossierHomologation,
     statutsDeploiement,
     statutDeploiementValide,
     statutsMesures,

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
@@ -1,0 +1,65 @@
+include ../inputChoix
+
+mixin unAvis(donneesUnAvis = {}, index = 0)
+  .item-ajoute
+    .icone-suppression
+    div(id = `element-un-avis-${index}`)
+      .cartouche: h3 Avis n°#{index + 1}
+      .contenu
+        .requis
+          label.champ-texte Prénom Nom du collaborateur métier ou technique renseignant l'avis
+            input(
+              id = `prenomNom-un-avis-${index}`,
+              name = `prenomNom-un-avis-${index}`,
+              type = 'text',
+              placeholder = 'ex: Louis Martin',
+              required,
+              pattern = '^\\D+$',
+              value = donneesUnAvis.collaborateurs ? donneesUnAvis.collaborateurs.toString() : '',
+            )
+            .message-erreur Le prénom nom est obligatoire. Veuillez renseigner des lettres. Les chiffres ne sont pas autorisés.
+
+        - donneesUnAvis[`statut-un-avis-${index}`] = donneesUnAvis.statut
+        .requis
+          +inputChoix({
+              type: 'radio',
+              nom: `statut-un-avis-${index}`,
+              titre: 'Statut',
+              items: referentiel.statutsAvisDossierHomologation(),
+              requis: true,
+              messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
+              objetDonnees: donneesUnAvis,
+            })
+
+        - donneesUnAvis[`dureeValidite-un-avis-${index}`] = donneesUnAvis.dureeValidite
+        .requis
+          +inputChoix({
+              type: 'radio',
+              nom: `dureeValidite-un-avis-${index}`,
+              titre: "Durée proposée de validité de l'homologation",
+              items: referentiel.echeancesRenouvellement(),
+              requis: true,
+              messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
+              objetDonnees: donneesUnAvis,
+            })
+
+        label.texte-libre Commentaires et recommandations
+          textarea(
+            rows = '10',
+            id = `commentaires-un-avis-${index}`,
+            name = `commentaires-un-avis-${index}`,
+            placeholder = 'ex : favorable pour la mise en ligne sous réserve que certaines mesures soient réalisées dans 1 mois.',
+          )= donneesUnAvis.commentaires
+
+mixin elementsAjoutablesAvis(donneesAvis = [])
+  .elements-ajoutables#avis
+    - 
+      if (Array.isArray(donneesAvis) && donneesAvis.length === 0) {
+        donneesAvis.push({})
+      }
+    each donneesUnAvis, index in donneesAvis 
+      +unAvis(donneesUnAvis, index)
+
+  a(class = 'nouvel-item', id = 'ajout-element-un-avis') Ajouter un avis
+
+  script(type = 'module', src = '/statique/modules/elementsAjoutables.js')

--- a/src/vues/service/etapeDossier/avis.pug
+++ b/src/vues/service/etapeDossier/avis.pug
@@ -1,0 +1,22 @@
+extends ../formulaireEtapier
+include ../../fragments/elementsAjoutables/elementsAjoutablesAvis
+
+block append styles
+  link(href = '/statique/assets/styles/etapesDossier/avis.css', rel = 'stylesheet')
+
+block formulaire
+  section.description
+    p.
+      Renseignez un ou plusieurs avis sur la sécurité du service pour aider l'autorité d'homologation à prendre sa décision.
+      Nous vous recommandons au moins un avis groupé.
+
+    .mention champ obligatoire
+
+  +elementsAjoutablesAvis(service.dossierCourant().avis.avis)
+
+block bouton-etape
+  button.bouton#suivant(
+      data-id-homologation = service.id,
+      data-id-etape = idEtape,
+      data-id-etape-suivante = referentiel.idEtapeSuivante(idEtape)
+    ) Suivant

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -292,6 +292,16 @@ describe('Le référentiel', () => {
     );
   });
 
+  it("connaît les statuts des avis de dossier d'homologation", () => {
+    const referentiel = Referentiel.creeReferentiel({
+      statutsAvisDossierHomologation: { favorable: { description: 'Favorable' }, defavorable: { description: 'Défavorable' } },
+    });
+
+    expect(referentiel.statutsAvisDossierHomologation()).to.eql(
+      { favorable: { description: 'Favorable' }, defavorable: { description: 'Défavorable' } }
+    );
+  });
+
   it("sait si un identifiant fait partie de la liste des statuts d'avis de dossier d'homologation", () => {
     const referentiel = Referentiel.creeReferentiel({
       statutsAvisDossierHomologation: { favorable: { } },


### PR DESCRIPTION
Dans le parcours d'homologation,
La future étape 2 est pas encore accessible,
Ce dev est le corps d'une page non liée au parcours

Notes : 
- pour voir la page il faut modifier les donneesReferentiel en ajoutant `{ numero: 2, libelle: 'Avis', id: 'avis' },` à l'objet etapesParcoursHomologation
- Il ne se passe rien quand on clique sur ajouter un élément car les éléments ajoutables coté clients ne sont pas encore présent
- L'enregistrement à la soumission du formulaire n'est pas présent non plus

<img width="540" alt="Capture d’écran 2023-03-16 à 16 19 30" src="https://user-images.githubusercontent.com/39462397/225663674-103efaf2-f73a-4fb9-bb26-f96a030f666e.png">
