### PR TITLE
[CORRECTION] Cesse de propager l'exception catchée par l'annuaire

### DIFF
--- a/donneesReferentielDepartements.js
+++ b/donneesReferentielDepartements.js
@@ -1,440 +1,113 @@
 module.exports = {
   departements: [
-    {
-      nom: 'Ain',
-      code: '01',
-    },
-    {
-      nom: 'Aisne',
-      code: '02',
-    },
-    {
-      nom: 'Allier',
-      code: '03',
-    },
-    {
-      nom: 'Alpes-de-Haute-Provence',
-      code: '04',
-    },
-    {
-      nom: 'Hautes-Alpes',
-      code: '05',
-    },
-    {
-      nom: 'Alpes-Maritimes',
-      code: '06',
-    },
-    {
-      nom: 'Ardèche',
-      code: '07',
-    },
-    {
-      nom: 'Ardennes',
-      code: '08',
-    },
-    {
-      nom: 'Ariège',
-      code: '09',
-    },
-    {
-      nom: 'Aube',
-      code: '10',
-    },
-    {
-      nom: 'Aude',
-      code: '11',
-    },
-    {
-      nom: 'Aveyron',
-      code: '12',
-    },
-    {
-      nom: 'Bouches-du-Rhône',
-      code: '13',
-    },
-    {
-      nom: 'Calvados',
-      code: '14',
-    },
-    {
-      nom: 'Cantal',
-      code: '15',
-    },
-    {
-      nom: 'Charente',
-      code: '16',
-    },
-    {
-      nom: 'Charente-Maritime',
-      code: '17',
-    },
-    {
-      nom: 'Cher',
-      code: '18',
-    },
-    {
-      nom: 'Corrèze',
-      code: '19',
-    },
-    {
-      nom: "Côte-d'Or",
-      code: '21',
-    },
-    {
-      nom: "Côtes-d'Armor",
-      code: '22',
-    },
-    {
-      nom: 'Creuse',
-      code: '23',
-    },
-    {
-      nom: 'Dordogne',
-      code: '24',
-    },
-    {
-      nom: 'Doubs',
-      code: '25',
-    },
-    {
-      nom: 'Drôme',
-      code: '26',
-    },
-    {
-      nom: 'Eure',
-      code: '27',
-    },
-    {
-      nom: 'Eure-et-Loir',
-      code: '28',
-    },
-    {
-      nom: 'Finistère',
-      code: '29',
-    },
-    {
-      nom: 'Corse-du-Sud',
-      code: '2A',
-    },
-    {
-      nom: 'Haute-Corse',
-      code: '2B',
-    },
-    {
-      nom: 'Gard',
-      code: '30',
-    },
-    {
-      nom: 'Haute-Garonne',
-      code: '31',
-    },
-    {
-      nom: 'Gers',
-      code: '32',
-    },
-    {
-      nom: 'Gironde',
-      code: '33',
-    },
-    {
-      nom: 'Hérault',
-      code: '34',
-    },
-    {
-      nom: 'Ille-et-Vilaine',
-      code: '35',
-    },
-    {
-      nom: 'Indre',
-      code: '36',
-    },
-    {
-      nom: 'Indre-et-Loire',
-      code: '37',
-    },
-    {
-      nom: 'Isère',
-      code: '38',
-    },
-    {
-      nom: 'Jura',
-      code: '39',
-    },
-    {
-      nom: 'Landes',
-      code: '40',
-    },
-    {
-      nom: 'Loir-et-Cher',
-      code: '41',
-    },
-    {
-      nom: 'Loire',
-      code: '42',
-    },
-    {
-      nom: 'Haute-Loire',
-      code: '43',
-    },
-    {
-      nom: 'Loire-Atlantique',
-      code: '44',
-    },
-    {
-      nom: 'Loiret',
-      code: '45',
-    },
-    {
-      nom: 'Lot',
-      code: '46',
-    },
-    {
-      nom: 'Lot-et-Garonne',
-      code: '47',
-    },
-    {
-      nom: 'Lozère',
-      code: '48',
-    },
-    {
-      nom: 'Maine-et-Loire',
-      code: '49',
-    },
-    {
-      nom: 'Manche',
-      code: '50',
-    },
-    {
-      nom: 'Marne',
-      code: '51',
-    },
-    {
-      nom: 'Haute-Marne',
-      code: '52',
-    },
-    {
-      nom: 'Mayenne',
-      code: '53',
-    },
-    {
-      nom: 'Meurthe-et-Moselle',
-      code: '54',
-    },
-    {
-      nom: 'Meuse',
-      code: '55',
-    },
-    {
-      nom: 'Morbihan',
-      code: '56',
-    },
-    {
-      nom: 'Moselle',
-      code: '57',
-    },
-    {
-      nom: 'Nièvre',
-      code: '58',
-    },
-    {
-      nom: 'Nord',
-      code: '59',
-    },
-    {
-      nom: 'Oise',
-      code: '60',
-    },
-    {
-      nom: 'Orne',
-      code: '61',
-    },
-    {
-      nom: 'Pas-de-Calais',
-      code: '62',
-    },
-    {
-      nom: 'Puy-de-Dôme',
-      code: '63',
-    },
-    {
-      nom: 'Pyrénées-Atlantiques',
-      code: '64',
-    },
-    {
-      nom: 'Hautes-Pyrénées',
-      code: '65',
-    },
-    {
-      nom: 'Pyrénées-Orientales',
-      code: '66',
-    },
-    {
-      nom: 'Bas-Rhin',
-      code: '67',
-    },
-    {
-      nom: 'Haut-Rhin',
-      code: '68',
-    },
-    {
-      nom: 'Rhône',
-      code: '69',
-    },
-    {
-      nom: 'Haute-Saône',
-      code: '70',
-    },
-    {
-      nom: 'Saône-et-Loire',
-      code: '71',
-    },
-    {
-      nom: 'Sarthe',
-      code: '72',
-    },
-    {
-      nom: 'Savoie',
-      code: '73',
-    },
-    {
-      nom: 'Haute-Savoie',
-      code: '74',
-    },
-    {
-      nom: 'Paris',
-      code: '75',
-    },
-    {
-      nom: 'Seine-Maritime',
-      code: '76',
-    },
-    {
-      nom: 'Seine-et-Marne',
-      code: '77',
-    },
-    {
-      nom: 'Yvelines',
-      code: '78',
-    },
-    {
-      nom: 'Deux-Sèvres',
-      code: '79',
-    },
-    {
-      nom: 'Somme',
-      code: '80',
-    },
-    {
-      nom: 'Tarn',
-      code: '81',
-    },
-    {
-      nom: 'Tarn-et-Garonne',
-      code: '82',
-    },
-    {
-      nom: 'Var',
-      code: '83',
-    },
-    {
-      nom: 'Vaucluse',
-      code: '84',
-    },
-    {
-      nom: 'Vendée',
-      code: '85',
-    },
-    {
-      nom: 'Vienne',
-      code: '86',
-    },
-    {
-      nom: 'Haute-Vienne',
-      code: '87',
-    },
-    {
-      nom: 'Vosges',
-      code: '88',
-    },
-    {
-      nom: 'Yonne',
-      code: '89',
-    },
-    {
-      nom: 'Territoire de Belfort',
-      code: '90',
-    },
-    {
-      nom: 'Essonne',
-      code: '91',
-    },
-    {
-      nom: 'Hauts-de-Seine',
-      code: '92',
-    },
-    {
-      nom: 'Seine-Saint-Denis',
-      code: '93',
-    },
-    {
-      nom: 'Val-de-Marne',
-      code: '94',
-    },
-    {
-      nom: "Val-d'Oise",
-      code: '95',
-    },
-    {
-      nom: 'Guadeloupe',
-      code: '971',
-    },
-    {
-      nom: 'Martinique',
-      code: '972',
-    },
-    {
-      nom: 'Guyane',
-      code: '973',
-    },
-    {
-      nom: 'La Réunion',
-      code: '974',
-    },
-    {
-      nom: 'Saint-Pierre-et-Miquelon',
-      code: '975',
-    },
-    {
-      nom: 'Mayotte',
-      code: '976',
-    },
-    {
-      nom: 'Saint-Barthélemy',
-      code: '977',
-    },
-    {
-      nom: 'Saint-Martin',
-      code: '978',
-    },
-    {
-      nom: 'Terres australes et antarctiques françaises',
-      code: '984',
-    },
-    {
-      nom: 'Wallis et Futuna',
-      code: '986',
-    },
-    {
-      nom: 'Polynésie française',
-      code: '987',
-    },
-    {
-      nom: 'Nouvelle-Calédonie',
-      code: '988',
-    },
-    {
-      nom: 'Île de Clipperton',
-      code: '989',
-    },
+    { nom: 'Ain', code: '01' },
+    { nom: 'Aisne', code: '02' },
+    { nom: 'Allier', code: '03' },
+    { nom: 'Alpes-de-Haute-Provence', code: '04' },
+    { nom: 'Hautes-Alpes', code: '05' },
+    { nom: 'Alpes-Maritimes', code: '06' },
+    { nom: 'Ardèche', code: '07' },
+    { nom: 'Ardennes', code: '08' },
+    { nom: 'Ariège', code: '09' },
+    { nom: 'Aube', code: '10' },
+    { nom: 'Aude', code: '11' },
+    { nom: 'Aveyron', code: '12' },
+    { nom: 'Bouches-du-Rhône', code: '13' },
+    { nom: 'Calvados', code: '14' },
+    { nom: 'Cantal', code: '15' },
+    { nom: 'Charente', code: '16' },
+    { nom: 'Charente-Maritime', code: '17' },
+    { nom: 'Cher', code: '18' },
+    { nom: 'Corrèze', code: '19' },
+    { nom: "Côte-d'Or", code: '21' },
+    { nom: "Côtes-d'Armor", code: '22' },
+    { nom: 'Creuse', code: '23' },
+    { nom: 'Dordogne', code: '24' },
+    { nom: 'Doubs', code: '25' },
+    { nom: 'Drôme', code: '26' },
+    { nom: 'Eure', code: '27' },
+    { nom: 'Eure-et-Loir', code: '28' },
+    { nom: 'Finistère', code: '29' },
+    { nom: 'Corse-du-Sud', code: '2A' },
+    { nom: 'Haute-Corse', code: '2B' },
+    { nom: 'Gard', code: '30' },
+    { nom: 'Haute-Garonne', code: '31' },
+    { nom: 'Gers', code: '32' },
+    { nom: 'Gironde', code: '33' },
+    { nom: 'Hérault', code: '34' },
+    { nom: 'Ille-et-Vilaine', code: '35' },
+    { nom: 'Indre', code: '36' },
+    { nom: 'Indre-et-Loire', code: '37' },
+    { nom: 'Isère', code: '38' },
+    { nom: 'Jura', code: '39' },
+    { nom: 'Landes', code: '40' },
+    { nom: 'Loir-et-Cher', code: '41' },
+    { nom: 'Loire', code: '42' },
+    { nom: 'Haute-Loire', code: '43' },
+    { nom: 'Loire-Atlantique', code: '44' },
+    { nom: 'Loiret', code: '45' },
+    { nom: 'Lot', code: '46' },
+    { nom: 'Lot-et-Garonne', code: '47' },
+    { nom: 'Lozère', code: '48' },
+    { nom: 'Maine-et-Loire', code: '49' },
+    { nom: 'Manche', code: '50' },
+    { nom: 'Marne', code: '51' },
+    { nom: 'Haute-Marne', code: '52' },
+    { nom: 'Mayenne', code: '53' },
+    { nom: 'Meurthe-et-Moselle', code: '54' },
+    { nom: 'Meuse', code: '55' },
+    { nom: 'Morbihan', code: '56' },
+    { nom: 'Moselle', code: '57' },
+    { nom: 'Nièvre', code: '58' },
+    { nom: 'Nord', code: '59' },
+    { nom: 'Oise', code: '60' },
+    { nom: 'Orne', code: '61' },
+    { nom: 'Pas-de-Calais', code: '62' },
+    { nom: 'Puy-de-Dôme', code: '63' },
+    { nom: 'Pyrénées-Atlantiques', code: '64' },
+    { nom: 'Hautes-Pyrénées', code: '65' },
+    { nom: 'Pyrénées-Orientales', code: '66' },
+    { nom: 'Bas-Rhin', code: '67' },
+    { nom: 'Haut-Rhin', code: '68' },
+    { nom: 'Rhône', code: '69' },
+    { nom: 'Haute-Saône', code: '70' },
+    { nom: 'Saône-et-Loire', code: '71' },
+    { nom: 'Sarthe', code: '72' },
+    { nom: 'Savoie', code: '73' },
+    { nom: 'Haute-Savoie', code: '74' },
+    { nom: 'Paris', code: '75' },
+    { nom: 'Seine-Maritime', code: '76' },
+    { nom: 'Seine-et-Marne', code: '77' },
+    { nom: 'Yvelines', code: '78' },
+    { nom: 'Deux-Sèvres', code: '79' },
+    { nom: 'Somme', code: '80' },
+    { nom: 'Tarn', code: '81' },
+    { nom: 'Tarn-et-Garonne', code: '82' },
+    { nom: 'Var', code: '83' },
+    { nom: 'Vaucluse', code: '84' },
+    { nom: 'Vendée', code: '85' },
+    { nom: 'Vienne', code: '86' },
+    { nom: 'Haute-Vienne', code: '87' },
+    { nom: 'Vosges', code: '88' },
+    { nom: 'Yonne', code: '89' },
+    { nom: 'Territoire de Belfort', code: '90' },
+    { nom: 'Essonne', code: '91' },
+    { nom: 'Hauts-de-Seine', code: '92' },
+    { nom: 'Seine-Saint-Denis', code: '93' },
+    { nom: 'Val-de-Marne', code: '94' },
+    { nom: "Val-d'Oise", code: '95' },
+    { nom: 'Guadeloupe', code: '971' },
+    { nom: 'Martinique', code: '972' },
+    { nom: 'Guyane', code: '973' },
+    { nom: 'La Réunion', code: '974' },
+    { nom: 'Saint-Pierre-et-Miquelon', code: '975' },
+    { nom: 'Mayotte', code: '976' },
+    { nom: 'Saint-Barthélemy', code: '977' },
+    { nom: 'Saint-Martin', code: '978' },
+    { nom: 'Terres australes et antarctiques françaises', code: '984' },
+    { nom: 'Wallis et Futuna', code: '986' },
+    { nom: 'Polynésie française', code: '987' },
+    { nom: 'Nouvelle-Calédonie', code: '988' },
+    { nom: 'Île de Clipperton', code: '989' },
   ],
 };

