### PR TITLE
Empêche le focus dans le tiroir si il n'est pas ouvert

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -514,10 +514,12 @@ label[for='recherche-service'] {
   width: 32em;
   transition: transform 0.2s ease-in-out;
   box-shadow: -10px 0px 34px 0px #00000026;
+  visibility: hidden;
 }
 
 .suivi-services .tiroir.ouvert {
   transform: translateX(-100%);
+  visibility: visible;
 }
 
 .suivi-services .entete-tiroir {


### PR DESCRIPTION
Actuellement, il est possible de `focus` le tiroir même si il n'est pas ouvert.

##### Pour reproduire :
- Aller sur la page du tableau de bord
- Focus sur le champ de recherche
- Appuyer sur tab plusieurs fois jusqu’à arriver au focus du tiroir qui n’est pourtant pas visible

On intercepte donc l'event de scroll et on le conditionne en fonction de l'état d'ouverture du tirroir.