### PR TITLE
Erreur typographique au mot statuts

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -62,7 +62,7 @@ module.exports = {
     },
   },
 
-  statutAvisDossierHomologation: {
+  statutsAvisDossierHomologation: {
     favorable: { description: 'Favorable' },
     favorableAvecReserve: { description: 'Favorable avec réserve' },
     defavorable: { description: 'Défavorable' },

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -29,7 +29,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const actionsSaisie = () => donnees.actionsSaisie || {};
   const identifiantsActionsSaisie = () => Object.keys(actionsSaisie());
   const actionSaisie = (id) => actionsSaisie()[id] || {};
-  const statutAvisDossierHomologation = () => donnees.statutAvisDossierHomologation || {};
+  const statutsAvisDossierHomologation = () => donnees.statutsAvisDossierHomologation || {};
   const positionActionSaisie = (id) => actionSaisie(id).position;
   const categoriesMesures = () => donnees.categoriesMesures;
   const descriptionCategorie = (idCategorie) => categoriesMesures()[idCategorie];
@@ -61,7 +61,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     identifiantsEcheancesRenouvellement().includes(idEcheance)
   );
   const identifiantsStatutAvisDossierHomologation = () => Object
-    .keys(statutAvisDossierHomologation());
+    .keys(statutsAvisDossierHomologation());
   const estIdentifiantStatutAvisDossierHomologationConnu = (idStatut) => (
     identifiantsStatutAvisDossierHomologation().includes(idStatut)
   );

--- a/test/modeles/avis.spec.js
+++ b/test/modeles/avis.spec.js
@@ -7,7 +7,7 @@ const Referentiel = require('../../src/referentiel');
 
 describe("Un avis sur un dossier d'homologation", () => {
   const referentiel = Referentiel.creeReferentiel({
-    statutAvisDossierHomologation: { favorable: {} },
+    statutsAvisDossierHomologation: { favorable: {} },
     echeancesRenouvellement: { unAn: {} },
   });
 

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -11,7 +11,7 @@ describe("Un dossier d'homologation", () => {
   beforeEach(() => referentiel.recharge({
     echeancesRenouvellement: { unAn: {} },
     documentsHomologation: { decision: {} },
-    statutAvisDossierHomologation: { favorable: {} },
+    statutsAvisDossierHomologation: { favorable: {} },
   }));
 
   it('sait se convertir en JSON', () => {
@@ -120,7 +120,7 @@ describe("Un dossier d'homologation", () => {
     beforeEach(() => {
       referentiel.recharge({
         echeancesRenouvellement: { unAn: { nbMoisDecalage: 12 } },
-        statutAvisDossierHomologation: { favorable: {} },
+        statutsAvisDossierHomologation: { favorable: {} },
       });
     });
 

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -46,7 +46,7 @@ describe('Les dossiers liés à un service', () => {
     beforeEach(() => (
       referentiel.recharge({
         echeancesRenouvellement: { unAn: { nbMoisDecalage: 12 } },
-        statutAvisDossierHomologation: { favorable: {} },
+        statutsAvisDossierHomologation: { favorable: {} },
       })
     ));
 

--- a/test/modeles/etapes/etapeAvis.spec.js
+++ b/test/modeles/etapes/etapeAvis.spec.js
@@ -7,7 +7,7 @@ describe('Une étape « Avis »', () => {
   it('sait se convertir en JSON ', () => {
     const referentiel = Referentiel.creeReferentiel({
       echeancesRenouvellement: { unAn: {} },
-      statutAvisDossierHomologation: { favorable: { } },
+      statutsAvisDossierHomologation: { favorable: { } },
     });
 
     const etape = new EtapeAvis({
@@ -38,7 +38,7 @@ describe('Une étape « Avis »', () => {
     it("n'est pas complète dès qu'un avis n'est pas saisi", () => {
       const referentiel = Referentiel.creeReferentiel({
         echeancesRenouvellement: { unAn: {} },
-        statutAvisDossierHomologation: { favorable: { } },
+        statutsAvisDossierHomologation: { favorable: { } },
       });
       const sansPrenomNom = { statut: 'favorable', dureeValidite: 'unAn' };
       const avecAvisNonSaisis = new EtapeAvis({ avis: [sansPrenomNom] }, referentiel);
@@ -49,7 +49,7 @@ describe('Une étape « Avis »', () => {
     it('est complète si tous les avis sont saisis', () => {
       const referentiel = Referentiel.creeReferentiel({
         echeancesRenouvellement: { unAn: {} },
-        statutAvisDossierHomologation: { favorable: { } },
+        statutsAvisDossierHomologation: { favorable: { } },
       });
       const avecAvisSaisis = new EtapeAvis(
         { avis: [{ collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn' }] },

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -449,7 +449,7 @@ describe('Une homologation', () => {
         reglesPersonnalisation: { mesuresBase: ['uneMesure'] },
         risques: { unRisque: {} },
         statutsDeploiement: { unStatutDeploiement: {} },
-        statutAvisDossierHomologation: { favorable: {} },
+        statutsAvisDossierHomologation: { favorable: {} },
       });
 
       const aujourdhui = new Date();

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -294,7 +294,7 @@ describe('Le référentiel', () => {
 
   it("sait si un identifiant fait partie de la liste des statuts d'avis de dossier d'homologation", () => {
     const referentiel = Referentiel.creeReferentiel({
-      statutAvisDossierHomologation: { favorable: { } },
+      statutsAvisDossierHomologation: { favorable: { } },
     });
 
     expect(referentiel.estIdentifiantStatutAvisDossierHomologationConnu('favorable')).to.be(true);

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -725,7 +725,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().metsAJourDossierCourant = () => Promise.resolve();
       testeur.referentiel().recharge({
         echeancesRenouvellement: { unAn: {} },
-        statutAvisDossierHomologation: { favorable: {} },
+        statutsAvisDossierHomologation: { favorable: {} },
       });
     });
 


### PR DESCRIPTION
Dans le référentiel, dans la clé `statutAvisDossierHomologation` il manquait un s à statut