### PR TITLE
[REMANIEMENT] Supprime la dépendance à un statut d'homologation réel

### DIFF
--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -7,7 +7,7 @@ const Referentiel = require('../../../src/referentiel');
 describe("L'objet d'API de `GET /services`", () => {
   const referentiel = Referentiel.creeReferentiel({
     statutsHomologation: {
-      aRealiser: { libelle: 'À réaliser', ordre: 1 },
+      unStatut: { libelle: "Un statut d'homologation", ordre: 0 },
     },
   });
 
@@ -32,6 +32,7 @@ describe("L'objet d'API de `GET /services`", () => {
       },
     ],
   });
+  unService.dossiers.statutHomologation = () => 'unStatut';
 
   const unAutreService = new Service({
     id: '456',
@@ -70,9 +71,9 @@ describe("L'objet d'API de `GET /services`", () => {
           },
         ],
         statutHomologation: {
-          libelle: 'À réaliser',
-          id: 'aRealiser',
-          ordre: 1,
+          libelle: "Un statut d'homologation",
+          id: 'unStatut',
+          ordre: 0,
         },
         nombreContributeurs: 1 + 1,
         estCreateur: true,

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -36,7 +36,7 @@ describe('Le serveur MSS des routes /api/*', () => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
       testeur.referentiel().recharge({
         statutsHomologation: {
-          aRealiser: { libelle: 'À réaliser', ordre: 1 },
+          unStatut: { libelle: "Un statut d'homologation", ordre: 0 },
         },
       });
 
@@ -114,7 +114,7 @@ describe('Le serveur MSS des routes /api/*', () => {
       testeur.adaptateurCsv().genereCsvServices = () => Promise.resolve();
       testeur.referentiel().recharge({
         statutsHomologation: {
-          aRealiser: { libelle: 'À réaliser', ordre: 1 },
+          unStatut: { libelle: "Un statut d'homologation", ordre: 0 },
         },
       });
     });
@@ -204,17 +204,18 @@ describe('Le serveur MSS des routes /api/*', () => {
     it('utilise un adaptateur de CSV pour la génération', (done) => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
-      testeur.depotDonnees().homologations = () =>
-        Promise.resolve([
-          new Service({
-            id: '456',
-            descriptionService: {
-              nomService: 'Un service',
-              organisationsResponsables: ['ANSSI'],
-            },
-            createur: { id: '123', email: 'email.createur@mail.fr' },
-          }),
-        ]);
+      testeur.depotDonnees().homologations = () => {
+        const service = new Service({
+          id: '456',
+          descriptionService: {
+            nomService: 'Un service',
+            organisationsResponsables: ['ANSSI'],
+          },
+          createur: { id: '123', email: 'email.createur@mail.fr' },
+        });
+        service.dossiers.statutHomologation = () => 'unStatut';
+        return Promise.resolve([service]);
+      };
 
       let adaptateurCsvAppele = false;
       testeur.adaptateurCsv().genereCsvServices = (donnees) => {
@@ -226,7 +227,9 @@ describe('Le serveur MSS des routes /api/*', () => {
         expect(service.nombreContributeurs).to.eql(1);
         expect(service.estCreateur).to.be(true);
         expect(service.indiceCyber).not.to.be(undefined);
-        expect(service.statutHomologation.libelle).to.be('À réaliser');
+        expect(service.statutHomologation.libelle).to.be(
+          "Un statut d'homologation"
+        );
 
         return Promise.resolve('Fichier CSV');
       };

--- a/test/routes/routesService.spec.js
+++ b/test/routes/routesService.spec.js
@@ -3,6 +3,7 @@ const expect = require('expect.js');
 
 const testeurMSS = require('./testeurMSS');
 const Homologation = require('../../src/modeles/homologation');
+const { unService } = require('../constructeurs/constructeurService');
 
 describe('Le serveur MSS des routes /service/*', () => {
   const testeur = testeurMSS();
@@ -36,10 +37,15 @@ describe('Le serveur MSS des routes /service/*', () => {
     it('recherche le service correspondant', (done) => {
       testeur.referentiel().recharge({
         statutsHomologation: {
-          aRealiser: { libelle: 'À réalisée' },
+          unStatut: { libelle: "Un statut d'homologation" },
         },
         etapesParcoursHomologation: [{ numero: 1 }],
       });
+      const service = unService(testeur.referentiel())
+        .avecId('456')
+        .construis();
+      service.dossiers.statutHomologation = () => 'unStatut';
+      testeur.middleware().reinitialise({ homologationARenvoyer: service });
       testeur
         .middleware()
         .verifieRechercheService('http://localhost:1234/service/456', done);


### PR DESCRIPTION
On cherche à modifier les statuts d'homologation plus facilement par la suite.
On supprime donc la dépendance à une vraie implémentation de `statutHomologation` dans `objetGetServices`.