### PR TITLE
Aide à la saisie pour l'organisation et son département

### DIFF
--- a/public/assets/images/icone_ok_pastille_bleue.svg
+++ b/public/assets/images/icone_ok_pastille_bleue.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22Z" fill="#0079D0"/>
+<path d="M7.75 11.9999L10.58 14.8299L16.25 9.16992" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -14,7 +14,8 @@ form a {
   text-decoration: none;
 }
 
-form label, fieldset {
+form label,
+fieldset {
   display: block;
   margin-bottom: 3em;
 
@@ -59,7 +60,8 @@ input[type='date'] {
   width: 11em;
 }
 
-input[type="checkbox"], input[type="radio"] {
+input[type="checkbox"],
+input[type="radio"] {
   appearance: none;
   background-color: #fff;
   margin: 0 1em 0 0;
@@ -81,7 +83,8 @@ input[type="radio"] {
   background-size: contain;
 }
 
-input[type="checkbox"]:focus, input[type="radio"]:focus {
+input[type="checkbox"]:focus,
+input[type="radio"]:focus {
   outline: 0.5px solid var(--bleu-mise-en-avant);
   outline-offset: 2px;
 }
@@ -100,7 +103,8 @@ input[type="radio"]:checked {
   background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="45" style="fill: white; stroke: %230f7ac7; stroke-width: 0.50em" /></svg>');
 }
 
-input[type="checkbox"]:checked::before, input[type="radio"]:checked::before {
+input[type="checkbox"]:checked::before,
+input[type="radio"]:checked::before {
   content: "";
   display: block;
 }
@@ -122,7 +126,8 @@ input[type="radio"]:checked::before {
   background-size: contain;
 }
 
-input[type='checkbox'] + label, input[type='radio'] + label {
+input[type='checkbox']+label,
+input[type='radio']+label {
   display: inline-block;
 
   margin: 1em 0 0;
@@ -185,7 +190,7 @@ select {
   grid-template-columns: auto 1fr;
 }
 
-.case-a-cocher > input[type='checkbox'] + label {
+.case-a-cocher>input[type='checkbox']+label {
   margin-top: 0;
 }
 
@@ -201,4 +206,37 @@ select {
   border-radius: 0.5em;
   padding: 0.6em 0.8em 0.6em 2.4em;
   background: url('../images/ampoule.svg') no-repeat 0.6em 0.6em;
+}
+
+.conteneur-nom-service {
+  position: relative;
+}
+
+#liste-suggestions {
+  position: absolute;
+  border: 1px solid var(--bleu-survol);
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+  background: white;
+  z-index: 2;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 0;
+  list-style: none;
+  padding-left: 0;
+  transform: translateY(-4px);
+  max-height: 10em;
+  overflow-y: scroll;
+  display: none;
+}
+
+.item-suggestion {
+  padding: 0.3em 0;
+  cursor: pointer;
+}
+
+.item-suggestion:hover {
+  background: var(--fond-gris-pale);
+  color: var(--bleu-mise-en-avant);
 }

--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -240,3 +240,35 @@ select {
   background: var(--fond-gris-pale);
   color: var(--bleu-mise-en-avant);
 }
+
+.icone-chargement {
+  display: none;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  right: 1em;
+  transform: translateY(-2.2em);
+  z-index: 10;
+}
+
+.icone-chargement::after {
+  content: " ";
+  display: block;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  border-radius: 50%;
+  border: 2px solid var(--gris-fonce);
+  border-color: var(--gris-fonce) transparent var(--gris-fonce) transparent;
+  animation: rotation 1.2s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -60,6 +60,10 @@
   transform: translateY(-3px);
 }
 
+.selectize-control:is(.single):is(.chargement-en-cours)+.icone-chargement {
+  display: inline-block;
+}
+
 .selectize-control:is(.multi, .single) .selectize-dropdown .active:not(.selected) {
   background-color: #fff;
 }

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -53,6 +53,13 @@
   border-color: var(--liseres);
 }
 
+.selectize-control:is(.single) .selectize-dropdown {
+  border: 1px solid var(--bleu-survol);
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+  transform: translateY(-3px);
+}
+
 .selectize-control:is(.multi, .single) .selectize-dropdown .active:not(.selected) {
   background-color: #fff;
 }

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -68,6 +68,11 @@
   background-color: #fff;
 }
 
+.selectize-control:is(.multi, .single) .selectize-dropdown .option:last-of-type {
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
 .selectized+.selectize-control.single .selectize-dropdown .selected {
   background-color: transparent;
   color: var(--bleu-mise-en-avant);

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -97,6 +97,10 @@
   border-color: var(--rose-anssi);
 }
 
+.selectized:not(.intouche, [required])+.selectize-control:is(.multi, .single) .selectize-input.has-items {
+  border-color: var(--bleu-mise-en-avant);
+}
+
 .selectized[required]:not(.intouche)+.selectize-control:is(.multi, .single) .selectize-input {
   border-color: var(--bleu-mise-en-avant);
 }

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -60,6 +60,18 @@
 .selectized+.selectize-control.single .selectize-dropdown .selected {
   background-color: transparent;
   color: var(--bleu-mise-en-avant);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.selectized+.selectize-control.single .selectize-dropdown .selected::after {
+  content: '';
+  width: 1em;
+  height: 1em;
+  background-image: url('/statique/assets/images/icone_ok_pastille_bleue.svg');
+  background-size: contain;
+  background-repeat: no-repeat;
 }
 
 .selectized+.selectize-control.single .selectize-dropdown .option:hover {

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -1,22 +1,27 @@
-.selectize-control {
+.selectize-control:is(.multi, .single) {
   margin-top: 0.3em;
   font-family: Marianne;
 }
 
-.selectize-control .selectize-input {
+.selectize-control:is(.multi, .single) .selectize-input {
   background: var(--fond-pale);
   padding: 0.8em;
   font-size: 1em;
   border: solid 1px var(--liseres);
   border-radius: 5px;
   box-shadow: none;
+  cursor: text;
 }
 
-.selectize-control .selectize-input.focus {
+.selectize-control:is(.multi, .single) .selectize-input input {
+  cursor: text;
+}
+
+.selectize-control:is(.multi, .single) .selectize-input.focus {
   box-shadow: none;
 }
 
-.selectized + .selectize-control .selectize-input :is(.item, .item[data-value].active) {
+.selectized + .selectize-control.multi .selectize-input :is(.item, .item[data-value].active) {
   background: #fff;
   box-shadow: none;
   border-radius: 0.3em;
@@ -27,11 +32,20 @@
   font-weight: normal;
 }
 
-.selectize-control .selectize-input .item a.remove {
+.selectized + .selectize-control.single .selectize-input :is(.item, .item[data-value].active) {
+  box-shadow: none;
+  border-radius: 0.3em;
+  border-color: #000;
+  color: var(--texte-fonce);
+  text-shadow: none;
+  font-weight: normal;
+}
+
+.selectize-control.multi .selectize-input .item a.remove {
   border-left: none;
 }
 
-.selectize-control .selectize-dropdown {
+.selectize-control:is(.multi, .single) .selectize-dropdown {
   font-weight: normal;
   font-size: 1em;
   color: var(--texte-fonce);
@@ -39,18 +53,31 @@
   border-color: var(--liseres);
 }
 
-.selectize-control .selectize-dropdown .active:not(.selected) {
+.selectize-control:is(.multi, .single) .selectize-dropdown .active:not(.selected) {
   background-color: #fff;
+}
+
+.selectized + .selectize-control.single .selectize-dropdown .selected {
+  background-color: transparent;
+  color: var(--bleu-mise-en-avant);
+}
+
+.selectized + .selectize-control.single .selectize-dropdown .option:hover {
+  background-color: var(--fond-gris-pale);
 }
 
 .selectized:not(.intouche, [required]) ~ .message-erreur {
   display: block;
 }
 
-.selectized:not(.intouche, [required]) + .selectize-control .selectize-input {
+.selectized:not(.intouche, [required]) + .selectize-control:is(.multi, .single) .selectize-input {
   border-color: var(--rose-anssi);
 }
 
-.selectized[required]:not(.intouche) + .selectize-control .selectize-input {
+.selectized[required]:not(.intouche) + .selectize-control:is(.multi, .single) .selectize-input {
   border-color: var(--bleu-mise-en-avant);
+}
+
+.selectize-control.single .selectize-input:after {
+  display: none;
 }

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -21,7 +21,7 @@
   box-shadow: none;
 }
 
-.selectized + .selectize-control.multi .selectize-input :is(.item, .item[data-value].active) {
+.selectized+.selectize-control.multi .selectize-input :is(.item, .item[data-value].active) {
   background: #fff;
   box-shadow: none;
   border-radius: 0.3em;
@@ -32,7 +32,7 @@
   font-weight: normal;
 }
 
-.selectized + .selectize-control.single .selectize-input :is(.item, .item[data-value].active) {
+.selectized+.selectize-control.single .selectize-input :is(.item, .item[data-value].active) {
   box-shadow: none;
   border-radius: 0.3em;
   border-color: #000;
@@ -57,27 +57,33 @@
   background-color: #fff;
 }
 
-.selectized + .selectize-control.single .selectize-dropdown .selected {
+.selectized+.selectize-control.single .selectize-dropdown .selected {
   background-color: transparent;
   color: var(--bleu-mise-en-avant);
 }
 
-.selectized + .selectize-control.single .selectize-dropdown .option:hover {
+.selectized+.selectize-control.single .selectize-dropdown .option:hover {
   background-color: var(--fond-gris-pale);
 }
 
-.selectized:not(.intouche, [required]) ~ .message-erreur {
+.selectized:not(.intouche, [required])~.message-erreur {
   display: block;
 }
 
-.selectized:not(.intouche, [required]) + .selectize-control:is(.multi, .single) .selectize-input {
+.selectized:not(.intouche, [required])+.selectize-control:is(.multi, .single) .selectize-input {
   border-color: var(--rose-anssi);
 }
 
-.selectized[required]:not(.intouche) + .selectize-control:is(.multi, .single) .selectize-input {
+.selectized[required]:not(.intouche)+.selectize-control:is(.multi, .single) .selectize-input {
   border-color: var(--bleu-mise-en-avant);
 }
 
 .selectize-control.single .selectize-input:after {
   display: none;
+}
+
+.no-results {
+  color: #667892;
+  font-weight: bold;
+  font-size: 12px;
 }

--- a/public/plugins/selectize.aucun-resultat.js
+++ b/public/plugins/selectize.aucun-resultat.js
@@ -1,0 +1,86 @@
+$(() => {
+  /*
+    Selectize ne permet pas nativement d'afficher un message lorsqu'il
+    n'y a aucun résultat associé à une recherche de suggestion.
+    Ce fichier est un plugin qui ajoute ce comportement.
+    Le code vient de https://gist.github.com/dwickwire/3b5c9485467b0d01ef24f7fdfa140d92
+  */
+
+  function pluginAucunResultat(options) {
+    const self = this;
+
+    // eslint-disable-next-line no-param-reassign
+    options = {
+      ...options,
+      message: 'Aucun résultat correspond à votre recherche',
+      html: (data) => (
+        `<div class="selectize-dropdown ${data.classNames}">
+           <div class="selectize-dropdown-content">
+             <div class="no-results">${data.message}</div>
+           </div>
+         </div>`),
+    };
+
+    self.displayEmptyResultsMessage = () => {
+      this.$empty_results_container.css('top', this.$control.outerHeight());
+      this.$empty_results_container.css('width', this.$control.outerWidth());
+      this.$empty_results_container.show();
+      this.$control.addClass('dropdown-active');
+    };
+
+    self.refreshOptions = ((...args) => {
+      const original = self.refreshOptions;
+
+      function basculeAffichageAucunResultat() {
+        original.apply(self, args);
+        if (this.hasOptions || !this.lastQuery) this.$empty_results_container.hide();
+        else this.displayEmptyResultsMessage();
+      }
+
+      return basculeAffichageAucunResultat;
+    })();
+
+    self.onKeyDown = (() => {
+      const original = self.onKeyDown;
+
+      function masqueSiEchap(...args) {
+        original.apply(self, args);
+        const event = args[0];
+        const estToucheEchap = event.keyCode === 27;
+        if (estToucheEchap) this.$empty_results_container.hide();
+      }
+
+      return masqueSiEchap;
+    })();
+
+    self.onBlur = ((...args) => {
+      const original = self.onBlur;
+
+      function masqueAucunResultat() {
+        original.apply(self, args);
+        this.$empty_results_container.hide();
+        this.$control.removeClass('dropdown-active');
+      }
+
+      return masqueAucunResultat;
+    })();
+
+    self.setup = ((...args) => {
+      const original = self.setup;
+
+      function initialise() {
+        original.apply(self, args);
+        self.$empty_results_container = $(options.html(
+          { ...options, classNames: self.$input.attr('class') }
+        ));
+        self.$empty_results_container.insertBefore(self.$dropdown);
+        self.$empty_results_container.hide();
+      }
+
+      return initialise;
+    })();
+  }
+
+  // eslint-disable-next-line no-undef
+  Selectize.define('aucun_resultat', pluginAucunResultat);
+});

--- a/public/utilisateur/suggestionEntite.js
+++ b/public/utilisateur/suggestionEntite.js
@@ -33,6 +33,7 @@ $(() => {
     searchField: 'label',
     loadingClass: 'chargement-en-cours',
     maxItems: 1,
+    normalize: true,
     render: {
       item: (item, escape) => `<div class="item" data-nom="${item.nom}" data-departement="${item.departement}">
                                     ${escape(item.label)}

--- a/public/utilisateur/suggestionEntite.js
+++ b/public/utilisateur/suggestionEntite.js
@@ -30,6 +30,7 @@ const rechercheSuggestions = (recherche, callback) => {
 
 $(() => {
   const $champSelectize = $('#nomEntitePublique-selectize').selectize({
+    plugins: ['aucun_resultat'],
     options: [],
     valueField: 'label',
     labelField: 'label',

--- a/public/utilisateur/suggestionEntite.js
+++ b/public/utilisateur/suggestionEntite.js
@@ -1,0 +1,44 @@
+const rechercheSuggestions = (recherche, callback) => {
+  if (recherche.length < 2) {
+    callback([]);
+    return;
+  }
+
+  axios.get('/api/annuaire/suggestions', { params: { recherche } })
+    .then((reponse) => {
+      const suggestions = reponse.data.suggestions.map(({ departement, nom }) => ({
+        departement,
+        nom,
+        label: `${nom} (${departement})`,
+      }));
+      callback(suggestions);
+    });
+};
+
+$(() => {
+  const $champSelectize = $('#nomEntitePublique-selectize').selectize({
+    options: [],
+    valueField: 'label',
+    labelField: 'label',
+    searchField: 'label',
+    maxItems: 1,
+    render: {
+      item: (item, escape) => `<div class="item" data-nom="${item.nom}" data-departement="${item.departement}">
+                                    ${escape(item.label)}
+                               </div>`,
+      option: (option, escape) => `<div class="option">${escape(option.label)}</div>`,
+    },
+    load: (recherche, callback) => {
+      $champSelectize[0].selectize.clearOptions();
+      rechercheSuggestions(recherche, callback);
+    },
+    onItemAdd: (_value, $item) => {
+      $('#nomEntitePublique').val($item.data('nom'));
+      $('#departementEntitePublique').val($item.data('departement'));
+    },
+    onItemRemove: () => {
+      $('#nomEntitePublique').val('');
+      $('#departementEntitePublique').val('');
+    },
+  });
+});

--- a/public/utilisateur/suggestionEntite.js
+++ b/public/utilisateur/suggestionEntite.js
@@ -1,3 +1,18 @@
+const uneSuggestion = (departement, nom) => ({ departement, nom, label: `${nom} (${departement})` });
+
+const preRemplirSiModeEdition = () => {
+  const nom = $('#nomEntitePublique').val();
+  const departement = $('#departementEntitePublique').val();
+  const enModeEdition = !!nom && !!departement;
+
+  if (!enModeEdition) return;
+
+  const $champSelectize = $('#nomEntitePublique-selectize')[0].selectize;
+  $champSelectize.addOption(uneSuggestion(departement, nom));
+  const modeSilencieux = true;
+  $champSelectize.setValue(`${nom} (${departement})`, modeSilencieux);
+};
+
 const rechercheSuggestions = (recherche, callback) => {
   if (recherche.length < 2) {
     callback([]);
@@ -6,11 +21,9 @@ const rechercheSuggestions = (recherche, callback) => {
 
   axios.get('/api/annuaire/suggestions', { params: { recherche } })
     .then((reponse) => {
-      const suggestions = reponse.data.suggestions.map(({ departement, nom }) => ({
-        departement,
-        nom,
-        label: `${nom} (${departement})`,
-      }));
+      const suggestions = reponse.data.suggestions
+        .map(({ departement, nom }) => uneSuggestion(departement, nom));
+
       callback(suggestions);
     });
 };
@@ -41,4 +54,6 @@ $(() => {
       $('#departementEntitePublique').val('');
     },
   });
+
+  preRemplirSiModeEdition();
 });

--- a/public/utilisateur/suggestionEntite.js
+++ b/public/utilisateur/suggestionEntite.js
@@ -35,6 +35,7 @@ $(() => {
     valueField: 'label',
     labelField: 'label',
     searchField: 'label',
+    loadingClass: 'chargement-en-cours',
     maxItems: 1,
     render: {
       item: (item, escape) => `<div class="item" data-nom="${item.nom}" data-departement="${item.departement}">

--- a/public/utilisateur/suggestionEntite.js
+++ b/public/utilisateur/suggestionEntite.js
@@ -73,7 +73,10 @@ $(() => {
     onItemAdd: (_value, $item) => {
       const departementActuel = $('#departementEntitePublique').val();
       const nouveauDepartement = $item.data('departement').toString();
-      if (nouveauDepartement !== departementActuel) $champSelectize[0].selectize.clear();
+      if (nouveauDepartement !== departementActuel) {
+        $champSelectize[0].selectize.clear();
+        $champSelectize[0].selectize.clearOptions();
+      }
       $('#departementEntitePublique').val(nouveauDepartement);
     },
   });

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const DepotDonnees = require('./src/depotDonnees');
 const MoteurRegles = require('./src/moteurRegles');
 const MSS = require('./src/mss');
 const Referentiel = require('./src/referentiel');
+const adaptateurAnnuaire = require('./src/adaptateurs/adaptateurAnnuaire');
 const adaptateurChiffrement = require('./src/adaptateurs/adaptateurChiffrement');
 const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
 const adaptateurGestionErreur = adaptateurEnvironnement.sentry().dsn()
@@ -37,6 +38,7 @@ const serveur = MSS.creeServeur(
   adaptateurPdf,
   adaptateurHorloge,
   adaptateurGestionErreur,
+  adaptateurAnnuaire,
 );
 
 serveur.ecoute(port, () => {

--- a/src/adaptateurs/adaptateurAnnuaire.js
+++ b/src/adaptateurs/adaptateurAnnuaire.js
@@ -1,0 +1,16 @@
+const axios = require('axios');
+
+const rechercheOrganisation = (terme, departement) => axios.get('https://recherche-entreprises.api.gouv.fr/search', {
+  params: {
+    q: terme,
+    ...(departement && { departement }),
+    per_page: 25,
+    page: 1,
+    limite_matching_etablissements: 1,
+    est_entrepreneur_individuel: false,
+  },
+}).then((reponse) => reponse.data.results.filter((r) => r.siege.departement !== null).map((r) => ({
+  nom: r.nom_complet, departement: r.siege.departement,
+})));
+
+module.exports = { rechercheOrganisation };

--- a/src/mss.js
+++ b/src/mss.js
@@ -18,6 +18,7 @@ const creeServeur = (
   adaptateurPdf,
   adaptateurHorloge,
   adaptateurGestionErreur,
+  adaptateurAnnuaire,
   avecCookieSecurise = (process.env.NODE_ENV === 'production'),
   avecPageErreur = (process.env.NODE_ENV === 'production'),
 ) => {
@@ -128,7 +129,7 @@ const creeServeur = (
     reponse.render('espacePersonnel');
   });
 
-  app.use('/api', routesApi(middleware, adaptateurMail, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf));
+  app.use('/api', routesApi(middleware, adaptateurMail, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf, adaptateurAnnuaire));
 
   app.use('/bibliotheques', routesBibliotheques());
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -98,6 +98,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const departements = () => donneesReferentiel.departements || [];
   const codeDepartements = () => donneesReferentiel
     .departements?.map((departement) => departement.code);
+  const estCodeDepartement = (code) => codeDepartements().includes(code);
   const departement = (code) => donneesReferentiel
     .departements?.find((unDepartement) => unDepartement.code === code)?.nom;
 
@@ -254,6 +255,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     descriptionsFonctionnalites,
     donneesCaracterePersonnel,
     echeancesRenouvellement,
+    estCodeDepartement,
     estDocumentHomologation,
     estIdentifiantEcheanceRenouvellementConnu,
     estIdentifiantStatutAvisDossierHomologationConnu,

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -20,7 +20,8 @@ const routesApi = (
   depotDonnees,
   referentiel,
   adaptateurHorloge,
-  adaptateurPdf
+  adaptateurPdf,
+  adaptateurAnnuaire
 ) => {
   const verifieSuccesEnvoiMessage = (promesseEnvoiMessage, utilisateur) => promesseEnvoiMessage
     .then(() => utilisateur)
@@ -301,6 +302,25 @@ const routesApi = (
 
   routes.get('/dureeSession', (_requete, reponse) => {
     reponse.send({ dureeSession: DUREE_SESSION });
+  });
+
+  routes.get('/annuaire/suggestions', (requete, reponse) => {
+    const {
+      recherche = '',
+      departement = null,
+    } = requete.query;
+
+    if (recherche === '') {
+      reponse.status(400).send('Le terme de recherche ne peut pas être vide');
+      return;
+    }
+    if (departement !== null && !referentiel.estCodeDepartement(departement)) {
+      reponse.status(400).send('Le département doit être valide (01 à 989)');
+      return;
+    }
+
+    adaptateurAnnuaire.rechercheOrganisation(recherche, departement)
+      .then((suggestions) => reponse.status(200).json({ suggestions }));
   });
 
   return routes;

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -92,6 +92,7 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
             placeHolder = 'ex : Agglomération de Mansart, Société Y',
             required,
           )
+          .icone-chargement
           .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.
           input(type='hidden' name='nomEntitePublique' id='nomEntitePublique' value != donnees.nomEntitePublique)
           input(type='hidden' name='departementEntitePublique' id='departementEntitePublique' value != donnees.departementEntitePublique)

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -8,6 +8,8 @@ block append styles
   link(href = '/statique/assets/styles/modules/selectize.css', rel = 'stylesheet')
 
 block append scripts
+  script(id = 'donnees-departements', type = 'application/json').
+    !{JSON.stringify(departements || [])}
   script(src = "/bibliotheques/selectize.min.js")
   script(src = "/statique/plugins/selectize.aucun-resultat.js")
   script(src = "/statique/utilisateur/suggestionEntite.js")
@@ -83,6 +85,13 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
           title = ''
         )
         .message-erreur Le numéro de téléphone doit respecter le format 0000000000.
+
+      label(for = 'departementEntitePublique-selectize') Département de votre organisation
+        select(
+          id = 'departementEntitePublique-selectize',
+          name = 'departementEntitePublique-selectize',
+          placeHolder = 'ex : 33, Morbihan',
+        )
 
       .requis
         label(for = 'nomEntitePublique-selectize') Nom de votre organisation

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -92,8 +92,8 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
             required,
           )
           .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.
-          input(type='hidden' name='nomEntitePublique' id='nomEntitePublique')
-          input(type='hidden' name='departementEntitePublique' id='departementEntitePublique')
+          input(type='hidden' name='nomEntitePublique' id='nomEntitePublique' value != donnees.nomEntitePublique)
+          input(type='hidden' name='departementEntitePublique' id='departementEntitePublique' value != donnees.departementEntitePublique)
 
       .requis(data-nom = 'rssi')
         +inputOuiNon({

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -4,6 +4,12 @@ block append styles
   link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/utilisateur.css', rel = 'stylesheet')
+  link(href = '/styles/selectize.default.min.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/modules/selectize.css', rel = 'stylesheet')
+
+block append scripts
+  script(src = "/bibliotheques/selectize.min.js")
+  script(src = "/statique/utilisateur/suggestionEntite.js")
 
 mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
   .mention champ obligatoire
@@ -77,6 +83,18 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
         )
         .message-erreur Le numéro de téléphone doit respecter le format 0000000000.
 
+      .requis
+        label(for = 'nomEntitePublique-selectize') Nom de votre organisation
+          select(
+            id = 'nomEntitePublique-selectize',
+            name = 'nomEntitePublique-selectize',
+            placeHolder = 'ex : Agglomération de Mansart, Société Y',
+            required,
+          )
+          .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.
+          input(type='hidden' name='nomEntitePublique' id='nomEntitePublique')
+          input(type='hidden' name='departementEntitePublique' id='departementEntitePublique')
+
       .requis(data-nom = 'rssi')
         +inputOuiNon({
           nom: 'rssi',
@@ -103,28 +121,3 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
           value != donnees.poste,
           placeholder = "ex : Cheffe/Chef de projet maîtrise d'ouvrage"
         )
-
-      .requis(data-nom = 'nomEntitePublique')
-        label Nom de votre organisation
-          br
-          input(
-            id = 'nomEntitePublique',
-            name = 'nomEntitePublique',
-            type = 'text',
-            value != donnees.nomEntitePublique,
-            placeholder = "ex : Agglomération de Mansart, Société Y",
-            required,
-            title = ''
-          )
-          .message-erreur Ce champ est obligatoire. Veuillez le renseigner.
-
-      .requis(data-nom = 'departementEntitePublique')
-        label Département de votre organisation
-          br
-          .selecteur-options
-            select(id = 'departementEntitePublique', name = 'departementEntitePublique', required, title = '')
-              option(value = '') - Sélectionnez un département -
-              each departement in departements
-                option(value = departement.code, selected = departement.code === donnees.departementEntitePublique).
-                  #{departement.code} #{departement.nom}
-            .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -9,6 +9,7 @@ block append styles
 
 block append scripts
   script(src = "/bibliotheques/selectize.min.js")
+  script(src = "/statique/plugins/selectize.aucun-resultat.js")
   script(src = "/statique/utilisateur/suggestionEntite.js")
 
 mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -535,6 +535,17 @@ describe('Le référentiel', () => {
     expect(referentiel.codeDepartements()).to.eql(['01', '02']);
   });
 
+  it('sait si un code de département est dans la liste des codes des départements', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      departements: [
+        { nom: 'Ain', code: '01' },
+      ],
+    });
+
+    expect(referentiel.estCodeDepartement('01')).to.eql(true);
+    expect(referentiel.estCodeDepartement('02')).to.eql(false);
+  });
+
   it("trouve le nom d'un département grace à son code", () => {
     const referentiel = Referentiel.creeReferentiel({
       departements: [{ nom: 'Ain', code: '01' }],

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -1155,4 +1155,48 @@ describe('Le serveur MSS des routes /api/*', () => {
         .catch((e) => done(e.response?.data || e));
     });
   });
+
+  describe('quand requête GET sur `/api/annuaire/suggestions`', () => {
+    beforeEach(() => {
+      testeur.referentiel().estCodeDepartement = () => true;
+    });
+
+    it('retourne une erreur HTTP 400 si le terme de recherche est vide', (done) => {
+      testeur.verifieRequeteGenereErreurHTTP(
+        400,
+        'Le terme de recherche ne peut pas être vide',
+        { method: 'get', url: 'http://localhost:1234/api/annuaire/suggestions?departement=75' },
+        done
+      );
+    });
+
+    it("retourne une erreur HTTP 400 si le département n'est pas dans le referentiel", (done) => {
+      testeur.referentiel().estCodeDepartement = () => false;
+      testeur.verifieRequeteGenereErreurHTTP(
+        400,
+        'Le département doit être valide (01 à 989)',
+        { method: 'get', url: 'http://localhost:1234/api/annuaire/suggestions?recherche=mairie&departement=990' },
+        done
+      );
+    });
+
+    it("recherche les organisations correspondantes grâce à l'adaptateur annuaire", (done) => {
+      let adaptateurAppele = false;
+      testeur.adaptateurAnnuaire().rechercheOrganisation = (terme, departement) => {
+        adaptateurAppele = true;
+        expect(terme).to.equal('mairie');
+        expect(departement).to.equal('01');
+        return Promise.resolve([{ nom: 'un résultat', departement: '01' }]);
+      };
+
+      axios.get('http://localhost:1234/api/annuaire/suggestions?recherche=mairie&departement=01')
+        .then((reponse) => {
+          expect(adaptateurAppele).to.be(true);
+          expect(reponse.status).to.be(200);
+          expect(reponse.data.suggestions).to.eql([{ nom: 'un résultat', departement: '01' }]);
+        })
+        .then(done)
+        .catch((e) => done(e.response?.data || e));
+    });
+  });
 });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -11,6 +11,7 @@ const Referentiel = require('../../src/referentiel');
 const middleware = require('../mocks/middleware');
 
 const testeurMss = () => {
+  let adaptateurAnnuaire;
   let adaptateurHorloge;
   let adaptateurMail;
   let adaptateurPdf;
@@ -37,6 +38,7 @@ const testeurMss = () => {
   };
 
   const initialise = (done) => {
+    adaptateurAnnuaire = {};
     adaptateurHorloge = adaptateurHorlogeParDefaut;
     adaptateurMail = {};
     adaptateurPdf = {};
@@ -55,6 +57,7 @@ const testeurMss = () => {
           adaptateurPdf,
           adaptateurHorloge,
           adaptateurGestionErreurVide,
+          adaptateurAnnuaire,
           false,
         );
         serveur.ecoute(1234, done);
@@ -65,6 +68,7 @@ const testeurMss = () => {
   const arrete = () => (serveur.arreteEcoute());
 
   return {
+    adaptateurAnnuaire: () => adaptateurAnnuaire,
     adaptateurHorloge: () => adaptateurHorloge,
     adaptateurMail: () => adaptateurMail,
     adaptateurPdf: () => adaptateurPdf,


### PR DESCRIPTION
Cette PR passe les champs « département » et « nom de l'organisation » de mode « Selectize ».

~~De plus, le champ « département de l'organisation » disparaît car cette information est désormais récupérée via l'API qui suggère les noms.~~
~~Donc lorsque l'utilisateur sélectionne son organisation dans la liste des suggestions, MSS récupère le département associé.~~

Pour « département » on utilise nos données de référentiel pour nourrir le `Selectize`.

Pour « organisation » on fait appel à l'API `https://recherche-entreprises.api.gouv.fr/search` via un adaptateur.