### PR TITLE
[CORRECTION] Derniers ajustement pour la synthèse de sécurité

### DIFF
--- a/src/pdf/graphiques/camembert.js
+++ b/src/pdf/graphiques/camembert.js
@@ -64,7 +64,22 @@ const genereGradientConique = (statistiques) => {
     ? anglesInitiaux
     : recalculPourFin360(anglesInitiaux);
 
-  return { angles: anglesFinaux };
+  const seulementStatistiquesConcernes = {
+    enCours: statistiques.enCours,
+    nonFait: statistiques.nonFait,
+    restant: statistiques.restant,
+    fait: statistiques.fait,
+  };
+  const contientUneValeurUnique = Object
+    .values(seulementStatistiquesConcernes)
+    .filter((v) => v !== 0).length === 1;
+  const unique = contientUneValeurUnique
+    ? Object
+      .keys(seulementStatistiquesConcernes)
+      .find((cle) => seulementStatistiquesConcernes[cle] !== 0)
+    : null;
+
+  return { angles: anglesFinaux, unique };
 };
 
 module.exports = { genereGradientConique };

--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -463,7 +463,7 @@ p {
 }
 
 .synthese-securite fieldset .contenu {
-  padding-left: 1em;
+  padding: 0 1em;
 }
 
 .synthese-securite .resume :is(dt, dd) {

--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -1,11 +1,11 @@
 extends base
 
-mixin chiffre(texte, angle, classe)
-  - const rayon = '3em';
+mixin chiffre(texte, angle, classe, estUnique)
+  - const rayon = estUnique ? '0' : '3em';
   if(texte !== 0)
     .chiffre(class=classe, style=`top: calc(${rayon} * cos(180deg - ${angle}deg)); left: calc(${rayon} * sin(180deg - ${angle}deg));`)!= texte
 
-mixin statistiquesMesures({ id, statistiques = {},  camembert = {}})
+mixin statistiquesMesures({ id, statistiques = {},  camembert = {}, unique = null})
   - const { total = 0, enCours = 0, nonFait = 0, fait = 0, restant = 0 } = statistiques
   - const chaineGradientConique = `background: conic-gradient(#75A1E8 ${camembert.enCours.debut}deg ${camembert.enCours.fin}deg, #D0E0F6 ${camembert.nonFait.debut}deg ${camembert.nonFait.fin}deg, #FFFFFF ${camembert.restant.debut}deg ${camembert.restant.fin}deg, transparent ${camembert.restant.fin}deg 360deg);`;
   - const chaineGradientConiqueFait = `background: conic-gradient(transparent 0deg ${camembert.fait.debut}deg, #0A4C8C ${camembert.fait.debut}deg ${camembert.fait.fin}deg);`;
@@ -17,11 +17,11 @@ mixin statistiquesMesures({ id, statistiques = {},  camembert = {}})
         .camembert.bordure-reste-a-faire(style=`background: conic-gradient(#0F7AC7 0deg ${camembert.restant.fin}deg, transparent ${camembert.restant.fin}deg 360deg);`)
         .camembert.masque-reste-a-faire
         .camembert(style=chaineGradientConique)
-        +chiffre(enCours, camembert.enCours.milieu, 'en-cours')
-        +chiffre(nonFait, camembert.nonFait.milieu, 'non-fait')
-        +chiffre(restant, camembert.restant.milieu, 'restant')
+        +chiffre(enCours, camembert.enCours.milieu, 'en-cours', unique === 'enCours')
+        +chiffre(nonFait, camembert.nonFait.milieu, 'non-fait', unique === 'nonFait')
+        +chiffre(restant, camembert.restant.milieu, 'restant', unique === 'restant')
         .camembert.fait(style=`${chaineGradientConiqueFait}; ${styleDecalageCamemberFait}`)
-        +chiffre(fait, camembert.fait.milieu, 'fait')
+        +chiffre(fait, camembert.fait.milieu, 'fait', unique == 'fait')
       .fleche
       .mesures-restantes
         p Il reste
@@ -103,6 +103,7 @@ block page
                   id: 'mesures-indispensables',
                   statistiques: service.statistiquesMesuresIndispensables(),
                   camembert: camembertIndispensables.angles,
+                  unique: camembertIndispensables.unique,
                 })
               .recommandees.conteneur
                 p.titre Recommandées
@@ -110,6 +111,7 @@ block page
                   id: 'mesures-recommandees',
                   statistiques: service.statistiquesMesuresRecommandees(),
                   camembert: camembertRecommandees.angles,
+                  unique: camembertRecommandees.unique,
                 })
               +totalMesures(service.nombreTotalMesuresGenerales())
           p.type Par catégorie

--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -66,8 +66,10 @@ block page
             dt Statut :
             dd= service.descriptionStatutDeploiement()
           dl
+          - const presentation = service.presentation();
+          - const tailleMaximale = 500;
             dt Présentation :
-            dd= service.presentation()
+            dd= presentation.length > tailleMaximale ? presentation.substring(0, tailleMaximale) + '…' : presentation
       fieldset(class='indice-cyber')
         - const indiceCyber = service.indiceCyber();
         - const noteMax = referentiel.indiceCyberNoteMax()

--- a/test/pdf/graphiques/camembert.spec.js
+++ b/test/pdf/graphiques/camembert.spec.js
@@ -13,6 +13,7 @@ describe('Les graphiques camembert', () => {
           restant: { debut: 180, milieu: 225, fin: 270 },
           fait: { debut: 270, milieu: 315, fin: 360 },
         },
+        unique: null,
       });
     });
 
@@ -26,6 +27,7 @@ describe('Les graphiques camembert', () => {
           restant: { debut: 360, milieu: 360, fin: 360 },
           fait: { debut: 360, milieu: 360, fin: 360 },
         },
+        unique: 'nonFait',
       });
     });
 
@@ -67,6 +69,7 @@ describe('Les graphiques camembert', () => {
           restant: { debut: 40, milieu: 50, fin: 60 },
           fait: { debut: 60, milieu: 210, fin: 360 },
         },
+        unique: null,
       });
     });
 
@@ -80,7 +83,20 @@ describe('Les graphiques camembert', () => {
           restant: { debut: 320, milieu: 330, fin: 340 },
           fait: { debut: 340, milieu: 350, fin: 360 },
         },
+        unique: null,
       });
+    });
+
+    it("s'assurent que le champs 'unique' est null si il y a au moins 2 portions non nulles", () => {
+      const statistiques = { enCours: 1, nonFait: 1, restant: 0, fait: 0 };
+
+      expect(genereGradientConique(statistiques).unique).to.equal(null);
+    });
+
+    it("s'assurent que le champs 'unique' porte la clé de la portion si une seule portion est présente", () => {
+      const statistiques = { enCours: 1, nonFait: 0, restant: 0, fait: 0 };
+
+      expect(genereGradientConique(statistiques).unique).to.equal('enCours');
     });
   });
 });


### PR DESCRIPTION
Dans cette PR, on ajuste la synthèse de sécurité :
- Limitation de la taille de la présentation
- Affichage du nombre au milieu du camembert en cas de mesure unique présente
- Correction du padding des camemberts