### PR TITLE
Supprime la mention obligatoire sur l'étape date

### DIFF
--- a/src/vues/service/etapeDossier/date.pug
+++ b/src/vues/service/etapeDossier/date.pug
@@ -8,8 +8,6 @@ block append styles
 block formulaire
   - const dossierCourant = service.dossierCourant()
 
-  .mention champ obligatoire
-
   section
     p.
       Saisissez les informations remplies par l'autorité d'homologation sur le document


### PR DESCRIPTION
On ne doit la voir apparaître que sur la première étape