### PR TITLE
[CORRECTION] Conserve toujours la pleine largeur des checkboxes

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -69,6 +69,7 @@ input[type="radio"] {
   width: 1.6em;
   height: 1.6em;
   transform: translateY(0.4em);
+  flex-shrink: 0;
 }
 
 input[type="checkbox"] {


### PR DESCRIPTION
… pour éviter d'avoir 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/d2f9db62-c7c0-4beb-8480-4907d5ba4d1c)

Le résultat 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/c269de99-0335-4aa0-9ccb-4293c91e15f6)
