### PR TITLE
[CORRECTION] Compteur de services homologués

### DIFF
--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -41,7 +41,7 @@ const donnees = (services, idUtilisateur, referentiel) => ({
   resume: {
     nombreServices: services.length,
     nombreServicesHomologues: services.filter(
-      (s) => s.dossiers.statutSaisie() === 'completes'
+      (s) => s.dossiers.statutHomologation() === Dossiers.ACTIVEE
     ).length,
   },
 });

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -3,6 +3,7 @@ const expect = require('expect.js');
 const Service = require('../../../src/modeles/service');
 const objetGetServices = require('../../../src/modeles/objetsApi/objetGetServices');
 const Referentiel = require('../../../src/referentiel');
+const Dossiers = require('../../../src/modeles/dossiers');
 
 describe("L'objet d'API de `GET /services`", () => {
   const referentiel = Referentiel.creeReferentiel({
@@ -86,7 +87,7 @@ describe("L'objet d'API de `GET /services`", () => {
   });
 
   it('fournit les données de résumé des services', () => {
-    unAutreService.dossiers.statutSaisie = () => 'completes';
+    unAutreService.dossiers.statutHomologation = () => Dossiers.ACTIVEE;
 
     const services = [unService, unAutreService];
     expect(objetGetServices.donnees(services, 'A', referentiel).resume).to.eql({


### PR DESCRIPTION
Le compteur de services homologués ne fonctionnait plus à cause du changement des statuts d'homologations.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/e59ea295-4016-4cff-9a80-a1766aa4f0bd)
