### PR TITLE
[CORRECTION] Corrige l'appel au constructeur de `ParcoursUtilisateur`

### DIFF
--- a/test/modeles/parcoursUtilisateur.spec.js
+++ b/test/modeles/parcoursUtilisateur.spec.js
@@ -26,13 +26,14 @@ describe('Un parcours utilisateur', () => {
         idUtilisateur: '456',
         dateDerniereConnexion: '2023-01-01',
       },
+      Referentiel.creeReferentielVide(),
       adaptateurHorloge
     );
 
     unParcours.enregistreDerniereConnexionMaintenant();
-    expect(unParcours.toJSON().dateDerniereConnexion).to.equal(
-      dateDeConnexion.toISOString()
-    );
+
+    const dateParcours = unParcours.toJSON().dateDerniereConnexion;
+    expect(dateParcours).to.equal(dateDeConnexion.toISOString());
   });
 
   describe('sur demande de recupération de nouvelle fonctionnalité', () => {


### PR DESCRIPTION
… pour que l'adaptateur horloge passé soit bel et bien utilisé.

Exemple de test fail : https://github.com/betagouv/mon-service-securise/actions/runs/5320676346/jobs/9634768769?pr=943