### PR TITLE
[HOMOLOGUER] Interdis les dates de décision dans le futur

### DIFF
--- a/src/vues/service/etapeDossier/decision.pug
+++ b/src/vues/service/etapeDossier/decision.pug
@@ -14,9 +14,11 @@ block formulaire
       <strong>Décision de l'homologation de sécurité</strong>.
 
     .requis
+      - const maintenant = new Date()
+      - const maintenantFormate = Intl.DateTimeFormat('fr-CA', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(maintenant)
       label Date d'homologation
         .infos-complementaires Cette date correspond à la date de signature de l'autorité d'homologation.
-        input(id = 'date-homologation' nom = 'dateHomologation', type = 'date', required, value = dossierCourant.decision.dateHomologation)
+        input(id = 'date-homologation' nom = 'dateHomologation', type = 'date', required, value = dossierCourant.decision.dateHomologation, max = maintenantFormate)
         .message-erreur Ce champ est obligatoire. Veuillez saisir une date.
 
     .requis


### PR DESCRIPTION
On utilise le formattage Canadien pour obtenir la date du jour au format YYYY-MM-DD qui est [requis par le standard HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#max).

Cela permet de bloquer l'UI sur les dates futures :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/2a4aa267-d16e-4fe4-923f-1d5719ad5373)
