### PR TITLE
[CORRECTION] Autorise la séléction de texte dans les PDF

### DIFF
--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -20,6 +20,10 @@ html {
   /* On utilise ces règles CSS pour assurer un rendu correct des images et graphiques */
   /* https://github.com/puppeteer/puppeteer/issues/2685#issuecomment-643573422 */
   -webkit-print-color-adjust: exact !important;
+}
+
+.statistiques-mesures,
+.entete {
   -webkit-filter: opacity(1) !important;
 }
 


### PR DESCRIPTION
Un utilisateur a fait remonter le problème suivant :
Dans nos PDFs, il est impossible de séléctionner ou rechercher du contenu texte.

Le bug provient d'une instruction CSS qui nous permettait de garantir un rendu correct des images et graphiques.
```css
-webkit-filter: opacity(1) !important;
```

On modifie donc ce sélecteur pour ne viser que les images concernées.