### PR TITLE
Ajoute les statuts d'homologations

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -798,21 +798,25 @@ module.exports = {
       nbMoisDecalage: 6,
       description: '6 mois',
       expiration: expiration('six mois'),
+      nbMoisBientotExpire: 2,
     },
     unAn: {
       nbMoisDecalage: 12,
       description: '1 an',
       expiration: expiration('un an'),
+      nbMoisBientotExpire: 2,
     },
     deuxAns: {
       nbMoisDecalage: 24,
       description: '2 ans',
       expiration: expiration('deux ans'),
+      nbMoisBientotExpire: 4,
     },
     troisAns: {
       nbMoisDecalage: 36,
       description: '3 ans',
       expiration: expiration('trois ans'),
+      nbMoisBientotExpire: 6,
     },
   },
 

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -25,6 +25,7 @@ class Dossier extends InformationsHomologation {
     });
     this.renseigneProprietes(donneesDossier, referentiel);
     this.referentiel = referentiel;
+    this.adaptateurHorloge = adaptateurHorloge;
 
     this.decision = new Decision(
       donneesDossier.decision,
@@ -68,6 +69,18 @@ class Dossier extends InformationsHomologation {
     if (this.finalise) throw new ErreurDossierDejaFinalise();
 
     this.autorite.enregistreAutoriteHomologation(nom, fonction);
+  }
+
+  estBientotExpire() {
+    const moisBientotExpire = this.referentiel.nbMoisBientotExpire(
+      this.decision.dureeValidite
+    );
+    const dateLimite = new Date(this.dateProchaineHomologation());
+    const premierJourDuBientotExpire =
+      dateLimite.getDate() - moisBientotExpire * 30;
+    dateLimite.setDate(premierJourDuBientotExpire);
+
+    return this.adaptateurHorloge.maintenant() > dateLimite;
   }
 
   declareSansAvis() {

--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -3,6 +3,13 @@ const ElementsConstructibles = require('./elementsConstructibles');
 const { ErreurDossiersInvalides } = require('../erreurs');
 const Referentiel = require('../referentiel');
 
+const STATUTS_HOMOLOGATION = {
+  A_REALISER: 'aRealiser',
+  A_FINALISER: 'aFinaliser',
+  REALISEE: 'realisee',
+  BIENTOT_EXPIREE: 'bientotExpiree',
+  EXPIREE: 'expiree',
+};
 class Dossiers extends ElementsConstructibles {
   constructor(
     donnees = { dossiers: [] },
@@ -31,6 +38,17 @@ class Dossiers extends ElementsConstructibles {
     return this.items.filter((i) => i.finalise);
   }
 
+  statutHomologation() {
+    if (this.nombre() === 0) return Dossiers.A_REALISER;
+    if (this.dossierCourant()) return Dossiers.A_FINALISER;
+    const dossierActif = this.dossierActif();
+    if (dossierActif) {
+      if (dossierActif.estBientotExpire()) return Dossiers.BIENTOT_EXPIREE;
+      return Dossiers.REALISEE;
+    }
+    return Dossiers.EXPIREE;
+  }
+
   statutSaisie() {
     if (this.nombre() === 0) {
       return Dossiers.A_SAISIR;
@@ -51,4 +69,5 @@ class Dossiers extends ElementsConstructibles {
   }
 }
 
+Object.assign(Dossiers, STATUTS_HOMOLOGATION);
 module.exports = Dossiers;

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -79,6 +79,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const typesService = () => donnees.typesService;
   const nbMoisDecalage = (idEcheance) =>
     echeancesRenouvellement()[idEcheance]?.nbMoisDecalage;
+  const nbMoisBientotExpire = (idEcheance) =>
+    echeancesRenouvellement()[idEcheance]?.nbMoisBientotExpire;
   const niveauxGravite = () => donnees.niveauxGravite || {};
   const niveauGravite = (idNiveau) => niveauxGravite()[idNiveau] || {};
   const identifiantsNiveauxGravite = () => Object.keys(niveauxGravite() || {});
@@ -310,6 +312,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     mesureIndispensable,
     mesures,
     nbMoisDecalage,
+    nbMoisBientotExpire,
     niveauGravite,
     niveauxGravite,
     numeroEtape,

--- a/test/constructeurs/constructeurDossier.js
+++ b/test/constructeurs/constructeurDossier.js
@@ -84,6 +84,29 @@ class ConstructeurDossierFantaisie {
     return this;
   }
 
+  quiVaExpirer(dansNJours, dureeValidite) {
+    // Aujourd'hui - (nb de mois de validité) + rajouter nb jours d'expiration
+    // Expire dans 3 jours, valide 1 an : je veux un début à 362 jours dans le passé.
+    const aujourdhui = new Date();
+    const debutActif = new Date(
+      aujourdhui.setMonth(
+        aujourdhui.getMonth() -
+          this.referentiel.echeancesRenouvellement()[dureeValidite]
+            .nbMoisDecalage
+      )
+    );
+    debutActif.setDate(debutActif.getDate() + dansNJours);
+    this.donnees.decision = {
+      dateHomologation: debutActif.toISOString(),
+      dureeValidite,
+    };
+    this.donnees.avis = this.donnees.avis.map((avis) => ({
+      ...avis,
+      dureeValidite,
+    }));
+    return this;
+  }
+
   quiEstNonFinalise() {
     this.donnees.finalise = false;
     return this;

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -378,4 +378,36 @@ describe("Un dossier d'homologation", () => {
       });
     });
   });
+
+  describe("sur demande d'une expiration survenant prochainement", () => {
+    it("retourne 'true' si le dossier va bientôt expirer", () => {
+      referentiel.recharge({
+        echeancesRenouvellement: {
+          sixMois: { nbMoisDecalage: 6, nbMoisBientotExpire: 2 },
+        },
+        statutsAvisDossierHomologation: { favorable: {} },
+      });
+      const dossierExpirantDans30Jours = unDossier(referentiel)
+        .quiEstComplet()
+        .quiVaExpirer(30, 'sixMois')
+        .construit();
+
+      expect(dossierExpirantDans30Jours.estBientotExpire()).to.be(true);
+    });
+
+    it("retourne 'false' si le dossier ne va pas bientôt expirer", () => {
+      referentiel.recharge({
+        echeancesRenouvellement: {
+          sixMois: { nbMoisDecalage: 6, nbMoisBientotExpire: 1 },
+        },
+        statutsAvisDossierHomologation: { favorable: {} },
+      });
+      const dossierExpirantDans60Jours = unDossier(referentiel)
+        .quiEstComplet()
+        .quiVaExpirer(60, 'sixMois')
+        .construit();
+
+      expect(dossierExpirantDans60Jours.estBientotExpire()).to.be(false);
+    });
+  });
 });


### PR DESCRIPTION
Afin de pouvoir utiliser les nouveaux statuts d'homologation dans le tableau de bord et la synthèse, on met en place de nouvelles règles métier. :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/ebf2aeb4-a367-4d04-a925-75ad35117277)
