### PR TITLE
[Newsletter] Acceptation infolettre

### DIFF
--- a/migrations/20230426144428_ajoutChampInfolettreAcceptee.js
+++ b/migrations/20230426144428_ajoutChampInfolettreAcceptee.js
@@ -1,0 +1,19 @@
+exports.up = (knex) => knex('utilisateurs')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .map(({ id, donnees }) => knex('utilisateurs')
+        .where({ id })
+        .update({ donnees: { ...donnees, infolettreAcceptee: false } }));
+
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) => knex('utilisateurs')
+  .then((lignes) => {
+    const misesAJour = lignes
+      .map(({ id, donnees: { infolettreAcceptee: _, ...autresDonnees } }) => knex('utilisateurs')
+        .where({ id })
+        .update({ donnees: { ...autresDonnees } }));
+
+    return Promise.all(misesAJour);
+  });

--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -272,3 +272,13 @@ select {
     transform: rotate(360deg);
   }
 }
+
+input[type="checkbox"]+label.label-checkbox {
+  width: 80%;
+  margin: 0;
+}
+
+#infolettreAcceptee {
+  vertical-align: top;
+  cursor: pointer;
+}

--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -59,7 +59,7 @@ form.champ-unique .requis::before {
 }
 
 .requis[data-nom='cguAcceptees'] {
-  margin-bottom: 2em;
+  margin: 2em 0;
 }
 
 :is(input, select, textarea):not(.intouche):valid {

--- a/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
+++ b/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
@@ -17,6 +17,7 @@ const brancheSoumissionFormulaireUtilisateur = (selecteurFormulaire, action) => 
     departementEntitePublique: () => $('#departementEntitePublique').val(),
     motDePasse: () => $('#mot-de-passe').val(),
     cguAcceptees: () => reponseAcceptee('cguAcceptees'),
+    infolettreAcceptee: () => $('#infolettreAcceptee').is(':checked'),
   };
 
   brancheValidation(selecteurFormulaire);

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -9,6 +9,17 @@ const enteteJSON = {
 };
 const urlBase = 'https://api.sendinblue.com/v3';
 
