### PR TITLE
[CORRECTION] Corrige un problème d'extraction d'index disponible

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -251,16 +251,17 @@ const creeDepot = (config = {}) => {
   );
 
   const trouveIndexDisponible = (idCreateur, nomHomologationDupliquee) => {
-    const filtreNomDuplique = new RegExp(`^${nomHomologationDupliquee} (\\d+)$`);
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+    const nomCompatibleRegExp = nomHomologationDupliquee.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const filtreNomDuplique = new RegExp(`^${nomCompatibleRegExp} (\\d+)$`);
+
     const maxMatch = (maxCourant, nomService) => {
       const index = parseInt(nomService.match(filtreNomDuplique)?.[1], 10);
       return index > maxCourant ? index : maxCourant;
     };
-    const indexMax = (hs) => {
-      const resultat = hs
-        .map((h) => h.nomService())
-        .reduce(maxMatch, -Infinity);
 
+    const indexMax = (hs) => {
+      const resultat = hs.map((h) => h.nomService()).reduce(maxMatch, -Infinity);
       return Math.max(0, resultat) + 1;
     };
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -1229,5 +1229,22 @@ describe('Le dépôt de données des homologations', () => {
         .then(() => done())
         .catch(done);
     });
+
+    it("sait extraire l'index disponible même dans des noms contenant des parenthèses", (done) => {
+      const referentiel = Referentiel.creeReferentielVide();
+      const original = uneDescriptionValide(referentiel).avecNomService('Service A (mairie) - Copie 1').construis().toJSON();
+      const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
+        homologations: [{ id: '123', descriptionService: original }],
+        autorisations: [{ idUtilisateur: '999', idHomologation: '123', idService: '123', type: 'createur' }],
+      });
+
+      const depot = DepotDonneesHomologations.creeDepot({ adaptateurPersistance, referentiel });
+
+      depot.trouveIndexDisponible('999', 'Service A (mairie) - Copie')
+        .then((index) => expect(index).to.equal(2))
+        .then(() => done())
+        .catch(done);
+    });
   });
 });


### PR DESCRIPTION
… en cas de caractère spécial dans le nom de service à dupliquer.

Exemple de scénario :
 - Avoir un service nommé avec des parenthèses : « Service A (mairie) ».
 - Dupliquer ce service : ça fonctionne et MSS trouve un nom « Service A (mairie) - Copie 1 ».
 - Dupliquer à nouveau le service original.

Comportement attendu : que MSS trouve le nom « Service A (mairie) - Copie 2 ». Comportement observé : MSS trouve le nom « Service A (mairie) - Copie 1 - Copie 1 ». Montrant ainsi qu'il échoue à extraire l'index disponible dans ce cas-là.

Ce commit corrige le problème.