### PR TITLE
Organisations responsables

### DIFF
--- a/migrations/20230327122127_ajouteOrganisationsResponsables.js
+++ b/migrations/20230327122127_ajouteOrganisationsResponsables.js
@@ -1,0 +1,34 @@
+const pourChaqueLigne = require('./utilitaires/pourChaqueLigne');
+
+const ajouteOrganisationsResponsables = (knex, table) => pourChaqueLigne(
+  knex(table)
+    .join('autorisations', `${table}.id`, knex.raw("(autorisations.donnees ->> 'idService')::UUID"))
+    .join('utilisateurs', knex.raw("(autorisations.donnees ->> 'idUtilisateur')::UUID"), 'utilisateurs.id')
+    .whereRaw("utilisateurs.donnees ->> 'nomEntitePublique' IS NOT NULL")
+    .whereRaw("autorisations.donnees ->> 'type' = 'createur'")
+    .select({
+      id: `${table}.id`,
+      donnees: `${table}.donnees`,
+      nomEntitePublique: knex.raw("utilisateurs.donnees ->> 'nomEntitePublique'"),
+    }),
+  ({ id, donnees, nomEntitePublique }) => {
+    donnees.descriptionService.organisationsResponsables = [nomEntitePublique];
+    return knex(table).where({ id }).update({ donnees });
+  },
+);
+
+const retireOrganisationsResponsables = (knex, table) => pourChaqueLigne(
+  knex(table),
+  ({ id, donnees }) => {
+    delete donnees.descriptionService.organisationsResponsables;
+    return knex(table).where({ id }).update({ donnees });
+  },
+);
+
+exports.up = (knex) => Promise.all(
+  ['homologations', 'services'].map((table) => ajouteOrganisationsResponsables(knex, table))
+);
+
+exports.down = (knex) => Promise.all(
+  ['homologations', 'services'].map((table) => retireOrganisationsResponsables(knex, table))
+);

--- a/public/modules/parametresDescriptionService.mjs
+++ b/public/modules/parametresDescriptionService.mjs
@@ -8,11 +8,17 @@ const extraisParametresDescriptionService = (selecteurFormulaire) => {
   params.risqueJuridiqueFinancierReputationnel = convertisReponseOuiNon(
     params.risqueJuridiqueFinancierReputationnel
   );
+
   listesAvecItemsExtraits.forEach(
     ({ cle, sourceRegExpParamsItem }) => (
       modifieParametresAvecItemsExtraits(params, cle, sourceRegExpParamsItem)
     )
   );
+
+  if (params.organisationsResponsables) {
+    params.organisationsResponsables = [params.organisationsResponsables];
+  }
+
   return params;
 };
 

--- a/src/modeles/descriptionService.js
+++ b/src/modeles/descriptionService.js
@@ -20,6 +20,7 @@ class DescriptionService extends InformationsHomologation {
       proprietesListes: [
         'donneesCaracterePersonnel',
         'fonctionnalites',
+        'organisationsResponsables',
         'typeService',
       ],
       listesAgregats: {

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -35,7 +35,7 @@ const routesApiService = (
 
   routes.use(routesApiServicePdf(middleware, adaptateurPdf, referentiel));
 
-  routes.post('/', middleware.verificationAcceptationCGU, middleware.aseptise('nomService'), middleware.aseptiseListes([
+  routes.post('/', middleware.verificationAcceptationCGU, middleware.aseptise('nomService', 'organisationsResponsables.*'), middleware.aseptiseListes([
     { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
     { nom: 'fonctionnalitesSpecifiques', proprietes: FonctionnalitesSpecifiques.proprietesItem() },
     { nom: 'donneesSensiblesSpecifiques', proprietes: DonneesSensiblesSpecifiques.proprietesItem() },
@@ -53,7 +53,7 @@ const routesApiService = (
       });
   });
 
-  routes.put('/:id', middleware.trouveHomologation, middleware.aseptise('nomService'), middleware.aseptiseListes([
+  routes.put('/:id', middleware.trouveHomologation, middleware.aseptise('nomService', 'organisationsResponsables.*'), middleware.aseptiseListes([
     { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
     { nom: 'fonctionnalitesSpecifiques', proprietes: FonctionnalitesSpecifiques.proprietesItem() },
     { nom: 'donneesSensiblesSpecifiques', proprietes: DonneesSensiblesSpecifiques.proprietesItem() },

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -24,6 +24,19 @@ mixin formulaireDescriptionService(idHomologation)
           .message-erreur Le nom est obligatoire. Veuillez le renseigner.
 
       .requis
+        label Organisation responsable du service numérique
+          br
+          input(
+            id = 'organisations-responsables',
+            name = 'organisationsResponsables',
+            type = 'text',
+            placeholder = 'ex : Agglomération de Mansart',
+            value != service.descriptionService.organisationsResponsables.toString(),
+            required
+          )
+          .message-erreur Ce champ est obligatoire. Veuillez le renseigner.
+
+      .requis
         +inputChoix({
           type: 'checkbox',
           nom: 'typeService',

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -23,6 +23,7 @@ describe('La description du service', () => {
       localisationDonnees: 'france',
       typeService: ['unType'],
       nomService: 'Super Service',
+      organisationsResponsables: ['Une organisation'],
       pointsAcces: [{ description: 'Une description' }],
       presentation: 'Une présentation du service',
       provenanceService: 'uneProvenance',
@@ -36,6 +37,7 @@ describe('La description du service', () => {
     expect(descriptionService.localisationDonnees).to.equal('france');
     expect(descriptionService.typeService).to.eql(['unType']);
     expect(descriptionService.nomService).to.equal('Super Service');
+    expect(descriptionService.organisationsResponsables).to.eql(['Une organisation']);
     expect(descriptionService.presentation).to.equal('Une présentation du service');
     expect(descriptionService.provenanceService).to.eql('uneProvenance');
     expect(descriptionService.risqueJuridiqueFinancierReputationnel).to.be(true);

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -493,6 +493,7 @@ describe('Une homologation', () => {
           donneesSensiblesSpecifiques: [],
           fonctionnalitesSpecifiques: [],
           pointsAcces: [],
+          organisationsResponsables: [],
         },
         dossiers: [{
           id: '1',

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -30,7 +30,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('aseptise les paramètres', (done) => {
       testeur.middleware().verifieAseptisationParametres(
-        ['nomService'],
+        ['nomService', 'organisationsResponsables.*'],
         { method: 'post', url: 'http://localhost:1234/api/service' },
         done
       );
@@ -126,7 +126,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('aseptise les paramètres', (done) => {
       testeur.middleware().verifieAseptisationParametres(
-        ['nomService'],
+        ['nomService', 'organisationsResponsables.*'],
         { method: 'put', url: 'http://localhost:1234/api/service/456' },
         done
       );


### PR DESCRIPTION
Dans la page Décrire,
nous souhaitons pouvoir donner la possibilité d'ajouter l'organisation responsable.
Pour alimenter ce champ nous récupérerons le champ Nom de votre organisation de l'utilisateur si il existe.

NOTE : ce dev comporte une migration de données