### PR TITLE
[SENTRY] Loggue les erreurs Brevo vers Sentry

### DIFF
--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -21,7 +21,9 @@ const basculeInfolettre = (destinataire, etat) =>
       enteteJSON
     )
     .catch((e) => {
-      fabriqueAdaptateurGestionErreur().logueErreur(e);
+      fabriqueAdaptateurGestionErreur().logueErreur(e, {
+        'Erreur renvoyée par API Brevo': e.response.data,
+      });
       return Promise.reject(e);
     });
 
@@ -45,7 +47,9 @@ const creeContact = (destinataire, prenom, nom, bloqueEmails) =>
       if (e.response.data.message === 'Contact already exist')
         return Promise.resolve();
 
-      fabriqueAdaptateurGestionErreur().logueErreur(e);
+      fabriqueAdaptateurGestionErreur().logueErreur(e, {
+        'Erreur renvoyée par API Brevo': e.response.data,
+      });
       return Promise.reject(e);
     });
 
@@ -61,7 +65,9 @@ const envoieEmail = (destinataire, idTemplate, params) =>
       enteteJSON
     )
     .catch((e) => {
-      fabriqueAdaptateurGestionErreur().logueErreur(e);
+      fabriqueAdaptateurGestionErreur().logueErreur(e, {
+        'Erreur renvoyée par SMTP Brevo': e.response.data,
+      });
       return Promise.reject(e);
     });
 

--- a/src/adaptateurs/adaptateurTrackingSendinblue.js
+++ b/src/adaptateurs/adaptateurTrackingSendinblue.js
@@ -24,7 +24,9 @@ const envoieTracking = (destinataire, typeEvenement, donneesEvenement = {}) =>
       enteteJSON
     )
     .catch((e) => {
-      fabriqueAdaptateurGestionErreur().logueErreur(e);
+      fabriqueAdaptateurGestionErreur().logueErreur(e, {
+        'Erreur renvoyée par API Tracking Brevo': e.response.data,
+      });
       // On veut ici délibérement ignorer l'erreur car l'echec de tracking ne devrait pas entrainer une dégradation de l'expérience utilisateur
       return Promise.resolve();
     });


### PR DESCRIPTION
On fait apparaître les `response.data` des erreurs remontées par Brevo afin d'avoir une meilleur visibilité coté Sentry.