### PR TITLE
[CORRECTION] Échappe correctement les commentaires d'avis

### DIFF
--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
@@ -49,7 +49,7 @@ mixin zoneSaisieUnAvis(donneesUnAvis = {}, index = 0, indexAvis = index + 1)
           id = `commentaires-un-avis-${index}`,
           name = `commentaires-un-avis-${index}`,
           placeholder = 'ex : favorable pour la mise en ligne sous réserve que certaines mesures soient réalisées dans 1 mois.',
-        )= donneesUnAvis.commentaires
+        )!= donneesUnAvis.commentaires
 
 mixin unAvis(donneesUnAvis = {}, index = 0)
   .item-ajoute


### PR DESCRIPTION
Un utilisateur a fait remonter un bug :

> Problème d'encodage des caractères
Bonjour,
Dans l'avis formulé dans une homologation, les caractères «'» sont mal encodés.
Quand on revient sur le formulaire, ils sont remplacés par le code HTML.
Exemple :/    Les conditions d&#x27;hygiène informatique sont conformes aux attentes./
Serait-il possible d'y remédier car cela affecte ensuite les rapports ?
Cordialement.

On échappe donc désormais le champ correctement.