### PR TITLE
Ajoute une propriété `avecAvis` à l'étape "Avis"

### DIFF
--- a/public/homologation/etapes/avis.js
+++ b/public/homologation/etapes/avis.js
@@ -8,14 +8,9 @@ const templateZoneDeSaisie = (template) => (index) => (
   $(template.replace('INDEX_AVIS', index + 1).replaceAll('INDEX', index))
 );
 
-const soumissionEtapeAvis = (selecteurFormulaire) => (idService) => {
-  const tousLesParametres = (selecteur) => {
-    const params = parametres(selecteur);
-
-    return arrangeParametresAvis(params);
-  };
-  return axios.put(`/api/service/${idService}/dossier/avis`, tousLesParametres(selecteurFormulaire));
-};
+const soumissionEtapeAvis = (selecteurFormulaire) => (idService) => (
+  axios.put(`/api/service/${idService}/dossier/avis`, { ...arrangeParametresAvis(parametres(selecteurFormulaire)), avecAvis: true })
+);
 
 const brancheCollaborateursEtiquettes = (conteneurSaisieItem) => {
   $("[id^='collaborateurs-un-avis-']", conteneurSaisieItem).selectize({

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -58,6 +58,12 @@ class Dossier extends InformationsHomologation {
     this.autorite.enregistreAutoriteHomologation(nom, fonction);
   }
 
+  declareSansAvis() {
+    if (this.finalise) throw new ErreurDossierDejaFinalise();
+
+    this.avis.declareSansAvis();
+  }
+
   enregistreAvis(avis) {
     if (this.finalise) throw new ErreurDossierDejaFinalise();
 

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -30,7 +30,10 @@ class Dossier extends InformationsHomologation {
       donneesDossier.datesTelechargements ?? {},
       referentiel
     );
-    this.avis = new EtapeAvis({ avis: donneesDossier.avis }, referentiel);
+    this.avis = new EtapeAvis({
+      avis: donneesDossier.avis,
+      avecAvis: donneesDossier.avecAvis,
+    }, referentiel);
   }
 
   descriptionDateHomologation() {

--- a/src/modeles/etapes/etapeAvis.js
+++ b/src/modeles/etapes/etapeAvis.js
@@ -4,22 +4,35 @@ const InformationsHomologation = require('../informationsHomologation');
 const { creeReferentielVide } = require('../../referentiel');
 
 class EtapeAvis extends Etape {
-  constructor({ avis = [] } = {}, referentiel = creeReferentielVide()) {
-    super({}, referentiel);
+  constructor({ avis = [], avecAvis = null } = {}, referentiel = creeReferentielVide()) {
+    super({ proprietesAtomiquesRequises: ['avecAvis'] }, referentiel);
 
-    this.enregistreAvis(avis);
-  }
-
-  enregistreAvis(avis) {
+    this.renseigneProprietes({ avecAvis });
     this.avis = avis.map((a) => new Avis(a, this.referentiel));
   }
 
+  enregistreAvis(avis) {
+    this.avecAvis = true;
+    this.avis = avis.map((a) => new Avis(a, this.referentiel));
+  }
+
+  declareSansAvis() {
+    this.avecAvis = false;
+    this.avis = [];
+  }
+
   estComplete() {
-    return this.avis.every((a) => a.statutSaisie() === InformationsHomologation.COMPLETES);
+    if (this.avecAvis === null) return false;
+    return this.avecAvis
+      ? this.avis.every((a) => a.statutSaisie() === InformationsHomologation.COMPLETES)
+      : true;
   }
 
   toJSON() {
-    return { avis: this.avis.map((a) => a.toJSON()) };
+    return {
+      avis: this.avis.map((a) => a.toJSON()),
+      avecAvis: this.avecAvis,
+    };
   }
 }
 

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -1,5 +1,6 @@
 const express = require('express');
 
+const { valeurBooleenne } = require('../utilitaires/aseptisation');
 const { DUREE_SESSION } = require('../http/configurationServeur');
 const { resultatValidation, valideMotDePasse } = require('../http/validationMotDePasse');
 const {
@@ -53,14 +54,6 @@ const routesApi = (
     )
       .then(() => contributeur)
   );
-
-  const valeurBooleenne = (valeur) => {
-    switch (valeur) {
-      case 'true': return true;
-      case 'false': return false;
-      default: return undefined;
-    }
-  };
 
   const obtentionDonneesDeBaseUtilisateur = (corps) => ({
     prenom: corps.prenom,

--- a/src/utilitaires/aseptisation.js
+++ b/src/utilitaires/aseptisation.js
@@ -1,0 +1,9 @@
+const valeurBooleenne = (valeur) => {
+  switch (valeur) {
+    case 'true': return true;
+    case 'false': return false;
+    default: return undefined;
+  }
+};
+
+module.exports = { valeurBooleenne };

--- a/test/constructeurs/constructeurDossier.js
+++ b/test/constructeurs/constructeurDossier.js
@@ -40,6 +40,7 @@ class ConstructeurDossierFantaisie {
 
   quiEstComplet() {
     this.donnees.finalise = true;
+    this.donnees.avecAvis = true;
     this.donnees.avis = [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }];
     this.donnees.decision = { dateHomologation: '2023-01-01', dureeValidite: 'unAn' };
     this.donnees.datesTelechargements = this.referentiel

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -20,6 +20,7 @@ describe("Un dossier d'homologation", () => {
       decision: { dateHomologation: '2022-12-01', dureeValidite: 'unAn' },
       autorite: { nom: 'Jean Courage', fonction: 'Responsable' },
       datesTelechargements: { decision: '2023-01-01T00:00:00.000Z' },
+      avecAvis: true,
       avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
       finalise: true,
     },
@@ -30,6 +31,7 @@ describe("Un dossier d'homologation", () => {
       decision: { dateHomologation: '2022-12-01', dureeValidite: 'unAn' },
       autorite: { nom: 'Jean Courage', fonction: 'Responsable' },
       datesTelechargements: { decision: '2023-01-01T00:00:00.000Z' },
+      avecAvis: true,
       avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
       finalise: true,
     });

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -112,6 +112,25 @@ describe("Un dossier d'homologation", () => {
       dossier.enregistreAvis([avisComplet]);
 
       expect(dossier.avis.avis[0].toJSON()).to.eql(avisComplet);
+      expect(dossier.avis.avecAvis).to.be(true);
+    });
+  });
+
+  describe('sur demande de déclaration sans avis', () => {
+    it('jette une erreur si le dossier est déjà finalisé', () => {
+      const dossierFinalise = new Dossier({ finalise: true });
+
+      expect(() => dossierFinalise.declareSansAvis())
+        .to.throwError((e) => expect(e).to.be.an(ErreurDossierDejaFinalise));
+    });
+
+    it('efface les avis existants', () => {
+      const dossier = new Dossier({ avis: [{ collaborateurs: ['Jean Dupond'], statut: 'favorable', dureeValidite: 'unAn' }], avecAvis: true }, referentiel);
+
+      dossier.declareSansAvis();
+
+      expect(dossier.avis.avecAvis).to.be(false);
+      expect(dossier.avis.avis).to.eql([]);
     });
   });
 

--- a/test/modeles/etapes/etapeAvis.spec.js
+++ b/test/modeles/etapes/etapeAvis.spec.js
@@ -4,59 +4,81 @@ const EtapeAvis = require('../../../src/modeles/etapes/etapeAvis');
 const Referentiel = require('../../../src/referentiel');
 
 describe('Une étape « Avis »', () => {
-  it('sait se convertir en JSON ', () => {
-    const referentiel = Referentiel.creeReferentiel({
-      echeancesRenouvellement: { unAn: {} },
-      statutsAvisDossierHomologation: { favorable: { } },
-    });
+  const referentiel = Referentiel.creeReferentiel({
+    echeancesRenouvellement: { unAn: {} },
+    statutsAvisDossierHomologation: { favorable: { } },
+  });
 
+  it('sait se convertir en JSON ', () => {
     const etape = new EtapeAvis({
       avis: [
         { collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' },
       ],
+      avecAvis: true,
     }, referentiel);
 
     expect(etape.toJSON()).to.eql({
       avis: [
         { collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' },
       ],
+      avecAvis: true,
     });
   });
 
   it("reste robuste s'il n'y a pas d'avis dans les données", () => {
     const etape = new EtapeAvis();
 
-    expect(etape.toJSON()).to.eql({ avis: [] });
+    expect(etape.toJSON()).to.eql({ avis: [], avecAvis: null });
+  });
+
+  it("sait déclarer l'étape sans avis", () => {
+    const etape = new EtapeAvis({}, referentiel);
+    etape.enregistreAvis([{ collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' }]);
+
+    etape.declareSansAvis();
+
+    expect(etape.avecAvis).to.be(false);
+    expect(etape.avis).to.eql([]);
+  });
+
+  it('sait enregistrer des avis', () => {
+    const etape = new EtapeAvis({}, referentiel);
+
+    etape.enregistreAvis([{ collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'OK pour moi' }]);
+
+    expect(etape.avecAvis).to.be(true);
   });
 
   describe("sur vérification que l'étape est complète", () => {
-    it("est complète s'il n'y a aucun avis", () => {
-      const aucunAvis = new EtapeAvis();
+    it('est incomplète par défaut', () => {
+      const etapeParDefaut = new EtapeAvis();
+      expect(etapeParDefaut.estComplete()).to.be(false);
+    });
+
+    it("est complète s'il n'y a aucun avis et qu'elle est déclarée sans avis", () => {
+      const aucunAvis = new EtapeAvis({ avis: [], avecAvis: false });
       expect(aucunAvis.estComplete()).to.be(true);
     });
 
-    it("n'est pas complète dès qu'un avis n'est pas saisi", () => {
-      const referentiel = Referentiel.creeReferentiel({
-        echeancesRenouvellement: { unAn: {} },
-        statutsAvisDossierHomologation: { favorable: { } },
+    describe("dans le cas où l'étape est déclarée avec avis", () => {
+      it("n'est pas complète dès qu'un avis n'est pas saisi", () => {
+        const sansPrenomNom = { statut: 'favorable', dureeValidite: 'unAn' };
+        const avecAvisNonSaisis = new EtapeAvis({
+          avis: [sansPrenomNom],
+          avecAvis: true,
+        }, referentiel);
+
+        expect(avecAvisNonSaisis.estComplete()).to.be(false);
       });
-      const sansPrenomNom = { statut: 'favorable', dureeValidite: 'unAn' };
-      const avecAvisNonSaisis = new EtapeAvis({ avis: [sansPrenomNom] }, referentiel);
 
-      expect(avecAvisNonSaisis.estComplete()).to.be(false);
-    });
+      it('est complète si tous les avis sont saisis', () => {
+        const avecAvisSaisis = new EtapeAvis(
+          { avis: [{ collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn' }], avecAvis: true },
+          referentiel
+        );
 
-    it('est complète si tous les avis sont saisis', () => {
-      const referentiel = Referentiel.creeReferentiel({
-        echeancesRenouvellement: { unAn: {} },
-        statutsAvisDossierHomologation: { favorable: { } },
+        expect(avecAvisSaisis.estComplete()).to.be(true);
       });
-      const avecAvisSaisis = new EtapeAvis(
-        { avis: [{ collaborateurs: ['Jean Durand'], statut: 'favorable', dureeValidite: 'unAn' }] },
-        referentiel
-      );
-
-      expect(avecAvisSaisis.estComplete()).to.be(true);
     });
   });
 });

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -496,6 +496,7 @@ describe('Une homologation', () => {
         },
         dossiers: [{
           id: '1',
+          avecAvis: true,
           avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
           autorite: { nom: 'Jean Dupond', fonction: 'RSSI' },
           decision: { dateHomologation: aujourdhui.toISOString(), dureeValidite: 'unAn' },


### PR DESCRIPTION
Cette propriété sera utile prochainement afin de sélectionner "avec avis" ou sans.
Cela permet d'avoir une relation 1:1 entre les données du domaine et ce qu'affiche le Front.