### PR TITLE
[Remaniement] Ajoute une fonction enrichis au constructeur de service

### DIFF
--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -270,6 +270,11 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     valideDonnees();
   };
 
+  const enrichis = (nouvellesDonnees) => {
+    donnees = { ...donnees, ...nouvellesDonnees };
+    valideDonnees();
+  };
+
   valideDonnees();
 
   return {
@@ -308,6 +313,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     estIdentifiantEcheanceRenouvellementConnu,
     estIdentifiantStatutAvisDossierHomologationConnu,
     derniereEtapeParcours,
+    enrichis,
     etapeExiste,
     etapesParcoursHomologation,
     etapeSuffisantePourDossierDecision,

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -20,6 +20,11 @@ class ConstructeurDepotDonneesServices {
     return this;
   }
 
+  avecJournalMSS(adaptateurJournalMSS) {
+    this.adaptateurJournalMSS = adaptateurJournalMSS;
+    return this;
+  }
+
   avecAdaptateurTracking(adaptateurTracking) {
     this.adaptateurTracking = adaptateurTracking;
     return this;

--- a/test/constructeurs/constructeurDescriptionService.js
+++ b/test/constructeurs/constructeurDescriptionService.js
@@ -3,7 +3,7 @@ const DescriptionService = require('../../src/modeles/descriptionService');
 class ConstructeurDescriptionService {
   constructor(referentiel) {
     this.referentiel = referentiel;
-    this.referentiel.recharge({
+    this.referentiel.enrichis({
       statutsDeploiement: { unStatutDeploiement: {} },
       localisationsDonnees: { uneLocalisation: {} },
     });

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -209,20 +209,24 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     beforeEach(() => {
-      const donneesHomologation = {
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      };
-      adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        homologations: [copie(donneesHomologation)],
-        services: [copie(donneesHomologation)],
-      });
+      const utilisateur = unUtilisateur().avecId('789').donnees;
+      const autorisation = uneAutorisation().deCreateurDeService(
+        '789',
+        '123'
+      ).donnees;
+      const service = unService(referentiel)
+        .avecId('123')
+        .avecNomService('nom').donnees;
+      adaptateurPersistance = unePersistanceMemoire()
+        .ajouteUnService(service)
+        .ajouteUneAutorisation(autorisation)
+        .ajouteUnUtilisateur(utilisateur);
       adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
-      depot = DepotDonneesHomologations.creeDepot({
-        adaptateurPersistance,
-        adaptateurJournalMSS,
-        referentiel,
-      });
+      depot = unDepotDeDonneesServices()
+        .avecReferentiel(referentiel)
+        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecJournalMSS(adaptateurJournalMSS)
+        .construis();
     });
 
     it("associe les mesures générales à l'homologation", (done) => {
@@ -243,7 +247,10 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     it('associe les mesures générales au service', (done) => {
-      const config = { adaptateurPersistance, referentiel };
+      const config = {
+        adaptateurPersistance: adaptateurPersistance.construis(),
+        referentiel,
+      };
       const depotServices = DepotDonneesServices.creeDepot(config);
       const generale = new MesureGenerale(
         { id: 'identifiantMesure', statut: MesureGenerale.STATUT_FAIT },
@@ -320,7 +327,8 @@ describe('Le dépôt de données des homologations', () => {
 
     it('associe les mesures spécifiques au service', (done) => {
       const depotServices = DepotDonneesServices.creeDepot({
-        adaptateurPersistance,
+        adaptateurPersistance: adaptateurPersistance.construis(),
+        referentiel,
       });
       const generales = [];
       const mesures = new MesuresSpecifiques({
@@ -370,16 +378,12 @@ describe('Le dépôt de données des homologations', () => {
       mesuresGenerales: [{ id: 'identifiantMesure', statut: 'fait' }],
     };
 
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
-      {
-        homologations: [copie(donneesHomologation)],
-        services: [copie(donneesHomologation)],
-      }
-    );
-    const depot = DepotDonneesHomologations.creeDepot({
-      adaptateurPersistance,
-      referentiel,
-    });
+    const adaptateurPersistance =
+      unePersistanceMemoire().ajouteUnService(donneesHomologation);
+    const depot = unDepotDeDonneesServices()
+      .avecAdaptateurPersistance(adaptateurPersistance)
+      .avecReferentiel(referentiel)
+      .construis();
 
     depot
       .homologation('123')


### PR DESCRIPTION
Lors de l'appel au constructeur de service, la fonction `uneDescriptionValide` force la recharge du référentiel en le modifiant avec les données du référentiel à vide ce qui avait un effet de bord dans les tests.

Le but est de pouvoir bénéficier d'un référentiel cohérent de bout en bout dans les tests.