### PR TITLE
Dossier actif - Multiple dossiers

### DIFF
--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -18,7 +18,13 @@ class Dossiers extends ElementsConstructibles {
   }
 
   dossierActif() {
-    return this.finalises().find((d) => d.estActif());
+    return this.finalises()
+      .filter((d) => d.estActif())
+      .sort(
+        (a, b) =>
+          new Date(b.decision.dateHomologation) -
+          new Date(a.decision.dateHomologation)
+      )[0];
   }
 
   finalises() {

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -67,7 +67,7 @@ describe('Les dossiers liés à un service', () => {
     );
 
     ils(
-      "retournent le premier dossier actif trouvé, sans se soucier des dates d'expiration",
+      "retournent le dossier actif dont la date de début d'homologation est la plus récente",
       () => {
         const dossiers = new Dossiers(
           {
@@ -81,7 +81,7 @@ describe('Les dossiers liés à un service', () => {
         );
 
         const dossierActif = dossiers.dossierActif();
-        expect(dossierActif.id).to.equal('actif-depuis-10-jours');
+        expect(dossierActif.id).to.equal('actif-depuis-hier');
       }
     );
 


### PR DESCRIPTION
On considère dorénavant que le dossier actif est celui dont la date d'homologation est la plus récente, dans le cas où plusieurs dossier sont actifs en même temps.

Exemple : 

> le 1er juin 22 je finalise une homologation (A) qui démarre au 01/06/22 pour 1 an
le 15 mai 23 je finalise une homologation (B) qui démarre DEMAIN : au 16/05/23 pour 1 an
Donc le 16 mai 23 j’ai 2 homologations qui couvrent la date du jour.
C’est la (B) qui doit être retenue selon la règle : C’est l’homologation dont la date de début est la plus récente qui est retenue.