### PR TITLE
Branchement du chiffrement des données de « Description Service »

### DIFF
--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,8 +1,9 @@
 const { createHash } = require('crypto');
 const bcrypt = require('bcrypt');
 
-const NOMBRE_DE_PASSES = 10;
+const chiffre = (chaine) => chaine;
 
+const NOMBRE_DE_PASSES = 10;
 const hacheBCrypt = (chaineEnClair) =>
   bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
 
@@ -14,4 +15,10 @@ const hacheSha256 = (chaine) =>
 const nonce = () =>
   hacheBCrypt(`${Math.random()}`).then((s) => s.replace(/[/$.]/g, ''));
 
-module.exports = { compareBCrypt: compare, hacheBCrypt, hacheSha256, nonce };
+module.exports = {
+  chiffre,
+  compareBCrypt: compare,
+  hacheBCrypt,
+  hacheSha256,
+  nonce,
+};

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -1,3 +1,4 @@
+const adaptateurChiffrementParDefaut = require('./adaptateurs/adaptateurChiffrement');
 const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurJournalMSS = require('./adaptateurs/fabriqueAdaptateurJournalMSS');
@@ -11,6 +12,7 @@ const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 
 const creeDepot = (config = {}) => {
   const {
+    adaptateurChiffrement = adaptateurChiffrementParDefaut,
     adaptateurJournalMSS = fabriqueAdaptateurJournalMSS(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
@@ -20,6 +22,7 @@ const creeDepot = (config = {}) => {
   } = config;
 
   const depotHomologations = depotDonneesHomologations.creeDepot({
+    adaptateurChiffrement,
     adaptateurJournalMSS,
     adaptateurPersistance,
     adaptateurTracking,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -26,6 +26,10 @@ const fabriqueChiffrement = (adaptateurChiffrement) => {
           descriptionService: {
             ...descriptionService,
             nomService: chiffre(descriptionService.nomService),
+            organisationsResponsables:
+              descriptionService.organisationsResponsables.map(
+                adaptateurChiffrement.chiffre
+              ),
           },
         };
       },

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -26,6 +26,7 @@ const fabriqueChiffrement = (adaptateurChiffrement) => {
           descriptionService: {
             ...descriptionService,
             nomService: chiffre(descriptionService.nomService),
+            presentation: chiffre(descriptionService.presentation),
             organisationsResponsables:
               descriptionService.organisationsResponsables.map(
                 adaptateurChiffrement.chiffre

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -31,6 +31,10 @@ const fabriqueChiffrement = (adaptateurChiffrement) => {
               descriptionService.organisationsResponsables.map(
                 adaptateurChiffrement.chiffre
               ),
+            pointsAcces: descriptionService.pointsAcces.map((p) => ({
+              ...p,
+              description: chiffre(p.description),
+            })),
           },
         };
       },

--- a/test/constructeurs/constructeurDescriptionService.js
+++ b/test/constructeurs/constructeurDescriptionService.js
@@ -36,6 +36,11 @@ class ConstructeurDescriptionService {
     return this;
   }
 
+  accessiblePar(...pointsAcces) {
+    this.donnees.pointsAcces = pointsAcces.map((p) => ({ description: p }));
+    return this;
+  }
+
   construis() {
     return new DescriptionService(this.donnees, this.referentiel);
   }

--- a/test/constructeurs/constructeurDescriptionService.js
+++ b/test/constructeurs/constructeurDescriptionService.js
@@ -12,6 +12,7 @@ class ConstructeurDescriptionService {
       delaiAvantImpactCritique: 'unDelai',
       localisationDonnees: 'uneLocalisation',
       nomService: 'Nom service',
+      organisationsResponsables: ['ANSSI'],
       presentation: 'Une présentation',
       provenanceService: 'uneProvenance',
       risqueJuridiqueFinancierReputationnel: false,
@@ -27,6 +28,11 @@ class ConstructeurDescriptionService {
 
   avecPresentation(presentation) {
     Object.assign(this.donnees, { presentation });
+    return this;
+  }
+
+  deLOrganisation(organisationResponsable) {
+    this.donnees.organisationsResponsables = [organisationResponsable];
     return this;
   }
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -767,15 +767,17 @@ describe('Le dépôt de données des homologations', () => {
 
       const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Service A')
+        .deLOrganisation('ANSSI')
         .construis()
         .toJSON();
 
       depot
         .nouvelleHomologation('123', { descriptionService })
         .then(() => {
-          expect(donneesPersistees.descriptionService.nomService).to.equal(
-            'Service A - chiffré'
-          );
+          const { nomService, organisationsResponsables } =
+            donneesPersistees.descriptionService;
+          expect(nomService).to.equal('Service A - chiffré');
+          expect(organisationsResponsables).to.eql(['ANSSI - chiffré']);
           done();
         })
         .catch(done);

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -768,16 +768,18 @@ describe('Le dépôt de données des homologations', () => {
       const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Service A')
         .deLOrganisation('ANSSI')
+        .avecPresentation('Le service fait A & B')
         .construis()
         .toJSON();
 
       depot
         .nouvelleHomologation('123', { descriptionService })
         .then(() => {
-          const { nomService, organisationsResponsables } =
+          const { nomService, organisationsResponsables, presentation } =
             donneesPersistees.descriptionService;
           expect(nomService).to.equal('Service A - chiffré');
           expect(organisationsResponsables).to.eql(['ANSSI - chiffré']);
+          expect(presentation).to.eql('Le service fait A & B - chiffré');
           done();
         })
         .catch(done);

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -769,17 +769,27 @@ describe('Le dépôt de données des homologations', () => {
         .avecNomService('Service A')
         .deLOrganisation('ANSSI')
         .avecPresentation('Le service fait A & B')
+        .accessiblePar('https://site.fr', 'https://autre.site.fr')
         .construis()
-        .toJSON();
+        .donneesSerialisees();
 
       depot
         .nouvelleHomologation('123', { descriptionService })
         .then(() => {
-          const { nomService, organisationsResponsables, presentation } =
-            donneesPersistees.descriptionService;
+          const {
+            nomService,
+            organisationsResponsables,
+            presentation,
+            pointsAcces,
+          } = donneesPersistees.descriptionService;
+
           expect(nomService).to.equal('Service A - chiffré');
           expect(organisationsResponsables).to.eql(['ANSSI - chiffré']);
           expect(presentation).to.eql('Le service fait A & B - chiffré');
+          expect(pointsAcces).to.eql([
+            { description: 'https://site.fr - chiffré' },
+            { description: 'https://autre.site.fr - chiffré' },
+          ]);
           done();
         })
         .catch(done);

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -20,7 +20,7 @@ describe('Le dépôt de données des utilisateurs', () => {
 
   beforeEach(() => {
     adaptateurJWT = 'Un adaptateur';
-    adaptateurChiffrement = fauxAdaptateurChiffrement;
+    adaptateurChiffrement = fauxAdaptateurChiffrement();
   });
 
   it("retourne l'utilisateur authentifié", (done) => {

--- a/test/depots/depotVide.js
+++ b/test/depots/depotVide.js
@@ -6,7 +6,7 @@ const DepotDonnees = require('../../src/depotDonnees');
 
 const depotVide = (
   config = {
-    adaptateurChiffrement: fauxAdaptateurChiffrement,
+    adaptateurChiffrement: fauxAdaptateurChiffrement(),
     adaptateurJournalMSS: adaptateurJournalMSSMemoire.nouvelAdaptateur(),
     adaptateurPersistance: fabriqueAdaptateurPersistance(),
   }

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -1,9 +1,9 @@
-const fauxAdaptateurChiffrement = {
+const fauxAdaptateurChiffrement = () => ({
   hacheBCrypt: (chaine) => Promise.resolve(`${chaine}-chiffré`),
   compareBCrypt: (enClair, chiffreeReference) =>
-    fauxAdaptateurChiffrement
+    fauxAdaptateurChiffrement()
       .hacheBCrypt(enClair)
       .then((chaineChiffree) => chaineChiffree === chiffreeReference),
-};
+});
 
 module.exports = fauxAdaptateurChiffrement;

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -1,5 +1,6 @@
 const fauxAdaptateurChiffrement = () => ({
-  hacheBCrypt: (chaine) => Promise.resolve(`${chaine}-chiffré`),
+  chiffre: (chaine) => chaine,
+  hacheBCrypt: (chaine) => Promise.resolve(`${chaine}-haché`),
   compareBCrypt: (enClair, chiffreeReference) =>
     fauxAdaptateurChiffrement()
       .hacheBCrypt(enClair)

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -669,7 +669,7 @@ describe('Une homologation', () => {
           donneesSensiblesSpecifiques: [],
           fonctionnalitesSpecifiques: [],
           pointsAcces: [],
-          organisationsResponsables: [],
+          organisationsResponsables: ['ANSSI'],
         },
         dossiers: [
           {


### PR DESCRIPTION
Cette PR pose les tuyaux qui permettent de chiffrer toutes les données voulues dans _« Description Service »_.

L'implémentation PROD du chiffrement est la fonction identité.
➡️ Donc à l'exécution rien n'est encore chiffré.

📋  La suite du plan : 
 - PR pour poser les tuyaux pour déchiffrer la description du service (en faisant attention aux fonctions de recherche par nom)
 - PR pour implémentation réelle du chiffrement/déchiffrement + migration