### PR TITLE
[Tracking SendinBlue] Événement de connexion

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,7 +11,8 @@ NOM_UTILISATEUR_DEMO= # nom de l'utilisateur de démonstration
 EMAIL_UTILISATEUR_DEMO= # adresse mail de l'utilisateur de démonstration
 MOT_DE_PASSE_UTILISATEUR_DEMO= # mot de passe de l'utilisateur de démonstration
 
-SENDINBLUE_CLEF_API= # clef d'API sendinblue utilisée pour envoi des mails
+SENDINBLUE_EMAIL_CLEF_API= # clef d'API sendinblue utilisée pour envoi des mails
+SENDINBLUE_TRACKING_CLEF_API= # clef d'API sendinblue utilisée pour les événements de tracking
 SENDINBLUE_TEMPLATE_FINALISATION_INSCRIPTION= # id de template
 SENDINBLUE_TEMPLATE_INVITATION_CONTRIBUTION= # id de template
 SENDINBLUE_TEMPLATE_INVITATION_INSCRIPTION= # id de template

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ const {
 const adaptateurGestionErreur = fabriqueAdaptateurGestionErreur();
 const adaptateurHorloge = require('./src/adaptateurs/adaptateurHorloge');
 const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
-const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPI()
+const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPIEmail()
   ? require('./src/adaptateurs/adaptateurMailSendinblue')
   : require('./src/adaptateurs/adaptateurMailMemoire');
 const adaptateurPdf = require('./src/adaptateurs/adaptateurPdf');

--- a/server.js
+++ b/server.js
@@ -19,6 +19,11 @@ const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPIEmail()
   : require('./src/adaptateurs/adaptateurMailMemoire');
 const adaptateurPdf = require('./src/adaptateurs/adaptateurPdf');
 const adaptateurZip = require('./src/adaptateurs/adaptateurZip');
+const adaptateurTracking = adaptateurEnvironnement
+  .sendinblue()
+  .clefAPITracking()
+  ? require('./src/adaptateurs/adaptateurTrackingSendinblue')
+  : require('./src/adaptateurs/adaptateurTrackingMemoire');
 
 const port = process.env.PORT || 3000;
 const referentiel = Referentiel.creeReferentiel();
@@ -44,7 +49,8 @@ const serveur = MSS.creeServeur(
   adaptateurGestionErreur,
   adaptateurAnnuaire,
   adaptateurCsv,
-  adaptateurZip
+  adaptateurZip,
+  adaptateurTracking
 );
 
 serveur.ecoute(port, () => {

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -13,7 +13,8 @@ const matomo = () => ({
 });
 
 const sendinblue = () => ({
-  clefAPI: () => process.env.SENDINBLUE_CLEF_API,
+  clefAPIEmail: () => process.env.SENDINBLUE_EMAIL_CLEF_API,
+  clefAPITracking: () => process.env.SENDINBLUE_TRACKING_CLEF_API,
 });
 
 const sentry = () => ({

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -6,7 +6,7 @@ const {
 
 const enteteJSON = {
   headers: {
-    'api-key': process.env.SENDINBLUE_CLEF_API,
+    'api-key': process.env.SENDINBLUE_EMAIL_CLEF_API,
     accept: 'application/json',
     'content-type': 'application/json',
   },

--- a/src/adaptateurs/adaptateurTrackingMemoire.js
+++ b/src/adaptateurs/adaptateurTrackingMemoire.js
@@ -1,0 +1,9 @@
+const envoieTrackingConnexion = (destinataire, donneesEvenement) =>
+  // eslint-disable-next-line no-console
+  console.log(
+    `EVENEMENT DE TRACKING: destinataire ${destinataire}, 'CONNEXION', ${JSON.stringify(
+      donneesEvenement
+    )} }`
+  );
+
+module.exports = { envoieTrackingConnexion };

--- a/src/adaptateurs/adaptateurTrackingSendinblue.js
+++ b/src/adaptateurs/adaptateurTrackingSendinblue.js
@@ -1,0 +1,35 @@
+const axios = require('axios');
+const {
+  fabriqueAdaptateurGestionErreur,
+} = require('./fabriqueAdaptateurGestionErreur');
+
+const enteteJSON = {
+  headers: {
+    'ma-key': process.env.SENDINBLUE_TRACKING_CLEF_API,
+    accept: 'application/json',
+    'content-type': 'application/json',
+  },
+};
+const urlBase = 'https://in-automate.sendinblue.com/api/v2';
+
+const envoieTracking = (destinataire, typeEvenement, donneesEvenement) =>
+  axios
+    .post(
+      `${urlBase}/trackEvent`,
+      {
+        email: destinataire,
+        event: typeEvenement,
+        eventdata: donneesEvenement,
+      },
+      enteteJSON
+    )
+    .catch((e) => {
+      fabriqueAdaptateurGestionErreur().logueErreur(e);
+      // On veut ici délibérement ignorer l'erreur car l'echec de tracking ne devrait pas entrainer une dégradation de l'expérience utilisateur
+      return Promise.resolve();
+    });
+
+const envoieTrackingConnexion = (destinataire, { nombreServices }) =>
+  envoieTracking(destinataire, 'CONNEXION', { nb_services: nombreServices });
+
+module.exports = { envoieTrackingConnexion };

--- a/src/mss.js
+++ b/src/mss.js
@@ -24,6 +24,7 @@ const creeServeur = (
   adaptateurAnnuaire,
   adaptateurCsv,
   adaptateurZip,
+  adaptateurTracking,
   avecCookieSecurise = process.env.NODE_ENV === 'production',
   avecPageErreur = process.env.NODE_ENV === 'production',
   avecProtectionCsrf = process.env.AVEC_PROTECTION_CSRF === 'true'
@@ -182,7 +183,8 @@ const creeServeur = (
       adaptateurPdf,
       adaptateurAnnuaire,
       adaptateurCsv,
-      adaptateurZip
+      adaptateurZip,
+      adaptateurTracking
     )
   );
 

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -29,7 +29,8 @@ const routesApi = (
   adaptateurPdf,
   adaptateurAnnuaire,
   adaptateurCsv,
-  adaptateurZip
+  adaptateurZip,
+  adaptateurTracking
 ) => {
   const verifieSuccesEnvoiMessage = (promesseEnvoiMessage, utilisateur) =>
     promesseEnvoiMessage
@@ -399,6 +400,11 @@ const routesApi = (
         if (utilisateur) {
           const token = utilisateur.genereToken();
           requete.session.token = token;
+          depotDonnees.homologations(utilisateur.id).then((services) =>
+            adaptateurTracking.envoieTrackingConnexion(utilisateur.email, {
+              nombreServices: services.length,
+            })
+          );
           reponse.json({ utilisateur: utilisateur.toJSON() });
         } else {
           reponse.status(401).send("L'authentification a échoué");

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -18,6 +18,7 @@ const testeurMss = () => {
   let adaptateurPdf;
   let adaptateurCsv;
   let adaptateurZip;
+  let adaptateurTracking;
   let depotDonnees;
   let moteurRegles;
   let referentiel;
@@ -58,6 +59,9 @@ const testeurMss = () => {
     };
     adaptateurCsv = {};
     adaptateurZip = { genereArchive: () => Promise.resolve('Archive ZIP') };
+    adaptateurTracking = {
+      envoieTrackingConnexion: () => Promise.resolve(),
+    };
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();
     moteurRegles = new MoteurRegles(referentiel);
@@ -76,6 +80,7 @@ const testeurMss = () => {
           adaptateurAnnuaire,
           adaptateurCsv,
           adaptateurZip,
+          adaptateurTracking,
           false,
           false,
           false
@@ -94,6 +99,7 @@ const testeurMss = () => {
     adaptateurPdf: () => adaptateurPdf,
     adaptateurCsv: () => adaptateurCsv,
     adaptateurZip: () => adaptateurZip,
+    adaptateurTracking: () => adaptateurTracking,
     depotDonnees: () => depotDonnees,
     middleware: () => middleware,
     moteurRegles: () => moteurRegles,


### PR DESCRIPTION
On ajoute maintenant un adaptateur pour envoyer à SendinBlue des événements de cycle de vie utilisateur, afin d'envoyer des emails transactionnels.

La documentation de l'API est [ici](https://tracker-doc.brevo.com/reference/trackevent-3).

:warning: Mettre les variables d'env Scalingo à jour :
- Ajouter `SENDINBLUE_TRACKING_CLEF_API`
- Renommer `SENDINBLUE_CLEF_API` en `SENDINBLUE_EMAIL_CLEF_API`