### PR TITLE
Enrichis l'objet get services avec des permissions

### DIFF
--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -30,6 +30,9 @@ const donnees = (services, idUtilisateur, referentiel) => ({
       nombreContributeurs: json.contributeurs.length + 1,
       estCreateur: json.createur.id === idUtilisateur,
       documentsPdfDisponibles: json.documentsPdfDisponibles,
+      permissions: {
+        suppressionContributeur: json.createur.id === idUtilisateur,
+      },
     })),
   resume: {
     nombreServices: services.length,

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -77,6 +77,9 @@ describe("L'objet d'API de `GET /services`", () => {
         nombreContributeurs: 1 + 1,
         estCreateur: true,
         documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
+        permissions: {
+          suppressionContributeur: true,
+        },
       },
     ]);
   });
@@ -88,6 +91,39 @@ describe("L'objet d'API de `GET /services`", () => {
     expect(objetGetServices.donnees(services, 'A', referentiel).resume).to.eql({
       nombreServices: 2,
       nombreServicesHomologues: 1,
+    });
+  });
+
+  describe('sur demande des permissions', () => {
+    it("autorise la suppression de contributeur si l'utilisateur est créateur", () => {
+      const unServiceDontAestCreateur = new Service({
+        id: '123',
+        descriptionService: { nomService: 'Un service' },
+        createur: { id: 'A', email: 'email.createur@mail.fr' },
+      });
+      const services = [unServiceDontAestCreateur];
+      expect(
+        objetGetServices.donnees(services, 'A', referentiel).services[0]
+          .permissions
+      ).to.eql({
+        suppressionContributeur: true,
+      });
+    });
+
+    it("n'autorise pas la suppression de contributeur si l'utilisateur est contributeur", () => {
+      const unServiceDontAestCreateur = new Service({
+        id: '123',
+        descriptionService: { nomService: 'Un service' },
+        createur: { id: 'A', email: 'email.createur@mail.fr' },
+      });
+      const idUtilisateur = 'un autre ID';
+      const services = [unServiceDontAestCreateur];
+      expect(
+        objetGetServices.donnees(services, idUtilisateur, referentiel)
+          .services[0].permissions
+      ).to.eql({
+        suppressionContributeur: false,
+      });
     });
   });
 });


### PR DESCRIPTION
On chercher à exposer un objet générique de permissions afin que le front puisse être conditionné sur des actions.
Ceci à pour but de faciliter le travail futur qui sera effectué sur les rôles (lecture/écriture).

Pour l'instant, on se base uniquement sur l'utilisateur qui fait la demande, si il est créateur ou non.