### PR TITLE
Référence l'URL en `.ssi.gouv.fr`

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 PORT_MSS= # port sur lequel le serveur écoute
-URL_BASE_MSS= # URL de base du site web, ex. http://www.monservicesecurise.beta.gouv.fr
+URL_BASE_MSS= # URL de base du site web, ex. http://www.monservicesecurise.ssi.gouv.fr
 CHEMIN_BASE_ABSOLU= # chemin où est déployé l'application. Exemple : /usr/src/app/
 
 LOGIN_ADMIN= # login accès pages administration

--- a/src/vues/cgu.pug
+++ b/src/vues/cgu.pug
@@ -75,7 +75,7 @@ block main
         d'Utilisation, afin notamment de prendre en compte toute évolution
         légale, réglementaire, jurisprudentielle et technique. La version qui
         prévaut est celle qui est accessible en ligne à l'adresse suivante :
-        <a href='https://www.monservicesecurise.beta.gouv.fr/cgu'>https://www.monservicesecurise.beta.gouv.fr/cgu</a>.
+        <a href='https://www.monservicesecurise.ssi.gouv.fr/cgu'>https://www.monservicesecurise.ssi.gouv.fr/cgu</a>.
 
       p.
         L'Utilisateur sera informé en cas de modification des Conditions


### PR DESCRIPTION
… au lieu de la version `.beta.gouv.fr` que nous abandonnons petit à petit.

Note :

- Pour l'instant `aide.monservicesecurise.beta.gouv.fr` n'est **pas** remplacée. Ça va nécessiter de synchroniser (A) la modifications des entrées DNS avec (B) le changement et déploiement de notre code source et (C) le changement de configuration côté Crisp.
- L'email `contact@mss.beta.gouv.fr` reste inchangé. Le sujet des emails en `@monservicesecurise.ssi.gouv.fr` est en discussion.

