### PR TITLE
[Tracking Sendingblue] Événement nouveau service créé

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -38,6 +38,7 @@ URL_SERVEUR_BASE_DONNEES_JOURNAL= # URL de la base de données du Journal MSS. e
 
 # interrupteurs de fonctionnalités (feature switches)
 AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire. Sinon le journal utilisera la base de données « URL_SERVEUR_BASE_DONNEES_JOURNAL »
-AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE = # `true` pour que le « Journal MSS » en mémoire logue les événements reçus dans la console
-AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE = # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
-AVEC_PROTECTION_CSRF = # `true` pour utiliser un protection contre les attaques CSRF
+AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que le « Journal MSS » en mémoire logue les événements reçus dans la console
+AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
+AVEC_PROTECTION_CSRF= # `true` pour utiliser un protection contre les attaques CSRF
+AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logés dans la console

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironneme
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./src/adaptateurs/fabriqueAdaptateurGestionErreur');
+const fabriqueAdaptateurTracking = require('./src/adaptateurs/fabriqueAdaptateurTracking');
 
 const adaptateurGestionErreur = fabriqueAdaptateurGestionErreur();
 const adaptateurHorloge = require('./src/adaptateurs/adaptateurHorloge');
@@ -19,11 +20,8 @@ const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPIEmail()
   : require('./src/adaptateurs/adaptateurMailMemoire');
 const adaptateurPdf = require('./src/adaptateurs/adaptateurPdf');
 const adaptateurZip = require('./src/adaptateurs/adaptateurZip');