+const basculeInfolettre = (
+  destinataire,
+  etat
+) => (axios.put(`${urlBase}/contacts/${encodeURIComponent(destinataire)}`,
+  { emailBlacklisted: etat },
+  enteteJSON)
+);
+
+const desinscrisInfolettre = (destinataire) => basculeInfolettre(destinataire, true);
+const inscrisInfolettre = (destinataire) => basculeInfolettre(destinataire, false);
+
 const creeContact = (
   destinataire, prenom, nom, bloqueEmails
 ) => (axios.post(`${urlBase}/contacts`,
@@ -92,6 +103,8 @@ const envoieNotificationTentativeReinscription = (
 
 module.exports = {
   creeContact,
+  desinscrisInfolettre,
+  inscrisInfolettre,
   envoieMessageFinalisationInscription,
   envoieMessageInvitationContribution,
   envoieMessageInvitationInscription,

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -10,10 +10,11 @@ const enteteJSON = {
 const urlBase = 'https://api.sendinblue.com/v3';
 
 const creeContact = (
-  destinataire, prenom, nom
+  destinataire, prenom, nom, bloqueEmails
 ) => (axios.post(`${urlBase}/contacts`,
   {
     email: destinataire,
+    emailBlacklisted: bloqueEmails,
     attributes: {
       PRENOM: prenom,
       NOM: nom,

--- a/src/adaptateurs/adaptateurMailSurConsole.js
+++ b/src/adaptateurs/adaptateurMailSurConsole.js
@@ -5,6 +5,16 @@ const creeContact = (...args) => {
   return Promise.resolve();
 };
 
+const desinscrisInfolettre = (...args) => {
+  console.log("Désinscription de l'infolettre MSS", args);
+  return Promise.resolve();
+};
+
+const inscrisInfolettre = (...args) => {
+  console.log("Inscription à l'infolettre MSS", args);
+  return Promise.resolve();
+};
+
 const envoieMessageFinalisationInscription = (...args) => {
   console.log("Envoie de l'email de finalisation de l'inscription", args);
   return Promise.resolve();
@@ -34,6 +44,8 @@ const envoieNotificationTentativeReinscription = (...args) => {
 
 module.exports = {
   creeContact,
+  desinscrisInfolettre,
+  inscrisInfolettre,
   envoieMessageFinalisationInscription,
   envoieMessageInvitationContribution,
   envoieMessageInvitationInscription,

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -24,6 +24,7 @@ class Utilisateur extends Base {
         'delegueProtectionDonnees',
         'nomEntitePublique',
         'departementEntitePublique',
+        'infolettreAcceptee',
       ],
     });
     valide(donnees);
@@ -66,7 +67,7 @@ class Utilisateur extends Base {
       validePresenceProprietes(['email']);
     }
     validePresenceProprietes(['prenom', 'nom', 'nomEntitePublique', 'departementEntitePublique']);
-    validePresenceProprietesBooleenes(['rssi', 'delegueProtectionDonnees']);
+    validePresenceProprietesBooleenes(['rssi', 'delegueProtectionDonnees', 'infolettreAcceptee']);
     valideDepartement(donnees.departementEntitePublique, referentiel);
   }
 
@@ -82,11 +83,16 @@ class Utilisateur extends Base {
       'delegueProtectionDonnees',
       'nomEntitePublique',
       'departementEntitePublique',
+      'infolettreAcceptee',
     ];
   }
 
   accepteCGU() {
     return !!this.cguAcceptees;
+  }
+
+  accepteInfolettre() {
+    return !!this.infolettreAcceptee;
   }
 
   estRSSI() {
@@ -130,6 +136,7 @@ class Utilisateur extends Base {
       nomEntitePublique: this.nomEntitePublique || '',
       departementEntitePublique: this.departementEntitePublique || '',
       profilEstComplet: this.profilEstComplet(),
+      infolettreAcceptee: this.accepteInfolettre(),
     };
   }
 }

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -31,7 +31,7 @@ const routesApi = (
   const creeContactEmail = (utilisateur) => (
     verifieSuccesEnvoiMessage(
       adaptateurMail.creeContact(
-        utilisateur.email, utilisateur.prenom, utilisateur.nom,
+        utilisateur.email, utilisateur.prenom, utilisateur.nom, !utilisateur.infolettreAcceptee
       ),
       utilisateur,
     ));

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -31,7 +31,7 @@ const routesApi = (
   const creeContactEmail = (utilisateur) => (
     verifieSuccesEnvoiMessage(
       adaptateurMail.creeContact(
-        utilisateur.email, utilisateur.prenom, utilisateur.nom, !utilisateur.infolettreAcceptee
+        utilisateur.email, utilisateur.prenom ?? '', utilisateur.nom ?? '', !utilisateur.infolettreAcceptee
       ),
       utilisateur,
     ));
@@ -293,6 +293,7 @@ const routesApi = (
         contributeurExistant
           ? Promise.resolve(contributeurExistant)
           : depotDonnees.nouvelUtilisateur({ email: emailContributeur })
+            .then(creeContactEmail)
       );
 
       const informeContributeur = (contributeurAInformer, contributeurExistant) => (

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -215,6 +215,26 @@ const routesApi = (
         return;
       }
 
+      depotDonnees.utilisateur(idUtilisateur)
+        .then((utilisateur) => {
+          if (!utilisateur) {
+            reponse.status(422).send(
+              `L'utilisateur '${idUtilisateur}' est introuvable.`
+            );
+            return;
+          }
+          const acceptationInfolettreActuelle = utilisateur.infolettreAcceptee;
+          const nouvelleAcceptationInfolettre = donnees.infolettreAcceptee;
+          const doitInscrire = !acceptationInfolettreActuelle && nouvelleAcceptationInfolettre;
+          const doitDesinscrire = acceptationInfolettreActuelle && !nouvelleAcceptationInfolettre;
+
+          if (doitInscrire) {
+            adaptateurMail.inscrisInfolettre(utilisateur.email);
+          } else if (doitDesinscrire) {
+            adaptateurMail.desinscrisInfolettre(utilisateur.email);
+          }
+        });
+
       depotDonnees.metsAJourUtilisateur(idUtilisateur, donnees)
         .then(() => reponse.json({ idUtilisateur }))
         .catch(suite);

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -74,6 +74,7 @@ const routesApi = (
     poste: corps.poste,
     nomEntitePublique: corps.nomEntitePublique,
     departementEntitePublique: corps.departementEntitePublique,
+    infolettreAcceptee: valeurBooleenne(corps.infolettreAcceptee),
   });
 
   const messageErreurDonneesUtilisateur = (donneesRequete, utilisateurExistant = false) => {

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -135,3 +135,11 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
           value != donnees.poste,
           placeholder = "ex : Cheffe/Chef de projet maîtrise d'ouvrage"
         )
+
+      input(
+        id = 'infolettreAcceptee',
+        name = 'infolettreAcceptee',
+        checked = donnees.infolettreAcceptee,
+        type = 'checkbox'
+      )
+      label.label-checkbox(for = 'infolettreAcceptee') J'accepte de recevoir la lettre d'information MonServiceSécurisé.

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -68,6 +68,7 @@ describe('Une homologation', () => {
         nomEntitePublique: '',
         departementEntitePublique: '',
         profilEstComplet: true,
+        infolettreAcceptee: false,
       },
       contributeurs: [{
         id: '999',
@@ -81,6 +82,7 @@ describe('Une homologation', () => {
         nomEntitePublique: '',
         departementEntitePublique: '',
         profilEstComplet: true,
+        infolettreAcceptee: false,
       }],
     });
   });

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -59,6 +59,7 @@ describe('Un utilisateur', () => {
       delegueProtectionDonnees: false,
       nomEntitePublique: 'Ville de Paris',
       departementEntitePublique: '75',
+      infolettreAcceptee: true,
     });
 
     expect(utilisateur.toJSON()).to.eql({
@@ -73,6 +74,7 @@ describe('Un utilisateur', () => {
       nomEntitePublique: 'Ville de Paris',
       departementEntitePublique: '75',
       profilEstComplet: true,
+      infolettreAcceptee: true,
     });
   });
 
@@ -106,6 +108,14 @@ describe('Un utilisateur', () => {
     expect(autreUtilisateur.accepteCGU()).to.be(false);
   });
 
+  it("sait détecter si l'infolettre a été acceptée", () => {
+    const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr', infolettreAcceptee: true });
+    expect(utilisateur.accepteInfolettre()).to.be(true);
+
+    const autreUtilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
+    expect(autreUtilisateur.accepteInfolettre()).to.be(false);
+  });
+
   it("exige que l'adresse électronique soit renseignée", (done) => {
     try {
       new Utilisateur({ prenom: 'Jean', nom: 'Dupont' });
@@ -136,6 +146,7 @@ describe('Un utilisateur', () => {
       'delegueProtectionDonnees',
       'nomEntitePublique',
       'departementEntitePublique',
+      'infolettreAcceptee',
     ];
     expect(Utilisateur.nomsProprietesBase()).to.eql(nomsProprietes);
   });
@@ -168,6 +179,7 @@ describe('Un utilisateur', () => {
         delegueProtectionDonnees: false,
         nomEntitePublique: 'Ville de Paris',
         departementEntitePublique: '75',
+        infolettreAcceptee: true,
       };
     });
 
@@ -211,6 +223,10 @@ describe('Un utilisateur', () => {
 
     it("exige que l'information de délégué à la protection des données soit renseignée", (done) => {
       verifiePresencePropriete('delegueProtectionDonnees', 'délégué à la protection des données', done);
+    });
+
+    it("exige que l'information d'acceptation de l'infolettre soit renseignée", (done) => {
+      verifiePresencePropriete('infolettreAcceptee', 'infolettre acceptée', done);
     });
 
     it('exige un département présent dans le référentiel', (done) => {

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -98,6 +98,7 @@ describe('Le serveur MSS des routes /api/*', () => {
         nomEntitePublique: 'Ville de Paris',
         departementEntitePublique: '75',
         cguAcceptees: 'true',
+        infolettreAcceptee: 'true',
       };
 
       testeur.referentiel().departement = () => 'Paris';
@@ -180,6 +181,19 @@ describe('Le serveur MSS des routes /api/*', () => {
         .catch(done);
     });
 
+    it("convertit l'infolettre acceptée en valeur booléenne", (done) => {
+      testeur.depotDonnees().nouvelUtilisateur = ({ infolettreAcceptee }) => {
+        expect(infolettreAcceptee).to.equal(true);
+        return Promise.resolve(utilisateur);
+      };
+
+      donneesRequete.infolettreAcceptee = 'true';
+
+      axios.post('http://localhost:1234/api/utilisateur', donneesRequete)
+        .then(() => done())
+        .catch(done);
+    });
+
     it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", (done) => {
       donneesRequete.prenom = '';
 
@@ -198,6 +212,7 @@ describe('Le serveur MSS des routes /api/*', () => {
           rssi: true,
           delegueProtectionDonnees: false,
           cguAcceptees: true,
+          infolettreAcceptee: true,
         };
         expect(donneesUtilisateur).to.eql(donneesAttendues);
         return Promise.resolve(utilisateur);

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -121,6 +121,7 @@ describe('Le serveur MSS des routes /api/*', () => {
           'delegueProtectionDonnees',
           'nomEntitePublique',
           'departementEntitePublique',
+          'infolettreAcceptee',
         ],
         { method: 'post', url: 'http://localhost:1234/api/utilisateur', data: donneesRequete },
         done
@@ -610,6 +611,7 @@ describe('Le serveur MSS des routes /api/*', () => {
           'delegueProtectionDonnees',
           'nomEntitePublique',
           'departementEntitePublique',
+          'infolettreAcceptee',
         ],
         { method: 'put', url: 'http://localhost:1234/api/utilisateur', data: donneesRequete },
         done

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -1155,6 +1155,7 @@ describe('Le serveur MSS des routes /api/*', () => {
         let utilisateurInexistant;
         testeur.depotDonnees().utilisateurAvecEmail = () => Promise.resolve(utilisateurInexistant);
         testeur.adaptateurMail().envoieMessageInvitationInscription = () => Promise.resolve();
+        testeur.adaptateurMail().creeContact = () => Promise.resolve();
 
         contributeurCree = { id: '789', email: 'jean.dupont@mail.fr', idResetMotDePasse: 'reset' };
         testeur.depotDonnees().nouvelUtilisateur = () => Promise.resolve(contributeurCree);
@@ -1180,6 +1181,28 @@ describe('Le serveur MSS des routes /api/*', () => {
             expect(nouveauContributeurCree).to.be(true);
             done();
           })
+          .catch((e) => done(e.response?.data || e));
+      });
+
+      it('crée un contact email', (done) => {
+        utilisateur.email = 'jean.dupont@mail.fr';
+        utilisateur.infolettreAcceptee = false;
+
+        testeur.adaptateurMail().creeContact = (
+          (destinataire, prenom, nom, bloqueEmails) => {
+            expect(destinataire).to.equal('jean.dupont@mail.fr');
+            expect(prenom).to.equal('');
+            expect(nom).to.equal('');
+            expect(bloqueEmails).to.equal(true);
+            return Promise.resolve();
+          }
+        );
+
+        axios.post('http://localhost:1234/api/autorisation', {
+          emailContributeur: 'jean.dupont@mail.fr',
+          idHomologation: '123',
+        })
+          .then(() => done())
           .catch((e) => done(e.response?.data || e));
       });
 

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -227,16 +227,18 @@ describe('Le serveur MSS des routes /api/*', () => {
         .catch(done);
     });
 
-    it('crée un contact email ', (done) => {
+    it('crée un contact email', (done) => {
       utilisateur.email = 'jean.dupont@mail.fr';
       utilisateur.prenom = 'Jean';
       utilisateur.nom = 'Dupont';
+      utilisateur.infolettreAcceptee = false;
 
       testeur.adaptateurMail().creeContact = (
-        (destinataire, prenom, nom) => {
+        (destinataire, prenom, nom, bloqueEmails) => {
           expect(destinataire).to.equal('jean.dupont@mail.fr');
           expect(prenom).to.equal('Jean');
           expect(nom).to.equal('Dupont');
+          expect(bloqueEmails).to.equal(true);
           return Promise.resolve();
         }
       );


### PR DESCRIPTION
On s'interface avec SendinBlue pour gérer l'abonnement ou non à notre infolettre.

On souhaite mettre le champ `emailBlacklisted` à `true` ou `false` au moment de la création du contact.
Lors de la mise à jour du profil, si l'abonnement à l'infolettre change, on met à jour le contact chez SendinBlue via la route `PUT https://api.sendinblue.com/v3/contacts/{identifier}`

Le désabonnement depuis le mail vers MSS se fera dans une deuxième PR.