### PR TITLE
Carte non homologué

### DIFF
--- a/public/assets/images/icone_ko_pastille_rose.svg
+++ b/public/assets/images/icone_ko_pastille_rose.svg
@@ -1,4 +1,6 @@
-<svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17" cy="17" r="17" fill="#FF6584"/>
-<path d="M15.5001 19.379L22.3941 12.4843L23.4553 13.5448L15.5001 21.5L10.7271 16.727L11.7876 15.6665L15.5001 19.379Z" fill="#FF6584" stroke="white" stroke-width="2"/>
+<svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9.0013 16.8327C13.5846 16.8327 17.3346 13.0827 17.3346 8.49935C17.3346 3.91602 13.5846 0.166016 9.0013 0.166016C4.41797 0.166016 0.667969 3.91602 0.667969 8.49935C0.667969 13.0827 4.41797 16.8327 9.0013 16.8327Z" fill="#EBEDF0"/>
+    <path d="M9.0013 16.8327C13.5846 16.8327 17.3346 13.0827 17.3346 8.49935C17.3346 3.91602 13.5846 0.166016 9.0013 0.166016C4.41797 0.166016 0.667969 3.91602 0.667969 8.49935C0.667969 13.0827 4.41797 16.8327 9.0013 16.8327Z" fill="#FF6584"/>
+    <path d="M5.5 12.166L12.5 5.16602" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M12.5 12.166L5.5 5.16602" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/assets/images/icone_ok_pastille_verte.svg
+++ b/public/assets/images/icone_ok_pastille_verte.svg
@@ -1,4 +1,4 @@
-<svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17" cy="17" r="17" fill="#4CB963"/>
-<path d="M15.5001 19.379L22.3941 12.4843L23.4553 13.5448L15.5001 21.5L10.7271 16.727L11.7876 15.6665L15.5001 19.379Z" fill="#4CB963" stroke="white" stroke-width="2"/>
+<svg width="17" height="18" viewBox="0 0 17 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8.33333 17.0671C12.9167 17.0671 16.6667 13.3171 16.6667 8.73372C16.6667 4.15039 12.9167 0.400391 8.33333 0.400391C3.75 0.400391 0 4.15039 0 8.73372C0 13.3171 3.75 17.0671 8.33333 17.0671Z" fill="#0E972B"/>
+    <path d="M4.45898 8.90033L6.81732 11.2587L11.5423 6.54199" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/assets/styles/carteInformations.css
+++ b/public/assets/styles/carteInformations.css
@@ -95,30 +95,30 @@
   display: none;
 }
 
-
 .carte .statut {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  column-gap: 0.5em;
+  width: fit-content;
+  margin: 1em 0;
+  padding: 0.5em 1em;
   border-radius: 1.5em;
-  padding: 0.25em 0 0.75em 0;
-  margin: 1.75em 0;
-  font-size: 0.85em;
+  font-size: 0.9em;
   font-weight: bold;
-  width: 100%;
+  color: var(--gris-fonce);
+  white-space: nowrap;
 }
 
 .carte .statut-non-homologue {
-  color: var(--statut-non-homologue);
   background-color: var(--statut-non-homologue-arriere-plan);
 }
 .carte .statut-homologue {
-  color: var(--statut-homologue);
   background-color: var(--statut-homologue-arriere-plan);
 }
 
 .carte .pastille {
-  position: relative;
-  bottom: -0.4em;
-  height: 1.53em;
-  padding: 0 0.5em 0 1em;
+  height: 1.5em;
 }
 .carte .statut-non-homologue .pastille {
   content: url(../images/icone_ko_pastille_rose.svg);


### PR DESCRIPTION
Dans la page de synthèse,
Quand le service n'est pas / plus homologué,
La carte d'information adopte un nouveau style avec une croix.

<img width="250" alt="Capture d’écran 2023-04-04 à 17 50 21" src="https://user-images.githubusercontent.com/39462397/229848078-eb0654dc-9998-4ef3-a82c-9beeca378e86.png">

