### PR TITLE
[CORRECTION] Le champ postes ne doit pas accepter de valeur vide

### DIFF
--- a/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
+++ b/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
@@ -26,6 +26,7 @@ const brancheValidationPoste = (selecteurFormulaire) => {
     });
   };
 
+  verifieEtatCasesACocher();
   $toutesCasesACocher.on('change', () => verifieEtatCasesACocher());
   $champSaisieAutre.on('input', () => verifieEtatCasesACocher());
 };


### PR DESCRIPTION
Il était possible de soumettre le formulaire sans valeur de 'Fonction/poste'