### PR TITLE
[MIGRATION] Archive les anciens dossiers d'homologations

### DIFF
--- a/migrations/20230627141030_archivageDossiersHomologations.js
+++ b/migrations/20230627141030_archivageDossiersHomologations.js
@@ -1,0 +1,62 @@
+const { avecPMapPourChaqueElement } = require('../src/utilitaires/pMap');
+
+const archiveDossiers = (dossiers) => {
+  const candidats = dossiers
+    .filter((d) => d.finalise)
+    .filter((d) => !d.archive);
+  const parOrdreDechronologique = candidats.sort(
+    (a, b) =>
+      new Date(b.decision?.dateHomologation) -
+      new Date(a.decision?.dateHomologation)
+  );
+  const [, ...lesPlusVieux] = parOrdreDechronologique;
+  lesPlusVieux.forEach((d) => (d.archive = true));
+};
+
+const archiveDossiersDansTable = async (knex, table) => {
+  const lignes = await knex(table);
+  const donneesAJour = Promise.all(
+    lignes
+      .filter(({ donnees }) => !!donnees.dossiers)
+      .map(({ id, donnees }) => {
+        archiveDossiers(donnees.dossiers);
+        return { id, donnees };
+      })
+  );
+  return avecPMapPourChaqueElement(donneesAJour, ({ id, donnees }) =>
+    knex(table).where({ id }).update({ donnees })
+  );
+};
+
+const supprimeArchivageDansTable = async (knex, table) => {
+  const lignes = await knex(table);
+  const donneesAJour = Promise.all(
+    lignes
+      .filter(({ donnees }) => !!donnees.dossiers)
+      .map(({ id, donnees }) => {
+        donnees.dossiers.forEach((d) => {
+          d.archive = undefined;
+        });
+        return { id, donnees };
+      })
+  );
+  return avecPMapPourChaqueElement(donneesAJour, ({ id, donnees }) =>
+    knex(table).where({ id }).update({ donnees })
+  );
+};
+
+exports.up = async (knex) =>
+  Promise.all(
+    ['homologations', 'services'].map((table) =>
+      archiveDossiersDansTable(knex, table)
+    )
+  );
+
+exports.down = async (knex) =>
+  Promise.all(
+    ['homologations', 'services'].map((table) =>
+      supprimeArchivageDansTable(knex, table)
+    )
+  );
+
+exports.archiveDossiers = archiveDossiers;

--- a/test_migrations/20230627141030_archivageDossiersHomologations.spec.js
+++ b/test_migrations/20230627141030_archivageDossiersHomologations.spec.js
@@ -1,0 +1,72 @@
+const expect = require('expect.js');
+
+const {
+  archiveDossiers,
+} = require('../migrations/20230627141030_archivageDossiersHomologations');
+
+describe("La migration de l'archivage des dossiers d'homologation", () => {
+  it("n'archive pas les dossiers non finalisés", () => {
+    const dossiers = [{ finalise: false }, {}];
+
+    archiveDossiers(dossiers);
+
+    expect(dossiers[0].archive).to.be(undefined);
+    expect(dossiers[1].archive).to.be(undefined);
+  });
+
+  it('archive tous les dossiers finalisés sauf le plus récent', () => {
+    const dossierRecent = {
+      finalise: true,
+      decision: { dateHomologation: '2023-06-27' },
+    };
+    const vieuxDossier = {
+      finalise: true,
+      decision: { dateHomologation: '2020-01-01' },
+    };
+
+    archiveDossiers([dossierRecent, vieuxDossier]);
+
+    expect(dossierRecent.archive).to.be(undefined);
+    expect(vieuxDossier.archive).to.be(true);
+  });
+
+  it('ne considère pas les dossiers déjà archivés', () => {
+    const dossier = {
+      finalise: true,
+      decision: { dateHomologation: '2022-01-21' },
+    };
+    const dossierPlusRecentMaisArchive = {
+      finalise: true,
+      decision: { dateHomologation: '2023-01-01' },
+      archive: true,
+    };
+
+    archiveDossiers([dossier, dossierPlusRecentMaisArchive]);
+
+    expect(dossier.archive).to.be(undefined);
+  });
+
+  it("archive systématiquement les dossiers finalisés qui n'ont pas de décision", () => {
+    const dossier = {
+      finalise: true,
+      decision: { dateHomologation: '2023-06-27' },
+    };
+    const dossierFinaliseSansDecision = {
+      finalise: true,
+    };
+    const dossierFinaliseSansDateHomologation = {
+      finalise: true,
+      decision: {},
+    };
+
+    archiveDossiers([
+      dossier,
+      dossierFinaliseSansDecision,
+      dossierFinaliseSansDateHomologation,
+    ]);
+
+    expect(dossier.archive).to.be(undefined);
+    expect(dossierFinaliseSansDecision.archive).to.be(true);
+    expect(dossierFinaliseSansDateHomologation.archive).to.be(true);
+  });
+});


### PR DESCRIPTION
On rajoute la propriété `archive` à tous les dossiers existants en suivant ces règles : 
- Les dossiers non `finalise` ne sont par archivés (dossier en cours)
- On archive tous les dossiers `finalise` sauf le plus récent (en se basant sur `decision.dateHomologation`)
- On archive systématiquement tout dossier dont la structure est compromise (`finalise` sans `decision` ou sans `dateHomologation`)

Afin de garantir l'exactitude de cette migration, on pourra utiliser la méthode `archiveDossiers` sur des données brutes en démo.