### PR TITLE
[CORRECTION] Tri correctement en fonction de la direction AUCUNE

### DIFF
--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -34,7 +34,7 @@ const tableauDesServices = {
       .sort((serviceA, serviceB) => {
         const { colonne, direction } = tableauDesServices.tri;
         if (colonne === null) return 0;
-        if (direction === null) return 0;
+        if (direction === AUCUNE) return 0;
         if (direction === ASC) return serviceB[colonne] - serviceA[colonne];
         return serviceA[colonne] - serviceB[colonne];
       });


### PR DESCRIPTION
... car le tri faisait une comparaison à `null` au lieu de `AUCUNE`, donc le tri ne revenait plus jamais en position initiale.