### PR TITLE
[Carrousel] Route `/nouvelleFonctionalite`

### DIFF
--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -111,6 +111,10 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     donneesReferentiel.departements?.find(
       (unDepartement) => unDepartement.code === code
     )?.nom;
+  const nouvelleFonctionnalite = (id) =>
+    donnees.nouvellesFonctionnalites.find(
+      (fonctionnalite) => fonctionnalite.id === id
+    );
 
   const coefficientIndiceCyberMesuresIndispensables = () =>
     donnees.indiceCyber?.coefficientIndispensables || 0.5;
@@ -327,6 +331,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     nbMoisBientotExpire,
     niveauGravite,
     niveauxGravite,
+    nouvelleFonctionnalite,
     numeroEtape,
     positionActionSaisie,
     premiereEtapeParcours,

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -603,6 +603,26 @@ const routesApi = (
     }
   );
 
+  routes.get(
+    '/nouvelleFonctionnalite/:id',
+    middleware.aseptise('id'),
+    (requete, reponse) => {
+      const idNouvelleFonctionnalite = requete.params.id;
+      const nouvelleFonctionnalite = referentiel.nouvelleFonctionnalite(
+        idNouvelleFonctionnalite
+      );
+
+      if (!nouvelleFonctionnalite) {
+        reponse.status(404).send('Nouvelle fonctionnalité inconnue');
+        return;
+      }
+
+      reponse.render(
+        `nouvellesFonctionnalites/${nouvelleFonctionnalite.fichierPug}`
+      );
+    }
+  );
+
   return routes;
 };
 

--- a/src/vues/nouvellesFonctionnalites/tableauDeBord.pug
+++ b/src/vues/nouvellesFonctionnalites/tableauDeBord.pug
@@ -1,0 +1,1 @@
+h1 Tableau de bord

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -817,4 +817,14 @@ describe('Le référentiel', () => {
       'nouveauté1Février'
     );
   });
+
+  it('sait renvoyer une nouvelle fonctionnalité via son id', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      nouvellesFonctionnalites: [{ id: 'nouveauté' }],
+    });
+
+    expect(referentiel.nouvelleFonctionnalite('nouveauté')).to.eql({
+      id: 'nouveauté',
+    });
+  });
 });

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -2013,4 +2013,44 @@ describe('Le serveur MSS des routes /api/*', () => {
         .catch((e) => done(e.response?.data || e));
     });
   });
+
+  describe('quand requête GET sur `/api/nouvelleFonctionnalite`', () => {
+    it("aseptise l'identifiant de nouvelle fonctionnalité", (done) => {
+      testeur.middleware().verifieAseptisationParametres(
+        ['id'],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/nouvelleFonctionnalite/nouveaute',
+        },
+        done
+      );
+    });
+
+    it("retourne une erreur HTTP 404 si la nouvelle fonctionnalité n'existe pas", (done) => {
+      testeur.verifieRequeteGenereErreurHTTP(
+        404,
+        'Nouvelle fonctionnalité inconnue',
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/nouvelleFonctionnalite/inconnue',
+        },
+        done
+      );
+    });
+
+    it('retourne le contenu de la nouvelle fonctionnalité', (done) => {
+      testeur.referentiel().recharge({
+        nouvellesFonctionnalites: [
+          { id: 'tdb', fichierPug: 'tableauDeBord.pug' },
+        ],
+      });
+      axios
+        .get('http://localhost:1234/api/nouvelleFonctionnalite/tdb')
+        .then((reponse) => {
+          expect(reponse.status).to.equal(200);
+          done();
+        })
+        .catch((e) => done(e.response?.data || e));
+    });
+  });
 });


### PR DESCRIPTION
On ajoute la route qui sert le contenu HTML d'une nouvelle fonctionnalité.
On ajoute aussi le premier PUG concernant le tableau de bord, afin de faciliter les tests et préparer l'affichage.
Cependant, cette nouvelle fonctionnalité n'est pas encore ajouté au référentiel car non disponible.