### PR TITLE
:warning: [ETAPE DOCUMENTS] Activation - A merger en dernier

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -675,9 +675,10 @@ module.exports = {
   etapesParcoursHomologation: [
     { numero: 1, libelle: 'Autorité', id: 'autorite' },
     { numero: 2, libelle: 'Avis', id: 'avis' },
-    { numero: 3, libelle: 'Décision', id: 'decision' },
-    { numero: 4, libelle: 'Date', id: 'date' },
-    { numero: 5, libelle: 'Récapitulatif', id: 'recapitulatif' },
+    { numero: 3, libelle: 'Documents', id: 'documents' },
+    { numero: 4, libelle: 'Décision', id: 'decision' },
+    { numero: 5, libelle: 'Date', id: 'date' },
+    { numero: 6, libelle: 'Récapitulatif', id: 'recapitulatif' },
   ],
 
   documentsHomologation: {

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -119,7 +119,7 @@ class Dossier extends InformationsHomologation {
   }
 
   static etapesObligatoires() {
-    return ['decision', 'datesTelechargements', 'autorite', 'avis'];
+    return ['decision', 'datesTelechargements', 'autorite', 'avis', 'documents'];
   }
 
   toJSON() {

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -254,7 +254,7 @@ describe("Un dossier d'homologation", () => {
       expect(() => dossier.enregistreFinalisation()).to.throwError((e) => {
         expect(e).to.be.an(ErreurDossierNonFinalisable);
         expect(e.message).to.equal('Ce dossier comporte des étapes incomplètes.');
-        expect(e.etapesIncompletes).to.eql(['decision', 'datesTelechargements', 'autorite', 'avis']);
+        expect(e.etapesIncompletes).to.eql(['decision', 'datesTelechargements', 'autorite', 'avis', 'documents']);
       });
     });
 


### PR DESCRIPTION
On active maintenant l'étape "Documents" dans le parcours d'homologation.

On la rend obligatoire pour pouvoir terminer le parcours.
