### PR TITLE
Perfomance get services

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -242,26 +242,12 @@ select {
   color: var(--bleu-mise-en-avant);
 }
 
-.icone-chargement {
+select ~ .icone-chargement {
   display: none;
-  width: 24px;
-  height: 24px;
   position: absolute;
   right: 1em;
   transform: translateY(-2.2em);
   z-index: 10;
-}
-
-.icone-chargement::after {
-  content: ' ';
-  display: block;
-  width: 16px;
-  height: 16px;
-  margin: 0;
-  border-radius: 50%;
-  border: 2px solid var(--gris-fonce);
-  border-color: var(--gris-fonce) transparent var(--gris-fonce) transparent;
-  animation: rotation 1.2s linear infinite;
 }
 
 @keyframes rotation {

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -119,3 +119,15 @@ section:last-of-type {
   margin: 2em 0 2em auto;
   padding: 1em 2em;
 }
+
+.icone-chargement::after {
+  content: '';
+  display: block;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  border-radius: 50%;
+  border: 2px solid var(--gris-fonce);
+  border-color: var(--gris-fonce) transparent var(--gris-fonce) transparent;
+  animation: rotation 1.2s linear infinite;
+}

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -324,6 +324,10 @@ label[for='recherche-service'] {
   opacity: 0;
 }
 
+.cellule-indice-cyber {
+  line-height: 0;
+}
+
 .tableau-services td .statut-homologation {
   border-radius: 40px;
   padding: 0.3em 0.7em;
@@ -771,9 +775,4 @@ label[for='recherche-service'] {
 
 #contenu-contributeurs .role.contributeur {
   background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
-}
-
-.icone-chargement {
-  position: relative;
-  transform: translateY(0);
 }

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -772,3 +772,8 @@ label[for='recherche-service'] {
 #contenu-contributeurs .role.contributeur {
   background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
 }
+
+.icone-chargement {
+  position: relative;
+  transform: translateY(0);
+}

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -10,7 +10,7 @@ const remplisCartesInformations = (resume) => {
   $('#nombre-services-homologues').text(resume.nombreServicesHomologues);
 };
 const remplisCarteInformationIndiceCyber = (indiceCyberMoyen) => {
-  $('#indice-cyber-moyen').text(indiceCyberMoyen?.toFixed(1) ?? '-');
+  $('#indice-cyber-moyen').text(indiceCyberMoyen);
 };
 
 const tableauDesServices = {

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -171,7 +171,9 @@ const tableauDesServices = {
       } else if (!service.indiceCyber) {
         contenuIndiceCyber = '<div class="icone-chargement"></div>';
       }
-      $ligne.append($(`<td>${contenuIndiceCyber}</td>`));
+      $ligne.append(
+        $(`<td class="cellule-indice-cyber">${contenuIndiceCyber}</td>`)
+      );
       $ligne.append(
         $(
           `<td><div class='statut-homologation statut-${service.statutHomologation.id}'>${service.statutHomologation.libelle}</div></td>`

--- a/src/modeles/objetsApi/objetGetIndicesCyber.js
+++ b/src/modeles/objetsApi/objetGetIndicesCyber.js
@@ -18,7 +18,11 @@ const donnees = (services) => {
       ...s,
       indiceCyber: s.indiceCyber.toFixed(1),
     })),
-    resume: { indiceCyberMoyen },
+    resume: {
+      indiceCyberMoyen: Number.isNaN(indiceCyberMoyen)
+        ? '-'
+        : indiceCyberMoyen?.toFixed(1),
+    },
   };
 };
 

--- a/src/modeles/objetsApi/objetGetIndicesCyber.js
+++ b/src/modeles/objetsApi/objetGetIndicesCyber.js
@@ -1,0 +1,25 @@
+const donnees = (services) => {
+  const servicesIndiceCyberCalcules = services.map((s) => ({
+    id: s.id,
+    indiceCyber: s.indiceCyber().total,
+  }));
+
+  const servicesAvecIndiceCyber = servicesIndiceCyberCalcules.filter(
+    (s) => s.indiceCyber > 0
+  );
+
+  const indiceCyberMoyen =
+    servicesIndiceCyberCalcules
+      .map((s) => s.indiceCyber)
+      .reduce((a, b) => a + b, 0) / servicesAvecIndiceCyber.length;
+
+  return {
+    services: servicesIndiceCyberCalcules.map((s) => ({
+      ...s,
+      indiceCyber: s.indiceCyber.toFixed(1),
+    })),
+    resume: { indiceCyberMoyen },
+  };
+};
+
+module.exports = { donnees };

--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -4,58 +4,45 @@ const STATUTS_HOMOLOGATION = {
   completes: 'Réalisée',
 };
 
-const donnees = (services, idUtilisateur) => {
-  const servicesAvecIndiceCyber = services.filter(
-    (s) => s.indiceCyber().total > 0
-  );
-
-  return {
-    services: services
-      .map((s) => ({
-        ...s.toJSON(),
-        organisationsResponsables:
-          s.descriptionService.organisationsResponsables,
-        indiceCyber: s.indiceCyber().total.toFixed(1),
-        statutHomologation: s.dossiers.statutSaisie(),
-        documentsPdfDisponibles: s.documentsPdfDisponibles(),
-      }))
-      .map((json) => ({
-        id: json.id,
-        nomService: json.nomService,
-        organisationsResponsables: json.organisationsResponsables ?? [],
-        createur: {
-          id: json.createur.id,
-          prenomNom: json.createur.prenomNom,
-          initiales: json.createur.initiales,
-          poste: json.createur.posteDetaille,
-        },
-        contributeurs: json.contributeurs.map((c) => ({
-          id: c.id,
-          prenomNom: c.prenomNom,
-          initiales: c.initiales,
-          cguAcceptees: c.cguAcceptees,
-          poste: c.posteDetaille,
-        })),
-        indiceCyber: json.indiceCyber,
-        statutHomologation: {
-          libelle: STATUTS_HOMOLOGATION[json.statutHomologation],
-          id: json.statutHomologation,
-        },
-        nombreContributeurs: json.contributeurs.length + 1,
-        estCreateur: json.createur.id === idUtilisateur,
-        documentsPdfDisponibles: json.documentsPdfDisponibles,
+const donnees = (services, idUtilisateur) => ({
+  services: services
+    .map((s) => ({
+      ...s.toJSON(),
+      organisationsResponsables: s.descriptionService.organisationsResponsables,
+      statutHomologation: s.dossiers.statutSaisie(),
+      documentsPdfDisponibles: s.documentsPdfDisponibles(),
+    }))
+    .map((json) => ({
+      id: json.id,
+      nomService: json.nomService,
+      organisationsResponsables: json.organisationsResponsables ?? [],
+      createur: {
+        id: json.createur.id,
+        prenomNom: json.createur.prenomNom,
+        initiales: json.createur.initiales,
+        poste: json.createur.posteDetaille,
+      },
+      contributeurs: json.contributeurs.map((c) => ({
+        id: c.id,
+        prenomNom: c.prenomNom,
+        initiales: c.initiales,
+        cguAcceptees: c.cguAcceptees,
+        poste: c.posteDetaille,
       })),
-    resume: {
-      nombreServices: services.length,
-      nombreServicesHomologues: services.filter(
-        (s) => s.dossiers.statutSaisie() === 'completes'
-      ).length,
-      indiceCyberMoyen:
-        servicesAvecIndiceCyber
-          .map((s) => s.indiceCyber().total)
-          .reduce((a, b) => a + b, 0) / servicesAvecIndiceCyber.length,
-    },
-  };
-};
+      statutHomologation: {
+        libelle: STATUTS_HOMOLOGATION[json.statutHomologation],
+        id: json.statutHomologation,
+      },
+      nombreContributeurs: json.contributeurs.length + 1,
+      estCreateur: json.createur.id === idUtilisateur,
+      documentsPdfDisponibles: json.documentsPdfDisponibles,
+    })),
+  resume: {
+    nombreServices: services.length,
+    nombreServicesHomologues: services.filter(
+      (s) => s.dossiers.statutSaisie() === 'completes'
+    ).length,
+  },
+});
 
 module.exports = { donnees };

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -17,6 +17,7 @@ const {
 const routesApiService = require('./routesApiService');
 const Utilisateur = require('../modeles/utilisateur');
 const objetGetServices = require('../modeles/objetsApi/objetGetServices');
+const objetGetIndicesCyber = require('../modeles/objetsApi/objetGetIndicesCyber');
 
 const routesApi = (
   middleware,
@@ -127,6 +128,17 @@ const routesApi = (
         .then((services) =>
           objetGetServices.donnees(services, requete.idUtilisateurCourant)
         )
+        .then((donnees) => reponse.json(donnees));
+    }
+  );
+
+  routes.get(
+    '/services/indices-cyber',
+    middleware.verificationAcceptationCGU,
+    (requete, reponse) => {
+      depotDonnees
+        .homologations(requete.idUtilisateurCourant)
+        .then((services) => objetGetIndicesCyber.donnees(services))
         .then((donnees) => reponse.json(donnees));
     }
   );

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -7,7 +7,7 @@ mixin carteInformation(sourceImage, classeFondImage, idNombre, textePremiereLign
       img(src=sourceImage)
     .conteneur-texte
       dl
-        dt.nombre(id=idNombre) 0
+        dt.nombre(id=idNombre) -
         dd!= textePremiereLigne
         dd!= texteDeuxiemeLigne
 

--- a/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
+++ b/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
@@ -1,0 +1,43 @@
+const expect = require('expect.js');
+
+const Service = require('../../../src/modeles/service');
+const objetGetIndicesCyber = require('../../../src/modeles/objetsApi/objetGetIndicesCyber');
+
+describe("L'objet d'API de `GET /services/indices-cyber`", () => {
+  let unService;
+  let unAutreService;
+
+  beforeEach(() => {
+    unService = new Service({ id: '123' });
+    unService.indiceCyber = () => ({ total: 3.51 });
+
+    unAutreService = new Service({ id: '456' });
+    unAutreService.indiceCyber = () => ({ total: 5 });
+  });
+
+  it('fournit les données nécessaires', () => {
+    expect(objetGetIndicesCyber.donnees([unService]).services).to.eql([
+      { id: '123', indiceCyber: 3.5 },
+    ]);
+  });
+
+  it('fournit les données de résumé des services', () => {
+    unService.indiceCyber = () => ({ total: 4 });
+    unAutreService.indiceCyber = () => ({ total: 5 });
+
+    const services = [unService, unAutreService];
+    expect(objetGetIndicesCyber.donnees(services).resume).to.eql({
+      indiceCyberMoyen: 4.5,
+    });
+  });
+
+  it('ne compte pas les indices cyber nuls dans le calcul de la moyenne', () => {
+    unService.indiceCyber = () => ({ total: 4 });
+    unAutreService.indiceCyber = () => ({ total: 0 });
+
+    const services = [unService, unAutreService];
+    expect(objetGetIndicesCyber.donnees(services).resume).to.eql({
+      indiceCyberMoyen: 4,
+    });
+  });
+});

--- a/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
+++ b/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
@@ -27,7 +27,7 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
 
     const services = [unService, unAutreService];
     expect(objetGetIndicesCyber.donnees(services).resume).to.eql({
-      indiceCyberMoyen: 4.5,
+      indiceCyberMoyen: '4.5',
     });
   });
 
@@ -36,8 +36,18 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
     unAutreService.indiceCyber = () => ({ total: 0 });
 
     const services = [unService, unAutreService];
-    expect(objetGetIndicesCyber.donnees(services).resume).to.eql({
-      indiceCyberMoyen: 4,
-    });
+    expect(
+      objetGetIndicesCyber.donnees(services).resume.indiceCyberMoyen
+    ).to.be('4.0');
+  });
+
+  it("donne une valeur vide pour l'indice cyber moyen quand la moyenne n'est pas calculable", () => {
+    unService.indiceCyber = () => ({ total: 0 });
+    unAutreService.indiceCyber = () => ({ total: 0 });
+
+    const services = [unService, unAutreService];
+    expect(
+      objetGetIndicesCyber.donnees(services).resume.indiceCyberMoyen
+    ).to.be('-');
   });
 });

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -26,7 +26,6 @@ describe("L'objet d'API de `GET /services`", () => {
       },
     ],
   });
