### PR TITLE
[CORRECTION] Utilise le bon ID pour « Aucun avis »

### DIFF
--- a/public/homologation/etapes/avis.js
+++ b/public/homologation/etapes/avis.js
@@ -48,7 +48,7 @@ const brancheBoutonsRadio = () => {
     const plusAucunAvis = $('.elements-ajoutables#avis').is(':empty');
 
     // `.change()` pour déclencher les handlers branchés sur le radio.
-    if (plusAucunAvis) $('#avecAvis-1').prop('checked', true).change();
+    if (plusAucunAvis) $('#avecAvis-0').prop('checked', true).change();
   });
 };
 


### PR DESCRIPTION
L'ID 0 est devenu celui de « Aucun avis » par 7148dbe0e6a7b7ccff123c984e55e51d85822028.