### PR TITLE
[CORRECTION] Enchaîne correctement les étapes du parcours d'homologation

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -672,8 +672,8 @@ module.exports = {
     { numero: 1, libelle: 'Autorité', id: 'autorite' },
     { numero: 2, libelle: 'Avis', id: 'avis' },
     { numero: 3, libelle: 'Documents', id: 'documents' },
-    { numero: 4, libelle: 'Décision', id: 'decision' },
-    { numero: 5, libelle: 'Date', id: 'dateTelechargement' },
+    { numero: 4, libelle: 'Décision', id: 'dateTelechargement' },
+    { numero: 5, libelle: 'Date', id: 'decision' },
     { numero: 6, libelle: 'Récapitulatif', id: 'recapitulatif' },
   ],
 

--- a/src/vues/service/etapeDossier/dateTelechargement.pug
+++ b/src/vues/service/etapeDossier/dateTelechargement.pug
@@ -1,35 +1,36 @@
-extends ../formulaireEtapier
-
-include ../../fragments/inputChoix
+extends ../formulaireEtapierRecommandation
 
 block append styles
-  link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/etapesDossier/decision.css', rel = 'stylesheet')
 
 block formulaire
-  - const dossierCourant = service.dossierCourant()
+  - const formatDateCourt = Intl.DateTimeFormat('fr-CA', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  - const formatDateLong = Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeStyle: 'short' });
+  - const maintenant = new Date();
+  - const nomFichier = `MSS_decision_${formatDateCourt.format(maintenant).replaceAll('-', '')}.zip`
+  - const dateTelechargement = service.dossierCourant()?.dateTelechargement.date;
 
-  section
-    p.
-      Saisissez les informations remplies par l'autorité d'homologation sur le document
-      <strong>Décision de l'homologation de sécurité</strong>.
+  span Voici les étapes à suivre pour finaliser l'homologation de sécurité de votre service :
+  .conteneur-telechargement
+    a.document-homologation(
+      href=`/api/service/${service.id}/pdf/documentsHomologation.zip`
+      data-action-enregistrement=`/api/service/${service.id}/homologation/telechargement`
+      target='_blank'
+      rel='noopener'
+    )= nomFichier
+    if(dateTelechargement)
+      span.date-telechargement= `Dernier téléchargement le : ${formatDateLong.format(new Date(dateTelechargement))}`
+  
+  .validation-telechargement
+    input(type='text', required, value=dateTelechargement)
+    .message-erreur Vous devez télécharger ce fichier .ZIP pour pouvoir passer à l'étape suivante.
+  
+  ul.consignes
+    li Télécharger le fichier .ZIP contenant les 3 PDF(s) : synthèse de sécurité, annexes et décision d'homologation de sécurité.
+    li Présenter, pour signature, la décision d'homologation de sécurité à l'autorité d'homologation ainsi que la synthèse de la sécurité.
+    li Se reconnecter ensuite pour renseigner la date de signature et la durée de validité de l'homologation dans les dernières étapes Date et Récapitulatif.
 
-    .requis
-      label Date d'homologation
-        .infos-complementaires Cette date correspond à la date de signature de l'autorité d'homologation.
-        input(id = 'date-homologation' nom = 'dateHomologation', type = 'date', required, value = dossierCourant.decision.dateHomologation)
-        .message-erreur Ce champ est obligatoire. Veuillez saisir une date.
-
-    .requis
-      +inputChoix({
-        type: 'radio',
-        nom: 'dureeValidite',
-        items: referentiel.echeancesRenouvellement(),
-        titre: "Durée de validité de l'homologation",
-        objetDonnees: dossierCourant.decision,
-        messageErreur: 'Ce champ est obligatoire. Veuillez choisir une option.',
-        requis: true,
-      })
-  script(type = "module", src = "/statique/service/homologation/etapes/etapeDate.js")
+  script(type = "module", src = "/statique/service/homologation/etapes/decision.js")
 
 block bouton-etape
   button.bouton#suivant(

--- a/src/vues/service/etapeDossier/decision.pug
+++ b/src/vues/service/etapeDossier/decision.pug
@@ -1,36 +1,35 @@
-extends ../formulaireEtapierRecommandation
+extends ../formulaireEtapier
+
+include ../../fragments/inputChoix
 
 block append styles
-  link(href = '/statique/assets/styles/etapesDossier/decision.css', rel = 'stylesheet')
+  link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
 
 block formulaire
