### PR TITLE
Focus après ajout d'une nouvelle mesure spécifique

### DIFF
--- a/public/homologation/mesures.js
+++ b/public/homologation/mesures.js
@@ -94,11 +94,17 @@ ${statuts}
       `;
   };
 
+  const actionSurZoneSaisieApresAjout = ($conteneurSaisieItem) => {
+    brancheConteneur($conteneurSaisieItem);
+    $("input[name^='description-mesure-specifique-']", $conteneurSaisieItem).get(0)
+      .scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
   const brancheAjoutMesureSpecifique = (...params) => brancheAjoutItem(
     ...params,
     zoneSaisieMesureSpecifique,
     () => (indexMaxMesuresSpecifiques += 1),
-    brancheConteneur,
+    actionSurZoneSaisieApresAjout,
     { ordreInverse: true },
   );
 


### PR DESCRIPTION
Dans la page Sécuriser,
Quand on clique sur Ajouter une mesure spécifique,
Nous souhaitons être positionnés sur la nouvelle mesure

NOTE : J'ai mis ~~le focus sur~~ un scroll vers le champ Intitulé de la nouvelle mesure