### PR TITLE
Coche le bouton radio « Aucun avis » lors de la suppression du dernier avis

### DIFF
--- a/public/homologation/etapes/avis.js
+++ b/public/homologation/etapes/avis.js
@@ -2,6 +2,7 @@ import arrangeParametresAvis from '../../modules/arrangeParametresAvis.mjs';
 import brancheComportemenFormulaireEtape from './formulaireEtape.js';
 import { brancheConteneur } from '../../modules/interactions/validation.mjs';
 import brancheElementsAjoutables from '../../modules/brancheElementsAjoutables.js';
+import { EVENEMENT_SUPPRESSION_ELEMENT } from '../../modules/saisieListeItems.js';
 import parametres from '../../modules/parametres.mjs';
 
 const soumissionEtapeAvis = (selecteurFormulaire) => (idService) => {
@@ -39,6 +40,13 @@ const brancheBoutonsRadio = () => {
       $('.elements-ajoutables#avis').empty();
       $('#ajout-element-un-avis').addClass('invisible');
     }
+  });
+
+  $('body').on(EVENEMENT_SUPPRESSION_ELEMENT, () => {
+    const plusAucunAvis = $('.elements-ajoutables#avis').is(':empty');
+
+    // `.change()` pour déclencher les handlers branchés sur le radio.
+    if (plusAucunAvis) $('#avecAvis-1').prop('checked', true).change();
   });
 };
 

--- a/public/modules/saisieListeItems.js
+++ b/public/modules/saisieListeItems.js
@@ -1,7 +1,10 @@
+const EVENEMENT_SUPPRESSION_ELEMENT = 'suppressionElement';
+
 const brancheSuppressionElement = () => {
   $('.icone-suppression').click((e) => {
     e.preventDefault();
     $(e.target).parent().remove();
+    $('body').trigger(EVENEMENT_SUPPRESSION_ELEMENT);
   });
 };
 
@@ -57,4 +60,5 @@ export {
   brancheAjoutItem,
   peupleListeItems,
   brancheSuppressionElement,
+  EVENEMENT_SUPPRESSION_ELEMENT,
 };


### PR DESCRIPTION
Cette PR ajoute et utilise un événement nouvellement lancé par la mécanique des éléments ajoutables.