### PR TITLE
Ajoute la route `/api/desinscriptionInfolettre` dans la liste des endpoints sans CSRF

### DIFF
--- a/src/http/configurationServeur.js
+++ b/src/http/configurationServeur.js
@@ -7,6 +7,8 @@ const ENDPOINTS_SANS_CSRF = [
   // Pareil pour l'inscription.
   { path: '/api/utilisateur', type: 'exact' },
   { path: '/api/reinitialisationMotDePasse', type: 'exact' },
+  // La désinscription est appelée par un webhook coté Brevo
+  { path: '/api/desinscriptionInfolettre', type: 'exact' },
   // Les événements Matomo partent vers l'infra beta : on ne fait que passe-plat donc on ne protège pas.
   { path: '/bibliotheques/evenementMatomo', type: 'exact' },
 ];


### PR DESCRIPTION
Afin de garantir que Brevo ai le droit de nous contacter sur cette route.