### PR TITLE
[CORRECTION] Affiche l'identité des contributeurs sans caractères encodés

### DIFF
--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
@@ -14,9 +14,9 @@ mixin zoneSaisieUnAvis(donneesUnAvis = {}, index = 0, indexAvis = index + 1)
             multiple
           )
             each collaborateur in donneesUnAvis.collaborateurs || []
-              option(value = collaborateur, selected) #{collaborateur}
+              option(value!= collaborateur, selected) !{collaborateur}
             each contributeur in [service.createur, ...service.contributeurs]
-              option(value = contributeur.prenomNom()) #{contributeur.prenomNom()}
+              option(value!= contributeur.prenomNom()) !{contributeur.prenomNom()}
           .message-erreur Au moins un prénom nom de collaborateur est obligatoire. Veuillez renseigner des lettres. Les chiffres ne sont pas autorisés.
 
       - donneesUnAvis[`statut-un-avis-${index}`] = donneesUnAvis.statut


### PR DESCRIPTION
Sans cette PR, les caractères spéciaux s'affichent mal 👇 

![image](https://user-images.githubusercontent.com/24898521/228775642-4f2c328b-8f64-474e-94e4-382e107b0577.png)

Cette PR répare l'affichage 👇 

![image](https://user-images.githubusercontent.com/24898521/228775975-c206d7db-0cf9-46a8-b1f9-deef529bf9ae.png)
