### PR TITLE
[CORRECTION] Force l'acceptation de l'infolettre à `false` lors d'une invitation

### DIFF
--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -292,7 +292,7 @@ const routesApi = (
       const creeContributeurSiNecessaire = (contributeurExistant) => (
         contributeurExistant
           ? Promise.resolve(contributeurExistant)
-          : depotDonnees.nouvelUtilisateur({ email: emailContributeur })
+          : depotDonnees.nouvelUtilisateur({ email: emailContributeur, infolettreAcceptee: false })
             .then(creeContactEmail)
       );
 

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -1185,9 +1185,6 @@ describe('Le serveur MSS des routes /api/*', () => {
       });
 
       it('crée un contact email', (done) => {
-        utilisateur.email = 'jean.dupont@mail.fr';
-        utilisateur.infolettreAcceptee = false;
-
         testeur.adaptateurMail().creeContact = (
           (destinataire, prenom, nom, bloqueEmails) => {
             expect(destinataire).to.equal('jean.dupont@mail.fr');


### PR DESCRIPTION
La valeur était évaluée à `true` car `!undefined = true`.
On fixe la valeur à `false` pour éviter la confusion.