### PR TITLE
[CORRECTION] Cas par défaut des statuts d'homologation

### DIFF
--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -71,6 +71,11 @@ class Dossier extends InformationsHomologation {
     this.autorite.enregistreAutoriteHomologation(nom, fonction);
   }
 
+  estExpire() {
+    const dateLimite = new Date(this.dateProchaineHomologation());
+    return this.adaptateurHorloge.maintenant() > dateLimite;
+  }
+
   estBientotExpire() {
     const moisBientotExpire = this.referentiel.nbMoisBientotExpire(
       this.decision.dureeValidite

--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -46,7 +46,9 @@ class Dossiers extends ElementsConstructibles {
       if (dossierActif.estBientotExpire()) return Dossiers.BIENTOT_EXPIREE;
       return Dossiers.REALISEE;
     }
-    return Dossiers.EXPIREE;
+    if (this.items.some((dossier) => dossier.estExpire()))
+      return Dossiers.EXPIREE;
+    return Dossiers.A_REALISER;
   }
 
   statutSaisie() {

--- a/test/constructeurs/constructeurDossier.js
+++ b/test/constructeurs/constructeurDossier.js
@@ -74,6 +74,16 @@ class ConstructeurDossierFantaisie {
     return this;
   }
 
+  quiSeraActif(dans) {
+    const debutActif = new Date();
+    debutActif.setDate(debutActif.getDate() + dans);
+    this.donnees.decision = {
+      dateHomologation: debutActif.toISOString(),
+      dureeValidite: 'unAn',
+    };
+    return this;
+  }
+
   quiEstExpire() {
     const tresVieux = new Date();
     tresVieux.setDate(tresVieux.getDate() - 400);

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -410,4 +410,31 @@ describe("Un dossier d'homologation", () => {
       expect(dossierExpirantDans60Jours.estBientotExpire()).to.be(false);
     });
   });
+
+  describe("sur demande d'expiration", () => {
+    beforeEach(() => {
+      referentiel.recharge({
+        echeancesRenouvellement: { unAn: { nbMoisDecalage: 12 } },
+        statutsAvisDossierHomologation: { favorable: {} },
+      });
+    });
+
+    it("retourne 'true' si le dossier est expiré", () => {
+      const dossierExpire = unDossier(referentiel)
+        .quiEstComplet()
+        .quiEstExpire()
+        .construit();
+
+      expect(dossierExpire.estExpire()).to.be(true);
+    });
+
+    it("retourne 'false' si le dossier n'est pas expiré", () => {
+      const dossierActif = unDossier(referentiel)
+        .quiEstComplet()
+        .quiEstActif()
+        .construit();
+
+      expect(dossierActif.estExpire()).to.be(false);
+    });
+  });
 });

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -193,5 +193,22 @@ describe('Les dossiers liés à un service', () => {
 
       expect(dossierExpire.statutHomologation()).to.equal(Dossiers.EXPIREE);
     });
+
+    ils(
+      'retournent « À réaliser » dans le cas par défaut, par exemple si la seule homologation présente ne sera valide que dans le futur',
+      () => {
+        const dossierValideDansLeFutur = new Dossiers(
+          {
+            dossiers: [unDossierComplet().quiSeraActif(30).donnees],
+          },
+          referentiel,
+          adaptateurHorloge
+        );
+
+        expect(dossierValideDansLeFutur.statutHomologation()).to.equal(
+          Dossiers.A_REALISER
+        );
+      }
+    );
   });
 });


### PR DESCRIPTION
En attendant d'explorer tous les cas aux limites, on accepte le fait que le cas par défaut pour un statut d'homologation soit 'À réaliser'.
Cela implique de vérifier explicitement si un dossier est expiré ou non.