### PR TITLE
Affiche une erreur en cas d'invitation déjà envoyée

### DIFF
--- a/public/modules/elementsDom/services.mjs
+++ b/public/modules/elementsDom/services.mjs
@@ -12,6 +12,10 @@ const $modaleNouveauContributeur = () => $(`
                placeholder="ex. jean.dupont@mail.fr">
         <input id="idService" name="idService" type="hidden">
       </div>
+      <div class="message-erreur" id="invitation-deja-envoyee">
+        Cet e-mail a déjà été utilisé. Veuillez en saisir un autre. <br>
+        Si vous souhaitez renvoyer une invitation, merci de nous contacter à <a href="mailto:support@monservicesecurise.beta.gouv.fr">support@monservicesecurise.beta.gouv.fr</a>.
+      </div>
       <div class="confirmation">
         <a class="bouton" id="nouveau-contributeur">Envoyer</a>
       </div>

--- a/public/modules/interactions/saisieContributeur.js
+++ b/public/modules/interactions/saisieContributeur.js
@@ -1,16 +1,29 @@
+const estInvitationDejaEnvoyee = (reponseErreur) => (
+  reponseErreur.status === 422
+    && reponseErreur.data?.erreur?.code === 'INVITATION_DEJA_ENVOYEE'
+);
+
 const brancheComportementSaisieContributeur = (selecteurAjoutContributeur) => {
   $(selecteurAjoutContributeur).on('click', (e) => {
     const idService = $(e.target).data('id-service');
     $('input#idService').val(idService);
   });
 
+  const idModale = '#rideau-nouveau-contributeur';
   $('.bouton#nouveau-contributeur').on('click', (e) => {
     e.stopPropagation();
+    $('.message-erreur', idModale).hide();
+
     const emailContributeur = $('input#emailContributeur').val();
     const idService = $('input#idService').val();
 
     axios.post('/api/autorisation', { emailContributeur, idHomologation: idService })
-      .then(() => (window.location = '/espacePersonnel'));
+      .then(() => (window.location = '/espacePersonnel'))
+      .catch(({ response }) => {
+        if (estInvitationDejaEnvoyee(response)) {
+          $('.message-erreur#invitation-deja-envoyee', idModale).show();
+        }
+      });
   });
 };
 

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -296,6 +296,8 @@ const routesApi = (
         .catch((e) => {
           if (e instanceof EchecAutorisation) {
             reponse.status(403).send("Ajout non autorisé d'un contributeur");
+          } else if (e instanceof ErreurAutorisationExisteDeja) {
+            reponse.status(422).json({ erreur: { code: 'INVITATION_DEJA_ENVOYEE' } });
           } else if (e instanceof EchecEnvoiMessage) {
             reponse.status(424).send("L'envoi de l'email de finalisation d'inscription a échoué");
           } else if (e instanceof ErreurModele) reponse.status(422).send(e.message);

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -983,6 +983,19 @@ describe('Le serveur MSS des routes /api/*', () => {
             })
             .catch((e) => done(e.response?.data || e));
         });
+
+        it("renvoie une erreur explicite à propos de l'invitation déjà envoyée", (done) => {
+          axios.post('http://localhost:1234/api/autorisation', {
+            emailContributeur: 'jean.dupont@mail.fr',
+            idHomologation: '123',
+          })
+            .then(() => done('Le serveur aurait dû lever une erreur HTTP'))
+            .catch((e) => {
+              expect(e.response.data).to.eql({ erreur: { code: 'INVITATION_DEJA_ENVOYEE' } });
+              done();
+            })
+            .catch((e) => done(e.response?.data || e));
+        });
       });
     });
 


### PR DESCRIPTION
… plutôt que de laisser l'utilisateur sans information.

On affiche un message : 

![image](https://user-images.githubusercontent.com/24898521/225705603-dbf1c1b4-2926-4597-85ad-11d1d95c2b34.png)

### Design

Cette PR trace une ébauche de gestion d'erreur où l'API renvoie un objet `{ erreur: { code: '…' } }`