--- a/src/adaptateurs/adaptateurAnnuaire.js
+++ b/src/adaptateurs/adaptateurAnnuaire.js
@@ -21,8 +21,10 @@ const rechercheOrganisation = (terme, departement) =>
         .map((r) => ({ nom: r.nom_complet, departement: r.siege.departement }))
     )
     .catch((e) => {
-      fabriqueAdaptateurGestionErreur().logueErreur(e);
-      return Promise.reject(e);
+      fabriqueAdaptateurGestionErreur().logueErreur(e, {
+        'Erreur renvoyée par API recherche-entreprise': e.response.data,
+      });
+      return Promise.resolve([]);
     });
 
 module.exports = { rechercheOrganisation };

--- a/src/adaptateurs/adaptateurGestionErreurSentry.js
+++ b/src/adaptateurs/adaptateurGestionErreurSentry.js
@@ -12,7 +12,14 @@ const controleurRequetes = () => Sentry.Handlers.requestHandler();
 
 const controleurErreurs = () => Sentry.Handlers.errorHandler();
 
-const logueErreur = (erreur) => Sentry.captureException(erreur);
+const logueErreur = (erreur, infosDeContexte = {}) => {
+  Sentry.withScope(() => {
+    Object.entries(infosDeContexte).forEach(([cle, valeur]) =>
+      Sentry.setExtra(cle, valeur)
+    );
+    Sentry.captureException(erreur);
+  });
+};
 
 module.exports = {
   initialise,


### PR DESCRIPTION
… pour éviter de faire crasher les appelants de l'adaptateur.

On a été alerté par [ce genre d'erreur](https://sentry.incubateur.net/organizations/betagouv/issues/29574/events/d00100868e6f4866a544ee70785d5447/?project=84) qui est associée à [ce log](https://dashboard.scalingo.com/apps/osc-secnum-fr1/anssi-mss-prod/activity/648c93e0995d2b000cccafd7).

On choisit de renvoyer un tableau vide dans le cas d'une erreur.

De plus, on augmente les capacités de log avec l'adaptateur qui va quand même loguer l'erreur et des infos de contexte chez Sentry 👇 
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/e2ff8e73-c784-4c0e-b529-cd74c8dc6816)
