### PR TITLE
Permets la soumissions du formulaire des avis

### DIFF
--- a/public/homologation/etapesDossier.js
+++ b/public/homologation/etapesDossier.js
@@ -1,8 +1,9 @@
 import { brancheValidation, declencheValidation } from '../modules/interactions/validation.mjs';
+import soumissionEtapeAvis from '../modules/soumissionEtapeAvis.mjs';
 
 let formulaireDejaSoumis = false;
 
-const action = (idEtape, idService) => {
+const action = (idEtape, idService, selecteurFormulaire) => {
   let resultat = Promise.resolve();
 
   if (idEtape === 'autorite') {
@@ -12,6 +13,8 @@ const action = (idEtape, idService) => {
     };
 
     resultat = axios.put(`/api/service/${idService}/dossier/autorite`, donnees);
+  } else if (idEtape === 'avis') {
+    resultat = soumissionEtapeAvis(selecteurFormulaire, idService);
   } else if (idEtape === 'date') {
     const donnees = {
       dateHomologation: $('#date-homologation').val(),
@@ -35,7 +38,7 @@ const brancheComportemenFormulaire = (selecteur, idService, idEtape, idEtapeSuiv
     if (!formulaireDejaSoumis) {
       formulaireDejaSoumis = true;
 
-      action(idEtape, idService)
+      action(idEtape, idService, selecteur)
         .then(() => (
           window.location = idEtapeSuivante
             ? `/service/${idService}/dossier/edition/etape/${idEtapeSuivante}`

--- a/public/modules/soumissionEtapeAvis.mjs
+++ b/public/modules/soumissionEtapeAvis.mjs
@@ -1,0 +1,33 @@
+import parametres, { modifieParametresAvecItemsExtraits } from './parametres.mjs';
+
+const integreCollaborateursDansAvis = (avis = []) => avis.map((unAvis) => {
+  if (!unAvis.prenomNom) {
+    return unAvis;
+  }
+  unAvis.collaborateurs = [unAvis.prenomNom];
+  delete unAvis.prenomNom;
+  return unAvis;
+});
+
+const arrangeParametresAvis = (params) => {
+  modifieParametresAvecItemsExtraits(
+    params, 'avis', '^(prenomNom|statut|dureeValidite|commentaires)-un-avis-'
+  );
+
+  params.avis = integreCollaborateursDansAvis(params.avis);
+
+  return params;
+};
+
+const soumissionEtapeAvis = (selecteurFormulaire, idService) => {
+  const tousLesParametres = (selecteur) => {
+    const params = parametres(selecteur);
+
+    return arrangeParametresAvis(params);
+  };
+
+  return axios.put(`/api/service/${idService}/dossier/avis`, tousLesParametres(selecteurFormulaire));
+};
+
+export { arrangeParametresAvis };
+export default soumissionEtapeAvis;

--- a/test_public/modules/soumissionEtapeAvis.spec.mjs
+++ b/test_public/modules/soumissionEtapeAvis.spec.mjs
@@ -1,0 +1,48 @@
+import expect from 'expect.js';
+import { arrangeParametresAvis } from '../../public/modules/soumissionEtapeAvis.mjs';
+
+describe("Une demande d'arrangement des paramètres des avis", () => {
+  it('range les avis dans un tableau', () => {
+    const parametres = {
+      'statut-un-avis-0': 'defavorable',
+      'statut-un-avis-1': 'favorable',
+    };
+
+    const parametresArranges = arrangeParametresAvis(parametres);
+
+    expect(parametresArranges.avis).to.eql([{ statut: 'defavorable' }, { statut: 'favorable' }]);
+  });
+
+  it('supprime les paramètres après les avoir rangés', () => {
+    const parametres = {
+      'statut-un-avis-0': 'defavorable',
+      'dureeValidite-un-avis-0': 'deuxAns',
+      'commentaires-un-avis-0': 'Des commentaires',
+    };
+
+    const parametresArranges = arrangeParametresAvis(parametres);
+
+    expect(parametresArranges.avis).to.eql([
+      {
+        statut: 'defavorable',
+        dureeValidite: 'deuxAns',
+        commentaires: 'Des commentaires',
+      },
+    ]);
+    expect(parametresArranges).to.not.have.property('statut-un-avis-0');
+    expect(parametresArranges).to.not.have.property('dureeValidite-un-avis-0');
+    expect(parametresArranges).to.not.have.property('commentaires-un-avis-0');
+  });
+
+  it('arrange le prénom et le nom dans un tableau de collaborateurs', () => {
+    const parametres = {
+      'prenomNom-un-avis-0': 'Jean',
+    };
+
+    const parametresArranges = arrangeParametresAvis(parametres);
+
+    expect(parametresArranges).to.not.have.property('prenomNom-un-avis-0');
+    expect(parametresArranges).to.not.have.property('prenomNom');
+    expect(parametresArranges).to.eql({ avis: [{ collaborateurs: ['Jean'] }] });
+  });
+});


### PR DESCRIPTION
Dans le parcours d'homologation,
La future étape 2 est pas encore accessible,
Ici on permet l'enregistrement des avis

NOTES :

pour voir la page il faut modifier les donneesReferentiel en ajoutant { numero: 2, libelle: 'Avis', id: 'avis' }, à l'objet etapesParcoursHomologation