### PR TITLE
[TDB] Adaptation des documents disponibles au téléchargement

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -665,6 +665,14 @@ label[for='recherche-service'] {
   margin-bottom: 1em;
 }
 
+#contenu-telechargement #conteneur-lien-decision-indisponible {
+  filter: grayscale(1);
+}
+
+#contenu-telechargement #conteneur-lien-decision-indisponible .lien-telechargement {
+  pointer-events: none;
+}
+
 #contenu-telechargement .document-telechargeable p {
   margin: 0;
 }

--- a/public/modules/tableauDeBord/gestionnaireTiroir.mjs
+++ b/public/modules/tableauDeBord/gestionnaireTiroir.mjs
@@ -51,6 +51,7 @@ const contenuActions = {
       $('#lien-archive').attr('href', `${urlBase}documentsHomologation.zip`);
 
       const donneesService = tableauDesServices.donneesDuService(idSelectionne);
+
       const $conteneurDuDisponible = $('#conteneur-lien-decision');
       const $conteneurDeIndisponible = $('#conteneur-lien-decision-indisponible');
       if (donneesService.documentsPdfDisponibles.includes('dossierDecision')) {
@@ -60,6 +61,8 @@ const contenuActions = {
         $conteneurDuDisponible.hide();
         $conteneurDeIndisponible.show();
       }
+
+      $('#nbPdfDisponibles', '#conteneur-lien-archive').text(donneesService.documentsPdfDisponibles.length);
     },
   },
 };

--- a/public/modules/tableauDeBord/gestionnaireTiroir.mjs
+++ b/public/modules/tableauDeBord/gestionnaireTiroir.mjs
@@ -49,6 +49,17 @@ const contenuActions = {
       $('#lien-annexes').attr('href', `${urlBase}annexes.pdf`);
       $('#lien-decision').attr('href', `${urlBase}dossierDecision.pdf`);
       $('#lien-archive').attr('href', `${urlBase}documentsHomologation.zip`);
+
+      const donneesService = tableauDesServices.donneesDuService(idSelectionne);
+      const $conteneurDuDisponible = $('#conteneur-lien-decision');
+      const $conteneurDeIndisponible = $('#conteneur-lien-decision-indisponible');
+      if (donneesService.documentsPdfDisponibles.includes('dossierDecision')) {
+        $conteneurDuDisponible.show();
+        $conteneurDeIndisponible.hide();
+      } else {
+        $conteneurDuDisponible.hide();
+        $conteneurDeIndisponible.show();
+      }
     },
   },
 };

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -76,10 +76,9 @@ const tableauDesServices = {
     $('.tableau-services thead th').attr('data-direction', 0);
     $(`.tableau-services thead th[data-colonne="${colonne}"]`).attr('data-direction', direction);
   },
-  nomDuService: (idService) => tableauDesServices
-    .donnees
-    .find((service) => service.id === idService)
-    ?.nomService,
+  donneesDuService: (idService) => tableauDesServices.donnees
+    .find((service) => service.id === idService),
+  nomDuService: (idService) => tableauDesServices.donneesDuService(idService)?.nomService,
   recupereServices: () => {
     axios.get('/api/utilisateurCourant')
       .then(() => axios.get('/api/services')

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -114,6 +114,12 @@ class Homologation {
     }, {});
   }
 
