### PR TITLE
[NOUVEAU SERVICE] Message d'erreur "Nom de service déjà utilisé"

### DIFF
--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -1,4 +1,4 @@
-.titre ~ .description {
+.titre~.description {
   font-weight: normal;
   font-size: 0.9em;
 }
@@ -7,10 +7,14 @@
   display: none;
 }
 
-#risqueJuridiqueFinancierReputationnel input[value = 'oui'] ~ .exemple::before {
+#risqueJuridiqueFinancierReputationnel input[value='oui']~.exemple::before {
   display: none;
 }
 
-#risqueJuridiqueFinancierReputationnel input[value = 'oui']:checked ~ :is(.exemple, .exemple + br) {
+#risqueJuridiqueFinancierReputationnel input[value='oui']:checked~ :is(.exemple, .exemple + br) {
   display: inline-block;
+}
+
+#nom-service.invalide {
+  border-color: var(--rose-anssi);
 }

--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -4,7 +4,7 @@
   margin-bottom: 1em;
 }
 
-:is(h1, hr) + .mention {
+:is(h1, hr)+.mention {
   margin: 2em 0 0;
 }
 
@@ -17,7 +17,8 @@
   left: -1em;
 }
 
-.mention::before, .requis::before {
+.mention::before,
+.requis::before {
   content: "*";
   color: var(--rose-anssi);
 }
@@ -30,7 +31,8 @@ form.champ-unique .requis::before {
   position: relative;
 }
 
-.message-erreur {
+.message-erreur,
+.message-erreur-specifique {
   position: relative;
   display: none;
 
@@ -41,7 +43,8 @@ form.champ-unique .requis::before {
   font-weight: normal;
 }
 
-.message-erreur::before {
+.message-erreur::before,
+.message-erreur-specifique::before {
   content: '';
 
   position: absolute;
@@ -55,11 +58,11 @@ form.champ-unique .requis::before {
   transform: translateY(0.35em);
 }
 
-.requis[data-nom = 'cguAcceptees'] {
+.requis[data-nom='cguAcceptees'] {
   margin-bottom: 2em;
 }
 
-:is(input, select, textarea):not(.intouche):valid{
+:is(input, select, textarea):not(.intouche):valid {
   border-color: var(--bleu-mise-en-avant);
 }
 
@@ -79,6 +82,6 @@ input[type="radio"]:not(.intouche):invalid {
   outline-color: var(--rose-anssi);
 }
 
-:is(input, select, textarea):not(.intouche):invalid ~ .message-erreur {
+:is(input, select, textarea):not(.intouche):invalid~.message-erreur {
   display: block;
 }

--- a/public/homologation/descriptionService.js
+++ b/public/homologation/descriptionService.js
@@ -2,12 +2,42 @@ import { brancheElementsAjoutablesDescription } from '../modules/brancheElements
 import extraisParametresDescriptionService from '../modules/parametresDescriptionService.mjs';
 import initialiseComportementFormulaire from '../modules/soumetsHomologation.mjs';
 
+const messageErreurNomDejaUtilise = {
+  affiche: () => {
+    $('#nom-deja-utilise').show();
+    const $champNomService = $('#nom-service');
+    $champNomService.get(0).scrollIntoView({ behavior: 'smooth', block: 'center' });
+    $champNomService.addClass('invalide');
+  },
+  masque: () => {
+    $('#nom-deja-utilise').hide();
+    $('#nom-service').removeClass('invalide');
+  },
+};
+
+const brancheComportementMessageErreur = () => {
+  $('#nom-service').on('keydown', () => {
+    messageErreurNomDejaUtilise.masque();
+  });
+};
+
+const estNomServiceDejaUtilise = (reponseErreur) => (
+  reponseErreur.status === 422
+    && reponseErreur.data?.erreur?.code === 'NOM_SERVICE_DEJA_EXISTANT'
+);
+
 $(() => {
   initialiseComportementFormulaire(
     'form#homologation',
     '.bouton#diagnostic',
     extraisParametresDescriptionService,
+    (e) => {
+      if (estNomServiceDejaUtilise(e.response)) {
+        messageErreurNomDejaUtilise.affiche();
+      }
+    }
   );
+  brancheComportementMessageErreur();
 
   brancheElementsAjoutablesDescription('donnees-sensibles-specifiques', 'donnees-sensibles');
   brancheElementsAjoutablesDescription('fonctionnalites-specifiques', 'fonctionnalite');

--- a/public/modules/soumetsHomologation.mjs
+++ b/public/modules/soumetsHomologation.mjs
@@ -5,6 +5,7 @@ const initialiseComportementFormulaire = (
   selecteurFormulaire,
   selecteurBouton,
   fonctionExtractionParametres,
+  callbackErreur = () => {},
   adaptateurAjax = adaptateurAjaxAxios
 ) => {
   const $bouton = $(selecteurBouton);
@@ -24,7 +25,8 @@ const initialiseComportementFormulaire = (
     );
 
     adaptateurAjax.execute(requete)
-      .then(redirigeVersSynthese);
+      .then(redirigeVersSynthese)
+      .catch(callbackErreur);
   }));
 
   $bouton.on('click', () => {

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -5,6 +5,7 @@ const {
   EchecAutorisation,
   ErreurModele,
   ErreurDonneesObligatoiresManquantes,
+  ErreurNomServiceDejaExistant,
 } = require('../erreurs');
 const ActeursHomologation = require('../modeles/acteursHomologation');
 const AutorisationCreateur = require('../modeles/autorisations/autorisationCreateur');
@@ -48,7 +49,8 @@ const routesApiService = (
       ))
       .then((idService) => reponse.json({ idService }))
       .catch((e) => {
-        if (e instanceof ErreurModele) reponse.status(422).send(e.message);
+        if (e instanceof ErreurNomServiceDejaExistant) reponse.status(422).json({ erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } });
+        else if (e instanceof ErreurModele) reponse.status(422).send(e.message);
         else suite(e);
       });
   });

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -22,6 +22,7 @@ mixin formulaireDescriptionService(idHomologation)
             required
           )
           .message-erreur Le nom est obligatoire. Veuillez le renseigner.
+          .message-erreur-specifique#nom-deja-utilise Ce nom est déjà utilisé pour un autre service. Veuillez en saisir un autre.
 
       .requis
         label Organisation responsable du service numérique

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -84,7 +84,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('retourne une erreur HTTP 422 si le nom du service existe déjà', (done) => {
       testeur.depotDonnees().nouvelleHomologation = () => Promise.reject(new ErreurNomServiceDejaExistant('oups'));
 
-      testeur.verifieRequeteGenereErreurHTTP(422, 'oups', {
+      testeur.verifieRequeteGenereErreurHTTP(422, { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } }, {
         method: 'post',
         url: 'http://localhost:1234/api/service',
         data: { nomService: 'Un nom déjà existant' },

--- a/test_public/modules/soumetsHomologation.spec.mjs
+++ b/test_public/modules/soumetsHomologation.spec.mjs
@@ -23,6 +23,7 @@ describe("L'initialisation du comportement du formulaire", () => {
 
     let ajaxRequete;
     const adaptateurAjax = {};
+    const callbackErreurParDefaut = () => {};
 
     beforeEach(() => {
       adaptateurAjax.execute = (requete) => {
@@ -33,7 +34,7 @@ describe("L'initialisation du comportement du formulaire", () => {
 
     it('envoie au serveur les données du service à créer', (done) => {
       const evenementsDifferes = $.Deferred();
-      initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, adaptateurAjax);
+      initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, callbackErreurParDefaut, adaptateurAjax);
 
       evenementsDifferes.resolveWith($('.bouton').trigger('click'))
         .then(() => {
@@ -49,7 +50,7 @@ describe("L'initialisation du comportement du formulaire", () => {
       const evenementsDifferes = $.Deferred();
       $('.bouton').attr('idHomologation', '12345');
 
-      initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, adaptateurAjax);
+      initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, callbackErreurParDefaut, adaptateurAjax);
 
       evenementsDifferes.resolveWith($('.bouton').trigger('click'))
         .then(() => {
@@ -63,10 +64,27 @@ describe("L'initialisation du comportement du formulaire", () => {
 
     it('renvoie vers la synthèse du service', (done) => {
       const evenementsDifferes = $.Deferred();
-      initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, adaptateurAjax);
+      initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, callbackErreurParDefaut, adaptateurAjax);
 
       evenementsDifferes.resolveWith($('.bouton').trigger('click'))
         .then(() => expect(window.location).to.equal('/service/123'))
+        .then(() => done())
+        .catch(done);
+    });
+
+    it("exécute la callback d'erreur en cas d'erreur", (done) => {
+      const evenementsDifferes = $.Deferred();
+      const adaptateurAjaxErreur = {
+        execute: () => Promise.reject(),
+      };
+      let callbackErreurAppele = false;
+      const callbackErreur = () => {
+        callbackErreurAppele = true;
+      };
+      initialiseComportementFormulaire('.formulaire', '.bouton', fonctionExtractionParametres, callbackErreur, adaptateurAjaxErreur);
+
+      evenementsDifferes.resolveWith($('.bouton').trigger('click'))
+        .then(() => expect(callbackErreurAppele).to.be(true))
         .then(() => done())
         .catch(done);
     });


### PR DESCRIPTION
Dans le cas ou le nom du service existe déjà, on affiche désormais un message d'erreur.
On passe désormais une callback d'erreur à l'adaptateur Ajax.

Le comportement `scrollIntoView` pourrait être utilisé à d'autres endroits pour indiquer quels champs de formulaire sont invalides.

![image](https://user-images.githubusercontent.com/1643465/229748203-006903f1-0ccb-4bea-8e1e-f961487de98b.png)
