### PR TITLE
[CORRECTION] Ajoute le curseur 'pointer' sur toutes les checkbox

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -75,6 +75,7 @@ input[type='radio'] {
 input[type='checkbox'] {
   border-radius: 0.15em;
   border: 1px solid var(--gris-fonce);
+  cursor: pointer;
 }
 
 input[type='radio'] {

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -544,10 +544,6 @@ label[for='recherche-service'] {
   pointer-events: none;
 }
 
-.tableau-services .selection-service {
-  cursor: pointer;
-}
-
 .tableau-services .checkbox-selection-tous-services,
 .tableau-services .checkbox-tous-services {
   transform: translateY(0);


### PR DESCRIPTION
Les checkbox sont stylisées afin de coller à notre UI Kit.
On doit donc forcer le `cursor: pointer` qui n'est pas le comportement par défaut.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/e3eb1881-4193-4d38-b014-59fa7bed5ed3)