+  documentsPdfDisponibles() {
+    const documents = ['annexes', 'syntheseSecurite'];
+    if (this.dossierCourant()) documents.push('dossierDecision');
+    return documents;
+  }
+
   donneesAPersister() {
     return new DonneesPersistanceHomologation({
       id: this.id,

--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -15,6 +15,7 @@ const donnees = (services, idUtilisateur) => {
         organisationsResponsables: s.descriptionService.organisationsResponsables,
         indiceCyber: s.indiceCyber().total.toFixed(1),
         statutHomologation: s.dossiers.statutSaisie(),
+        documentsPdfDisponibles: s.documentsPdfDisponibles(),
       }))
       .map((json) => ({
         id: json.id,
@@ -38,6 +39,7 @@ const donnees = (services, idUtilisateur) => {
         },
         nombreContributeurs: json.contributeurs.length + 1,
         estCreateur: json.createur.id === idUtilisateur,
+        documentsPdfDisponibles: json.documentsPdfDisponibles,
       })),
     resume: {
       nombreServices: services.length,

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -22,7 +22,7 @@ mixin documentTelechargeable(nom, description, type, idLien)
     .contenu
       .contenu-texte
         p.titre-document= nom
-        p.description-document= description
+        p.description-document!= description
       img.icone-type-document(src=sourceImage)
     a.lien-telechargement.bouton(href='', target='_blank', rel='noopener', id=idLien) Télécharger
 
@@ -150,7 +150,7 @@ block main
           +documentTelechargeable('Annexes', 'Ce PDF détaille toutes les informations renseignées sur la sécurité du service.', 'PDF', 'lien-annexes')
           +documentTelechargeable("Décision d'homologation de sécurité", "Ce PDF est à faire signer auprès de l'autorité d'homologation.", 'PDF', 'lien-decision')
           +documentTelechargeable("Décision d'homologation de sécurité", "Ce PDF sera disponible dès qu'une homologation sera en cours.", 'PDF', 'lien-decision-indisponible')
-          +documentTelechargeable('Tous les documents', 'Ce fichier .ZIP contient les 3 PDF(s).', 'ZIP', 'lien-archive')
+          +documentTelechargeable('Tous les documents', 'Ce fichier .ZIP contient les <span id="nbPdfDisponibles"></span> PDF(s).', 'ZIP', 'lien-archive')
 
 
   script(type = 'module', src = '/statique/tableauDeBord.js')

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -18,7 +18,7 @@ mixin actionAvecIcone(sourceImage, texteAction, action, id)
 
 mixin documentTelechargeable(nom, description, type, idLien)
   - const sourceImage = `/statique/assets/images/icone_telechargement_${type.toLowerCase()}.svg`
-  .document-telechargeable
+  .document-telechargeable(id= `conteneur-${idLien}`)
     .contenu
       .contenu-texte
         p.titre-document= nom
@@ -149,6 +149,7 @@ block main
           +documentTelechargeable('Synthèse de la sécurité du service', "Ce PDF résume visuellement en 1 page l'état de la sécurité du service.", 'PDF', 'lien-synthese')
           +documentTelechargeable('Annexes', 'Ce PDF détaille toutes les informations renseignées sur la sécurité du service.', 'PDF', 'lien-annexes')
           +documentTelechargeable("Décision d'homologation de sécurité", "Ce PDF est à faire signer auprès de l'autorité d'homologation.", 'PDF', 'lien-decision')
+          +documentTelechargeable("Décision d'homologation de sécurité", "Ce PDF sera disponible dès qu'une homologation sera en cours.", 'PDF', 'lien-decision-indisponible')
           +documentTelechargeable('Tous les documents', 'Ce fichier .ZIP contient les 3 PDF(s).', 'ZIP', 'lien-archive')
 
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -149,6 +149,30 @@ describe('Une homologation', () => {
     expect(homologation.dossierCourant().id).to.equal('999');
   });
 
+  describe('sur demande des documents PDF disponibles', () => {
+    it("inclut tous les documents lorsqu'elle a un dossier d'homologation courant", () => {
+      const referentiel = Referentiel.creeReferentielVide();
+
+      const homologationAvecDossier = new Homologation(
+        { id: '123', dossiers: [{ id: '999' }] },
+        referentiel
+      );
+
+      expect(homologationAvecDossier.documentsPdfDisponibles()).to.eql(['annexes', 'syntheseSecurite', 'dossierDecision']);
+    });
+
+    it("exclut le dossier de décision en cas d'absence de dossier d'homologation courant", () => {
+      const referentiel = Referentiel.creeReferentielVide();
+
+      const homologationSansDossier = new Homologation(
+        { id: '123', dossiers: [] },
+        referentiel
+      );
+
+      expect(homologationSansDossier.documentsPdfDisponibles()).to.eql(['annexes', 'syntheseSecurite']);
+    });
+  });
+
   it('connaît ses risques spécifiques', () => {
     const homologation = new Homologation({
       id: '123',

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -2,6 +2,7 @@ const expect = require('expect.js');
 
 const Service = require('../../../src/modeles/service');
 const objetGetServices = require('../../../src/modeles/objetsApi/objetGetServices');
+const { unDossier } = require('../../constructeurs/constructeurDossier');
 
 describe("L'objet d'API de `GET /services`", () => {
   const unService = new Service({
@@ -13,6 +14,7 @@ describe("L'objet d'API de `GET /services`", () => {
     ],
   });
   unService.indiceCyber = () => ({ total: 3.51 });
+  unService.dossierCourant = () => unDossier().construit();
 
   const unAutreService = new Service({
     id: '456',
@@ -38,6 +40,7 @@ describe("L'objet d'API de `GET /services`", () => {
         statutHomologation: { libelle: 'À réaliser', id: 'aSaisir' },
         nombreContributeurs: 1 + 1,
         estCreateur: true,
+        documentsPdfDisponibles: ['annexes', 'syntheseSecurite', 'dossierDecision'],
       }],
     );
   });

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -1,7 +1,7 @@
 const expect = require('expect.js');
 
 const Service = require('../../../src/modeles/service');
-const vueEspacePersonnel = require('../../../src/modeles/objetsApi/objetGetServices');
+const objetGetServices = require('../../../src/modeles/objetsApi/objetGetServices');
 
 describe("L'objet d'API de `GET /services`", () => {
   const unService = new Service({
@@ -25,7 +25,7 @@ describe("L'objet d'API de `GET /services`", () => {
 
   it('fournit les données nécessaires', () => {
     const services = [unService];
-    expect(vueEspacePersonnel.donnees(services, 'A').services).to.eql(
+    expect(objetGetServices.donnees(services, 'A').services).to.eql(
       [{
         id: '123',
         nomService: 'Un service',
@@ -48,7 +48,7 @@ describe("L'objet d'API de `GET /services`", () => {
     unAutreService.indiceCyber = () => ({ total: 5 });
 
     const services = [unService, unAutreService];
-    expect(vueEspacePersonnel.donnees(services).resume).to.eql(
+    expect(objetGetServices.donnees(services).resume).to.eql(
       {
         nombreServices: 2,
         nombreServicesHomologues: 1,
@@ -62,7 +62,7 @@ describe("L'objet d'API de `GET /services`", () => {
     unAutreService.indiceCyber = () => ({ total: 0 });
 
     const services = [unService, unAutreService];
-    expect(vueEspacePersonnel.donnees(services).resume).to.eql(
+    expect(objetGetServices.donnees(services).resume).to.eql(
       {
         nombreServices: 2,
         nombreServicesHomologues: 1,


### PR DESCRIPTION
Dans le tiroir de téléchargement des PDFs, cette PR explicite le cas où le dossier de décision d'homologation est indisponible.

Conteneur grisé & nombre de documents qui passe à « 2 »👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/f959a9e5-2c10-4929-9e83-7d9536061dab)

