### PR TITLE
Disponibilité du dossier de décision

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -825,6 +825,8 @@ module.exports = {
     { numero: 6, libelle: 'Récapitulatif', id: 'recapitulatif' },
   ],
 
+  etapeNecessairePourDossierDecision: 'dateTelechargement',
+
   reglesPersonnalisation: {
     clefsDescriptionServiceAConsiderer: [
       'typeService',

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -127,7 +127,15 @@ class Homologation {
 
   documentsPdfDisponibles() {
     const documents = ['annexes', 'syntheseSecurite'];
-    if (this.dossierCourant()) documents.push('dossierDecision');
+    const dossierCourant = this.dossierCourant();
+    if (
+      dossierCourant &&
+      this.referentiel.etapeSuffisantePourDossierDecision(
+        dossierCourant.etapeCourante()
+      )
+    ) {
+      documents.push('dossierDecision');
+    }
     return documents;
   }
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -204,6 +204,9 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     );
   };
 
+  const numeroEtape = (idEtape) =>
+    etapesParcoursHomologation().find((e) => e.id === idEtape)?.numero;
+
   const premiereEtapeParcours = () =>
     etapesParcoursHomologation().find((e) => e.numero === 1);
 
@@ -219,13 +222,18 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
       .map((e) => e.id)
       .includes(idEtape);
 
-  const numeroEtape = (idEtape) =>
-    etapesParcoursHomologation().find((e) => e.id === idEtape)?.numero;
-
   const idEtapeSuivante = (idEtape) => {
     const numeroSuivant = numeroEtape(idEtape) + 1;
     return etapesParcoursHomologation().find((e) => e.numero === numeroSuivant)
       .id;
+  };
+
+  const etapeSuffisantePourDossierDecision = (idEtape) => {
+    const numeroEtapeSuffisante = numeroEtape(
+      donnees.etapeNecessairePourDossierDecision
+    );
+    const numeroEtapeCourante = numeroEtape(idEtape);
+    return numeroEtapeCourante >= numeroEtapeSuffisante;
   };
 
   const valideDonnees = () => {
@@ -284,6 +292,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     derniereEtapeParcours,
     etapeExiste,
     etapesParcoursHomologation,
+    etapeSuffisantePourDossierDecision,
     fonctionnalites,
     identifiantsActionsSaisie,
     identifiantsCategoriesMesures,

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -208,11 +208,23 @@ describe('Une homologation', () => {
   });
 
   describe('sur demande des documents PDF disponibles', () => {
-    it("inclut tous les documents lorsqu'elle a un dossier d'homologation courant", () => {
-      const referentiel = Referentiel.creeReferentielVide();
+    const referentiel = Referentiel.creeReferentiel({
+      etapesParcoursHomologation: [
+        { id: 'autorite', numero: 1 },
+        { id: 'avis', numero: 2 },
+      ],
+      etapeNecessairePourDossierDecision: 'avis',
+    });
 
+    it("inclut tous les documents lorsqu'elle a un dossier d'homologation courant à une étape suffisante", () => {
       const homologationAvecDossier = new Homologation(
-        { id: '123', dossiers: [{ id: '999' }] },
+        {
+          id: '123',
+          dossiers: [
+            unDossier(referentiel).avecAutorite('Jean Dujardin', 'RSSI')
+              .donnees,
+          ],
+        },
         referentiel
       );
 
@@ -224,10 +236,20 @@ describe('Une homologation', () => {
     });
 
     it("exclut le dossier de décision en cas d'absence de dossier d'homologation courant", () => {
-      const referentiel = Referentiel.creeReferentielVide();
-
       const homologationSansDossier = new Homologation(
         { id: '123', dossiers: [] },
+        referentiel
+      );
+
+      expect(homologationSansDossier.documentsPdfDisponibles()).to.eql([
+        'annexes',
+        'syntheseSecurite',
+      ]);
+    });
+
+    it("exclut le dossier de décision si l'étape courante du dossier d'homologation n'est pas suffisante", () => {
+      const homologationSansDossier = new Homologation(
+        { id: '123', dossiers: [unDossier(referentiel).donnees] },
         referentiel
       );
 

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -2,7 +2,6 @@ const expect = require('expect.js');
 
 const Service = require('../../../src/modeles/service');
 const objetGetServices = require('../../../src/modeles/objetsApi/objetGetServices');
-const { unDossier } = require('../../constructeurs/constructeurDossier');
 
 describe("L'objet d'API de `GET /services`", () => {
   const unService = new Service({
@@ -26,7 +25,6 @@ describe("L'objet d'API de `GET /services`", () => {
       },
     ],
   });
-  unService.dossierCourant = () => unDossier().construit();
 
   const unAutreService = new Service({
     id: '456',
@@ -65,11 +63,7 @@ describe("L'objet d'API de `GET /services`", () => {
         statutHomologation: { libelle: 'À réaliser', id: 'aSaisir' },
         nombreContributeurs: 1 + 1,
         estCreateur: true,
-        documentsPdfDisponibles: [
-          'annexes',
-          'syntheseSecurite',
-          'dossierDecision',
-        ],
+        documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
       },
     ]);
   });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -716,6 +716,27 @@ describe('Le référentiel', () => {
     });
   });
 
+  it('sait si une étape est suffisante pour obtenir le dossier de décision', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      etapesParcoursHomologation: [
+        { id: 'premiere', numero: 1 },
+        { id: 'deuxieme', numero: 2 },
+        { id: 'troisieme', numero: 3 },
+      ],
+      etapeNecessairePourDossierDecision: 'deuxieme',
+    });
+
+    expect(referentiel.etapeSuffisantePourDossierDecision('premiere')).to.be(
+      false
+    );
+    expect(referentiel.etapeSuffisantePourDossierDecision('deuxieme')).to.be(
+      true
+    );
+    expect(referentiel.etapeSuffisantePourDossierDecision('troisieme')).to.be(
+      true
+    );
+  });
+
   it('peut être construit sans donnée', () => {
     const referentiel = Referentiel.creeReferentielVide();
     expect(referentiel.typesService()).to.eql({});

--- a/test/routes/routesApiServicePdf.spec.js
+++ b/test/routes/routesApiServicePdf.spec.js
@@ -199,6 +199,11 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       referentiel
     );
     homologationARenvoyer.mesures.indiceCyber = () => 3.5;
+    homologationARenvoyer.documentsPdfDisponibles = () => [
+      'annexes',
+      'syntheseSecurite',
+      'dossierDecision',
+    ];
 
     beforeEach(() => {
       testeur.middleware().reinitialise({ homologationARenvoyer });


### PR DESCRIPTION
On souhaite maintenant rendre le dossier de décision disponible uniquement si :
- Il y a un `dossierCourant`
- Ce `dossierCourant` est au moins à une étape précise (dans notre cas, étape `décision`)

On ajoute donc cette indication d'étape au données du référentiel.