### PR TITLE
[REMANIEMENT] Extraction constructeurs test

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,4 +41,4 @@ AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire
 AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que le « Journal MSS » en mémoire logue les événements reçus dans la console
 AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
 AVEC_PROTECTION_CSRF= # `true` pour utiliser un protection contre les attaques CSRF
-AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logés dans la console
+AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logués dans la console

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -1,0 +1,38 @@
+const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
+
+class ConstructeurAdaptateurPersistanceMemoire {
+  constructor() {
+    this.autorisations = [];
+    this.services = [];
+    this.utilisateurs = [];
+  }
+
+  ajouteUneAutorisation(autorisation) {
+    this.autorisations.push(autorisation);
+    return this;
+  }
+
+  ajouteUnService(service) {
+    this.services.push(service);
+    return this;
+  }
+
+  ajouteUnUtilisateur(utilisateur) {
+    this.utilisateurs.push(utilisateur);
+    return this;
+  }
+
+  construis() {
+    return AdaptateurPersistanceMemoire.nouvelAdaptateur({
+      autorisations: this.autorisations,
+      homologations: this.services,
+      services: this.services,
+      utilisateurs: this.utilisateurs,
+    });
+  }
+}
+
+const unNouvelAdaptateurMemoire = () =>
+  new ConstructeurAdaptateurPersistanceMemoire();
+
+module.exports = { unNouvelAdaptateurMemoire };

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -32,7 +32,7 @@ class ConstructeurAdaptateurPersistanceMemoire {
   }
 }
 
-const unNouvelAdaptateurMemoire = () =>
+const unePersistanceMemoire = () =>
   new ConstructeurAdaptateurPersistanceMemoire();
 
-module.exports = { unNouvelAdaptateurMemoire };
+module.exports = { unePersistanceMemoire };

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -1,5 +1,5 @@
 const {
-  unNouvelAdaptateurMemoire,
+  unePersistanceMemoire,
 } = require('./constructeurAdaptateurPersistanceMemoire');
 const adaptateurTrackingMemoire = require('../../src/adaptateurs/adaptateurTrackingMemoire');
 const DepotDonneesHomologations = require('../../src/depots/depotDonneesHomologations');
