### PR TITLE
[CORRECTION] Force le vidage de l'input caché

### DIFF
--- a/public/homologation/etapes/documents.js
+++ b/public/homologation/etapes/documents.js
@@ -11,7 +11,7 @@ const montreListeDocuments = ($element) => {
   } else {
     $('#liste-documents').empty();
     $('#documents').addClass('invisible');
-    $('#au-moins-un-document').removeAttr('required');
+    $('#au-moins-un-document').removeAttr('required').val('');
   }
 };
 


### PR DESCRIPTION
Il est actuellement possible de passer a l'étape suivante avec aucun documents :
- On enregistre un document
- On clique sur "aucun document"
- On clique de nouveau sur "un ou plusieurs document"
- On fait suivant

Cette PR corrige ce bug