-const adaptateurTracking = adaptateurEnvironnement
-  .sendinblue()
-  .clefAPITracking()
-  ? require('./src/adaptateurs/adaptateurTrackingSendinblue')
-  : require('./src/adaptateurs/adaptateurTrackingMemoire');
+
+const adaptateurTracking = fabriqueAdaptateurTracking();
 
 const port = process.env.PORT || 3000;
 const referentiel = Referentiel.creeReferentiel();

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -15,6 +15,8 @@ const matomo = () => ({
 const sendinblue = () => ({
   clefAPIEmail: () => process.env.SENDINBLUE_EMAIL_CLEF_API,
   clefAPITracking: () => process.env.SENDINBLUE_TRACKING_CLEF_API,
+  logEvenementsTrackingEnConsole: () =>
+    process.env.AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE === 'true',
 });
 
 const sentry = () => ({

--- a/src/adaptateurs/adaptateurTrackingMemoire.js
+++ b/src/adaptateurs/adaptateurTrackingMemoire.js
@@ -1,10 +1,18 @@
-const envoieTracking = (destinataire, typeEvenement, donneesEvenement = {}) =>
-  // eslint-disable-next-line no-console
-  console.log(
-    `EVENEMENT DE TRACKING: destinataire ${destinataire}, ${typeEvenement}, ${JSON.stringify(
-      donneesEvenement
-    )} }`
-  );
+const adaptateurEnvironnement = require('./adaptateurEnvironnement');
+
+const envoieTracking = (destinataire, typeEvenement, donneesEvenement = {}) => {
+  const doitLoguer = adaptateurEnvironnement
+    .sendinblue()
+    .logEvenementsTrackingEnConsole();
+  if (doitLoguer) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `EVENEMENT DE TRACKING: destinataire ${destinataire}, ${typeEvenement}, ${JSON.stringify(
+        donneesEvenement
+      )} }`
+    );
+  }
+};
 
 const envoieTrackingConnexion = (destinataire, donneesEvenement) =>
   envoieTracking(destinataire, 'CONNEXION', donneesEvenement);

--- a/src/adaptateurs/adaptateurTrackingMemoire.js
+++ b/src/adaptateurs/adaptateurTrackingMemoire.js
@@ -15,8 +15,12 @@ const envoieTrackingInscription = (destinataire) =>
 const envoieTrackingInvitationContributeur = (destinataire, donneesEvenement) =>
   envoieTracking(destinataire, 'INVITATION_CONTRIBUTEUR', donneesEvenement);
 
+const envoieTrackingNouveauServiceCree = (destinataire, donneesEvenement) =>
+  envoieTracking(destinataire, 'NOUVEAU_SERVICE_CREE', donneesEvenement);
+
 module.exports = {
   envoieTrackingConnexion,
   envoieTrackingInscription,
   envoieTrackingInvitationContributeur,
+  envoieTrackingNouveauServiceCree,
 };

--- a/src/adaptateurs/adaptateurTrackingSendinblue.js
+++ b/src/adaptateurs/adaptateurTrackingSendinblue.js
@@ -43,8 +43,14 @@ const envoieTrackingInvitationContributeur = (
     nb_moyen_contributeurs: nombreMoyenContributeurs,
   });
 
+const envoieTrackingNouveauServiceCree = (destinataire, { nombreServices }) =>
+  envoieTracking(destinataire, 'NOUVEAU_SERVICE_CREE', {
+    nb_services: nombreServices,
+  });
+
 module.exports = {
   envoieTrackingConnexion,
   envoieTrackingInscription,
   envoieTrackingInvitationContributeur,
+  envoieTrackingNouveauServiceCree,
 };

--- a/src/adaptateurs/fabriqueAdaptateurTracking.js
+++ b/src/adaptateurs/fabriqueAdaptateurTracking.js
@@ -1,0 +1,10 @@
+const adaptateurEnvironnement = require('./adaptateurEnvironnement');
+const adaptateurTrackingSendinblue = require('./adaptateurTrackingSendinblue');
+const adaptateurTrackingMemoire = require('./adaptateurTrackingMemoire');
+
+const fabriqueAdaptateurTracking = () =>
+  adaptateurEnvironnement.sendinblue().clefAPITracking()
+    ? adaptateurTrackingSendinblue
+    : adaptateurTrackingMemoire;
+
+module.exports = fabriqueAdaptateurTracking;

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -2,6 +2,7 @@ const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurJournalMSS = require('./adaptateurs/fabriqueAdaptateurJournalMSS');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
+const fabriqueAdaptateurTracking = require('./adaptateurs/fabriqueAdaptateurTracking');
 const Referentiel = require('./referentiel');
 const depotDonneesAutorisations = require('./depots/depotDonneesAutorisations');
 const depotDonneesHomologations = require('./depots/depotDonneesHomologations');
@@ -12,6 +13,7 @@ const creeDepot = (config = {}) => {
     adaptateurJournalMSS = fabriqueAdaptateurJournalMSS(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
+    adaptateurTracking = fabriqueAdaptateurTracking(),
     adaptateurUUID = adaptateurUUIDParDefaut,
     referentiel = Referentiel.creeReferentiel(),
   } = config;
@@ -19,6 +21,7 @@ const creeDepot = (config = {}) => {
   const depotHomologations = depotDonneesHomologations.creeDepot({
     adaptateurJournalMSS,
     adaptateurPersistance,
+    adaptateurTracking,
     adaptateurUUID,
     referentiel,
   });

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -1,3 +1,4 @@
+const fabriqueAdaptateurTracking = require('../adaptateurs/fabriqueAdaptateurTracking');
 const {
   ErreurDonneesObligatoiresManquantes,
   ErreurHomologationInexistante,
@@ -16,6 +17,7 @@ const creeDepot = (config = {}) => {
   const {
     adaptateurJournalMSS,
     adaptateurPersistance,
+    adaptateurTracking = fabriqueAdaptateurTracking(),
     adaptateurUUID,
     referentiel,
   } = config;
@@ -295,6 +297,12 @@ const creeDepot = (config = {}) => {
               ...h.completudeMesures(),
             }).toJSON()
           ),
+          homologations(idUtilisateur).then((hs) => {
+            adaptateurTracking.envoieTrackingNouveauServiceCree(
+              donneesHomologation.createur.email,
+              { nombreServices: hs.length }
+            );
+          }),
         ])
       )
       .then(() => idHomologation);

--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -1,12 +1,12 @@
+const uneDescriptionValide = require('./constructeurDescriptionService');
+const Referentiel = require('../../src/referentiel');
 const Service = require('../../src/modeles/service');
 
 class ConstructeurService {
-  constructor() {
+  constructor(referentiel) {
     this.donnees = {
       id: '',
-      descriptionService: {
-        nomService: '',
-      },
+      descriptionService: uneDescriptionValide(referentiel).donnees,
     };
   }
 
@@ -25,6 +25,7 @@ class ConstructeurService {
   }
 }
 
-const unService = () => new ConstructeurService();
+const unService = (referentiel = Referentiel.creeReferentielVide()) =>
+  new ConstructeurService(referentiel);
 
-module.exports = { ConstructeurService, unService };
+module.exports = { unService };

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -63,6 +63,7 @@ const testeurMss = () => {
       envoieTrackingConnexion: () => Promise.resolve(),
       envoieTrackingInscription: () => Promise.resolve(),
       envoieTrackingInvitationContributeur: () => Promise.resolve(),
+      envoieTrackingNouveauServiceCree: () => Promise.resolve(),
     };
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();


### PR DESCRIPTION
On souhaite tracer les événements de création / duplication de nouveaux services.

L'envoi s'opère lors d'une nouvelle homologation au même moment où on consigne les événements.