### PR TITLE
Exclure le dossier de décision de l'archive « Tous les documents »

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPI()
   ? require('./src/adaptateurs/adaptateurMailSendinblue')
   : require('./src/adaptateurs/adaptateurMailMemoire');
 const adaptateurPdf = require('./src/adaptateurs/adaptateurPdf');
+const adaptateurZip = require('./src/adaptateurs/adaptateurZip');
 
 const port = process.env.PORT || 3000;
 const referentiel = Referentiel.creeReferentiel();
@@ -40,7 +41,8 @@ const serveur = MSS.creeServeur(
   adaptateurHorloge,
   adaptateurGestionErreur,
   adaptateurAnnuaire,
-  adaptateurCsv
+  adaptateurCsv,
+  adaptateurZip
 );
 
 serveur.ecoute(port, () => {

--- a/src/adaptateurs/adaptateurPdf.js
+++ b/src/adaptateurs/adaptateurPdf.js
@@ -1,6 +1,5 @@
 const { PDFDocument } = require('pdf-lib');
 const pug = require('pug');
-const JSZip = require('jszip');
 const { lanceNavigateur } = require('./adaptateurPdf.puppeteer');
 const { fabriqueAdaptateurGestionErreur } = require('./fabriqueAdaptateurGestionErreur');
 
@@ -117,26 +116,8 @@ const genereSyntheseSecurite = async (donnees) => {
   }
 };
 
-const genereArchiveTousDocuments = (donnees) => Promise.all([
-  genereAnnexes(donnees),
-  genereDossierDecision(donnees),
-  genereSyntheseSecurite(donnees),
-])
-  .then(([annexes, dossierDecision, syntheseSecurite]) => {
-    const zip = new JSZip();
-    zip.file('Annexes.pdf', annexes, { binary: true });
-    zip.file('DossierDecison.pdf', dossierDecision, { binary: true });
-    zip.file('SyntheseSecurite.pdf', syntheseSecurite, { binary: true });
-    return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE', compressionOptions: { level: 9 } });
-  })
-  .catch((e) => {
-    fabriqueAdaptateurGestionErreur().logueErreur(e);
-    return Promise.reject(e);
-  });
-
 module.exports = {
   genereAnnexes,
   genereDossierDecision,
   genereSyntheseSecurite,
-  genereArchiveTousDocuments,
 };

--- a/src/adaptateurs/adaptateurZip.js
+++ b/src/adaptateurs/adaptateurZip.js
@@ -1,0 +1,17 @@
+const JSZip = require('jszip');
+const { fabriqueAdaptateurGestionErreur } = require('./fabriqueAdaptateurGestionErreur');
+
+const genereArchive = (tableauDeFichiers) => {
+  try {
+    const zip = new JSZip();
+    tableauDeFichiers.forEach(({ nom, buffer }) => {
+      zip.file(nom, buffer, { binary: true });
+    });
+    return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE', compressionOptions: { level: 9 } });
+  } catch (e) {
+    fabriqueAdaptateurGestionErreur().logueErreur(e);
+    return Promise.reject(e);
+  }
+};
+
+module.exports = { genereArchive };

--- a/src/mss.js
+++ b/src/mss.js
@@ -20,6 +20,7 @@ const creeServeur = (
   adaptateurGestionErreur,
   adaptateurAnnuaire,
   adaptateurCsv,
+  adaptateurZip,
   avecCookieSecurise = (process.env.NODE_ENV === 'production'),
   avecPageErreur = (process.env.NODE_ENV === 'production'),
 ) => {
@@ -134,7 +135,7 @@ const creeServeur = (
     reponse.render('tableauDeBord');
   });
 
-  app.use('/api', routesApi(middleware, adaptateurMail, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf, adaptateurAnnuaire, adaptateurCsv));
+  app.use('/api', routesApi(middleware, adaptateurMail, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf, adaptateurAnnuaire, adaptateurCsv, adaptateurZip));
 
   app.use('/bibliotheques', routesBibliotheques());
 

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -23,7 +23,8 @@ const routesApi = (
   adaptateurHorloge,
   adaptateurPdf,
   adaptateurAnnuaire,
-  adaptateurCsv
+  adaptateurCsv,
+  adaptateurZip
 ) => {
   const verifieSuccesEnvoiMessage = (promesseEnvoiMessage, utilisateur) => promesseEnvoiMessage
     .then(() => utilisateur)
@@ -113,7 +114,7 @@ const routesApi = (
       .catch(() => reponse.sendStatus(424));
   });
 
-  routes.use('/service', routesApiService(middleware, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf));
+  routes.use('/service', routesApiService(middleware, depotDonnees, referentiel, adaptateurHorloge, adaptateurPdf, adaptateurZip));
 
   routes.get('/seuilCriticite', middleware.verificationAcceptationCGU, (requete, reponse) => {
     const {

--- a/src/routes/routesApiService.js
+++ b/src/routes/routesApiService.js
@@ -30,11 +30,18 @@ const routesApiService = (
   depotDonnees,
   referentiel,
   adaptateurHorloge,
-  adaptateurPdf
+  adaptateurPdf,
+  adaptateurZip
 ) => {
   const routes = express.Router();
 
-  routes.use(routesApiServicePdf(middleware, adaptateurHorloge, adaptateurPdf, referentiel));
+  routes.use(routesApiServicePdf(
+    middleware,
+    adaptateurHorloge,
+    adaptateurPdf,
+    adaptateurZip,
+    referentiel
+  ));
 
   routes.post('/', middleware.verificationAcceptationCGU, middleware.aseptise('nomService', 'organisationsResponsables.*'), middleware.aseptiseListes([
     { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },

--- a/src/routes/routesApiServicePdf.js
+++ b/src/routes/routesApiServicePdf.js
@@ -5,25 +5,20 @@ const { dateYYYYMMDD } = require('../utilitaires/date');
 const routesApiServicePdf = (middleware, adaptateurHorloge, adaptateurPdf, referentiel) => {
   const routes = express.Router();
 
-  routes.get('/:id/pdf/annexes.pdf', middleware.trouveService, (requete, reponse, suite) => {
-    const { homologation } = requete;
+  const generePdfAnnexes = (homologation) => {
     const donneesDescription = homologation.vueAnnexePDFDescription().donnees();
     const donneesMesures = homologation.vueAnnexePDFMesures().donnees();
     const donneesRisques = homologation.vueAnnexePDFRisques().donnees();
 
-    adaptateurPdf.genereAnnexes({
+    return adaptateurPdf.genereAnnexes({
       donneesDescription,
       donneesMesures,
       donneesRisques,
       referentiel,
-    })
-      .then((pdf) => reponse.contentType('application/pdf').send(pdf))
-      .catch(suite);
-  });
+    });
+  };
 
-  routes.get('/:id/pdf/dossierDecision.pdf', middleware.trouveService, middleware.trouveDossierCourant, (requete, reponse, suite) => {
-    const { homologation, dossierCourant } = requete;
-
+  const generePdfDossierDecision = (homologation, dossierCourant) => {
     const donnees = {
       nomService: homologation.nomService(),
       nomPrenomAutorite: dossierCourant.autorite.nom,
@@ -35,14 +30,10 @@ const routesApiServicePdf = (middleware, adaptateurHorloge, adaptateurPdf, refer
       ...dossierCourant.documents.toJSON(),
     };
 
-    adaptateurPdf.genereDossierDecision(donnees)
-      .then((pdf) => reponse.contentType('application/pdf').send(pdf))
-      .catch(suite);
-  });
+    return adaptateurPdf.genereDossierDecision(donnees);
+  };
 
-  routes.get('/:id/pdf/syntheseSecurite.pdf', middleware.trouveService, (requete, reponse, suite) => {
-    const { homologation } = requete;
-
+  const generePdfSyntheseSecurite = (homologation) => {
     const donnees = {
       service: homologation,
       camembertIndispensables: genereGradientConique(
@@ -54,7 +45,29 @@ const routesApiServicePdf = (middleware, adaptateurHorloge, adaptateurPdf, refer
       referentiel,
     };
 
-    adaptateurPdf.genereSyntheseSecurite(donnees)
+    return adaptateurPdf.genereSyntheseSecurite(donnees);
+  };
+
+  routes.get('/:id/pdf/annexes.pdf', middleware.trouveService, (requete, reponse, suite) => {
+    const { homologation } = requete;
+
+    generePdfAnnexes(homologation)
+      .then((pdf) => reponse.contentType('application/pdf').send(pdf))
+      .catch(suite);
+  });
+
+  routes.get('/:id/pdf/dossierDecision.pdf', middleware.trouveService, middleware.trouveDossierCourant, (requete, reponse, suite) => {
+    const { homologation, dossierCourant } = requete;
+
+    generePdfDossierDecision(homologation, dossierCourant)
+      .then((pdf) => reponse.contentType('application/pdf').send(pdf))
+      .catch(suite);
+  });
+
+  routes.get('/:id/pdf/syntheseSecurite.pdf', middleware.trouveService, (requete, reponse, suite) => {
+    const { homologation } = requete;
+
+    generePdfSyntheseSecurite(homologation)
       .then((pdf) => reponse.contentType('application/pdf').send(pdf))
       .catch(suite);
   });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -17,6 +17,7 @@ const testeurMss = () => {
   let adaptateurMail;
   let adaptateurPdf;
   let adaptateurCsv;
+  let adaptateurZip;
   let depotDonnees;
   let moteurRegles;
   let referentiel;
@@ -43,8 +44,13 @@ const testeurMss = () => {
     adaptateurAnnuaire = {};
     adaptateurHorloge = adaptateurHorlogeParDefaut;
     adaptateurMail = adaptateurMailMemoire;
-    adaptateurPdf = {};
+    adaptateurPdf = {
+      genereAnnexes: () => Promise.resolve('PDF Annexe'),
+      genereDossierDecision: () => Promise.resolve('PDF Dossier decision'),
+      genereSyntheseSecurite: () => Promise.resolve('PDF Synthese securite'),
+    };
     adaptateurCsv = {};
+    adaptateurZip = { genereArchive: () => Promise.resolve('Archive ZIP') };
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();
     moteurRegles = new MoteurRegles(referentiel);
@@ -62,6 +68,7 @@ const testeurMss = () => {
           adaptateurGestionErreurVide,
           adaptateurAnnuaire,
           adaptateurCsv,
+          adaptateurZip,
           false,
         );
         serveur.ecoute(1234, done);
@@ -77,6 +84,7 @@ const testeurMss = () => {
     adaptateurMail: () => adaptateurMail,
     adaptateurPdf: () => adaptateurPdf,
     adaptateurCsv: () => adaptateurCsv,
+    adaptateurZip: () => adaptateurZip,
     depotDonnees: () => depotDonnees,
     middleware: () => middleware,
     moteurRegles: () => moteurRegles,


### PR DESCRIPTION
… pour les services qui n'ont pas de dossier d'homologation en cours.

Car pour ces services, les données nécessaires au dossier de décision sont indisponibles.
