### PR TITLE
[TDB] Affichage en cas de recherche sans résultats

### DIFF
--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -126,6 +126,17 @@ const tableauDesServices = {
     );
   },
   remplisTableau: (donnees) => {
+    if (donnees.length === 0) {
+      tableauDesServices.$tableau.append(`
+      <tr>
+        <td colspan='5'>
+          Aucun service ne correspond à la recherche.
+        </td>
+      </tr>
+      `);
+      return;
+    }
+
     donnees.forEach((service) => {
       const estSelectionne = tableauDesServices.servicesSelectionnes.has(
         service.id


### PR DESCRIPTION
Afin de montrer que la recherche ne donne aucun résultat et ne pas cacher tout le tableau.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/2d99fe69-f377-400c-88fb-1bf75b4ef0eb)
