### PR TITLE
[Carrousel] Ajoute un bouton pour afficher une nouvelle fonctionnalité dans la page dédiée

### DIFF
--- a/public/assets/styles/nouvellesFonctionnalites.css
+++ b/public/assets/styles/nouvellesFonctionnalites.css
@@ -85,3 +85,13 @@
   display: flex;
   justify-content: end;
 }
+
+.conteneur-action {
+  display: flex;
+  justify-content: center;
+}
+
+.conteneur-action .bouton {
+  padding: 0.5em 1em;
+  margin: 2em 0;
+}

--- a/public/nouvellesFonctionnalites.js
+++ b/public/nouvellesFonctionnalites.js
@@ -1,0 +1,20 @@
+import brancheComportementModaleNouvelleFonctionnalite from './modules/modaleNouvellesFonctionnalites.mjs';
+
+const brancheComportementAffichageCarrousel = () => {
+  $('.bouton[data-id-nouvelle-fonctionnalite]', '.conteneur-action').on(
+    'click',
+    (evenement) => {
+      const id = $(evenement.target).attr('data-id-nouvelle-fonctionnalite');
+      window.location = encodeURI(
+        `/nouvellesFonctionnalites?nouvelleFonctionnalite=${id}`
+      );
+    }
+  );
+};
+
+$(() => {
+  brancheComportementModaleNouvelleFonctionnalite(
+    $('.modale-nouvelles-fonctionnalites')
+  );
+  brancheComportementAffichageCarrousel();
+});

--- a/src/vues/nouvellesFonctionnalites.pug
+++ b/src/vues/nouvellesFonctionnalites.pug
@@ -5,6 +5,9 @@ block append styles
   link(href = '/statique/assets/styles/nouvellesFonctionnalites.css', rel = 'stylesheet')
 
 block main
+
+  include nouvellesFonctionnalites/modaleNouvellesFonctionnalites.pug
+  
   .marges-fixes
     .documentation
       h1 Nouveautés
@@ -24,6 +27,8 @@ block main
           span Exportez d'un seul clic une liste de vos services au format CSV.
           br
           span Dupliquez vos services simplement pour accélérer la constitution de vos nouveaux dossiers.
+          .conteneur-action
+            button.bouton(data-id-nouvelle-fonctionnalite='tableauDeBord') Voir la version en image
         li
           h4 Dupliquer un service déjà renseigné
           .
@@ -77,3 +82,5 @@ block main
 
       .boutons
         a.bouton(href = '/tableauDeBord') Revenir au tableau de bord
+
+  script(type = 'module', src = '/statique/nouvellesFonctionnalites.js')


### PR DESCRIPTION
On peut désormais afficher le carrousel 'à la demande' depuis la page `/nouvellesFonctionnalites`.

:point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/47998e20-a34b-4d2c-9a3f-bc3f144cd9bc)
