### PR TITLE
Balise open graph avec le nom du site

### DIFF
--- a/src/vues/base.pug
+++ b/src/vues/base.pug
@@ -1,6 +1,7 @@
 doctype html
 meta(charset='utf-8')
 meta(name = 'viewport', content = 'width=device-width')
+meta(property = 'og:site_name', content = 'MonServiceSécurisé')
 link(rel='icon', href='/statique/assets/images/favicons/favicon.ico')
 
 block page


### PR DESCRIPTION
Il y a de maigre chance que grace à cela google affiche MonServiceSécurisé à la place de Béta.gouv.
Pour info les balises open graph sont utilisées pour les réseaux sociaux (https://www.referenseo.com/guide-seo/open-graph/)