### PR TITLE
Changement des routes `dossier` en routes `homologation`

### DIFF
--- a/public/service/homologation/etapes/autorite.js
+++ b/public/service/homologation/etapes/autorite.js
@@ -7,6 +7,6 @@ $(() => {
       fonction: $('#fonction').val(),
     };
 
-    return axios.put(`/api/service/${idService}/dossier/autorite`, donnees);
+    return axios.put(`/api/service/${idService}/homologation/autorite`, donnees);
   });
 });

--- a/public/service/homologation/etapes/avis.js
+++ b/public/service/homologation/etapes/avis.js
@@ -12,7 +12,7 @@ const soumissionEtapeAvis = (selecteurFormulaire) => (idService) => {
   const avecAvis = estValeurAvecAvis($radioAvisSelectionne.val());
   return (
     axios.put(
-      `/api/service/${idService}/dossier/avis`,
+      `/api/service/${idService}/homologation/avis`,
       { ...arrangeParametresAvis(parametres(selecteurFormulaire)), avecAvis }
     )
   );

--- a/public/service/homologation/etapes/documents.js
+++ b/public/service/homologation/etapes/documents.js
@@ -80,7 +80,7 @@ const soumissionEtapeDocuments = (selecteurFormulaire) => (idService) => {
 
   return (
     axios.put(
-      `/api/service/${idService}/dossier/documents`,
+      `/api/service/${idService}/homologation/documents`,
       { documents, avecDocuments }
     )
   );

--- a/public/service/homologation/etapes/etapeDate.js
+++ b/public/service/homologation/etapes/etapeDate.js
@@ -7,6 +7,6 @@ $(() => {
       dureeValidite: $('input[name="dureeValidite"]:checked').val(),
     };
 
-    return axios.put(`/api/service/${idService}/dossier/decision`, donnees);
+    return axios.put(`/api/service/${idService}/homologation/decision`, donnees);
   });
 });

--- a/public/service/homologation/etapes/recapitulatif.js
+++ b/public/service/homologation/etapes/recapitulatif.js
@@ -2,5 +2,5 @@ import brancheComportemenFormulaireEtape from '../formulaireEtape.js';
 
 $(() => {
   brancheComportemenFormulaireEtape((idService) => axios
-    .post(`/api/service/${idService}/dossier/finalise`));
+    .post(`/api/service/${idService}/homologation/finalise`));
 });

--- a/public/service/homologation/formulaireEtape.js
+++ b/public/service/homologation/formulaireEtape.js
@@ -20,7 +20,7 @@ const brancheComportemenFormulaireEtape = (actionSoumission) => {
       actionSoumission(idService, selecteurFormulaire)
         .then(() => (
           window.location = idEtapeSuivante
-            ? `/service/${idService}/dossier/edition/etape/${idEtapeSuivante}`
+            ? `/service/${idService}/homologation/edition/etape/${idEtapeSuivante}`
             : `/service/${idService}/dossiers`
         ));
     }

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -178,7 +178,7 @@ const routesApiService = (
     }
   });
 
