### PR TITLE
Enlève le tri sur la colonne « Homologation »

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -178,7 +178,7 @@ label[for='recherche-service'] {
   padding: 0.7em 1.5em;
 }
 
-.tableau-services thead th:not(:first-child):not(:last-child) {
+.tableau-services thead th[data-colonne] {
   cursor: pointer;
 }
 

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -83,7 +83,7 @@ block main
                     p.filtre-mes-services Mes services
 
             th.triable(data-colonne='indiceCyber', data-ordre='0') Indice Cyber
-            th.triable(data-colonne='statutHomologation', data-ordre='0') Homologation
+            th Homologation
             th
           tr#barre-outils
             th(colspan=5)


### PR DESCRIPTION
… qui n'est pas pertinent tant que les statuts d'homologations ne sont pas plus détaillés.

L'indicateur de tri disparaît donc sur la colonne 👇 
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/29ff1caa-4d08-495a-abbf-2c1c227c03df)
