### PR TITLE
[CORRECTION] Affiche la modale par dessus tout le reste

### DIFF
--- a/public/assets/styles/modale.css
+++ b/public/assets/styles/modale.css
@@ -16,7 +16,7 @@
   cursor: default;
 
   display: none;
-  z-index: 10;
+  z-index: 99;
 
   position: fixed;
   top: 0;
@@ -112,6 +112,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 1em;
 
   background-image: url('../images/forme_rectangle_vague.svg');
   background-size: 100% 40%;


### PR DESCRIPTION
La modale s'affiche désormais par dessus tout le reste.

![image](https://user-images.githubusercontent.com/1643465/229810685-64a9d29d-f086-4c9d-a5f7-6cfbccdfcdb2.png)
