### PR TITLE
Etape document - Back

### DIFF
--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -2,6 +2,7 @@ const adaptateurHorlogeParDefaut = require('../adaptateurs/adaptateurHorloge');
 const Autorite = require('./etapes/autorite');
 const DatesTelechargements = require('./etapes/datesTelechargements');
 const Decision = require('./etapes/decision');
+const Document = require('./etapes/document');
 const EtapeAvis = require('./etapes/etapeAvis');
 const InformationsHomologation = require('./informationsHomologation');
 const Referentiel = require('../referentiel');
@@ -34,6 +35,10 @@ class Dossier extends InformationsHomologation {
       avis: donneesDossier.avis,
       avecAvis: donneesDossier.avecAvis,
     }, referentiel);
+    this.documents = new Document({
+      documents: donneesDossier.documents,
+      avecDocument: donneesDossier.avecDocument,
+    });
   }
 
   descriptionDateHomologation() {
@@ -112,6 +117,7 @@ class Dossier extends InformationsHomologation {
       autorite: this.autorite.toJSON(),
       datesTelechargements: this.datesTelechargements.toJSON(),
       ...this.avis.toJSON(),
+      ...this.documents.toJSON(),
     };
   }
 }

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -2,7 +2,7 @@ const adaptateurHorlogeParDefaut = require('../adaptateurs/adaptateurHorloge');
 const Autorite = require('./etapes/autorite');
 const DatesTelechargements = require('./etapes/datesTelechargements');
 const Decision = require('./etapes/decision');
-const Document = require('./etapes/document');
+const Documents = require('./etapes/documents');
 const EtapeAvis = require('./etapes/etapeAvis');
 const InformationsHomologation = require('./informationsHomologation');
 const Referentiel = require('../referentiel');
@@ -35,9 +35,9 @@ class Dossier extends InformationsHomologation {
       avis: donneesDossier.avis,
       avecAvis: donneesDossier.avecAvis,
     }, referentiel);
