### PR TITLE
Événement inscription utilisateur

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -7,7 +7,7 @@ const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurJournalMSS = require('./src/adaptateurs/fabriqueAdaptateurJournalMSS');
 const EvenementCompletudeServiceModifiee = require('./src/modeles/journalMSS/evenementCompletudeServiceModifiee');
 const EvenementNouvelleHomologationCreee = require('./src/modeles/journalMSS/evenementNouvelleHomologationCreee');
-const EvenementProfilUtilisateurModifie = require('./src/modeles/journalMSS/evenementProfilUtilisateurModifie');
+const EvenementNouvelUtilisateurInscrit = require('./src/modeles/journalMSS/evenementNouvelUtilisateurInscrit');
 const { avecPMapPourChaqueElement } = require('./src/utilitaires/pMap');
 
 class ConsoleAdministration {
@@ -66,12 +66,16 @@ class ConsoleAdministration {
     return avecPMapPourChaqueElement(evenements, journal.consigneEvenement);
   }
 
-  genereTousEvenementsProfilUtilisateur(persisteEvenements = false) {
+  genereTousEvenementsNouvelUtilisateurInscrit(persisteEvenements = false) {
     const journal = (persisteEvenements ? this.adaptateurJournalMSS : this.journalConsole);
 
     const evenements = this.depotDonnees.tousUtilisateurs()
-      .then((tous) => tous.map(({ id, ...donnees }) => ({ idUtilisateur: id, ...donnees })))
-      .then((donnees) => donnees.map((d) => new EvenementProfilUtilisateurModifie(d).toJSON()))
+      .then((tous) => tous.map(({ id, dateCreation }) => (
+        new EvenementNouvelUtilisateurInscrit(
+          { idUtilisateur: id },
+          { date: dateCreation }
+        ).toJSON()
+      )))
       .then((evenementsBruts) => evenementsBruts.map(({ donnees, ...reste }) => (
         { donnees: { ...donnees, genereParAdministrateur: true }, ...reste }
       )));

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -8,6 +8,7 @@ const {
   ErreurUtilisateurExistant,
   ErreurUtilisateurInexistant,
 } = require('../erreurs');
+const EvenementNouvelUtilisateurInscrit = require('../modeles/journalMSS/evenementNouvelUtilisateurInscrit');
 const EvenementProfilUtilisateurModifie = require('../modeles/journalMSS/evenementProfilUtilisateurModifie');
 const Utilisateur = require('../modeles/utilisateur');
 
@@ -42,6 +43,9 @@ const creeDepot = (config = {}) => {
             donneesUtilisateur.motDePasse = hash;
 
             adaptateurPersistance.ajouteUtilisateur(id, donneesUtilisateur)
+              .then(() => adaptateurJournalMSS.consigneEvenement(
+                new EvenementNouvelUtilisateurInscrit({ idUtilisateur: id }).toJSON()
+              ))
               .then(() => adaptateurJournalMSS.consigneEvenement(
                 new EvenementProfilUtilisateurModifie(
                   { idUtilisateur: id, ...donneesUtilisateur }

--- a/src/modeles/journalMSS/evenementNouvelUtilisateurInscrit.js
+++ b/src/modeles/journalMSS/evenementNouvelUtilisateurInscrit.js
@@ -1,0 +1,26 @@
+const Evenement = require('./evenement');
+const {
+  ErreurIdentifiantUtilisateurManquant,
+} = require('./erreurs');
+
+class EvenementNouvelUtilisateurInscrit extends Evenement {
+  constructor(donnees, options = {}) {
+    const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
+
+    const valide = () => {
+      if (!donnees.idUtilisateur) throw new ErreurIdentifiantUtilisateurManquant();
+    };
+
+    valide();
+
+    super(
+      'NOUVEL_UTILISATEUR_INSCRIT',
+      {
+        idUtilisateur: adaptateurChiffrement.hacheSha256(donnees.idUtilisateur),
+      },
+      date
+    );
+  }
+}
+
+module.exports = EvenementNouvelUtilisateurInscrit;

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -345,14 +345,17 @@ describe('Le dépôt de données des utilisateurs', () => {
           .catch(done);
       });
 
-      it('consigne un événement de profil utilisateur modifié', (done) => {
+      it("consigne des événements traçants l'inscription de l'utilisateur", (done) => {
+        const evenementConsignes = [];
         adaptateurJournalMSS.consigneEvenement = (evenement) => {
-          expect(evenement.type).to.equal('PROFIL_UTILISATEUR_MODIFIE');
-          done();
+          evenementConsignes.push(evenement);
           return Promise.resolve();
         };
 
-        depot.nouvelUtilisateur({ prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' });
+        depot.nouvelUtilisateur({ prenom: 'Jean', nom: 'Dupont', email: 'jean.dupont@mail.fr' })
+          .then(() => expect(evenementConsignes.map((e) => e.type)).to.eql(['NOUVEL_UTILISATEUR_INSCRIT', 'PROFIL_UTILISATEUR_MODIFIE']))
+          .then(() => done())
+          .catch(done);
       });
     });
 

--- a/test/modeles/journalMSS/evenementNouvelUtilisateurInscrit.spec.js
+++ b/test/modeles/journalMSS/evenementNouvelUtilisateurInscrit.spec.js
@@ -1,0 +1,43 @@
+const expect = require('expect.js');
+const EvenementNouvelUtilisateurInscrit = require('../../../src/modeles/journalMSS/evenementNouvelUtilisateurInscrit');
+const { ErreurIdentifiantUtilisateurManquant } = require('../../../src/modeles/journalMSS/erreurs');
+
+describe('Un événement de nouvel utilisateur inscrit', () => {
+  const hacheEnMajuscules = { hacheSha256: (valeur) => valeur?.toUpperCase() };
+
+  it("chiffre l'identifiant de l'utilisateur qui lui est donné", () => {
+    const evenement = new EvenementNouvelUtilisateurInscrit(
+      { idUtilisateur: 'abc' },
+      { adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+    expect(evenement.toJSON().donnees.idUtilisateur).to.be('ABC');
+  });
+
+  it('sait se convertir en JSON', () => {
+    const evenement = new EvenementNouvelUtilisateurInscrit(
+      { idUtilisateur: 'abc' },
+      { date: '17/11/2022', adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+    expect(evenement.toJSON()).to.eql({
+      type: 'NOUVEL_UTILISATEUR_INSCRIT',
+      donnees: { idUtilisateur: 'ABC' },
+      date: '17/11/2022',
+    });
+  });
+
+  it("exige que l'identifiant utilisateur soit renseigné", (done) => {
+    try {
+      new EvenementNouvelUtilisateurInscrit(
+        { },
+        { adaptateurChiffrement: hacheEnMajuscules }
+      );
+
+      done(Error("L'instanciation de l'événement aurait dû lever une exception"));
+    } catch (e) {
+      expect(e).to.be.an(ErreurIdentifiantUtilisateurManquant);
+      done();
+    }
+  });
+});


### PR DESCRIPTION
On souhaite décorréler les événements de modification de profil de ceux d'inscription d'un nouvel utilisateur. Ce sont deux choses sémantiquement différentes.

Ceci nous permettra d'obtenir une courbe du nombre d'inscrits sur la plateforme.