### PR TITLE
Correction du comportement de la checkbox « sélection tous service »

### DIFF
--- a/public/modules/tableauDeBord/gestionnaireEvenements.mjs
+++ b/public/modules/tableauDeBord/gestionnaireEvenements.mjs
@@ -22,9 +22,9 @@ const gestionnaireEvenements = {
       if ($elementClique.hasClass('selection-service')) {
         gestionnaireEvenements.selectionneService($elementClique);
       } else if ($elementClique.hasClass('checkbox-selection-tous-services')) {
-        gestionnaireEvenements.selectionneTousServices($elementClique);
+        gestionnaireEvenements.basculeSelectionTousServices($elementClique);
       } else if ($elementClique.hasClass('checkbox-tous-services')) {
-        gestionnaireEvenements.selectionneTousServices($elementClique);
+        gestionnaireEvenements.basculeSelectionTousServices($elementClique);
       } else if ($elementClique.hasClass('action')) {
         gestionnaireEvenements.afficheTiroirAction($elementClique);
       } else if ($elementClique.hasClass('contributeurs')) {
@@ -120,17 +120,23 @@ const gestionnaireEvenements = {
     gestionnaireBarreOutils.afficheOutils();
     gestionnaireTiroir.basculeOuvert(false);
   },
-  selectionneTousServices: ($checkbox) => {
-    const selectionne = $checkbox.is(':checked');
+  basculeSelectionTousServices: ($checkbox) => {
     $checkbox.removeClass('selection-partielle');
+
+    const pasEncoreToutCoche =
+      tableauDesServices.servicesSelectionnes.size !==
+      tableauDesServices.donneesAffichees.length;
+
+    const doitCocherTousService =
+      $checkbox.is(':checked') && pasEncoreToutCoche;
 
     $('.selection-service').each((_, input) => {
       const $checkboxService = $(input);
       tableauDesServices.basculeSelectionService(
         $checkboxService.parents('.ligne-service').data('id-service'),
-        selectionne
+        doitCocherTousService
       );
-      $checkboxService.prop('checked', selectionne);
+      $checkboxService.prop('checked', doitCocherTousService);
     });
 
     gestionnaireEvenements.fermeMenuFlottant();

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -25,6 +25,7 @@ const remplisCarteInformationIndiceCyber = (indiceCyberMoyen) => {
 const tableauDesServices = {
   $tableau: $('.contenu-tableau-services'),
   donnees: [],
+  donneesAffichees: [],
   nombreServices: 0,
   servicesSelectionnes: new Set(),
   termeRecherche: '',
@@ -32,31 +33,8 @@ const tableauDesServices = {
   filtre: { seulementProprietaire: false },
   afficheDonnees: () => {
     tableauDesServices.videTableau();
-    const donneesAAfficher = tableauDesServices.donnees
-      .filter(
-        (service) =>
-          tableauDesServices.termeRecherche === '' ||
-          service.nomService
-            .toLowerCase()
-            .includes(tableauDesServices.termeRecherche.toLowerCase()) ||
-          service.organisationsResponsables[0]
-            ?.toLowerCase()
-            .includes(tableauDesServices.termeRecherche.toLowerCase())
-      )
-      .filter((service) =>
-        tableauDesServices.filtre.seulementProprietaire
-          ? service.estCreateur
-          : true
-      )
-      .sort((serviceA, serviceB) => {
-        const { colonne, ordre } = tableauDesServices.tri;
-        if (colonne === null) return 0;
-        if (ordre === ORDRE_DE_TRI.AUCUN) return 0;
-        if (ordre === ORDRE_DE_TRI.ASC)
-          return serviceB[colonne] - serviceA[colonne];
-        return serviceA[colonne] - serviceB[colonne];
-      });
-    tableauDesServices.remplisTableau(donneesAAfficher);
+    tableauDesServices.filtreEtTriDonnees();
+    tableauDesServices.remplisTableau();
   },
   afficheEtatSelection: () => {
     const nbServiceSelectionnes = tableauDesServices.servicesSelectionnes.size;
@@ -139,6 +117,32 @@ const tableauDesServices = {
     tableauDesServices.afficheEtatSelection();
     tableauDesServices.afficheDonnees();
   },
+  filtreEtTriDonnees() {
+    tableauDesServices.donneesAffichees = tableauDesServices.donnees
+      .filter(
+        (service) =>
+          tableauDesServices.termeRecherche === '' ||
+          service.nomService
+            .toLowerCase()
+            .includes(tableauDesServices.termeRecherche.toLowerCase()) ||
+          service.organisationsResponsables[0]
+            ?.toLowerCase()
+            .includes(tableauDesServices.termeRecherche.toLowerCase())
+      )
+      .filter((service) =>
+        tableauDesServices.filtre.seulementProprietaire
+          ? service.estCreateur
+          : true
+      )
+      .sort((serviceA, serviceB) => {
+        const { colonne, ordre } = tableauDesServices.tri;
+        if (colonne === null) return 0;
+        if (ordre === ORDRE_DE_TRI.AUCUN) return 0;
+        if (ordre === ORDRE_DE_TRI.ASC)
+          return serviceB[colonne] - serviceA[colonne];
+        return serviceA[colonne] - serviceB[colonne];
+      });
+  },
   nomDuService: (idService) =>
     tableauDesServices.donneesDuService(idService)?.nomService,
   recupereServices: () => {
@@ -165,8 +169,8 @@ const tableauDesServices = {
         })
     );
   },
-  remplisTableau: (donnees) => {
-    if (donnees.length === 0) {
+  remplisTableau: () => {
+    if (tableauDesServices.donneesAffichees.length === 0) {
       tableauDesServices.$tableau.append(`
       <tr>
         <td colspan='5'>
@@ -177,7 +181,7 @@ const tableauDesServices = {
       return;
     }
 
-    donnees.forEach((service) => {
+    tableauDesServices.donneesAffichees.forEach((service) => {
       const estSelectionne = tableauDesServices.servicesSelectionnes.has(
         service.id
       );


### PR DESCRIPTION
Avec ce fix, quand on est dans un cas de filtre + sélection 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/046b4720-d3d1-4981-b7f3-184ebe06a7b8)

Cliquer sur la checkbox désélectionne tous les services, comme il se doit.

Avant ce commit, rien ne se passait dans ce cas.