### PR TITLE
Organisation responsable d'un nouveau service préremplie

### DIFF
--- a/src/routes/routesService.js
+++ b/src/routes/routesService.js
@@ -12,9 +12,21 @@ const routesService = (
 ) => {
   const routes = express.Router();
 
-  routes.get('/creation', middleware.verificationAcceptationCGU, (_requete, reponse) => {
-    const service = new Homologation({});
-    reponse.render('service/creation', { referentiel, service });
+  routes.get('/creation', middleware.verificationAcceptationCGU, (requete, reponse, suite) => {
+    const { idUtilisateurCourant } = requete;
+    depotDonnees.utilisateur(idUtilisateurCourant)
+      .then((utilisateur) => {
+        const donneesService = {};
+        if (utilisateur.nomEntitePublique) {
+          donneesService.descriptionService = {
+            organisationsResponsables: [utilisateur.nomEntitePublique],
+          };
+        }
+
+        const service = new Homologation(donneesService);
+        reponse.render('service/creation', { referentiel, service });
+      })
+      .catch(suite);
   });
 
   routes.get('/:id', middleware.trouveHomologation, (requete, reponse) => {

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -11,6 +11,24 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   afterEach(testeur.arrete);
 
+  describe('quand requête GET sur `/service/creation `', () => {
+    it("Récupère dans le dépôt le nom de l'organisation de l'utilisateur", (done) => {
+      testeur.middleware().reinitialise({ idUtilisateur: '123' });
+      let depotDonneesUtilisateursAppelle = false;
+
+      testeur.depotDonnees().utilisateur = (idUtilisateur) => {
+        expect(idUtilisateur).to.equal('123');
+        depotDonneesUtilisateursAppelle = true;
+        return Promise.resolve({ id: idUtilisateur, nomEntitePublique: 'une entité' });
+      };
+
+      axios('http://localhost:1234/service/creation')
+        .then(() => expect(depotDonneesUtilisateursAppelle).to.be(true))
+        .then(() => done())
+        .catch((e) => done(e.response?.data || e));
+    });
+  });
+
   describe('quand requête GET sur `/service/:id`', () => {
     it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(


### PR DESCRIPTION
Dans l'espace personnel,
quand on crée un nouveau service,
le champ **Organisations responsables** est prérempli avec l'organisation de l'utilisateur créateur
<img width="1034" alt="Capture d’écran 2023-04-03 à 14 23 46" src="https://user-images.githubusercontent.com/39462397/229508184-f1652554-807d-4e32-8e06-f65a06400153.png">
