### PR TITLE
Considère que l'étape « Avis » est complète s'il n'y a aucun avis

### DIFF
--- a/src/modeles/etapes/etapeAvis.js
+++ b/src/modeles/etapes/etapeAvis.js
@@ -15,8 +15,7 @@ class EtapeAvis extends Etape {
   }
 
   estComplete() {
-    return this.avis.length > 0
-        && this.avis.every((a) => a.statutSaisie() === InformationsHomologation.COMPLETES);
+    return this.avis.every((a) => a.statutSaisie() === InformationsHomologation.COMPLETES);
   }
 
   toJSON() {

--- a/test/modeles/etapes/etapeAvis.spec.js
+++ b/test/modeles/etapes/etapeAvis.spec.js
@@ -30,9 +30,9 @@ describe('Une étape « Avis »', () => {
   });
 
   describe("sur vérification que l'étape est complète", () => {
-    it("n'est pas complète s'il n'y a aucun avis", () => {
+    it("est complète s'il n'y a aucun avis", () => {
       const aucunAvis = new EtapeAvis();
-      expect(aucunAvis.estComplete()).to.be(false);
+      expect(aucunAvis.estComplete()).to.be(true);
     });
 
     it("n'est pas complète dès qu'un avis n'est pas saisi", () => {


### PR DESCRIPTION
… pour respecter une demande métier.

La partie « UI » de cette évolution arrivera dans un second temps.
On peut dores et déjà supprimer l'avis ajouté par défaut, mais ce n'est pas l'UX finale.