### PR TITLE
Correction dans l'affichage des postes sur le tableau de bord

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionContributeurs.mjs
+++ b/public/modules/tableauDeBord/actions/ActionContributeurs.mjs
@@ -6,7 +6,7 @@ const metEnFormeContributeur = (contributeur, estProprietaire) =>
       }'>${contributeur.initiales}</div>
       <div class='nom-prenom-poste'>
         <div class='nom-contributeur'>${contributeur.prenomNom}</div>
-        <div class='poste-contributeur'>${contributeur.poste || '…'}</div>
+        <div class='poste-contributeur'>${contributeur.poste}</div>
       </div>
     </div>
     <div class='role ${estProprietaire ? 'proprietaire' : 'contributeur'}'>${

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -136,7 +136,7 @@ class Utilisateur extends Base {
     return (
       `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(
         this.nom
-      )}` || '…'
+      )}` || ''
     );
   }
 

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -141,9 +141,10 @@ class Utilisateur extends Base {
   }
 
   posteDetaille() {
-    const postes = [this.poste];
+    const postes = [];
     if (this.estRSSI()) postes.push('RSSI');
     if (this.estDelegueProtectionDonnees()) postes.push('DPO');
+    postes.push(this.poste);
     return formatteListeFr(postes.filter((p) => !!p));
   }
 

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -36,7 +36,7 @@ describe('Un utilisateur', () => {
 
     it('reste robuste en cas de prénom ou de nom absent', () => {
       const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
-      expect(utilisateur.initiales()).to.equal('…');
+      expect(utilisateur.initiales()).to.equal('');
     });
   });
 

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -99,9 +99,7 @@ describe('Un utilisateur', () => {
         poste: 'Maire',
       });
 
-      expect(toutEnMemeTemps.posteDetaille()).to.contain('RSSI');
-      expect(toutEnMemeTemps.posteDetaille()).to.contain('DPO');
-      expect(toutEnMemeTemps.posteDetaille()).to.contain('Maire');
+      expect(toutEnMemeTemps.posteDetaille()).to.eql('RSSI, DPO et Maire');
     });
   });
   it('sait se convertir en JSON', () => {
@@ -127,7 +125,7 @@ describe('Un utilisateur', () => {
       telephone: '0100000000',
       initiales: 'JD',
       poste: 'Maire',
-      posteDetaille: 'Maire et RSSI',
+      posteDetaille: 'RSSI et Maire',
       rssi: true,
       delegueProtectionDonnees: false,
       nomEntitePublique: 'Ville de Paris',


### PR DESCRIPTION
Suite aux démo, on enlève les `…` utilisés lorsque les infos sont manquantes 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/38dccdbc-8ce3-4e4d-9db5-065bf46fe261)


On laisse chaîne vide.