### PR TITLE
Ajout du champ `postes` dans le modèle `Utilisateur`

### DIFF
--- a/migrations/20230704144300_ajouteChampPostes.js
+++ b/migrations/20230704144300_ajouteChampPostes.js
@@ -1,0 +1,25 @@
+exports.up = (knex) =>
+  knex('utilisateurs').then((lignes) => {
+    const misesAJour = lignes.map(({ id, donnees }) => {
+      const postes = [
+        ...(donnees.rssi ? ['RSSI'] : []),
+        ...(donnees.delegueProtectionDonnees ? ['DPO'] : []),
+        ...(donnees.poste ? [donnees.poste] : []),
+      ];
+      return knex('utilisateurs')
+        .where({ id })
+        .update({ donnees: { ...donnees, postes } });
+    });
+
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) =>
+  knex('utilisateurs').then((lignes) => {
+    const misesAJour = lignes.map(
+      ({ id, donnees: { postes, ...autresDonnees } }) =>
+        knex('utilisateurs').where({ id }).update({ donnees: autresDonnees })
+    );
+
+    return Promise.all(misesAJour);
+  });

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -28,6 +28,7 @@ class Utilisateur extends Base {
         'poste',
         'rssi',
         'delegueProtectionDonnees',
+        'postes',
         'nomEntitePublique',
         'departementEntitePublique',
         'infolettreAcceptee',

--- a/src/routes/routesApi.js
+++ b/src/routes/routesApi.js
@@ -92,17 +92,30 @@ const routesApi = (
       )
       .then(() => contributeur);
 
-  const obtentionDonneesDeBaseUtilisateur = (corps) => ({
-    prenom: corps.prenom,
-    nom: corps.nom,
-    telephone: corps.telephone,
-    rssi: valeurBooleenne(corps.rssi),
-    delegueProtectionDonnees: valeurBooleenne(corps.delegueProtectionDonnees),
-    poste: corps.poste,
-    nomEntitePublique: corps.nomEntitePublique,
-    departementEntitePublique: corps.departementEntitePublique,
-    infolettreAcceptee: valeurBooleenne(corps.infolettreAcceptee),
-  });
+  const obtentionDonneesDeBaseUtilisateur = (corps) => {
+    const rssi = valeurBooleenne(corps.rssi);
+    const delegueProtectionDonnees = valeurBooleenne(
+      corps.delegueProtectionDonnees
+    );
+    const { poste } = corps;
+
+    return {
+      prenom: corps.prenom,
+      nom: corps.nom,
+      telephone: corps.telephone,
+      rssi,
+      delegueProtectionDonnees,
+      poste,
+      nomEntitePublique: corps.nomEntitePublique,
+      departementEntitePublique: corps.departementEntitePublique,
+      infolettreAcceptee: valeurBooleenne(corps.infolettreAcceptee),
+      postes: [
+        ...(rssi ? ['RSSI'] : []),
+        ...(delegueProtectionDonnees ? ['DPO'] : []),
+        ...(poste !== '' ? [poste] : []),
+      ],
+    };
+  };
 
   const messageErreurDonneesUtilisateur = (
     donneesRequete,

--- a/test/routes/routesApi.spec.js
+++ b/test/routes/routesApi.spec.js
@@ -447,6 +447,22 @@ describe('Le serveur MSS des routes /api/*', () => {
         .catch(done);
     });
 
+    it('aggrège les champs RSSI, DPO et poste dans le champs postes', (done) => {
+      testeur.depotDonnees().nouvelUtilisateur = ({ postes }) => {
+        expect(postes).to.eql(['RSSI', 'DPO', 'Maire']);
+        return Promise.resolve(utilisateur);
+      };
+
+      donneesRequete.rssi = 'true';
+      donneesRequete.delegueProtectionDonnees = 'true';
+      donneesRequete.poste = 'Maire';
+
+      axios
+        .post('http://localhost:1234/api/utilisateur', donneesRequete)
+        .then(() => done())
+        .catch(done);
+    });
+
     it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", (done) => {
       donneesRequete.prenom = '';
 
@@ -470,6 +486,7 @@ describe('Le serveur MSS des routes /api/*', () => {
           delegueProtectionDonnees: false,
           cguAcceptees: true,
           infolettreAcceptee: true,
+          postes: ['RSSI', "Chargé des systèmes d'informations"],
         };
         expect(donneesUtilisateur).to.eql(donneesAttendues);
         return Promise.resolve(utilisateur);
@@ -1116,6 +1133,10 @@ describe('Le serveur MSS des routes /api/*', () => {
           expect(donnees.poste).to.equal("Chargé des systèmes d'informations");
           expect(donnees.nomEntitePublique).to.equal('Ville de Paris');
           expect(donnees.departementEntitePublique).to.equal('75');
+          expect(donnees.postes).to.eql([
+            'RSSI',
+            "Chargé des systèmes d'informations",
+          ]);
           infosMisesAJour = true;
           return Promise.resolve(utilisateur);
         } catch (e) {


### PR DESCRIPTION
On ajoute le champ `postes` pour préparer la modification du front.
On 'craft' ce champ en fonction de l'existant sur l'API.

On réalise une migration pour ajouter ce champ chez tous nos utilisateurs.