### PR TITLE
Pointe vers l'étape courante si un dossier d'homologation existe déjà

### DIFF
--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -41,7 +41,9 @@ block formulaire
     script(type = "module", src = "/statique/service/homologation/dossiers.js")
 
 block bouton-etape
+  - const etapeSuivante = dossierCourant?.etapeCourante() ?? premiereEtapeParcours.id
+
   button.bouton#suivant(
     data-id-homologation = service.id,
-    data-id-etape-suivante = premiereEtapeParcours.id
+    data-id-etape-suivante = etapeSuivante
     ) Nouvelle homologation


### PR DESCRIPTION
### :warning:  Cette PR met en avant un bug connu. 

Les étapes "Décision" et "DateTéléchargement" sont inversées entre notre front et notre back. Il y a donc un problème de redirection lorsque l'étape 4 `estComplete`.