### PR TITLE
Déplace un objet API dans le bon répertoire

### DIFF
--- a/src/modeles/objetsApi/objetApiStatutHomologation.js
+++ b/src/modeles/objetsApi/objetApiStatutHomologation.js
@@ -1,6 +1,6 @@
 const Dossiers = require('../dossiers');
 
-class VueStatutHomologation {
+class ObjetApiStatutHomologation {
   constructor(service, referentiel) {
     this.service = service;
     this.referentiel = referentiel;
@@ -89,4 +89,4 @@ class VueStatutHomologation {
   }
 }
 
-module.exports = VueStatutHomologation;
+module.exports = ObjetApiStatutHomologation;

--- a/src/routes/routesService.js
+++ b/src/routes/routesService.js
@@ -3,7 +3,7 @@ const express = require('express');
 const ActionsSaisie = require('../modeles/actionsSaisie');
 const Homologation = require('../modeles/homologation');
 const InformationsHomologation = require('../modeles/informationsHomologation');
-const VueStatutHomologation = require('../modeles/objetsVues/vueStatutHomologation');
+const ObjetApiStatutHomologation = require('../modeles/objetsApi/objetApiStatutHomologation');
 
 const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   const routes = express.Router();
@@ -46,7 +46,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
       actionsSaisie,
       referentiel,
       service: homologation,
-      donneesStatutHomologation: new VueStatutHomologation(
+      donneesStatutHomologation: new ObjetApiStatutHomologation(
         homologation,
         referentiel
       ).donnees(),

--- a/test/modeles/objetsApi/objetApiStatutHomologation.spec.js
+++ b/test/modeles/objetsApi/objetApiStatutHomologation.spec.js
@@ -1,12 +1,12 @@
 const expect = require('expect.js');
 
-const VueStatutHomologation = require('../../../src/modeles/objetsVues/vueStatutHomologation');
+const ObjetApiStatutHomologation = require('../../../src/modeles/objetsApi/objetApiStatutHomologation');
 const Referentiel = require('../../../src/referentiel');
 const { unService } = require('../../constructeurs/constructeurService');
 const { unDossier } = require('../../constructeurs/constructeurDossier');
 const { dateEnFrancais } = require('../../../src/utilitaires/date');
 
-describe("Les données de statut d'une homologation", () => {
+describe("La représentation API du statut d'une homologation", () => {
   describe("sur demande du statut d'homologation", () => {
     const referentiel = Referentiel.creeReferentiel({
       statutsHomologation: {
@@ -35,7 +35,7 @@ describe("Les données de statut d'une homologation", () => {
         .avecDossiers([])
         .construis();
 
-      const donnees = new VueStatutHomologation(
+      const donnees = new ObjetApiStatutHomologation(
         homologationNonRealisee,
         referentiel
       ).donnees();
@@ -68,7 +68,7 @@ describe("Les données de statut d'une homologation", () => {
         ])
         .construis();
 
-      const donnees = new VueStatutHomologation(
+      const donnees = new ObjetApiStatutHomologation(
         homologationBientotActive,
         referentiel
       ).donnees();
@@ -91,7 +91,7 @@ describe("Les données de statut d'une homologation", () => {
         ])
         .construis();
 
-      const donnees = new VueStatutHomologation(
+      const donnees = new ObjetApiStatutHomologation(
         homologationActive,
         referentiel
       ).donnees();
@@ -119,7 +119,7 @@ describe("Les données de statut d'une homologation", () => {
         ])
         .construis();
 
-      const donnees = new VueStatutHomologation(
+      const donnees = new ObjetApiStatutHomologation(
         homologationBientotExpiree,
         referentiel
       ).donnees();
@@ -152,7 +152,7 @@ describe("Les données de statut d'une homologation", () => {
         ])
         .construis();
 
-      const donnees = new VueStatutHomologation(
+      const donnees = new ObjetApiStatutHomologation(
         homologationExpiree,
         referentiel
       ).donnees();


### PR DESCRIPTION
Il avait été créé dans `objetsVue` par erreur.