@@ -8,15 +8,15 @@ const Referentiel = require('../../src/referentiel');
 
 class ConstructeurDepotDonneesServices {
   constructor() {
-    this.adaptateurPersistance = unNouvelAdaptateurMemoire().construis();
+    this.constructeurAdaptateurPersistance = unePersistanceMemoire();
     this.adaptateurTracking = adaptateurTrackingMemoire;
     this.adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
     this.adaptateurUUID = { genereUUID: () => 'unUUID' };
     this.referentiel = Referentiel.creeReferentielVide();
   }
 
-  avecAdaptateurPersistance(adaptateurPersistance) {
-    this.adaptateurPersistance = adaptateurPersistance;
+  avecAdaptateurPersistance(constructeurAdaptateurPersistance) {
+    this.constructeurAdaptateurPersistance = constructeurAdaptateurPersistance;
     return this;
   }
 
@@ -33,7 +33,7 @@ class ConstructeurDepotDonneesServices {
   construis() {
     return DepotDonneesHomologations.creeDepot({
       adaptateurJournalMSS: this.adaptateurJournalMSS,
-      adaptateurPersistance: this.adaptateurPersistance,
+      adaptateurPersistance: this.constructeurAdaptateurPersistance.construis(),
       adaptateurTracking: this.adaptateurTracking,
       adaptateurUUID: this.adaptateurUUID,
       referentiel: this.referentiel,

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -1,0 +1,46 @@
+const {
+  unNouvelAdaptateurMemoire,
+} = require('./constructeurAdaptateurPersistanceMemoire');
+const adaptateurTrackingMemoire = require('../../src/adaptateurs/adaptateurTrackingMemoire');
+const DepotDonneesHomologations = require('../../src/depots/depotDonneesHomologations');
+const AdaptateurJournalMSSMemoire = require('../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const Referentiel = require('../../src/referentiel');
+
+class ConstructeurDepotDonneesServices {
+  constructor() {
+    this.adaptateurPersistance = unNouvelAdaptateurMemoire().construis();
+    this.adaptateurTracking = adaptateurTrackingMemoire;
+    this.adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+    this.adaptateurUUID = { genereUUID: () => 'unUUID' };
+    this.referentiel = Referentiel.creeReferentielVide();
+  }
+
+  avecAdaptateurPersistance(adaptateurPersistance) {
+    this.adaptateurPersistance = adaptateurPersistance;
+    return this;
+  }
+
+  avecAdaptateurTracking(adaptateurTracking) {
+    this.adaptateurTracking = adaptateurTracking;
+    return this;
+  }
+
+  avecReferentiel(referentiel) {
+    this.referentiel = referentiel;
+    return this;
+  }
+
+  construis() {
+    return DepotDonneesHomologations.creeDepot({
+      adaptateurJournalMSS: this.adaptateurJournalMSS,
+      adaptateurPersistance: this.adaptateurPersistance,
+      adaptateurTracking: this.adaptateurTracking,
+      adaptateurUUID: this.adaptateurUUID,
+      referentiel: this.referentiel,
+    });
+  }
+}
+
+const unDepotDeDonneesServices = () => new ConstructeurDepotDonneesServices();
+
+module.exports = { unDepotDeDonneesServices };

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -41,6 +41,9 @@ const { unService } = require('../constructeurs/constructeurService');
 const {
   unNouvelAdaptateurMemoire,
 } = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
+const {
+  unDepotDeDonneesServices,
+} = require('../constructeurs/constructeurDepotDonneesServices');
 
 describe('Le dépôt de données des homologations', () => {
   it("connaît toutes les homologations d'un utilisateur donné", (done) => {
@@ -862,13 +865,11 @@ describe('Le dépôt de données des homologations', () => {
         .ajouteUnService(unServiceExistant)
         .ajouteUnUtilisateur(utilisateur)
         .construis();
-      depot = DepotDonneesHomologations.creeDepot({
-        adaptateurJournalMSS,
-        adaptateurPersistance,
-        adaptateurTracking,
-        adaptateurUUID,
-        referentiel,
-      });
+      depot = unDepotDeDonneesServices()
+        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecAdaptateurTracking(adaptateurTracking)
+        .avecReferentiel(referentiel)
+        .construis();
 
       depot
         .nouvelleHomologation(utilisateur.id, { descriptionService })

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -39,7 +39,7 @@ const {
 } = require('../constructeurs/constructeurAutorisation');
 const { unService } = require('../constructeurs/constructeurService');
 const {
-  unNouvelAdaptateurMemoire,
+  unePersistanceMemoire,
 } = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
 const {
   unDepotDeDonneesServices,
@@ -860,11 +860,10 @@ describe('Le dépôt de données des homologations', () => {
         utilisateur.id,
         unServiceExistant.id
       ).donnees;
-      adaptateurPersistance = unNouvelAdaptateurMemoire()
+      adaptateurPersistance = unePersistanceMemoire()
         .ajouteUneAutorisation(uneAutorisationExistante)
         .ajouteUnService(unServiceExistant)
-        .ajouteUnUtilisateur(utilisateur)
-        .construis();
+        .ajouteUnUtilisateur(utilisateur);
       depot = unDepotDeDonneesServices()
         .avecAdaptateurPersistance(adaptateurPersistance)
         .avecAdaptateurTracking(adaptateurTracking)

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -38,6 +38,9 @@ const {
   uneAutorisation,
 } = require('../constructeurs/constructeurAutorisation');
 const { unService } = require('../constructeurs/constructeurService');
+const {
+  unNouvelAdaptateurMemoire,
+} = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
 
 describe('Le dépôt de données des homologations', () => {
   it("connaît toutes les homologations d'un utilisateur donné", (done) => {
@@ -854,12 +857,11 @@ describe('Le dépôt de données des homologations', () => {
         utilisateur.id,
         unServiceExistant.id
       ).donnees;
-      adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        autorisations: [uneAutorisationExistante],
-        homologations: [unServiceExistant],
-        services: [unServiceExistant],
-        utilisateurs: [utilisateur],
-      });
+      adaptateurPersistance = unNouvelAdaptateurMemoire()
+        .ajouteUneAutorisation(uneAutorisationExistante)
+        .ajouteUnService(unServiceExistant)
+        .ajouteUnUtilisateur(utilisateur)
+        .construis();
       depot = DepotDonneesHomologations.creeDepot({
         adaptateurJournalMSS,
         adaptateurPersistance,


### PR DESCRIPTION
Facilite l'initialisation des tests afin de masquer certains détails d'implémentations qui suivant les contextes embrouillent la compréhension et l'intention.