### PR TITLE
[Tracking Sendingblue] Envoie la completude vers Sendingblue lors de la création d'un nouveau service

### DIFF
--- a/src/adaptateurs/adaptateurTrackingMemoire.js
+++ b/src/adaptateurs/adaptateurTrackingMemoire.js
@@ -26,7 +26,13 @@ const envoieTrackingInvitationContributeur = (destinataire, donneesEvenement) =>
 const envoieTrackingNouveauServiceCree = (destinataire, donneesEvenement) =>
   envoieTracking(destinataire, 'NOUVEAU_SERVICE_CREE', donneesEvenement);
 
+const envoieTrackingCompletudeService = (destinataire, donneesEvenement) =>
+  envoieTracking(destinataire, 'COMPLETUDE_SERVICE_MODIFIEE', {
+    donneesEvenement,
+  });
+
 module.exports = {
+  envoieTrackingCompletudeService,
   envoieTrackingConnexion,
   envoieTrackingInscription,
   envoieTrackingInvitationContributeur,

--- a/src/adaptateurs/adaptateurTrackingSendinblue.js
+++ b/src/adaptateurs/adaptateurTrackingSendinblue.js
@@ -48,9 +48,20 @@ const envoieTrackingNouveauServiceCree = (destinataire, { nombreServices }) =>
     nb_services: nombreServices,
   });
 
+const envoieTrackingCompletudeService = (
+  destinataire,
+  { nombreServices, nombreMoyenContributeurs, tauxCompletudeMoyenTousServices }
+) =>
+  envoieTracking(destinataire, 'COMPLETUDE_SERVICE_MODIFIEE', {
+    nb_services: nombreServices,
+    nb_moyen_contributeurs: nombreMoyenContributeurs,
+    taux_completude_moyen_tous_services: tauxCompletudeMoyenTousServices,
+  });
+
 module.exports = {
   envoieTrackingConnexion,
   envoieTrackingInscription,
   envoieTrackingInvitationContributeur,
   envoieTrackingNouveauServiceCree,
+  envoieTrackingCompletudeService,
 };

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -13,6 +13,7 @@ const EvenementNouveauServiceCree = require('../modeles/journalMSS/evenementNouv
 const EvenementNouvelleHomologationCreee = require('../modeles/journalMSS/evenementNouvelleHomologationCreee');
 const EvenementServiceSupprime = require('../modeles/journalMSS/evenementServiceSupprime');
 const { avecPMapPourChaqueElement } = require('../utilitaires/pMap');
+const ServiceTracking = require('../tracking/serviceTracking');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -90,6 +91,7 @@ const creeDepot = (config = {}) => {
     adaptateurTracking = fabriqueAdaptateurTracking(),
     adaptateurUUID,
     referentiel,
+    serviceTracking = ServiceTracking.creeService(),
   } = config;
 
   const p = fabriquePersistance(
@@ -348,6 +350,17 @@ const creeDepot = (config = {}) => {
               { nombreServices: hs.length }
             );
           }),
+          serviceTracking
+            .completudeDesServicesPourUtilisateur(
+              { homologations },
+              idUtilisateur
+            )
+            .then((tauxCompletude) =>
+              adaptateurTracking.envoieTrackingCompletudeService(
+                h.createur.email,
+                tauxCompletude
+              )
+            ),
         ])
       )
       .then(() => idHomologation);

--- a/src/tracking/serviceTracking.js
+++ b/src/tracking/serviceTracking.js
@@ -28,8 +28,8 @@ const creeService = () => {
     ]);
 
     return {
-      nbServices: hs.length,
-      nbMoyenContributeurs,
+      nombreServices: hs.length,
+      nombreMoyenContributeurs: nbMoyenContributeurs,
       tauxCompletudeMoyenTousServices: Math.floor(
         (hs.reduce((accumulateur, h) => {
           const completudeMesures = h.completudeMesures();

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -5,6 +5,7 @@ const adaptateurTrackingMemoire = require('../../src/adaptateurs/adaptateurTrack
 const DepotDonneesHomologations = require('../../src/depots/depotDonneesHomologations');
 const AdaptateurJournalMSSMemoire = require('../../src/adaptateurs/adaptateurJournalMSSMemoire');
 const Referentiel = require('../../src/referentiel');
+const ServiceTracking = require('../../src/tracking/serviceTracking');
 
 class ConstructeurDepotDonneesServices {
   constructor() {
@@ -13,6 +14,7 @@ class ConstructeurDepotDonneesServices {
     this.adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
     this.adaptateurUUID = { genereUUID: () => 'unUUID' };
     this.referentiel = Referentiel.creeReferentielVide();
+    this.serviceTracking = ServiceTracking.creeService();
   }
 
   avecAdaptateurPersistance(constructeurAdaptateurPersistance) {
@@ -30,6 +32,11 @@ class ConstructeurDepotDonneesServices {
     return this;
   }
 
+  avecServiceTracking(serviceTracking) {
+    this.serviceTracking = serviceTracking;
+    return this;
+  }
+
   avecReferentiel(referentiel) {
     this.referentiel = referentiel;
     return this;
@@ -42,6 +49,7 @@ class ConstructeurDepotDonneesServices {
       adaptateurTracking: this.adaptateurTracking,
       adaptateurUUID: this.adaptateurUUID,
       referentiel: this.referentiel,
+      serviceTracking: this.serviceTracking,
     });
   }
 }

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -943,8 +943,8 @@ describe('Le dépôt de données des homologations', () => {
       };
       const serviceTracking = {
         completudeDesServicesPourUtilisateur: async () => ({
-          nbServices: 2,
-          nbMoyenContributeurs: 3,
+          nombreServices: 2,
+          nombreMoyenContributeurs: 3,
           tauxCompletudeMoyenTousServices: 12,
         }),
       };
@@ -967,8 +967,8 @@ describe('Le dépôt de données des homologations', () => {
       expect(donneesPassees).to.eql({
         destinataire: 'jean.dujardin@beta.gouv.com',
         donneesEvenement: {
-          nbServices: 2,
-          nbMoyenContributeurs: 3,
+          nombreServices: 2,
+          nombreMoyenContributeurs: 3,
           tauxCompletudeMoyenTousServices: 12,
         },
       });

--- a/test/tracking/serviceTracking.spec.js
+++ b/test/tracking/serviceTracking.spec.js
@@ -32,8 +32,8 @@ describe('Le service de tracking des services', () => {
         );
 
       expect(completude).to.eql({
-        nbServices: 2,
-        nbMoyenContributeurs: 2,
+        nombreServices: 2,
+        nombreMoyenContributeurs: 2,
         tauxCompletudeMoyenTousServices: ((18 / 20 + 18 / 100) * 100) / 2,
       });
     });


### PR DESCRIPTION
Permet d'envoyer la complétude des services vers Sendingblue lorsqu'un nouveau service est créé