### PR TITLE
Affichage des étiquettes collaborateurs au dessus de la barre collante

### DIFF
--- a/public/assets/styles/homologation/formulaire.css
+++ b/public/assets/styles/homologation/formulaire.css
@@ -135,6 +135,7 @@ label.exemple {
 
 .enregistrement {
   position: sticky;
+  z-index: 10;
   background-color: #fff;
   bottom: 0;
   display: flex;


### PR DESCRIPTION
Dans la page avis du parcours d'homologation,
Les étiquettes et le menu contextuel des collaborateurs passe au dessus de la barre collant d'enregistrement

Avant :
<img width="904" alt="Capture d’écran 2023-03-24 à 13 48 03" src="https://user-images.githubusercontent.com/39462397/227525364-c8cdf4e6-b330-47f6-914d-433fe600a5b6.png">
Après :
<img width="884" alt="Capture d’écran 2023-03-24 à 13 48 14" src="https://user-images.githubusercontent.com/39462397/227525440-efc98ed8-0d63-4419-b078-903590815380.png">

NOTE : j'ai mis un z-index 10 comme le BOM car moins le menu contextuel passe au dessus et plus le BOM est en dessous