### PR TITLE
[CORRECTION] Affiche les chiffres uniquement si ils existent

### DIFF
--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -2,7 +2,8 @@ extends base
 
 mixin chiffre(texte, angle, classe)
   - const rayon = '3em';
-  .chiffre(class=classe,style=`top: calc(${rayon} * cos(180deg - ${angle}deg)); left: calc(${rayon} * sin(180deg - ${angle}deg));`)!= texte
+  if(texte !== 0)
+    .chiffre(class=classe, style=`top: calc(${rayon} * cos(180deg - ${angle}deg)); left: calc(${rayon} * sin(180deg - ${angle}deg));`)!= texte
 
 mixin statistiquesMesures({ id, statistiques = {},  camembert = {}})
   - const { total = 0, enCours = 0, nonFait = 0, fait = 0, restant = 0 } = statistiques


### PR DESCRIPTION
Cette PR règle un problème dans le cas ou certains chiffres sont à 0.
Ils étaient affichés tout de même, les uns sur les autres :
![image](https://user-images.githubusercontent.com/1643465/232076937-acabce70-b3c5-45cd-a91a-6679bdbd516c.png)