-    this.documents = new Document({
+    this.documents = new Documents({
       documents: donneesDossier.documents,
-      avecDocument: donneesDossier.avecDocument,
+      avecDocuments: donneesDossier.avecDocuments,
     });
   }
 
@@ -73,6 +73,18 @@ class Dossier extends InformationsHomologation {
     if (this.finalise) throw new ErreurDossierDejaFinalise();
 
     this.avis.enregistreAvis(avis);
+  }
+
+  declareSansDocument() {
+    if (this.finalise) throw new ErreurDossierDejaFinalise();
+
+    this.documents.declareSansDocument();
+  }
+
+  enregistreDocuments(documents) {
+    if (this.finalise) throw new ErreurDossierDejaFinalise();
+
+    this.documents.enregistreDocuments(documents);
   }
 
   enregistreDateTelechargement(nomDocument, date) {

--- a/src/modeles/etapes/documents.js
+++ b/src/modeles/etapes/documents.js
@@ -1,0 +1,28 @@
+const Etape = require('./etape');
+
+class Documents extends Etape {
+  constructor({ documents = [], avecDocuments = null } = {}) {
+    super({ proprietesAtomiquesRequises: ['avecDocuments'], proprietesListes: ['documents'] });
+
+    this.renseigneProprietes({ documents, avecDocuments });
+  }
+
+  enregistreDocuments(documents) {
+    this.avecDocuments = true;
+    this.documents = documents;
+  }
+
+  declareSansDocument() {
+    this.avecDocuments = false;
+    this.documents = [];
+  }
+
+  estComplete() {
+    if (this.avecDocuments === null) return false;
+    return this.avecDocuments
+      ? this.documents.length > 0
+      : true;
+  }
+}
+
+module.exports = Documents;

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -249,6 +249,28 @@ const routesApiService = (
         .catch(suite);
     });
 
+  routes.put('/:id/dossier/document',
+    middleware.trouveHomologation,
+    middleware.trouveDossierCourant,
+    middleware.aseptise('documents.*', 'avecDocument'),
+    (requete, reponse, suite) => {
+      const { body: { documents } } = requete;
+      if (!documents) {
+        reponse.sendStatus(400);
+        return;
+      }
+
+      const { homologation, dossierCourant } = requete;
+      const avecDocument = valeurBooleenne(requete.body.avecDocument);
+
+      if (avecDocument) dossierCourant.enregistreDocuments(documents);
+      else dossierCourant.declareSansDocument();
+
+      depotDonnees.enregistreDossierCourant(homologation.id, dossierCourant)
+        .then(() => reponse.sendStatus(204))
+        .catch(suite);
+    });
+
   routes.post('/:id/dossier/finalise',
     middleware.trouveHomologation,
     middleware.trouveDossierCourant,

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -249,10 +249,10 @@ const routesApiService = (
         .catch(suite);
     });
 
-  routes.put('/:id/dossier/document',
+  routes.put('/:id/dossier/documents',
     middleware.trouveHomologation,
     middleware.trouveDossierCourant,
-    middleware.aseptise('documents.*', 'avecDocument'),
+    middleware.aseptise('documents.*', 'avecDocuments'),
     (requete, reponse, suite) => {
       const { body: { documents } } = requete;
       if (!documents) {
@@ -261,9 +261,9 @@ const routesApiService = (
       }
 
       const { homologation, dossierCourant } = requete;
-      const avecDocument = valeurBooleenne(requete.body.avecDocument);
+      const avecDocuments = valeurBooleenne(requete.body.avecDocuments);
 
-      if (avecDocument) dossierCourant.enregistreDocuments(documents);
+      if (avecDocuments) dossierCourant.enregistreDocuments(documents);
       else dossierCourant.declareSansDocument();
 
       depotDonnees.enregistreDossierCourant(homologation.id, dossierCourant)

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -210,7 +210,7 @@ const routesApiService = (
         .catch(suite);
     });
 
-  routes.put('/:id/dossier/document/:idDocument', middleware.trouveHomologation, middleware.trouveDossierCourant, (requete, reponse, suite) => {
+  routes.put('/:id/dossier/telechargement/:idDocument', middleware.trouveHomologation, middleware.trouveDossierCourant, (requete, reponse, suite) => {
     const { homologation, dossierCourant } = requete;
 
     const { idDocument } = requete.params;

--- a/src/vues/service/etapeDossier/decision.pug
+++ b/src/vues/service/etapeDossier/decision.pug
@@ -6,7 +6,7 @@ mixin document({ nom, description, dateTelechargement })
 
   a.document-homologation(
     href= referentiel.urlDocumentHomologation(nom, service.id)
-    data-action-enregistrement = `/api/service/${service.id}/dossier/document/${nom}`
+    data-action-enregistrement = `/api/service/${service.id}/dossier/telechargement/${nom}`
     target='_blank'
     rel='noopener'
     )

--- a/test/constructeurs/constructeurDossier.js
+++ b/test/constructeurs/constructeurDossier.js
@@ -42,6 +42,8 @@ class ConstructeurDossierFantaisie {
     this.donnees.finalise = true;
     this.donnees.avecAvis = true;
     this.donnees.avis = [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }];
+    this.donnees.avecDocuments = true;
+    this.donnees.documents = ['unDocument'];
     this.donnees.decision = { dateHomologation: '2023-01-01', dureeValidite: 'unAn' };
     this.donnees.datesTelechargements = this.referentiel
       .tousDocumentsHomologation()

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -22,6 +22,8 @@ describe("Un dossier d'homologation", () => {
       datesTelechargements: { decision: '2023-01-01T00:00:00.000Z' },
       avecAvis: true,
       avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
+      avecDocuments: true,
+      documents: ['unDocument'],
       finalise: true,
     },
     referentiel);
@@ -33,6 +35,8 @@ describe("Un dossier d'homologation", () => {
       datesTelechargements: { decision: '2023-01-01T00:00:00.000Z' },
       avecAvis: true,
       avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
+      avecDocuments: true,
+      documents: ['unDocument'],
       finalise: true,
     });
   });

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -138,6 +138,43 @@ describe("Un dossier d'homologation", () => {
     });
   });
 
+  describe("sur demande d'enregistrement des documents", () => {
+    it('jette une erreur si le dossier est déjà finalisé', () => {
+      const dossierFinalise = new Dossier({ finalise: true });
+
+      expect(() => dossierFinalise.enregistreDocuments([]))
+        .to.throwError((e) => expect(e).to.be.an(ErreurDossierDejaFinalise));
+    });
+
+    it('remplace les documents par ceux fournis', () => {
+      const dossier = new Dossier({}, referentiel);
+      const documents = ['unDocument'];
+
+      dossier.enregistreDocuments(documents);
+
+      expect(dossier.documents.documents).to.eql(documents);
+      expect(dossier.documents.avecDocuments).to.be(true);
+    });
+  });
+
+  describe('sur demande de déclaration sans document', () => {
+    it('jette une erreur si le dossier est déjà finalisé', () => {
+      const dossierFinalise = new Dossier({ finalise: true });
+
+      expect(() => dossierFinalise.declareSansDocument())
+        .to.throwError((e) => expect(e).to.be.an(ErreurDossierDejaFinalise));
+    });
+
+    it('efface les documents existants', () => {
+      const dossier = new Dossier({ documents: ['unDocument'], avecDocuments: true }, referentiel);
+
+      dossier.declareSansDocument();
+
+      expect(dossier.documents.avecDocuments).to.be(false);
+      expect(dossier.documents.documents).to.eql([]);
+    });
+  });
+
   describe('sur vérification que ce dossier est complet', () => {
     it('demande à chaque étape si elle est complète', () => {
       const etapesInterrogees = [];

--- a/test/modeles/etapes/documents.spec.js
+++ b/test/modeles/etapes/documents.spec.js
@@ -1,0 +1,61 @@
+const expect = require('expect.js');
+
+const Documents = require('../../../src/modeles/etapes/documents');
+
+describe('Une étape « Documents »', () => {
+  it('sait se convertir en JSON ', () => {
+    const etape = new Documents({ documents: ['unDocument'], avecDocuments: true });
+
+    expect(etape.toJSON()).to.eql({ avecDocuments: true, documents: ['unDocument'] });
+  });
+
+  it("sait déclarer l'étape sans document", () => {
+    const etape = new Documents({ documents: ['A', 'B'] });
+
+    etape.declareSansDocument();
+
+    expect(etape.avecDocuments).to.be(false);
+    expect(etape.documents).to.eql([]);
+  });
+
+  it('sait enregistrer des documents', () => {
+    const etape = new Documents();
+
+    etape.enregistreDocuments(['A', 'B']);
+
+    expect(etape.avecDocuments).to.be(true);
+    expect(etape.documents).to.eql(['A', 'B']);
+  });
+
+  describe("sur vérification que l'étape est complète", () => {
+    it('est incomplète par défaut', () => {
+      const etapeParDefaut = new Documents();
+      expect(etapeParDefaut.estComplete()).to.be(false);
+    });
+
+    it("est complète s'il n'y a aucun document et qu'elle est déclarée sans document", () => {
+      const aucunDocuments = new Documents({ documents: [], avecDocuments: false });
+      expect(aucunDocuments.estComplete()).to.be(true);
+    });
+
+    describe("dans le cas où l'étape est déclarée avec documents", () => {
+      it("n'est pas complète s'il n'y a pas de document", () => {
+        const sansDocuments = new Documents({
+          documents: [],
+          avecDocuments: true,
+        });
+
+        expect(sansDocuments.estComplete()).to.be(false);
+      });
+
+      it("est complète s'il y a des documents", () => {
+        const avecDocumentss = new Documents({
+          documents: ['unDocument'],
+          avecDocuments: true,
+        });
+
+        expect(avecDocumentss.estComplete()).to.be(true);
+      });
+    });
+  });
+});

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -498,6 +498,8 @@ describe('Une homologation', () => {
           id: '1',
           avecAvis: true,
           avis: [{ collaborateurs: ['Jean Dupond'], dureeValidite: 'unAn', statut: 'favorable' }],
+          avecDocuments: true,
+          documents: ['unDocument'],
           autorite: { nom: 'Jean Dupond', fonction: 'RSSI' },
           decision: { dateHomologation: aujourdhui.toISOString(), dureeValidite: 'unAn' },
           datesTelechargements: { decision: aujourdhui.toISOString() },

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -638,7 +638,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
   });
 
-  describe('quand requête PUT sur `/api/service/:id/dossier/document/:idDocument', () => {
+  describe('quand requête PUT sur `/api/service/:id/dossier/telechargement/:idDocument', () => {
     beforeEach(() => {
       const homologationAvecDossier = new Homologation({ id: '456', descriptionService: { nomService: 'un service' }, dossiers: [{ id: '999' }] });
       testeur.middleware().reinitialise({ homologationARenvoyer: homologationAvecDossier });
@@ -648,14 +648,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
-        { url: 'http://localhost:1234/api/service/456/dossier/document/decision', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/dossier/telechargement/decision', method: 'put' },
         done,
       );
     });
 
     it('recherche le dossier courant correspondant', (done) => {
       testeur.middleware().verifieRechercheDossierCourant(
-        { url: 'http://localhost:1234/api/service/456/dossier/document/decision', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/dossier/telechargement/decision', method: 'put' },
         done,
       );
     });
@@ -673,14 +673,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return Promise.resolve();
       };
 
-      axios.put('http://localhost:1234/api/service/456/dossier/document/decision')
+      axios.put('http://localhost:1234/api/service/456/dossier/telechargement/decision')
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
     });
 
     it("reste robuste si l'id de document ne correspond pas à un document connu", (done) => {
-      axios.put('http://localhost:1234/api/service/456/dossier/document/mauvaisId')
+      axios.put('http://localhost:1234/api/service/456/dossier/telechargement/mauvaisId')
         .catch(({ response }) => {
           expect(response.status).to.be(422);
           expect(response.data).to.equal('Identifiant de document invalide');


### PR DESCRIPTION
On rajoute une étape dans le parcours d'homologation (back).
Cette étape a un comportement proche de l'étape "Avis" :
- On peut choisir de renseigner des documents, ou non
- Si oui, on doit fournir au moins un nom de document

Cette PR se concentre uniquement sur le back-end