### PR TITLE
[REMANIEMENT] Objet API pour le modèle `Utilisateur`

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -10,6 +10,7 @@ const ObjetPersistanceHomologation = require('./objetsPersistance/objetPersistan
 const Risques = require('./risques');
 const RolesResponsabilites = require('./rolesResponsabilites');
 const Utilisateur = require('./utilisateur');
+const { enUtilisateurApi } = require('./objetsApi/objetApiUtilisateur');
 const ObjetPDFAnnexeDescription = require('./objetsPDF/objetPDFAnnexeDescription');
 const ObjetPDFAnnexeMesures = require('./objetsPDF/objetPDFAnnexeMesures');
 const ObjetPDFAnnexeRisques = require('./objetsPDF/objetPDFAnnexeRisques');
@@ -256,8 +257,8 @@ class Homologation {
   toJSON() {
     return {
       id: this.id,
-      createur: this.createur.toJSON(),
-      contributeurs: this.contributeurs.map((c) => c.toJSON()),
+      createur: enUtilisateurApi(this.createur),
+      contributeurs: this.contributeurs.map(enUtilisateurApi),
       nomService: this.nomService(),
     };
   }

--- a/src/modeles/objetsApi/objetApiUtilisateur.js
+++ b/src/modeles/objetsApi/objetApiUtilisateur.js
@@ -1,0 +1,19 @@
+const enUtilisateurApi = (utilisateur) => ({
+  id: utilisateur.id,
+  cguAcceptees: utilisateur.accepteCGU(),
+  initiales: utilisateur.initiales(),
+  prenom: utilisateur.prenom,
+  nom: utilisateur.nom,
+  prenomNom: utilisateur.prenomNom(),
+  telephone: utilisateur.telephone || '',
+  poste: utilisateur.poste || '',
+  posteDetaille: utilisateur.posteDetaille(),
+  rssi: utilisateur.estRSSI(),
+  delegueProtectionDonnees: utilisateur.estDelegueProtectionDonnees(),
+  nomEntitePublique: utilisateur.nomEntitePublique || '',
+  departementEntitePublique: utilisateur.departementEntitePublique || '',
+  profilEstComplet: utilisateur.profilEstComplet(),
+  infolettreAcceptee: utilisateur.accepteInfolettre(),
+});
+
+module.exports = { enUtilisateurApi };

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -155,24 +155,6 @@ class Utilisateur extends Base {
   profilEstComplet() {
     return (this.nom?.trim() ?? '') !== '';
   }
-
-  toJSON() {
-    return {
-      id: this.id,
-      cguAcceptees: this.accepteCGU(),
-      initiales: this.initiales(),
-      prenomNom: this.prenomNom(),
-      telephone: this.telephone || '',
-      poste: this.poste || '',
-      posteDetaille: this.posteDetaille(),
-      rssi: this.estRSSI(),
-      delegueProtectionDonnees: this.estDelegueProtectionDonnees(),
-      nomEntitePublique: this.nomEntitePublique || '',
-      departementEntitePublique: this.departementEntitePublique || '',
-      profilEstComplet: this.profilEstComplet(),
-      infolettreAcceptee: this.accepteInfolettre(),
-    };
-  }
 }
 
 module.exports = Utilisateur;

--- a/src/mss.js
+++ b/src/mss.js
@@ -144,7 +144,9 @@ const creeServeur = (
         }
 
         requete.session.token = utilisateur.genereToken();
-        reponse.render('motDePasse/edition', { utilisateur });
+        reponse.render('motDePasse/edition', {
+          utilisateur: enUtilisateurApi(utilisateur),
+        });
       });
     }
   );

