### PR TITLE
[CORRECTION] Chaîne proprement les promesses de mise à jour de l'utilisateur

### DIFF
--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -217,25 +217,16 @@ const routesApi = (
 
       depotDonnees.utilisateur(idUtilisateur)
         .then((utilisateur) => {
-          if (!utilisateur) {
-            reponse.status(422).send(
-              `L'utilisateur '${idUtilisateur}' est introuvable.`
-            );
-            return;
-          }
           const acceptationInfolettreActuelle = utilisateur.infolettreAcceptee;
           const nouvelleAcceptationInfolettre = donnees.infolettreAcceptee;
           const doitInscrire = !acceptationInfolettreActuelle && nouvelleAcceptationInfolettre;
           const doitDesinscrire = acceptationInfolettreActuelle && !nouvelleAcceptationInfolettre;
 
-          if (doitInscrire) {
-            adaptateurMail.inscrisInfolettre(utilisateur.email);
-          } else if (doitDesinscrire) {
-            adaptateurMail.desinscrisInfolettre(utilisateur.email);
-          }
-        });
-
-      depotDonnees.metsAJourUtilisateur(idUtilisateur, donnees)
+          if (doitInscrire) return adaptateurMail.inscrisInfolettre(utilisateur.email);
+          if (doitDesinscrire) return adaptateurMail.desinscrisInfolettre(utilisateur.email);
+          return Promise.resolve();
+        })
+        .then(() => depotDonnees.metsAJourUtilisateur(idUtilisateur, donnees))
         .then(() => reponse.json({ idUtilisateur }))
         .catch(suite);
     });

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -769,18 +769,6 @@ describe('Le serveur MSS des routes /api/*', () => {
           .catch(done);
       });
 
-      it("jette une erreur si l'utilisateur n'existe pas", (done) => {
-        testeur.middleware().reinitialise({ idUtilisateur: utilisateur.id });
-        testeur.depotDonnees().utilisateur = () => Promise.resolve(undefined);
-
-        testeur.verifieRequeteGenereErreurHTTP(
-          422,
-          "L'utilisateur '123' est introuvable.",
-          { method: 'put', url: 'http://localhost:1234/api/utilisateur', data: donneesRequete },
-          done
-        );
-      });
-
       it("inscrit l'utilisateur à l'infolettre si il l'a demandé", (done) => {
         let inscriptionAppelee = false;
         donneesRequete.infolettreAcceptee = 'true';


### PR DESCRIPTION
… pour éviter les promesses concurrentes d'une part et d'autre part la sortie en erreur dans les tests :

```
✔ jette une erreur si l'utilisateur n'existe pas
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:399:5)
    at ServerResponse.setHeader (node:_http_outgoing:663:11)
    …
```

On en profite pour supprimer le test et le code de vérification de l'existence de l'utilisateur, car c'est déjà assuré par le middleware `verificationJWT`.