-  unService.indiceCyber = () => ({ total: 3.51 });
   unService.dossierCourant = () => unDossier().construit();
 
   const unAutreService = new Service({
@@ -63,7 +62,6 @@ describe("L'objet d'API de `GET /services`", () => {
             poste: 'Maire',
           },
         ],
-        indiceCyber: 3.5,
         statutHomologation: { libelle: 'À réaliser', id: 'aSaisir' },
         nombreContributeurs: 1 + 1,
         estCreateur: true,
@@ -77,27 +75,12 @@ describe("L'objet d'API de `GET /services`", () => {
   });
 
   it('fournit les données de résumé des services', () => {
-    unService.indiceCyber = () => ({ total: 4 });
     unAutreService.dossiers.statutSaisie = () => 'completes';
-    unAutreService.indiceCyber = () => ({ total: 5 });
 
     const services = [unService, unAutreService];
-    expect(objetGetServices.donnees(services).resume).to.eql({
+    expect(objetGetServices.donnees(services, 'A').resume).to.eql({
       nombreServices: 2,
       nombreServicesHomologues: 1,
-      indiceCyberMoyen: 4.5,
-    });
-  });
-
-  it('ne compte pas les indice cyber nuls pour calculer la moyenne', () => {
-    unService.indiceCyber = () => ({ total: 4 });
-    unAutreService.indiceCyber = () => ({ total: 0 });
-
-    const services = [unService, unAutreService];
-    expect(objetGetServices.donnees(services).resume).to.eql({
-      nombreServices: 2,
-      nombreServicesHomologues: 1,
-      indiceCyberMoyen: 4,
     });
   });
 });


### PR DESCRIPTION
Après investiguation, on se rends compte que le calcul de l’indice cyber est très lent, ce qui rend la récupération des services très longues.

On déplace donc l’obtention des informations d'indice cyber sur une deuxième route.
On afficher un "loader" en attendant que l'info soit récupérée.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/9583151c-82b5-4688-a3c4-2e0494675e87)