--- a/src/mss.js
+++ b/src/mss.js
@@ -209,6 +209,7 @@ const creeServeur = (
       const idUtilisateur = requete.idUtilisateurCourant;
       depotDonnees
         .utilisateur(idUtilisateur)
+        .then(enUtilisateurApi)
         .then((utilisateur) =>
           reponse.render('utilisateur/edition', { utilisateur, departements })
         );

--- a/src/mss.js
+++ b/src/mss.js
@@ -9,6 +9,7 @@ const routesApi = require('./routes/routesApi');
 const { routesBibliotheques } = require('./routes/routesBibliotheques');
 const routesService = require('./routes/routesService');
 const routesStyles = require('./routes/routesStyles');
+const { enUtilisateurApi } = require('./modeles/objetsApi/objetApiUtilisateur');
 
 require('dotenv').config();
 
@@ -86,6 +87,7 @@ const creeServeur = (
       const idUtilisateur = requete.idUtilisateurCourant;
       depotDonnees
         .utilisateur(idUtilisateur)
+        .then(enUtilisateurApi)
         .then((utilisateur) =>
           reponse.render('motDePasse/edition', { utilisateur })
         );

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -431,7 +431,7 @@ const routesApi = (
                 .sauvegardeParcoursUtilisateur(parcoursUtilisateur)
                 .then(() =>
                   reponse.json({
-                    utilisateur: utilisateur.toJSON(),
+                    utilisateur: enUtilisateurApi(utilisateur),
                     nouvelleFonctionnalite,
                   })
                 );

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -20,6 +20,9 @@ const ServiceTracking = require('../tracking/serviceTracking');
 const Utilisateur = require('../modeles/utilisateur');
 const objetGetServices = require('../modeles/objetsApi/objetGetServices');
 const objetGetIndicesCyber = require('../modeles/objetsApi/objetGetIndicesCyber');
+const {
+  enUtilisateurApi,
+} = require('../modeles/objetsApi/objetApiUtilisateur');
 
 const routesApi = (
   middleware,
@@ -394,9 +397,12 @@ const routesApi = (
     (requete, reponse) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       if (idUtilisateur) {
-        depotDonnees.utilisateur(idUtilisateur).then((utilisateur) => {
-          reponse.json({ utilisateur: utilisateur.toJSON() });
-        });
+        depotDonnees
+          .utilisateur(idUtilisateur)
+          .then(enUtilisateurApi)
+          .then((utilisateur) => {
+            reponse.json({ utilisateur });
+          });
       } else reponse.status(401).send("Pas d'utilisateur courant");
     }
   );

--- a/src/vues/motDePasse/edition.pug
+++ b/src/vues/motDePasse/edition.pug
@@ -36,7 +36,7 @@ block main
         input(id='mot-de-passe-confirmation', name = 'motDePasseConfirmation', type='password', required)
         .message-erreur Les deux mots de passe sont différents
 
-      if !utilisateur.accepteCGU()
+      if !utilisateur.cguAcceptees
         +questionCgu
 
     button(type = 'submit').bouton Valider

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -1,7 +1,7 @@
 const Utilisateur = require('../../src/modeles/utilisateur');
 
 class ConstructeurUtilisateur {
-  constructor() {
+  constructor(adaptateurJWT = {}) {
     this.donnees = {
       dateCreation: '',
       id: '',
@@ -18,6 +18,7 @@ class ConstructeurUtilisateur {
       departementEntitePublique: '',
       infolettreAcceptee: '',
     };
+    this.adaptateurJWT = adaptateurJWT;
   }
 
   avecId(idUtilisateur) {
@@ -30,11 +31,18 @@ class ConstructeurUtilisateur {
     return this;
   }
 
+  avecPrenomNom(prenom, nom) {
+    this.donnees.prenom = prenom;
+    this.donnees.nom = nom;
+    return this;
+  }
+
   construis() {
-    return new Utilisateur(this.donnees);
+    return new Utilisateur(this.donnees, { adaptateurJWT: this.adaptateurJWT });
   }
 }
 
-const unUtilisateur = () => new ConstructeurUtilisateur();
+const unUtilisateur = (adaptateurJWT) =>
+  new ConstructeurUtilisateur(adaptateurJWT);
 
 module.exports = { ConstructeurUtilisateur, unUtilisateur };

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -21,6 +21,11 @@ class ConstructeurUtilisateur {
     this.adaptateurJWT = adaptateurJWT;
   }
 
+  avecCguAcceptees() {
+    this.donnees.cguAcceptees = true;
+    return this;
+  }
+
   avecId(idUtilisateur) {
     this.donnees.id = idUtilisateur;
     return this;

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -86,6 +86,8 @@ describe('Une homologation', () => {
       createur: {
         id: '456',
         cguAcceptees: false,
+        prenom: 'Bruno',
+        nom: 'Dumans',
         prenomNom: 'Bruno Dumans',
         telephone: '',
         initiales: 'BD',
@@ -102,6 +104,8 @@ describe('Une homologation', () => {
         {
           id: '999',
           cguAcceptees: false,
+          prenom: 'Jean',
+          nom: 'Dupont',
           prenomNom: 'Jean Dupont',
           telephone: '',
           initiales: 'JD',

--- a/test/modeles/objetsApi/objetApiUtilisateur.spec.js
+++ b/test/modeles/objetsApi/objetApiUtilisateur.spec.js
@@ -1,0 +1,45 @@
+const expect = require('expect.js');
+
+const Utilisateur = require('../../../src/modeles/utilisateur');
+const {
+  enUtilisateurApi,
+} = require('../../../src/modeles/objetsApi/objetApiUtilisateur');
+
+describe("La représentation API d'un Utilisateur", () => {
+  it('est un objet de données', () => {
+    const utilisateur = new Utilisateur({
+      id: '123',
+      prenom: 'Jean',
+      nom: 'Dupont',
+      email: 'jean.dupont@mail.fr',
+      telephone: '0100000000',
+      motDePasse: 'XXX',
+      poste: 'Maire',
+      rssi: true,
+      delegueProtectionDonnees: false,
+      nomEntitePublique: 'Ville de Paris',
+      departementEntitePublique: '75',
+      infolettreAcceptee: true,
+    });
+
+    const donneesApi = enUtilisateurApi(utilisateur);
+
+    expect(donneesApi).to.eql({
+      id: '123',
+      cguAcceptees: false,
+      prenom: 'Jean',
+      nom: 'Dupont',
+      prenomNom: 'Jean Dupont',
+      telephone: '0100000000',
+      initiales: 'JD',
+      poste: 'Maire',
+      posteDetaille: 'RSSI et Maire',
+      rssi: true,
+      delegueProtectionDonnees: false,
+      nomEntitePublique: 'Ville de Paris',
+      departementEntitePublique: '75',
+      profilEstComplet: true,
+      infolettreAcceptee: true,
+    });
+  });
+});

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -102,38 +102,6 @@ describe('Un utilisateur', () => {
       expect(toutEnMemeTemps.posteDetaille()).to.eql('RSSI, DPO et Maire');
     });
   });
-  it('sait se convertir en JSON', () => {
-    const utilisateur = new Utilisateur({
-      id: '123',
-      prenom: 'Jean',
-      nom: 'Dupont',
-      email: 'jean.dupont@mail.fr',
-      telephone: '0100000000',
-      motDePasse: 'XXX',
-      poste: 'Maire',
-      rssi: true,
-      delegueProtectionDonnees: false,
-      nomEntitePublique: 'Ville de Paris',
-      departementEntitePublique: '75',
-      infolettreAcceptee: true,
-    });
-
-    expect(utilisateur.toJSON()).to.eql({
-      id: '123',
-      cguAcceptees: false,
-      prenomNom: 'Jean Dupont',
-      telephone: '0100000000',
-      initiales: 'JD',
-      poste: 'Maire',
-      posteDetaille: 'RSSI et Maire',
-      rssi: true,
-      delegueProtectionDonnees: false,
-      nomEntitePublique: 'Ville de Paris',
-      departementEntitePublique: '75',
-      profilEstComplet: true,
-      infolettreAcceptee: true,
-    });
-  });
 
   it('sait générer son JWT', (done) => {
     const adaptateurJWT = {};

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -166,7 +166,7 @@ describe('Le serveur MSS', () => {
 
   describe('quand requête GET sur `/utilisateur/edition`', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
-      const utilisateur = { accepteCGU: () => true };
+      const utilisateur = unUtilisateur().avecCguAcceptees().construis();
       testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
       testeur
         .middleware()

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -83,11 +83,12 @@ describe('Le serveur MSS', () => {
 
   describe('quand requête GET sur `/initialisationMotDePasse/:idReset`', () => {
     describe('avec idReset valide', () => {
-      const utilisateur = {
-        id: '123',
+      const adaptateurJWT = {
         genereToken: () => 'un token',
-        accepteCGU: () => false,
       };
+      const utilisateur = unUtilisateur(adaptateurJWT)
+        .avecId('123')
+        .construis();
 
       beforeEach(() => {
         testeur.depotDonnees().utilisateurAFinaliser = () =>

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const expect = require('expect.js');
 
 const testeurMSS = require('./routes/testeurMSS');
+const { unUtilisateur } = require('./constructeurs/constructeurUtilisateur');
 
 describe('Le serveur MSS', () => {
   const testeur = testeurMSS();
@@ -57,7 +58,7 @@ describe('Le serveur MSS', () => {
 
   describe('quand GET sur /motDePasse/edition', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
-      const utilisateur = { accepteCGU: () => true };
+      const utilisateur = unUtilisateur().avecCguAcceptees().construis();
       testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
 
       testeur

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -1260,7 +1260,10 @@ describe('Le serveur MSS des routes /api/*', () => {
         return p;
       };
 
-      const utilisateur = { toJSON: () => {}, genereToken: () => {} };
+      const adaptateurJWT = {
+        genereToken: () => 'un token',
+      };
+      const utilisateur = unUtilisateur(adaptateurJWT).construis();
 
       testeur.depotDonnees().utilisateurAuthentifie = (login, motDePasse) => {
         try {
@@ -1283,12 +1286,14 @@ describe('Le serveur MSS des routes /api/*', () => {
 
     describe("avec authentification réussie de l'utilisateur", () => {
       beforeEach(() => {
-        const utilisateur = {
-          email: 'jean.dupont@mail.fr',
-          id: '456',
-          toJSON: () => ({ prenomNom: 'Jean Dupont' }),
+        const adaptateurJWT = {
           genereToken: () => 'un token',
         };
+        const utilisateur = unUtilisateur(adaptateurJWT)
+          .avecEmail('jean.dupont@mail.fr')
+          .avecPrenomNom('Jean', 'Dupont')
+          .avecId('456')
+          .construis();
 
         testeur.depotDonnees().utilisateurAuthentifie = () =>
           Promise.resolve(utilisateur);
@@ -1308,9 +1313,8 @@ describe('Le serveur MSS des routes /api/*', () => {
           })
           .then((reponse) => {
             expect(reponse.status).to.equal(200);
-            expect(reponse.data.utilisateur).to.eql({
-              prenomNom: 'Jean Dupont',
-            });
+            expect(reponse.data.utilisateur.prenomNom).to.eql('Jean Dupont');
+            expect(reponse.data.utilisateur.id).to.eql('456');
             done();
           })
           .catch(done);

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -12,6 +12,7 @@ const {
 } = require('../../src/erreurs');
 
 const testeurMSS = require('./testeurMSS');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
 const Service = require('../../src/modeles/service');
 const ParcoursUtilisateur = require('../../src/modeles/parcoursUtilisateur');
 
@@ -1218,7 +1219,7 @@ describe('Le serveur MSS des routes /api/*', () => {
       depotDonnees.utilisateur = (idUtilisateur) => {
         try {
           expect(idUtilisateur).to.equal('123');
-          return Promise.resolve({ toJSON: () => ({ id: '123' }) });
+          return Promise.resolve(unUtilisateur().avecId('123').construis());
         } catch (erreur) {
           return Promise.reject(erreur);
         }


### PR DESCRIPTION
On cherche à découpler les objets qui transite par l'API, les modèles et les objets de persistance.

Dans cette PR, on créer une représentation `API` pour le modèle `Utilisateur` afin de pouvoir modifier le modèle sans casser les contrats d'API (pour la feature `Fonction/poste`).