### PR TITLE
Supprime le lien vers `Questions fréquentes`

### DIFF
--- a/src/vues/mssConnexionEnCours.pug
+++ b/src/vues/mssConnexionEnCours.pug
@@ -1,5 +1,4 @@
 extends mss
 
 block navigation
-  a(href = 'https://aide.monservicesecurise.beta.gouv.fr' target='_blank' rel='noopener') Questions fréquentes
   a(href = 'mailto:support@monservicesecurise.beta.gouv.fr') Contactez-nous

--- a/src/vues/mssDeconnecte.pug
+++ b/src/vues/mssDeconnecte.pug
@@ -1,6 +1,5 @@
 extends mss
 
 block navigation
-  a(href = 'https://aide.monservicesecurise.beta.gouv.fr' target='_blank' rel='noopener') Questions fréquentes
   a(href = 'mailto:support@monservicesecurise.beta.gouv.fr') Contactez-nous
   .utilisateur-courant


### PR DESCRIPTION
Le lien est maintenant disponible dans le BOM.

Il y'a toujours une redirection dans `mss.js`, doit on l'enlever ?

```js
  // Pour que les utilisateurs ayant cette page en favoris ne soient pas perdus.
  app.get('/questionsFrequentes', (_requete, reponse) => {
    reponse.redirect('https://aide.monservicesecurise.beta.gouv.fr');
  });
```