-  - const formatDateCourt = Intl.DateTimeFormat('fr-CA', { year: 'numeric', month: '2-digit', day: '2-digit' });
-  - const formatDateLong = Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeStyle: 'short' });
-  - const maintenant = new Date();
-  - const nomFichier = `MSS_decision_${formatDateCourt.format(maintenant).replaceAll('-', '')}.zip`
-  - const dateTelechargement = service.dossierCourant()?.dateTelechargement.date;
+  - const dossierCourant = service.dossierCourant()
 
-  span Voici les étapes à suivre pour finaliser l'homologation de sécurité de votre service :
-  .conteneur-telechargement
-    a.document-homologation(
-      href=`/api/service/${service.id}/pdf/documentsHomologation.zip`
-      data-action-enregistrement=`/api/service/${service.id}/homologation/telechargement`
-      target='_blank'
-      rel='noopener'
-    )= nomFichier
-    if(dateTelechargement)
-      span.date-telechargement= `Dernier téléchargement le : ${formatDateLong.format(new Date(dateTelechargement))}`
-  
-  .validation-telechargement
-    input(type='text', required, value=dateTelechargement)
-    .message-erreur Vous devez télécharger ce fichier .ZIP pour pouvoir passer à l'étape suivante.
-  
-  ul.consignes
-    li Télécharger le fichier .ZIP contenant les 3 PDF(s) : synthèse de sécurité, annexes et décision d'homologation de sécurité.
-    li Présenter, pour signature, la décision d'homologation de sécurité à l'autorité d'homologation ainsi que la synthèse de la sécurité.
-    li Se reconnecter ensuite pour renseigner la date de signature et la durée de validité de l'homologation dans les dernières étapes Date et Récapitulatif.
+  section
+    p.
+      Saisissez les informations remplies par l'autorité d'homologation sur le document
+      <strong>Décision de l'homologation de sécurité</strong>.
 
-  script(type = "module", src = "/statique/service/homologation/etapes/decision.js")
+    .requis
+      label Date d'homologation
+        .infos-complementaires Cette date correspond à la date de signature de l'autorité d'homologation.
+        input(id = 'date-homologation' nom = 'dateHomologation', type = 'date', required, value = dossierCourant.decision.dateHomologation)
+        .message-erreur Ce champ est obligatoire. Veuillez saisir une date.
+
+    .requis
+      +inputChoix({
+        type: 'radio',
+        nom: 'dureeValidite',
+        items: referentiel.echeancesRenouvellement(),
+        titre: "Durée de validité de l'homologation",
+        objetDonnees: dossierCourant.decision,
+        messageErreur: 'Ce champ est obligatoire. Veuillez choisir une option.',
+        requis: true,
+      })
+  script(type = "module", src = "/statique/service/homologation/etapes/etapeDate.js")
 
 block bouton-etape
   button.bouton#suivant(

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -136,7 +136,7 @@ describe('Le serveur MSS des routes /service/*', () => {
   describe('quand requête GET sur `/service/:id/homologation/edition/etape/:idEtape`', () => {
     beforeEach(() => {
       testeur.referentiel().recharge({
-        etapesParcoursHomologation: [{ numero: 1, id: 'decision' }, { numero: 2, id: 'deuxieme' }],
+        etapesParcoursHomologation: [{ numero: 1, id: 'dateTelechargement' }, { numero: 2, id: 'deuxieme' }],
       });
       testeur.depotDonnees().ajouteDossierCourantSiNecessaire = () => Promise.resolve();
       testeur.depotDonnees().homologation = () => Promise.resolve(
@@ -146,7 +146,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
     it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
-        'http://localhost:1234/service/456/homologation/edition/etape/decision',
+        'http://localhost:1234/service/456/homologation/edition/etape/dateTelechargement',
         done,
       );
     });
@@ -170,7 +170,7 @@ describe('Le serveur MSS des routes /service/*', () => {
         }
       };
 
-      axios('http://localhost:1234/service/456/homologation/edition/etape/decision')
+      axios('http://localhost:1234/service/456/homologation/edition/etape/dateTelechargement')
         .then(() => expect(dossierAjoute).to.be(true))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));
@@ -187,7 +187,7 @@ describe('Le serveur MSS des routes /service/*', () => {
         }
       };
 
-      axios('http://localhost:1234/service/456/homologation/edition/etape/decision')
+      axios('http://localhost:1234/service/456/homologation/edition/etape/dateTelechargement')
         .then(() => expect(chargementsService).to.equal(1))
         .then(() => done())
         .catch((e) => done(e.response?.data || e));


### PR DESCRIPTION
Avant ce commit, les étapes `decision` et `dateTelechargement` étaient inversées dans notre modèle.

Une explication est l'influence du wording utilisé par le front : l'étape de téléchargement utilise le libellé « Décision » et l'étape d'enregistrement de la décision utilise le libellé « Date ».