### PR TITLE
[CORRECTION] Fermeture modale deconnexion

### DIFF
--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -34,7 +34,12 @@ header nav a,
   color: var(--systeme-design-etat-bleu);
 }
 
-:is(header nav a, .nom-utilisateur-courant, .logo-anssi, .logo-mss):hover {
+:is(
+    header nav a:not(.bouton),
+    .nom-utilisateur-courant,
+    .logo-anssi,
+    .logo-mss
+  ):hover {
   background-color: var(--systeme-design-etat-gris-survol);
 }
 

--- a/public/assets/styles/modale.css
+++ b/public/assets/styles/modale.css
@@ -134,8 +134,8 @@
   margin: 0;
 }
 
-.modale.deconnexion .bouton:hover {
-  color: #fff;
+.modale.deconnexion .fermeture-modale {
+  display: none;
 }
 
 .modale.deconnexion .image-deconnexion {


### PR DESCRIPTION
On supprime la possibilité de fermer la modale de déconnexion afin de forcer les utilisateurs à se reconnecter.
On en profite pour styliser proprement le bouton de reconnexion.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/a0a3db57-ed8f-43f8-8e30-7cc8fea26309)
