### PR TITLE
[CORRECTION] Utilise le champs `properties` au lieu du champ `eventdata`

### DIFF
--- a/src/adaptateurs/adaptateurTrackingSendinblue.js
+++ b/src/adaptateurs/adaptateurTrackingSendinblue.js
@@ -19,7 +19,7 @@ const envoieTracking = (destinataire, typeEvenement, donneesEvenement) =>
       {
         email: destinataire,
         event: typeEvenement,
-        eventdata: donneesEvenement,
+        properties: donneesEvenement,
       },
       enteteJSON
     )


### PR DESCRIPTION
Le champ `properties` permet d'agir sur les workflows d'envoie de mail, donc c'est ce que l'on cherche à faire.
Le champ `eventdata` est en fait réservé pour les données servant à 'customiser' le contenu d'un mail. Nous pourrons nous en servir par la suite.