### PR TITLE
[Tracking SendinBlue] Événement d'inscription

### DIFF
--- a/src/adaptateurs/adaptateurTrackingMemoire.js
+++ b/src/adaptateurs/adaptateurTrackingMemoire.js
@@ -1,9 +1,15 @@
-const envoieTrackingConnexion = (destinataire, donneesEvenement) =>
+const envoieTracking = (destinataire, typeEvenement, donneesEvenement = {}) =>
   // eslint-disable-next-line no-console
   console.log(
-    `EVENEMENT DE TRACKING: destinataire ${destinataire}, 'CONNEXION', ${JSON.stringify(
+    `EVENEMENT DE TRACKING: destinataire ${destinataire}, ${typeEvenement}, ${JSON.stringify(
       donneesEvenement
     )} }`
   );
 
-module.exports = { envoieTrackingConnexion };
+const envoieTrackingConnexion = (destinataire, donneesEvenement) =>
+  envoieTracking(destinataire, 'CONNEXION', donneesEvenement);
+
+const envoieTrackingInscription = (destinataire) =>
+  envoieTracking(destinataire, 'INSCRIPTION');
+
+module.exports = { envoieTrackingConnexion, envoieTrackingInscription };

--- a/src/adaptateurs/adaptateurTrackingSendinblue.js
+++ b/src/adaptateurs/adaptateurTrackingSendinblue.js
@@ -12,7 +12,7 @@ const enteteJSON = {
 };
 const urlBase = 'https://in-automate.sendinblue.com/api/v2';
 
-const envoieTracking = (destinataire, typeEvenement, donneesEvenement) =>
+const envoieTracking = (destinataire, typeEvenement, donneesEvenement = {}) =>
   axios
     .post(
       `${urlBase}/trackEvent`,
@@ -32,4 +32,7 @@ const envoieTracking = (destinataire, typeEvenement, donneesEvenement) =>
 const envoieTrackingConnexion = (destinataire, { nombreServices }) =>
   envoieTracking(destinataire, 'CONNEXION', { nb_services: nombreServices });
 
-module.exports = { envoieTrackingConnexion };
+const envoieTrackingInscription = (destinataire) =>
+  envoieTracking(destinataire, 'INSCRIPTION');
+
+module.exports = { envoieTrackingConnexion, envoieTrackingInscription };

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -246,6 +246,10 @@ const routesApi = (
           .nouvelUtilisateur(donnees)
           .then(creeContactEmail)
           .then(envoieMessageFinalisationInscription)
+          .then((utilisateur) => {
+            adaptateurTracking.envoieTrackingInscription(utilisateur.email);
+            return utilisateur;
+          })
           .catch((erreur) => {
             if (erreur instanceof ErreurUtilisateurExistant) {
               return adaptateurMail

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -474,6 +474,29 @@ describe('Le serveur MSS des routes /api/*', () => {
         .catch(done);
     });
 
+    it("utilise l'adaptateur de tracking pour envoyer un événement d'inscription", (done) => {
+      testeur.depotDonnees().nouvelUtilisateur = () =>
+        Promise.resolve({ email: 'jean.dupont@mail.fr' });
+
+      let donneesPassees = {};
+      testeur.adaptateurTracking().envoieTrackingInscription = (
+        destinataire
+      ) => {
+        donneesPassees = { destinataire };
+        return Promise.resolve();
+      };
+
+      axios
+        .post('http://localhost:1234/api/utilisateur', donneesRequete)
+        .then(() => {
+          expect(donneesPassees).to.eql({
+            destinataire: 'jean.dupont@mail.fr',
+          });
+          done();
+        })
+        .catch(done);
+    });
+
     it('crée un contact email', (done) => {
       utilisateur.email = 'jean.dupont@mail.fr';
       utilisateur.prenom = 'Jean';

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -61,6 +61,7 @@ const testeurMss = () => {
     adaptateurZip = { genereArchive: () => Promise.resolve('Archive ZIP') };
     adaptateurTracking = {
       envoieTrackingConnexion: () => Promise.resolve(),
+      envoieTrackingInscription: () => Promise.resolve(),
     };
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();


### PR DESCRIPTION
On souhaite tracker les events d'inscription pour pouvoir relancer les personnes qui ne reviennent pas sur la plateforme.
On ne prend pas en compte les personnes qui sont invitées à collaborer (uniquement inscription 'volontaire')