### PR TITLE
[CORRECTION] Angles de 360 degré maximum pour les camemberts

### DIFF
--- a/src/pdf/graphiques/camembert.js
+++ b/src/pdf/graphiques/camembert.js
@@ -1,5 +1,5 @@
 const genereGradientConique = (statistiques) => {
-  const ANGLE_MINIMUM = 10;
+  const ANGLE_MINIMUM = 20;
 
   const fixeDebutFin = (debut, fin) => {
     const avecValeur = debut !== fin;

--- a/src/pdf/graphiques/camembert.js
+++ b/src/pdf/graphiques/camembert.js
@@ -1,27 +1,70 @@
-const genereGradientConique = (statistiques) => {
-  const ANGLE_MINIMUM = 20;
+const ANGLE_MINIMUM = 20;
 
-  const fixeDebutFin = (debut, fin) => {
-    const avecValeur = debut !== fin;
-    const finVisible = avecValeur ? Math.max(fin, debut + ANGLE_MINIMUM) : fin;
-    return { debut, milieu: (finVisible - debut) / 2 + debut, fin: finVisible };
+const detailAngle = (debut, fin) => ({ debut, milieu: (fin - debut) / 2 + debut, fin });
+
+const recalculPourFin360 = (angles) => {
+  const { fait, enCours, nonFait, restant } = angles;
+
+  const depassement = fait.fin - 360;
+  const nbAnglesAModifier = Object.values(angles)
+    .map(({ debut, fin }) => fin - debut === ANGLE_MINIMUM)
+    .filter((estAngleMinimum) => estAngleMinimum === false)
+    .length;
+  const angleASoustraire = depassement / nbAnglesAModifier;
+
+  const valeurRevisee = (angle) => (angle.fin - angle.debut === ANGLE_MINIMUM
+    ? ANGLE_MINIMUM
+    : angle.fin - angle.debut - angleASoustraire
+  );
+
+  const valeurRevisees = {
+    enCours: valeurRevisee(enCours),
+    nonFait: valeurRevisee(nonFait),
+    restant: valeurRevisee(restant),
+    fait: valeurRevisee(fait),
   };
 
-  const total = statistiques.enCours + statistiques.nonFait
-    + statistiques.restant + statistiques.fait;
-  const enCours = (statistiques.enCours / total) * 360;
-  const nonFait = (statistiques.nonFait / total) * 360;
-  const restant = (statistiques.restant / total) * 360;
-  const fait = (statistiques.fait / total) * 360;
+  const enCoursRevise = detailAngle(0, valeurRevisees.enCours);
+  const nonFaitRevise = detailAngle(enCoursRevise.fin, enCoursRevise.fin + valeurRevisees.nonFait);
+  const restantRevise = detailAngle(nonFaitRevise.fin, nonFaitRevise.fin + valeurRevisees.restant);
+  const faitRevise = detailAngle(restantRevise.fin, restantRevise.fin + valeurRevisees.fait);
 
   return {
-    angles: {
-      enCours: fixeDebutFin(0, enCours),
-      nonFait: fixeDebutFin(enCours, enCours + nonFait),
-      restant: fixeDebutFin(enCours + nonFait, enCours + nonFait + restant),
-      fait: fixeDebutFin(enCours + nonFait + restant, enCours + nonFait + restant + fait),
-    },
+    enCours: enCoursRevise,
+    nonFait: nonFaitRevise,
+    restant: restantRevise,
+    fait: faitRevise,
   };
+};
+
+const genereGradientConique = (statistiques) => {
+  const avecAngleMinimum = (uneStatistique) => {
+    const total = statistiques.enCours
+    + statistiques.nonFait
+    + statistiques.restant
+    + statistiques.fait;
+
+    const valeurBrute = (uneStatistique / total) * 360;
+    return (valeurBrute === 0) ? 0 : Math.max(valeurBrute, ANGLE_MINIMUM);
+  };
+
+  const enCours = avecAngleMinimum(statistiques.enCours);
+  const nonFait = avecAngleMinimum(statistiques.nonFait);
+  const restant = avecAngleMinimum(statistiques.restant);
+  const fait = avecAngleMinimum(statistiques.fait);
+
+  const anglesInitiaux = {
+    enCours: detailAngle(0, enCours),
+    nonFait: detailAngle(enCours, enCours + nonFait),
+    restant: detailAngle(enCours + nonFait, enCours + nonFait + restant),
+    fait: detailAngle(enCours + nonFait + restant, enCours + nonFait + restant + fait),
+  };
+
+  const anglesFinaux = anglesInitiaux.fait.fin <= 360
+    ? anglesInitiaux
+    : recalculPourFin360(anglesInitiaux);
+
+  return { angles: anglesFinaux };
 };
 
 module.exports = { genereGradientConique };

--- a/test/pdf/graphiques/camembert.spec.js
+++ b/test/pdf/graphiques/camembert.spec.js
@@ -41,5 +41,46 @@ describe('Les graphiques camembert', () => {
       verifieAngleMinimum({ enCours: 0, nonFait: 0, fait: 100, restant: 1 }, 'restant');
       verifieAngleMinimum({ enCours: 0, nonFait: 0, fait: 1, restant: 100 }, 'fait');
     });
+
+    it("s'assurent que les « débuts » et « fins » des angles minimum ne se chevauchent pas", () => {
+      const statistiques = { enCours: 1, nonFait: 1, restant: 1, fait: 47 };
+
+      const { angles } = genereGradientConique(statistiques);
+
+      const verifieDebutFin = (debut, fin, idStatut) => {
+        expect(angles[idStatut].debut).to.equal(debut);
+        expect(angles[idStatut].fin).to.equal(fin);
+      };
+
+      verifieDebutFin(0, 20, 'enCours');
+      verifieDebutFin(20, 40, 'nonFait');
+      verifieDebutFin(40, 60, 'restant');
+    });
+
+    it("s'assurent de ne pas dépasser 360 degrés, même en cas d'utilisation d'angle(s) minimum(s) au début du camembert", () => {
+      const statistiques = { enCours: 1, nonFait: 1, restant: 1, fait: 47 };
+
+      expect(genereGradientConique(statistiques)).to.eql({
+        angles: {
+          enCours: { debut: 0, milieu: 10, fin: 20 },
+          nonFait: { debut: 20, milieu: 30, fin: 40 },
+          restant: { debut: 40, milieu: 50, fin: 60 },
+          fait: { debut: 60, milieu: 210, fin: 360 },
+        },
+      });
+    });
+
+    it("s'assurent de ne pas dépasser 360 degrés, même en cas d'utilisation d'angle(s) minimum(s) à la fin du camembert", () => {
+      const statistiques = { enCours: 47, nonFait: 1, restant: 2, fait: 2 };
+
+      expect(genereGradientConique(statistiques)).to.eql({
+        angles: {
+          enCours: { debut: 0, milieu: 150, fin: 300 },
+          nonFait: { debut: 300, milieu: 310, fin: 320 },
+          restant: { debut: 320, milieu: 330, fin: 340 },
+          fait: { debut: 340, milieu: 350, fin: 360 },
+        },
+      });
+    });
   });
 });

