### PR TITLE
Renomme les fonctions de hachage utilisant `bcrypt`

### DIFF
--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -3,7 +3,8 @@ const bcrypt = require('bcrypt');
 
 const NOMBRE_DE_PASSES = 10;
 
-const chiffre = (chaineEnClair) => bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
+const hacheBCrypt = (chaineEnClair) =>
+  bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
 
 const { compare } = bcrypt;
 
@@ -11,6 +12,6 @@ const hacheSha256 = (chaine) =>
   createHash('sha256').update(chaine).digest('hex');
 
 const nonce = () =>
-  chiffre(`${Math.random()}`).then((s) => s.replace(/[/$.]/g, ''));
+  hacheBCrypt(`${Math.random()}`).then((s) => s.replace(/[/$.]/g, ''));
 
-module.exports = { chiffre, compare, hacheSha256, nonce };
+module.exports = { compareBCrypt: compare, hacheBCrypt, hacheSha256, nonce };

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -45,7 +45,7 @@ const creeDepot = (config = {}) => {
         const id = adaptateurUUID.genereUUID();
         donneesUtilisateur.idResetMotDePasse = adaptateurUUID.genereUUID();
         return adaptateurChiffrement
-          .chiffre(adaptateurUUID.genereUUID())
+          .hacheBCrypt(adaptateurUUID.genereUUID())
           .then((hash) => {
             donneesUtilisateur.motDePasse = hash;
 
@@ -85,7 +85,7 @@ const creeDepot = (config = {}) => {
       if (!motDePasseStocke) return Promise.resolve(echecAuthentification);
 
       return adaptateurChiffrement
-        .compare(motDePasse, motDePasseStocke)
+        .compareBCrypt(motDePasse, motDePasseStocke)
         .then((authentificationReussie) =>
           authentificationReussie
             ? new Utilisateur(u, { adaptateurJWT })
@@ -99,7 +99,7 @@ const creeDepot = (config = {}) => {
 
   const metsAJourMotDePasse = (idUtilisateur, motDePasse) =>
     adaptateurChiffrement
-      .chiffre(motDePasse)
+      .hacheBCrypt(motDePasse)
       .then((hash) =>
         adaptateurPersistance.metsAJourUtilisateur(idUtilisateur, {
           motDePasse: hash,

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -25,11 +25,11 @@ describe('Le dépôt de données des utilisateurs', () => {
 
   it("retourne l'utilisateur authentifié", (done) => {
     adaptateurChiffrement = {
-      chiffre: (chaine) => {
+      hacheBCrypt: (chaine) => {
         expect(chaine).to.equal('mdp_12345');
         return Promise.resolve('12345-chiffré');
       },
-      compare: (chaine1, chaine2) => {
+      compareBCrypt: (chaine1, chaine2) => {
         expect(chaine1).to.equal('mdp_12345');
         expect(chaine2).to.equal('12345-chiffré');
         return Promise.resolve(true);

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -1,8 +1,8 @@
 const fauxAdaptateurChiffrement = {
-  chiffre: (chaine) => Promise.resolve(`${chaine}-chiffré`),
-  compare: (enClair, chiffreeReference) =>
+  hacheBCrypt: (chaine) => Promise.resolve(`${chaine}-chiffré`),
+  compareBCrypt: (enClair, chiffreeReference) =>
     fauxAdaptateurChiffrement
-      .chiffre(enClair)
+      .hacheBCrypt(enClair)
       .then((chaineChiffree) => chaineChiffree === chiffreeReference),
 };
 


### PR DESCRIPTION
… car il s'agit bel et bien de hachage et non de chiffrement – puisque le déchiffrement est impossible.

Si on laisse `chiffre` comme nom, alors ça va compliquer l'arrivée du code qui chiffrera réellement les données métier puisqu'il va vouloir créer une fonction `chiffre()`.