### PR TITLE
[TDB] Barre d'outils des actions de service

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -413,7 +413,8 @@ label[for='recherche-service'] {
   cursor: pointer;
 }
 
-.tableau-services .checkbox-selection-tous-services {
+.tableau-services .checkbox-selection-tous-services,
+.tableau-services .checkbox-tous-services {
   transform: translateY(0);
 }
 
@@ -433,8 +434,8 @@ label[for='recherche-service'] {
   border-radius: 8px;
 }
 
-.tableau-services .texte-nombre-service {
-  cursor: pointer;
+.tableau-services .texte-nombre-service,
+.tableau-services .texte-tous-service {
   font-weight: 500;
 }
 
@@ -805,11 +806,16 @@ label[for='recherche-service'] {
     hue-rotate(190deg) brightness(90%) contrast(91%);
 }
 
-.tableau-services .conteneur-selection-multiple {
+.tableau-services .conteneur-selection-multiple,
+.tableau-services .conteneur-tous-selection {
   display: flex;
   padding-top: 0.7em;
   padding-right: 0.7em;
   padding-bottom: 0.7em;
+}
+
+.tableau-services .conteneur-tous-selection {
+  padding-left: 1.5em;
 }
 
 .tableau-services .conteneur-barre-outils hr {

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -446,6 +446,17 @@ label[for='recherche-service'] {
   font-size: 0.9em;
 }
 
+.tableau-services .action.actif {
+  color: #08416a;
+}
+
+.tableau-services .action.actif img {
+  /* On utilise ici un site web pour générer la couleur cible en partant d'une icône noire */
+  /* https://codepen.io/sosuke/pen/Pjoqqp */
+  filter: brightness(0) invert(18%) sepia(34%) saturate(2472%)
+    hue-rotate(179deg) brightness(97%) contrast(97%);
+}
+
 .tableau-services .action :is(img, p) {
   pointer-events: none;
 }
@@ -765,7 +776,7 @@ label[for='recherche-service'] {
 }
 
 .tableau-services #barre-outils.visible .conteneur-barre-outils {
-  /* Cette valeur est volontairement trop élevée pour assure l'affichage complet de la barre d'outils */
+  /* Cette valeur est volontairement trop élevée pour assurer l'affichage complet de la barre d'outils */
   max-height: 4em;
   padding: 0 1.5em;
 }
@@ -785,6 +796,13 @@ label[for='recherche-service'] {
 .tableau-services .conteneur-barre-outils .action:hover {
   background: #f1f5f9;
   color: #0c5c98;
+}
+
+.tableau-services .conteneur-barre-outils .action:hover img {
+  /* On utilise ici un site web pour générer la couleur cible en partant d'une icône noire */
+  /* https://codepen.io/sosuke/pen/Pjoqqp */
+  filter: brightness(0) invert(21%) sepia(46%) saturate(4342%)
+    hue-rotate(190deg) brightness(90%) contrast(91%);
 }
 
 .tableau-services .conteneur-selection-multiple {

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -199,7 +199,7 @@ label[for='recherche-service'] {
   justify-content: left;
 }
 
-.tableau-services thead th::after {
+.tableau-services thead th:not(:first-of-type)::after {
   content: '\00a0\00a0\00a0';
   margin-left: 0.3em;
 }
@@ -220,7 +220,7 @@ label[for='recherche-service'] {
   background: none;
 }
 
-.tableau-services thead tr th:last-of-type {
+.tableau-services thead tr:not(:last-of-type) th:last-of-type {
   border-top-right-radius: 8px;
 }
 
@@ -238,10 +238,6 @@ label[for='recherche-service'] {
 
 .tableau-services tbody tr.selectionne {
   background: #eff6ff;
-}
-
-.tableau-services tbody tr:first-of-type td:first-of-type {
-  border-top-left-radius: 8px;
 }
 
 .tableau-services tbody tr:last-of-type td {
@@ -437,26 +433,9 @@ label[for='recherche-service'] {
   border-radius: 8px;
 }
 
-.tableau-services .conteneur-selection-services {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
 .tableau-services .texte-nombre-service {
   cursor: pointer;
-}
-
-.tableau-services .fleche-droite {
-  transform: translateY(1px);
-}
-
-.tableau-services .actions-services {
-  position: absolute;
-  right: 0;
-  top: -1px;
-  transform: translateX(100%);
-  border-top-left-radius: 0;
+  font-weight: 500;
 }
 
 .tableau-services .action {
@@ -464,15 +443,7 @@ label[for='recherche-service'] {
   flex-shrink: none;
   align-items: center;
   color: #0079d0;
-}
-
-.tableau-services .action.inactif {
-  color: var(--gris-inactif);
-  pointer-events: none;
-}
-
-.tableau-services .action.inactif img {
-  filter: grayscale(1);
+  font-size: 0.9em;
 }
 
 .tableau-services .action :is(img, p) {
@@ -482,19 +453,6 @@ label[for='recherche-service'] {
 .tableau-services .action p {
   margin: 0;
   margin-left: 0.5em;
-}
-
-.tableau-services .conteneur-selection-services {
-  border: 1px solid transparent;
-  border-bottom-left-radius: 4px;
-  border-top-left-radius: 4px;
-  padding: 0.5em 1.5em;
-  margin-bottom: 0.2em;
-}
-
-.tableau-services .conteneur-selection-services.actif {
-  background: #f1f5f9;
-  border: 1px solid #08416a;
 }
 
 .tableau-services .conteneur-collaborateur {
@@ -785,4 +743,60 @@ label[for='recherche-service'] {
 
 #contenu-contributeurs .role.contributeur {
   background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
+}
+
+.tableau-services .conteneur-barre-outils {
+  display: flex;
+  gap: 0.3em;
+  padding: 0 1.5em;
+  max-height: 0;
+  overflow: hidden;
+  box-sizing: border-box;
+  transition: max-height 0.2s, padding 0.2s;
+}
+
+.tableau-services #barre-outils th {
+  border: none;
+}
+
+.tableau-services #barre-outils.visible th {
+  border: 1px solid #cbd5e1;
+  border-style: solid solid none solid;
+}
+
+.tableau-services #barre-outils.visible .conteneur-barre-outils {
+  /* Cette valeur est volontairement trop élevée pour assure l'affichage complet de la barre d'outils */
+  max-height: 4em;
+  padding: 0 1.5em;
+}
+
+.tableau-services .conteneur-barre-outils .action {
+  border-radius: 4px;
+  user-select: none;
+  cursor: pointer;
+  font-weight: 500;
+  padding: 0.5em 0.7em;
+}
+
+.tableau-services .conteneur-barre-outils .action:hover {
+  background: #f1f5f9;
+  color: #0c5c98;
+}
+
+.tableau-services .conteneur-selection-multiple {
+  display: flex;
+  padding-top: 0.7em;
+  padding-right: 0.7em;
+  padding-bottom: 0.7em;
+}
+
+.tableau-services .conteneur-barre-outils hr {
+  margin: 0;
+  border: 1px solid #cbd5e1;
+  border-style: none none none solid;
+  margin: 0.2em 0;
+}
+
+.tableau-services .conteneur-barre-outils hr.action {
+  padding: 0;
 }

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -778,6 +778,10 @@ label[for='recherche-service'] {
   padding: 0.5em 0.7em;
 }
 
+.tableau-services .conteneur-barre-outils .action.inactif {
+  display: none;
+}
+
 .tableau-services .conteneur-barre-outils .action:hover {
   background: #f1f5f9;
   color: #0c5c98;

--- a/public/modules/tableauDeBord/gestionnaireEvenements.mjs
+++ b/public/modules/tableauDeBord/gestionnaireEvenements.mjs
@@ -19,8 +19,6 @@ const gestionnaireEvenements = {
         gestionnaireEvenements.selectionneService($elementClique);
       } else if ($elementClique.hasClass('checkbox-selection-tous-services')) {
         gestionnaireEvenements.selectionneTousServices($elementClique);
-      } else if ($elementClique.hasClass('texte-nombre-service')) {
-        gestionnaireEvenements.afficheMenuAction($elementClique);
       } else if ($elementClique.hasClass('action')) {
         gestionnaireEvenements.afficheTiroirAction($elementClique);
       } else if ($elementClique.hasClass('contributeurs')) {
@@ -56,34 +54,6 @@ const gestionnaireEvenements = {
   afficheTiroirAction: ($action, ...args) => {
     gestionnaireTiroir.afficheContenuAction($action.data('action'), ...args);
     gestionnaireEvenements.fermeMenuFlottant();
-  },
-  afficheMenuAction: ($bouton) => {
-    if (tableauDesServices.servicesSelectionnes.size === 0) return;
-    const doitOuvrirMenu = !$bouton
-      .parents('.conteneur-selection-services')
-      .hasClass('actif');
-    gestionnaireEvenements.fermeMenuFlottant();
-    if (doitOuvrirMenu) {
-      $bouton.parents('.conteneur-selection-services').addClass('actif');
-      $('.menu-flotant.actions-services').removeClass('invisible');
-      const auMoinsUnNonCreateur = [...tableauDesServices.servicesSelectionnes]
-        .map((idService) =>
-          tableauDesServices.donnees.find((service) => service.id === idService)
-        )
-        .some((service) => !service.estCreateur);
-      if (auMoinsUnNonCreateur) {
-        $('.actions-services .action').addClass('inactif');
-      } else {
-        $('.actions-services .action').removeClass('inactif');
-        const plusDunService =
-          [...tableauDesServices.servicesSelectionnes].length > 1;
-        if (plusDunService)
-          $('#action-flotante-telechargement').addClass('inactif');
-      }
-    } else {
-      $bouton.parents('.conteneur-selection-services').removeClass('actif');
-      $('.menu-flotant.actions-services').addClass('invisible');
-    }
   },
   selectionneService: ($checkbox) => {
     const selectionne = $checkbox.is(':checked');

--- a/public/modules/tableauDeBord/gestionnaireEvenements.mjs
+++ b/public/modules/tableauDeBord/gestionnaireEvenements.mjs
@@ -52,6 +52,8 @@ const gestionnaireEvenements = {
     });
   },
   afficheTiroirAction: ($action, ...args) => {
+    $('#barre-outils .action').removeClass('actif');
+    $action.addClass('actif');
     gestionnaireTiroir.afficheContenuAction($action.data('action'), ...args);
     gestionnaireEvenements.fermeMenuFlottant();
   },

--- a/public/modules/tableauDeBord/gestionnaireEvenements.mjs
+++ b/public/modules/tableauDeBord/gestionnaireEvenements.mjs
@@ -19,6 +19,8 @@ const gestionnaireEvenements = {
         gestionnaireEvenements.selectionneService($elementClique);
       } else if ($elementClique.hasClass('checkbox-selection-tous-services')) {
         gestionnaireEvenements.selectionneTousServices($elementClique);
+      } else if ($elementClique.hasClass('checkbox-tous-services')) {
+        gestionnaireEvenements.selectionneTousServices($elementClique);
       } else if ($elementClique.hasClass('action')) {
         gestionnaireEvenements.afficheTiroirAction($elementClique);
       } else if ($elementClique.hasClass('contributeurs')) {

--- a/public/modules/tableauDeBord/gestionnaireTiroir.mjs
+++ b/public/modules/tableauDeBord/gestionnaireTiroir.mjs
@@ -126,10 +126,13 @@ const gestionnaireTiroir = {
     initialise(args);
     gestionnaireTiroir.basculeOuvert(true);
   },
-  basculeOuvert: (statut) => {
-    if (statut) $('.tiroir').addClass('ouvert');
-    else $('.tiroir').removeClass('ouvert');
-    $(document).trigger(EVENEMENT_BASCULE_TIROIR, { ouvert: statut });
+  basculeOuvert: (doitOuvrir) => {
+    if (doitOuvrir) $('.tiroir').addClass('ouvert');
+    else {
+      $('.tiroir').removeClass('ouvert');
+      $('#barre-outils .action').removeClass('actif');
+    }
+    $(document).trigger(EVENEMENT_BASCULE_TIROIR, { ouvert: doitOuvrir });
   },
 };
 

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -66,6 +66,21 @@ const tableauDesServices = {
       );
       $barreOutils.addClass('visible');
     }
+
+    const auMoinsUnNonCreateur = [...tableauDesServices.servicesSelectionnes]
+      .map((idService) =>
+        tableauDesServices.donnees.find((service) => service.id === idService)
+      )
+      .some((service) => !service.estCreateur);
+    if (auMoinsUnNonCreateur) {
+      $('.conteneur-barre-outils .action').addClass('inactif');
+    } else {
+      $('.conteneur-barre-outils .action').removeClass('inactif');
+      const plusDunService =
+        [...tableauDesServices.servicesSelectionnes].length > 1;
+      if (plusDunService)
+        $('#action-flotante-telechargement').addClass('inactif');
+    }
   },
   basculeSelectionService: (idService, statut) => {
     if (statut) {

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -45,14 +45,17 @@ const tableauDesServices = {
   afficheEtatSelection: () => {
     const nbServiceSelectionnes = tableauDesServices.servicesSelectionnes.size;
     const $checkboxTousServices = $('.checkbox-selection-tous-services');
+    const $barreOutils = $('#barre-outils');
     if (nbServiceSelectionnes === tableauDesServices.nombreServices) {
       $checkboxTousServices.removeClass('selection-partielle');
       $checkboxTousServices.prop('checked', true);
       $('.texte-nombre-service').text('Tous sélectionnés');
+      $barreOutils.addClass('visible');
     } else if (nbServiceSelectionnes === 0) {
       $checkboxTousServices.removeClass('selection-partielle');
       $checkboxTousServices.prop('checked', false);
       $('.texte-nombre-service').text('0 sélectionné');
+      $barreOutils.removeClass('visible');
     } else {
       $checkboxTousServices.addClass('selection-partielle');
       $checkboxTousServices.prop('checked', false);
@@ -61,6 +64,7 @@ const tableauDesServices = {
           nbServiceSelectionnes > 1 ? 's' : ''
         }`
       );
+      $barreOutils.addClass('visible');
     }
   },
   basculeSelectionService: (idService, statut) => {

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -46,16 +46,16 @@ const tableauDesServices = {
     const nbServiceSelectionnes = tableauDesServices.servicesSelectionnes.size;
     const $checkboxTousServices = $('.checkbox-selection-tous-services');
     const $barreOutils = $('#barre-outils');
+    const $raccourciTous = $('.conteneur-tous-selection');
+    const $checkboxRaccourciTous = $('.checkbox-tous-services');
     if (nbServiceSelectionnes === tableauDesServices.nombreServices) {
       $checkboxTousServices.removeClass('selection-partielle');
       $checkboxTousServices.prop('checked', true);
       $('.texte-nombre-service').text('Tous sélectionnés');
-      $barreOutils.addClass('visible');
     } else if (nbServiceSelectionnes === 0) {
       $checkboxTousServices.removeClass('selection-partielle');
       $checkboxTousServices.prop('checked', false);
       $('.texte-nombre-service').text('0 sélectionné');
-      $barreOutils.removeClass('visible');
     } else {
       $checkboxTousServices.addClass('selection-partielle');
       $checkboxTousServices.prop('checked', false);
@@ -64,7 +64,14 @@ const tableauDesServices = {
           nbServiceSelectionnes > 1 ? 's' : ''
         }`
       );
+    }
+    if (nbServiceSelectionnes > 0) {
       $barreOutils.addClass('visible');
+      $raccourciTous.fadeOut(200);
+    } else {
+      $barreOutils.removeClass('visible');
+      $checkboxRaccourciTous.prop('checked', false);
+      $raccourciTous.fadeIn(200);
     }
 
     const auMoinsUnNonCreateur = [...tableauDesServices.servicesSelectionnes]

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -61,6 +61,9 @@ block main
         thead
           tr
             th.entete-selection
+              .conteneur-tous-selection
+                input.checkbox-tous-services(type='checkbox')
+                .texte-tous-service Tous
             th.entete-contributeurs(data-colonne='nombreContributeurs') Contributeur(s)
             th(data-colonne='indiceCyber') Indice Cyber
             th(data-colonne='statutHomologation') Homologation

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -74,7 +74,7 @@ block main
                 hr
                 +actionAvecIcone('/statique/assets/images/icone_ajout_contributeur.svg', 'Inviter contributeur(s)', 'invitation')
                 +actionAvecIcone('/statique/assets/images/icone_action_telechargement.svg', 'Télécharger PDF(s)', 'telechargement', 'action-flotante-telechargement')
-                hr
+                hr.action
                 +actionAvecIcone('/statique/assets/images/icone_exporter_service.svg', 'Exporter la sélection', 'export')
                 +actionAvecIcone('/statique/assets/images/icone_dupliquer_service.svg', 'Dupliquer', 'duplication')
                 +actionAvecIcone('/statique/assets/images/icone_supprimer.svg', 'Supprimer', 'suppression')

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -12,7 +12,7 @@ mixin carteInformation(sourceImage, classeFondImage, idNombre, textePremiereLign
         dd!= texteDeuxiemeLigne
 
 mixin actionAvecIcone(sourceImage, texteAction, action, id)
-  .action(data-action=action, id=id)
+  .action(data-action=action, id=id, tabindex=0)
     img(src=sourceImage)
     p!= texteAction
 
@@ -61,21 +61,23 @@ block main
         thead
           tr
             th.entete-selection
-              .conteneur-selection-services
-                input.checkbox-selection-tous-services(type='checkbox')
-                .texte-nombre-service 0 sélectionné
-                img.fleche-droite(src='/statique/assets/images/fleche_pointe_droite.svg')
-                .menu-flotant.actions-services.invisible
-                  +actionAvecIcone('/statique/assets/images/icone_ajout_contributeur.svg', 'Inviter contributeur(s)', 'invitation')
-                  +actionAvecIcone('/statique/assets/images/icone_action_telechargement.svg', 'Télécharger PDF(s)', 'telechargement', 'action-flotante-telechargement')
-                  hr
-                  +actionAvecIcone('/statique/assets/images/icone_exporter_service.svg', 'Exporter la sélection', 'export')
-                  +actionAvecIcone('/statique/assets/images/icone_dupliquer_service.svg', 'Dupliquer', 'duplication')
-                  +actionAvecIcone('/statique/assets/images/icone_supprimer.svg', 'Supprimer', 'suppression')
             th.entete-contributeurs(data-colonne='nombreContributeurs') Contributeur(s)
             th(data-colonne='indiceCyber') Indice Cyber
             th(data-colonne='statutHomologation') Homologation
-            th 
+            th
+          tr#barre-outils
+            th(colspan=5)
+              .conteneur-barre-outils
+                .conteneur-selection-multiple
+                  input.checkbox-selection-tous-services(type='checkbox')
+                  .texte-nombre-service 0 sélectionné
+                hr
+                +actionAvecIcone('/statique/assets/images/icone_ajout_contributeur.svg', 'Inviter contributeur(s)', 'invitation')
+                +actionAvecIcone('/statique/assets/images/icone_action_telechargement.svg', 'Télécharger PDF(s)', 'telechargement', 'action-flotante-telechargement')
+                hr
+                +actionAvecIcone('/statique/assets/images/icone_exporter_service.svg', 'Exporter la sélection', 'export')
+                +actionAvecIcone('/statique/assets/images/icone_dupliquer_service.svg', 'Dupliquer', 'duplication')
+                +actionAvecIcone('/statique/assets/images/icone_supprimer.svg', 'Supprimer', 'suppression')
         tbody.contenu-tableau-services
     .tiroir
       .entete-tiroir


### PR DESCRIPTION
Nous remettons en forme les actions de service pour coller avec les nouvelles maquettes Figma, suite aux retours UX.

Les actions s'affichent désormais dans un format "barre d'outils".

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/61918d03-ad59-4c2d-b11e-00b967d575bc)