-  routes.put('/:id/dossier/autorite', middleware.trouveHomologation, middleware.trouveDossierCourant, middleware.aseptise('nom', 'fonction'), (requete, reponse, suite) => {
+  routes.put('/:id/homologation/autorite', middleware.trouveHomologation, middleware.trouveDossierCourant, middleware.aseptise('nom', 'fonction'), (requete, reponse, suite) => {
     const { homologation, dossierCourant } = requete;
 
     const { body: { nom, fonction } } = requete;
@@ -188,7 +188,7 @@ const routesApiService = (
       .catch(suite);
   });
 
-  routes.put('/:id/dossier/decision',
+  routes.put('/:id/homologation/decision',
     middleware.trouveHomologation,
     middleware.trouveDossierCourant,
     middleware.aseptise('dateHomologation', 'dureeValidite'),
@@ -212,7 +212,7 @@ const routesApiService = (
         .catch(suite);
     });
 
-  routes.put('/:id/dossier/telechargement/:idDocument', middleware.trouveHomologation, middleware.trouveDossierCourant, (requete, reponse, suite) => {
+  routes.put('/:id/homologation/telechargement/:idDocument', middleware.trouveHomologation, middleware.trouveDossierCourant, (requete, reponse, suite) => {
     const { homologation, dossierCourant } = requete;
 
     const { idDocument } = requete.params;
@@ -228,7 +228,7 @@ const routesApiService = (
       .catch(suite);
   });
 
-  routes.put('/:id/dossier/avis',
+  routes.put('/:id/homologation/avis',
     middleware.trouveHomologation,
     middleware.trouveDossierCourant,
     middleware.aseptiseListes([{ nom: 'avis', proprietes: [...Avis.proprietesAtomiquesRequises(), ...Avis.proprietesAtomiquesFacultatives()] }]),
@@ -251,7 +251,7 @@ const routesApiService = (
         .catch(suite);
     });
 
-  routes.put('/:id/dossier/documents',
+  routes.put('/:id/homologation/documents',
     middleware.trouveHomologation,
     middleware.trouveDossierCourant,
     middleware.aseptise('documents.*', 'avecDocuments'),
@@ -273,7 +273,7 @@ const routesApiService = (
         .catch(suite);
     });
 
-  routes.post('/:id/dossier/finalise',
+  routes.post('/:id/homologation/finalise',
     middleware.trouveHomologation,
     middleware.trouveDossierCourant,
     (requete, reponse, suite) => {

--- a/src/routes/routesService.js
+++ b/src/routes/routesService.js
@@ -96,7 +96,7 @@ const routesService = (
     });
   });
 
-  routes.get('/:id/dossier/edition/etape/:idEtape', middleware.trouveHomologation, (requete, reponse, suite) => {
+  routes.get('/:id/homologation/edition/etape/:idEtape', middleware.trouveHomologation, (requete, reponse, suite) => {
     const { homologation } = requete;
     const { idEtape } = requete.params;
 

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -17,7 +17,7 @@ mixin dossier({ statut, dossier, idService })
           div= `Étapes complétées : ${numeroDerniereEtapeCompletee} / ${nombreTotalEtapes}`
     if idService
       nav
-        a(href = `/service/${idService}/dossier/edition/etape/${etapeCourante}`) Consulter
+        a(href = `/service/${idService}/homologation/edition/etape/${etapeCourante}`) Consulter
 
 mixin dossierFinalise({ dossier })
   +dossier({ statut: 'Homologation finalisée', dossier })

--- a/src/vues/service/etapeDossier/decision.pug
+++ b/src/vues/service/etapeDossier/decision.pug
@@ -5,7 +5,7 @@ mixin document({ nom, description, dateTelechargement })
 
   a.document-homologation(
     href= referentiel.urlDocumentHomologation(nom, service.id)
-    data-action-enregistrement = `/api/service/${service.id}/dossier/telechargement/${nom}`
+    data-action-enregistrement = `/api/service/${service.id}/homologation/telechargement/${nom}`
     target='_blank'
     rel='noopener'
     )

--- a/src/vues/service/formulaireEtapier.pug
+++ b/src/vues/service/formulaireEtapier.pug
@@ -15,7 +15,7 @@ mixin barre-progression({ numeroEtapeCourante })
       .etape(class = classeEtape)
         if classeEtape === 'passee'
           .numero-etape
-            a(href = `/service/${service.id}/dossier/edition/etape/${etape.id}`).coche
+            a(href = `/service/${service.id}/homologation/edition/etape/${etape.id}`).coche
           .libelle-etape= etape.libelle
         else
           +descriptionEtape({ etape })

--- a/test/routes/routesApiService.spec.js
+++ b/test/routes/routesApiService.spec.js
@@ -521,7 +521,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
   });
 
-  describe('quand requête PUT sur /api/service/:id/dossier/autorite', () => {
+  describe('quand requête PUT sur /api/service/:id/homologation/autorite', () => {
     beforeEach(() => {
       const homologationAvecDossier = new Homologation({ id: '456', descriptionService: { nomService: 'un service' }, dossiers: [{ id: '999' }] });
       testeur.middleware().reinitialise({ homologationARenvoyer: homologationAvecDossier });
@@ -530,14 +530,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
-        { url: 'http://localhost:1234/api/service/456/dossier/autorite', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/autorite', method: 'put' },
         done,
       );
     });
 
     it('recherche le dossier courant correspondant', (done) => {
       testeur.middleware().verifieRechercheDossierCourant(
-        { url: 'http://localhost:1234/api/service/456/dossier/autorite', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/autorite', method: 'put' },
         done,
       );
     });
@@ -545,7 +545,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('aseptise les paramètres reçus', (done) => {
       testeur.middleware().verifieAseptisationParametres(
         ['nom', 'fonction'],
-        { url: 'http://localhost:1234/api/service/456/dossier/autorite', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/autorite', method: 'put' },
         done
       );
     });
@@ -561,14 +561,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return Promise.resolve();
       };
 
-      axios.put('http://localhost:1234/api/service/456/dossier/autorite', { nom: 'Jean Dupond', fonction: 'RSSI' })
+      axios.put('http://localhost:1234/api/service/456/homologation/autorite', { nom: 'Jean Dupond', fonction: 'RSSI' })
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
     });
   });
 
-  describe('quand requête PUT sur /api/service/:id/dossier/decision', () => {
+  describe('quand requête PUT sur /api/service/:id/homologation/decision', () => {
     beforeEach(() => {
       const homologationAvecDossier = new Homologation({ id: '456', descriptionService: { nomService: 'un service' }, dossiers: [{ id: '999' }] });
       testeur.middleware().reinitialise({ homologationARenvoyer: homologationAvecDossier });
@@ -578,14 +578,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
-        { url: 'http://localhost:1234/api/service/456/dossier/decision', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/decision', method: 'put' },
         done,
       );
     });
 
     it('recherche le dossier courant correspondant', (done) => {
       testeur.middleware().verifieRechercheDossierCourant(
-        { url: 'http://localhost:1234/api/service/456/dossier/decision', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/decision', method: 'put' },
         done,
       );
     });
@@ -593,13 +593,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('aseptise les paramètres reçus', (done) => {
       testeur.middleware().verifieAseptisationParametres(
         ['dateHomologation', 'dureeValidite'],
-        { url: 'http://localhost:1234/api/service/456/dossier/decision', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/decision', method: 'put' },
         done
       );
     });
 
     it("renvoie une erreur 422 si la date d'homologation est invalide", (done) => {
-      axios.put('http://localhost:1234/api/service/456/dossier/decision', { dateHomologation: 'dateInvalide', dureeValidite: 'unAn' })
+      axios.put('http://localhost:1234/api/service/456/homologation/decision', { dateHomologation: 'dateInvalide', dureeValidite: 'unAn' })
         .then(() => done('Une erreur aurait dû être levée'))
         .catch((e) => {
           expect(e.response.status).to.be(422);
@@ -610,7 +610,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('renvoie une erreur 422 si la durée de validité est inconnue du référentiel', (done) => {
-      axios.put('http://localhost:1234/api/service/456/dossier/decision', { dateHomologation: new Date(), dureeValidite: 'dureeInconnue' })
+      axios.put('http://localhost:1234/api/service/456/homologation/decision', { dateHomologation: new Date(), dureeValidite: 'dureeInconnue' })
         .then(() => done('Une erreur aurait dû être levée'))
         .catch((e) => {
           expect(e.response.status).to.be(422);
@@ -631,14 +631,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return Promise.resolve();
       };
 
-      axios.put('http://localhost:1234/api/service/456/dossier/decision', { dateHomologation: '2023-01-01', dureeValidite: 'unAn' })
+      axios.put('http://localhost:1234/api/service/456/homologation/decision', { dateHomologation: '2023-01-01', dureeValidite: 'unAn' })
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
     });
   });
 
-  describe('quand requête PUT sur `/api/service/:id/dossier/telechargement/:idDocument', () => {
+  describe('quand requête PUT sur `/api/service/:id/homologation/telechargement/:idDocument', () => {
     beforeEach(() => {
       const homologationAvecDossier = new Homologation({ id: '456', descriptionService: { nomService: 'un service' }, dossiers: [{ id: '999' }] });
       testeur.middleware().reinitialise({ homologationARenvoyer: homologationAvecDossier });
@@ -648,14 +648,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
-        { url: 'http://localhost:1234/api/service/456/dossier/telechargement/decision', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/telechargement/decision', method: 'put' },
         done,
       );
     });
 
     it('recherche le dossier courant correspondant', (done) => {
       testeur.middleware().verifieRechercheDossierCourant(
-        { url: 'http://localhost:1234/api/service/456/dossier/telechargement/decision', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/telechargement/decision', method: 'put' },
         done,
       );
     });
@@ -673,14 +673,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return Promise.resolve();
       };
 
-      axios.put('http://localhost:1234/api/service/456/dossier/telechargement/decision')
+      axios.put('http://localhost:1234/api/service/456/homologation/telechargement/decision')
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
     });
 
     it("reste robuste si l'id de document ne correspond pas à un document connu", (done) => {
-      axios.put('http://localhost:1234/api/service/456/dossier/telechargement/mauvaisId')
+      axios.put('http://localhost:1234/api/service/456/homologation/telechargement/mauvaisId')
         .catch(({ response }) => {
           expect(response.status).to.be(422);
           expect(response.data).to.equal('Identifiant de document invalide');
@@ -690,7 +690,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
   });
 
-  describe('quand requête PUT sur /api/service/:id/dossier/avis', () => {
+  describe('quand requête PUT sur /api/service/:id/homologation/avis', () => {
     beforeEach(() => {
       const homologationAvecDossier = new Homologation({ id: '456', descriptionService: { nomService: 'un service' }, dossiers: [{ id: '999' }] }, testeur.referentiel());
       testeur.middleware().reinitialise({ homologationARenvoyer: homologationAvecDossier });
@@ -703,20 +703,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
-        { url: 'http://localhost:1234/api/service/456/dossier/avis', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/avis', method: 'put' },
         done,
       );
     });
 
     it('recherche le dossier courant correspondant', (done) => {
       testeur.middleware().verifieRechercheDossierCourant(
-        { url: 'http://localhost:1234/api/service/456/dossier/avis', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/avis', method: 'put' },
         done,
       );
     });
 
     it('aseptise la liste des avis', (done) => {
-      axios.put('http://localhost:1234/api/service/456/dossier/avis', { avis: [] })
+      axios.put('http://localhost:1234/api/service/456/homologation/avis', { avis: [] })
         .then(() => {
           testeur.middleware().verifieAseptisationListe('avis', ['statut', 'dureeValidite', 'commentaires']);
           done();
@@ -726,12 +726,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('aseptise les collaborateurs mentionnés dans les avis et le paramètres "avecAvis"', (done) => {
       testeur.middleware().verifieAseptisationParametres(
-        ['avis.*.collaborateurs.*', 'avecAvis'], { url: 'http://localhost:1234/api/service/456/dossier/avis', method: 'put' }, done
+        ['avis.*.collaborateurs.*', 'avecAvis'], { url: 'http://localhost:1234/api/service/456/homologation/avis', method: 'put' }, done
       );
     });
 
     it("renvoie une 400 si aucun avis n'est envoyé", (done) => {
-      axios.put('http://localhost:1234/api/service/456/dossier/avis', {})
+      axios.put('http://localhost:1234/api/service/456/homologation/avis', {})
         .then(() => {
           done('Une erreur aurait du être renvoyée');
         })
@@ -754,7 +754,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios.put('http://localhost:1234/api/service/456/dossier/avis', { avis: [{ collaborateurs: ['Jean Dupond'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'Ok' }], avecAvis: 'true' })
+        axios.put('http://localhost:1234/api/service/456/homologation/avis', { avis: [{ collaborateurs: ['Jean Dupond'], statut: 'favorable', dureeValidite: 'unAn', commentaires: 'Ok' }], avecAvis: 'true' })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
           .catch((e) => done(e.response?.data || e));
@@ -770,7 +770,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios.put('http://localhost:1234/api/service/456/dossier/avis', { avis: [], avecAvis: 'false' })
+        axios.put('http://localhost:1234/api/service/456/homologation/avis', { avis: [], avecAvis: 'false' })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
           .catch((e) => done(e.response?.data || e));
@@ -778,7 +778,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
   });
 
-  describe('quand requête PUT sur /api/service/:id/dossier/documents', () => {
+  describe('quand requête PUT sur /api/service/:id/homologation/documents', () => {
     beforeEach(() => {
       const homologationAvecDossier = new Homologation({ id: '456', descriptionService: { nomService: 'un service' }, dossiers: [{ id: '999' }] }, testeur.referentiel());
       testeur.middleware().reinitialise({ homologationARenvoyer: homologationAvecDossier });
@@ -787,26 +787,26 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
-        { url: 'http://localhost:1234/api/service/456/dossier/documents', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/documents', method: 'put' },
         done,
       );
     });
 
     it('recherche le dossier courant correspondant', (done) => {
       testeur.middleware().verifieRechercheDossierCourant(
-        { url: 'http://localhost:1234/api/service/456/dossier/documents', method: 'put' },
+        { url: 'http://localhost:1234/api/service/456/homologation/documents', method: 'put' },
         done,
       );
     });
 
     it('aseptise la liste des documents et le paramètres "avecDocuments"', (done) => {
       testeur.middleware().verifieAseptisationParametres(
-        ['documents.*', 'avecDocuments'], { url: 'http://localhost:1234/api/service/456/dossier/documents', method: 'put' }, done
+        ['documents.*', 'avecDocuments'], { url: 'http://localhost:1234/api/service/456/homologation/documents', method: 'put' }, done
       );
     });
 
     it("renvoie une 400 si aucun document n'est envoyé", (done) => {
-      axios.put('http://localhost:1234/api/service/456/dossier/documents', {})
+      axios.put('http://localhost:1234/api/service/456/homologation/documents', {})
         .then(() => done('Une erreur aurait du être renvoyée'))
         .catch((e) => {
           expect(e.response.status).to.be(400);
@@ -827,7 +827,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios.put('http://localhost:1234/api/service/456/dossier/documents', { documents: ['unDocument'], avecDocuments: 'true' })
+        axios.put('http://localhost:1234/api/service/456/homologation/documents', { documents: ['unDocument'], avecDocuments: 'true' })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
           .catch((e) => done(e.response?.data || e));
@@ -843,7 +843,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios.put('http://localhost:1234/api/service/456/dossier/documents', { documents: [], avecDocuments: 'false' })
+        axios.put('http://localhost:1234/api/service/456/homologation/documents', { documents: [], avecDocuments: 'false' })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
           .catch((e) => done(e.response?.data || e));
@@ -851,7 +851,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
   });
 
-  describe('quand requête POST sur /api/service/:id/dossier/finalise', () => {
+  describe('quand requête POST sur /api/service/:id/homologation/finalise', () => {
     beforeEach(() => {
       testeur.referentiel().recharge({
         echeancesRenouvellement: { unAn: {} },
@@ -871,14 +871,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
-        { url: 'http://localhost:1234/api/service/456/dossier/finalise', method: 'post' },
+        { url: 'http://localhost:1234/api/service/456/homologation/finalise', method: 'post' },
         done,
       );
     });
 
     it('recherche le dossier courant correspondant', (done) => {
       testeur.middleware().verifieRechercheDossierCourant(
-        { url: 'http://localhost:1234/api/service/456/dossier/finalise', method: 'post' },
+        { url: 'http://localhost:1234/api/service/456/homologation/finalise', method: 'post' },
         done,
       );
     });
@@ -892,7 +892,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return Promise.resolve();
       };
 
-      axios.post('http://localhost:1234/api/service/456/dossier/finalise')
+      axios.post('http://localhost:1234/api/service/456/homologation/finalise')
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -142,7 +142,7 @@ describe('Le serveur MSS des routes /service/*', () => {
     });
   });
 
-  describe('quand requête GET sur `/service/:id/dossier/edition/etape/:idEtape`', () => {
+  describe('quand requête GET sur `/service/:id/homologation/edition/etape/:idEtape`', () => {
     beforeEach(() => {
       testeur.referentiel().recharge({
         etapesParcoursHomologation: [{ numero: 1, id: 'decision' }, { numero: 2, id: 'deuxieme' }],
@@ -155,7 +155,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
     it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
-        'http://localhost:1234/service/456/dossier/edition/etape/decision',
+        'http://localhost:1234/service/456/homologation/edition/etape/decision',
         done,
       );
     });
@@ -163,7 +163,7 @@ describe('Le serveur MSS des routes /service/*', () => {
     it("répond avec une erreur HTTP 404 si l'identifiant d'étape n'est pas connu du référentiel", (done) => {
       testeur.verifieRequeteGenereErreurHTTP(404, 'Étape inconnue', {
         method: 'get',
-        url: 'http://localhost:1234/service/456/dossier/edition/etape/inconnue',
+        url: 'http://localhost:1234/service/456/homologation/edition/etape/inconnue',
       }, done);
     });
 
@@ -179,7 +179,7 @@ describe('Le serveur MSS des routes /service/*', () => {
         }
       };
 
-      axios('http://localhost:1234/service/456/dossier/edition/etape/decision')
+      axios('http://localhost:1234/service/456/homologation/edition/etape/decision')
         .then(() => expect(dossierAjoute).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
@@ -196,7 +196,7 @@ describe('Le serveur MSS des routes /service/*', () => {
         }
       };
 
-      axios('http://localhost:1234/service/456/dossier/edition/etape/decision')
+      axios('http://localhost:1234/service/456/homologation/edition/etape/decision')
         .then(() => expect(chargementsService).to.equal(1))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));


### PR DESCRIPTION
Dans l'entreprise Homologations -> services ; dossiers -> homologations,
Cette PR correspond à la tache Routes `/service/:id/dossier/*` -> `/service/:id/homologation/*` de la checklist

PR précédente #822

- [x] Routes `/api/homologation/*` -> `/api/service/*`
- [x] Routes `/homologation/*` -> `/service/*`
- [x] Routes `/api/homologations` -> `/api/services`
- [x] Répertoires `src/vues/homologation/*` -> `src/vues/service/*` #711 
- [x] Répertoires `public/*/homologation/*` -> `public/*/service/*`
- [ ] **Routes `/service/:id/dossier/*` -> `/service/:id/homologation/*` 👈 CETTE PR**
- [ ] Routes `/service/:id/dossiers` -> `/service/:id/homologations`
- [ ] `Middleware.trouveHomologation` -> `Middleware.trouveService`
- [ ] `depotHomologation` -> `depotService`

Les routes concernées sont les routes des étapes du parcours homologuer et les routes api de ce parcours