### PR TITLE
[CORRECTION] Réintégration de l'indice cyber dans l'export CSV

### DIFF
--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -19,7 +19,7 @@ const ligneDuService = (service) =>
       .join(' - '),
     service.nombreContributeurs,
     remplaceBooleen(service.estCreateur),
-    service.indiceCyber,
+    Number(service.indiceCyber) ? service.indiceCyber : '-',
     service.statutHomologation.libelle,
   ].join(SEPARATEUR);
 

--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -23,7 +23,7 @@ const ligneDuService = (service) =>
     service.statutHomologation.libelle,
   ].join(SEPARATEUR);
 
-const genereCsvServices = (donneesObjetGetServices) => {
+const genereCsvServices = (tableauServices) => {
   try {
     const entete = [
       'Nom du service',
@@ -34,10 +34,7 @@ const genereCsvServices = (donneesObjetGetServices) => {
       'Statut homologation',
     ].join(SEPARATEUR);
 
-    const contenu = [
-      entete,
-      ...donneesObjetGetServices.services.map(ligneDuService),
-    ].join(EOL);
+    const contenu = [entete, ...tableauServices.map(ligneDuService)].join(EOL);
 
     const avecBOM = '\uFEFF';
     return Buffer.from(`${avecBOM}${contenu}`, 'utf-8');

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -2,6 +2,7 @@ const express = require('express');
 
 const { valeurBooleenne } = require('../utilitaires/aseptisation');
 const { dateYYYYMMDD } = require('../utilitaires/date');
+const { zipTableaux } = require('../utilitaires/tableau');
 const { DUREE_SESSION } = require('../http/configurationServeur');
 const {
   resultatValidation,
@@ -150,14 +151,26 @@ const routesApi = (
     (requete, reponse) => {
       const { idsServices = [] } = requete.query;
 
+      const donneesCsvServices = (services) => {
+        const servicesSansIndice = objetGetServices.donnees(
+          services,
+          requete.idUtilisateurCourant
+        );
+        const indicesCyber = objetGetIndicesCyber.donnees(services);
+
+        return zipTableaux(
+          servicesSansIndice.services,
+          indicesCyber.services,
+          'id'
+        );
+      };
+
       depotDonnees
         .homologations(requete.idUtilisateurCourant)
         .then((services) =>
           services.filter((service) => idsServices.includes(service.id))
         )
-        .then((services) =>
-          objetGetServices.donnees(services, requete.idUtilisateurCourant)
-        )
+        .then((services) => donneesCsvServices(services))
         .then((donneesServices) =>
           adaptateurCsv.genereCsvServices(donneesServices)
         )

--- a/src/utilitaires/tableau.js
+++ b/src/utilitaires/tableau.js
@@ -1,0 +1,19 @@
+function zipTableaux(tableauGauche, tableauDroite, proprieteCommune) {
+  const erreurTailleDifferente = () =>
+    new Error(
+      `Impossible de ziper des tableaux de tailles différentes. Ici [${tableauGauche.length}] et [${tableauDroite.length}].`
+    );
+
+  if (tableauGauche.length !== tableauDroite.length)
+    throw erreurTailleDifferente();
+
+  return tableauGauche.map((gauche) => {
+    const droite = tableauDroite.find(
+      (autre) => gauche[proprieteCommune] === autre[proprieteCommune]
+    );
+
+    return { ...gauche, ...droite };
+  });
+}
+
+module.exports = { zipTableaux };

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -179,8 +179,8 @@ describe('Le serveur MSS des routes /api/*', () => {
         ]);
 
       testeur.adaptateurCsv().genereCsvServices = (donneesServices) => {
-        expect(donneesServices.services.length).to.be(1);
-        expect(donneesServices.services[0].id).to.equal('456');
+        expect(donneesServices.length).to.be(1);
+        expect(donneesServices[0].id).to.equal('456');
         done();
         return Promise.resolve('Fichier CSV');
       };
@@ -209,11 +209,12 @@ describe('Le serveur MSS des routes /api/*', () => {
       testeur.adaptateurCsv().genereCsvServices = (donnees) => {
         adaptateurCsvAppele = true;
 
-        const service = donnees.services[0];
+        const service = donnees[0];
         expect(service.nomService).to.eql('Un service');
         expect(service.organisationsResponsables).to.eql(['ANSSI']);
         expect(service.nombreContributeurs).to.eql(1);
         expect(service.estCreateur).to.be(true);
+        expect(service.indiceCyber).not.to.be(undefined);
         expect(service.statutHomologation.libelle).to.be('À réaliser');
 
         return Promise.resolve('Fichier CSV');

--- a/test/utilitaires/tableau.spec.js
+++ b/test/utilitaires/tableau.spec.js
@@ -1,0 +1,26 @@
+const expect = require('expect.js');
+const { zipTableaux } = require('../../src/utilitaires/tableau');
+
+describe('Utilitaires sur les tableaux', () => {
+  describe('La fonction `zip` entre 2 tableaux', () => {
+    it('fusionne les objets des 2 tableaux en se basant sur une propriété donnée', () => {
+      const a = [{ id: '1', provientDeA: true }];
+      const b = [{ id: '1', provientDeB: true }];
+
+      const zip = zipTableaux(a, b, 'id');
+
+      expect(zip).to.eql([{ id: '1', provientDeA: true, provientDeB: true }]);
+    });
+
+    it('ne permet pas le zip de tableaux de longueurs différentes', () => {
+      const a = [];
+      const b = [{ id: '1', provientDeB: true }];
+
+      expect(() => zipTableaux(a, b, 'id')).to.throwError((e) => {
+        expect(e.message).to.be(
+          'Impossible de ziper des tableaux de tailles différentes. Ici [0] et [1].'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
L'indice cyber avait disparu suite au changement visant à séparer le chargement de l'indice cyber de toutes les autres données, pour favoriser le _time to pixel_ du tableau de bord.