### PR TITLE
[TDB] Statuts d'homologation

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -75,6 +75,14 @@ module.exports = {
     defavorable: { description: 'Défavorable' },
   },
 
+  statutsHomologation: {
+    expiree: { libelle: 'Expirée', ordre: 0 },
+    bientotExpiree: { libelle: 'Bientôt expirée', ordre: 1 },
+    aFinaliser: { libelle: 'À finaliser', ordre: 2 },
+    realisee: { libelle: 'Réalisée', ordre: 3 },
+    aRealiser: { libelle: 'À réaliser', ordre: 4 },
+  },
+
   seuilsCriticites: ['critique', 'eleve', 'moyen', 'faible'],
 
   typesService: {

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -178,6 +178,10 @@ label[for='recherche-service'] {
   width: 20%;
 }
 
+.tableau-services colgroup :is(.indice-cyber, .statut-homologation) {
+  width: 15%;
+}
+
 .tableau-services thead th {
   user-select: none;
   padding: 0.7em 1.5em;
@@ -484,16 +488,24 @@ label[for='recherche-service'] {
   padding: 0.3em 0.7em;
 }
 
-.tableau-services td .statut-homologation.statut-aSaisir {
+.tableau-services td .statut-homologation.statut-aRealiser {
   background: #e9ddff;
 }
 
-.tableau-services td .statut-homologation.statut-aCompleter {
+.tableau-services td .statut-homologation.statut-aFinaliser {
   background: #dbeeff;
 }
 
-.tableau-services td .statut-homologation.statut-completes {
+.tableau-services td .statut-homologation.statut-realisee {
   background: #d4f4db;
+}
+
+.tableau-services td .statut-homologation.statut-bientotExpiree {
+  background: #fff2de;
+}
+
+.tableau-services td .statut-homologation.statut-expiree {
+  background: #ffdfdf;
 }
 
 .tableau-services .cellule-actions {

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -153,6 +153,9 @@ const tableauDesServices = {
           remplisCartesInformations(data.resume);
           tableauDesServices.nombreServices = data.resume.nombreServices;
           tableauDesServices.donnees = data.services;
+          tableauDesServices.donnees.forEach((service) => {
+            service.ordreStatutHomologation = service.statutHomologation.ordre;
+          });
           tableauDesServices.afficheDonnees();
           tableauDesServices.afficheEtatSelection();
         })

--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -1,15 +1,9 @@
-const STATUTS_HOMOLOGATION = {
-  aSaisir: 'À réaliser',
-  aCompleter: 'À finaliser',
-  completes: 'Réalisée',
-};
-
-const donnees = (services, idUtilisateur) => ({
+const donnees = (services, idUtilisateur, referentiel) => ({
   services: services
     .map((s) => ({
       ...s.toJSON(),
       organisationsResponsables: s.descriptionService.organisationsResponsables,
-      statutHomologation: s.dossiers.statutSaisie(),
+      statutHomologation: s.dossiers.statutHomologation(),
       documentsPdfDisponibles: s.documentsPdfDisponibles(),
     }))
     .map((json) => ({
@@ -30,8 +24,8 @@ const donnees = (services, idUtilisateur) => ({
         poste: c.posteDetaille,
       })),
       statutHomologation: {
-        libelle: STATUTS_HOMOLOGATION[json.statutHomologation],
         id: json.statutHomologation,
+        ...referentiel.statutHomologation(json.statutHomologation),
       },
       nombreContributeurs: json.contributeurs.length + 1,
       estCreateur: json.createur.id === idUtilisateur,

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -31,6 +31,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const actionSaisie = (id) => actionsSaisie()[id] || {};
   const statutsAvisDossierHomologation = () =>
     donnees.statutsAvisDossierHomologation || {};
+  const statutHomologation = (idStatut) =>
+    donnees.statutsHomologation[idStatut];
   const positionActionSaisie = (id) => actionSaisie(id).position;
   const categoriesMesures = () => donnees.categoriesMesures;
   const descriptionCategorie = (idCategorie) =>
@@ -329,6 +331,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     statutsAvisDossierHomologation,
     statutsDeploiement,
     statutDeploiementValide,
+    statutHomologation,
     statutsMesures,
     trancheIndiceCyber,
     typeService,

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -128,7 +128,11 @@ const routesApi = (
       depotDonnees
         .homologations(requete.idUtilisateurCourant)
         .then((services) =>
-          objetGetServices.donnees(services, requete.idUtilisateurCourant)
+          objetGetServices.donnees(
+            services,
+            requete.idUtilisateurCourant,
+            referentiel
+          )
         )
         .then((donnees) => reponse.json(donnees));
     }
@@ -155,7 +159,8 @@ const routesApi = (
       const donneesCsvServices = (services) => {
         const servicesSansIndice = objetGetServices.donnees(
           services,
-          requete.idUtilisateurCourant
+          requete.idUtilisateurCourant,
+          referentiel
         );
         const indicesCyber = objetGetIndicesCyber.donnees(services);
 

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -83,7 +83,7 @@ block main
                     p.filtre-mes-services Mes services
 
             th.triable(data-colonne='indiceCyber', data-ordre='0') Indice Cyber
-            th Homologation
+            th.triable(data-colonne='ordreStatutHomologation', data-ordre='0') Homologation
             th
           tr#barre-outils
             th(colspan=5)

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -2,8 +2,15 @@ const expect = require('expect.js');
 
 const Service = require('../../../src/modeles/service');
 const objetGetServices = require('../../../src/modeles/objetsApi/objetGetServices');
+const Referentiel = require('../../../src/referentiel');
 
 describe("L'objet d'API de `GET /services`", () => {
+  const referentiel = Referentiel.creeReferentiel({
+    statutsHomologation: {
+      aRealiser: { libelle: 'À réaliser', ordre: 1 },
+    },
+  });
+
   const unService = new Service({
     id: '123',
     descriptionService: {
@@ -40,7 +47,9 @@ describe("L'objet d'API de `GET /services`", () => {
 
   it('fournit les données nécessaires', () => {
     const services = [unService];
-    expect(objetGetServices.donnees(services, 'A').services).to.eql([
+    expect(
+      objetGetServices.donnees(services, 'A', referentiel).services
+    ).to.eql([
       {
         id: '123',
         nomService: 'Un service',
@@ -60,7 +69,11 @@ describe("L'objet d'API de `GET /services`", () => {
             poste: 'Maire',
           },
         ],
-        statutHomologation: { libelle: 'À réaliser', id: 'aSaisir' },
+        statutHomologation: {
+          libelle: 'À réaliser',
+          id: 'aRealiser',
+          ordre: 1,
+        },
         nombreContributeurs: 1 + 1,
         estCreateur: true,
         documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
@@ -72,7 +85,7 @@ describe("L'objet d'API de `GET /services`", () => {
     unAutreService.dossiers.statutSaisie = () => 'completes';
 
     const services = [unService, unAutreService];
-    expect(objetGetServices.donnees(services, 'A').resume).to.eql({
+    expect(objetGetServices.donnees(services, 'A', referentiel).resume).to.eql({
       nombreServices: 2,
       nombreServicesHomologues: 1,
     });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -372,6 +372,18 @@ describe('Le référentiel', () => {
     });
   });
 
+  it("connaît le statut d'homologation", () => {
+    const referentiel = Referentiel.creeReferentiel({
+      statutsHomologation: {
+        expiree: { libelle: 'Expirée' },
+      },
+    });
+
+    expect(referentiel.statutHomologation('expiree')).to.eql({
+      libelle: 'Expirée',
+    });
+  });
+
   it("sait si un identifiant fait partie de la liste des statuts d'avis de dossier d'homologation", () => {
     const referentiel = Referentiel.creeReferentiel({
       statutsAvisDossierHomologation: { favorable: {} },

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -33,6 +33,11 @@ describe('Le serveur MSS des routes /api/*', () => {
 
     it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
+      testeur.referentiel().recharge({
+        statutsHomologation: {
+          aRealiser: { libelle: 'À réaliser', ordre: 1 },
+        },
+      });
 
       testeur.depotDonnees().homologations = (idUtilisateur) => {
         expect(idUtilisateur).to.equal('123');
@@ -106,6 +111,11 @@ describe('Le serveur MSS des routes /api/*', () => {
   describe('quand requête GET sur `/api/services/export.csv`', () => {
     beforeEach(() => {
       testeur.adaptateurCsv().genereCsvServices = () => Promise.resolve();
+      testeur.referentiel().recharge({
+        statutsHomologation: {
+          aRealiser: { libelle: 'À réaliser', ordre: 1 },
+        },
+      });
     });
 
     it("vérifie que l'utilisateur est authentifié", (done) => {


### PR DESCRIPTION
On intègre les nouveaux status d'homologation 'Bientôt expirée' et 'Expirée' à l'affichage du tabeau de bord.

Le tri est maintenant possible sur cette colonne, en suivant la règle :

> Le classement des homologations par ordre croissant (niveau plus urgent au moins urgent) est : expiré, bientôt expiré, à finaliser, réalisée, à réaliser.


![image](https://github.com/betagouv/mon-service-securise/assets/1643465/930313ea-d264-45f6-9148-ede0656bacc7)