--- a/test/pdf/graphiques/camembert.spec.js
+++ b/test/pdf/graphiques/camembert.spec.js
@@ -16,7 +16,7 @@ describe('Les graphiques camembert', () => {
       });
     });
 
-    it("retournent un seul angle valant 360 degrés quand il n'y a qu'un seul statut", () => {
+    it("retournent un seul angle valant 360 degrés quand il n'y a qu'un seul statut possédant une valeur", () => {
       const statistiques = { enCours: 0, nonFait: 5, fait: 0, restant: 0 };
 
       expect(genereGradientConique(statistiques)).to.eql({
@@ -29,11 +29,11 @@ describe('Les graphiques camembert', () => {
       });
     });
 
-    it("s'assurent qu'une portion avec valeur fasse au moins 10 degrés pour rester visible", () => {
+    it("s'assurent qu'une portion avec valeur fasse au moins 20 degrés pour rester visible", () => {
       const verifieAngleMinimum = (statistiques, identifiantStatut) => {
         const { angles } = genereGradientConique(statistiques);
         const { debut, fin } = angles[identifiantStatut];
-        expect(fin - debut).to.equal(10);
+        expect(fin - debut).to.equal(20);
       };
 
       verifieAngleMinimum({ enCours: 1, nonFait: 0, fait: 100, restant: 0 }, 'enCours');


### PR DESCRIPTION
Pour que la dernière section du camembert ne soit pas tronquée, il faut veiller à répartir les angles entre 0 et 360 degrés 👇 

![image](https://user-images.githubusercontent.com/24898521/232815691-d2c257de-b574-4a51-9a15-19f314e5163e.png)

De plus pour améliorer la lisibilité on passe à un angle minimum de 20 degrés.