### PR TITLE
Création du contact dans SendinBlue à l'inscription

### DIFF
--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -1,18 +1,36 @@
 const axios = require('axios');
 
+const enteteJSON = {
+  headers: {
+    'api-key': process.env.SENDINBLUE_CLEF_API,
+    accept: 'application/json',
+    'content-type': 'application/json',
+  },
+};
+const urlBase = 'https://api.sendinblue.com/v3';
+
+const creeContact = (
+  destinataire, prenom, nom
+) => (axios.post(`${urlBase}/contacts`,
+  {
+    email: destinataire,
+    attributes: {
+      PRENOM: prenom,
+      NOM: nom,
+    },
+  },
+  enteteJSON)
+);
+
 const envoieEmail = (
   destinataire, idTemplate, params
-) => (axios.post('https://api.sendinblue.com/v3/smtp/email',
+) => (axios.post(`${urlBase}/smtp/email`,
   {
     to: [{ email: destinataire }],
     templateId: idTemplate,
     params,
   },
-  { headers: {
-    'api-key': process.env.SENDINBLUE_CLEF_API,
-    accept: 'application/json',
-    'content-type': 'application/json',
-  } })
+  enteteJSON)
 );
 
 const envoieMessageFinalisationInscription = (
@@ -72,6 +90,7 @@ const envoieNotificationTentativeReinscription = (
 );
 
 module.exports = {
+  creeContact,
   envoieMessageFinalisationInscription,
   envoieMessageInvitationContribution,
   envoieMessageInvitationInscription,

--- a/src/adaptateurs/adaptateurMailSurConsole.js
+++ b/src/adaptateurs/adaptateurMailSurConsole.js
@@ -1,5 +1,10 @@
 /* eslint-disable no-console */
 
+const creeContact = (...args) => {
+  console.log("Création d'un contact email", args);
+  return Promise.resolve();
+};
+
 const envoieMessageFinalisationInscription = (...args) => {
   console.log("Envoie de l'email de finalisation de l'inscription", args);
   return Promise.resolve();
@@ -28,6 +33,7 @@ const envoieNotificationTentativeReinscription = (...args) => {
 /* eslint-enable no-console */
 
 module.exports = {
+  creeContact,
   envoieMessageFinalisationInscription,
   envoieMessageInvitationContribution,
   envoieMessageInvitationInscription,

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -28,6 +28,14 @@ const routesApi = (
     .catch(() => depotDonnees.supprimeUtilisateur(utilisateur.id)
       .then(() => Promise.reject(new EchecEnvoiMessage())));
 
+  const creeContactEmail = (utilisateur) => (
+    verifieSuccesEnvoiMessage(
+      adaptateurMail.creeContact(
+        utilisateur.email, utilisateur.prenom, utilisateur.nom,
+      ),
+      utilisateur,
+    ));
+
   const envoieMessageInvitationInscription = (emetteur, contributeur, service) => (
     verifieSuccesEnvoiMessage(
       adaptateurMail.envoieMessageInvitationInscription(
@@ -115,6 +123,7 @@ const routesApi = (
         reponse.status(422).send(`La création d'un nouvel utilisateur a échoué car les paramètres sont invalides. ${messageErreur}`);
       } else {
         depotDonnees.nouvelUtilisateur(donnees)
+          .then(creeContactEmail)
           .then(envoieMessageFinalisationInscription)
           .catch((erreur) => {
             if (erreur instanceof ErreurUtilisateurExistant) {

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -101,6 +101,7 @@ describe('Le serveur MSS des routes /api/*', () => {
       };
 
       testeur.referentiel().departement = () => 'Paris';
+      testeur.adaptateurMail().creeContact = () => Promise.resolve();
       testeur.adaptateurMail().envoieMessageFinalisationInscription = () => Promise.resolve();
       testeur.adaptateurMail().envoieMessageReinitialisationMotDePasse = () => Promise.resolve();
 
@@ -208,6 +209,25 @@ describe('Le serveur MSS des routes /api/*', () => {
           done();
         })
         .catch(done);
+    });
+
+    it('crée un contact email ', (done) => {
+      utilisateur.email = 'jean.dupont@mail.fr';
+      utilisateur.prenom = 'Jean';
+      utilisateur.nom = 'Dupont';
+
+      testeur.adaptateurMail().creeContact = (
+        (destinataire, prenom, nom) => {
+          expect(destinataire).to.equal('jean.dupont@mail.fr');
+          expect(prenom).to.equal('Jean');
+          expect(nom).to.equal('Dupont');
+          return Promise.resolve();
+        }
+      );
+
+      axios.post('http://localhost:1234/api/utilisateur', donneesRequete)
+        .then(() => done())
+        .catch((e) => done(e.response?.data || e));
     });
 
     it("envoie un message de notification à l'utilisateur créé", (done) => {


### PR DESCRIPTION
Nous nous sommes rendu compte que les contacts dans SendinBlue sont crées uniquement lorsque le premier email est **ouvert**.
Afin de préparer le comportement de l'infolettre, on souhaite créer systématiquement ce contact au moment de l'inscription.

De plus, cela nous permet de remplir les champs `PRENOM` et `NOM`.
![image](https://user-images.githubusercontent.com/1643465/234833653-c780997b-81d5-4e27-9f4c-1c128928c698.png)
