### PR TITLE
[REMANIEMENT] Utilisation d'une vérification JWT unifiée sur les routes privées

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -178,6 +178,7 @@ const creeServeur = (
 
   app.use(
     '/api',
+    middleware.verificationJWT,
     routesApiPrivee({
       middleware,
       adaptateurMail,

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -207,7 +207,6 @@ const routesApiPrivee = ({
 
   routes.put(
     '/motDePasse',
-    middleware.verificationJWT,
     middleware.aseptise('cguAcceptees'),
     (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
@@ -255,7 +254,6 @@ const routesApiPrivee = ({
 
   routes.put(
     '/utilisateur',
-    middleware.verificationJWT,
     middleware.aseptise([
       ...Utilisateur.nomsProprietesBase().filter((nom) => nom !== 'email'),
     ]),
@@ -296,18 +294,14 @@ const routesApiPrivee = ({
     }
   );
 
-  routes.get(
-    '/utilisateurCourant',
-    middleware.verificationJWT,
-    (requete, reponse) => {
-      const idUtilisateur = requete.idUtilisateurCourant;
-      if (idUtilisateur) {
-        depotDonnees.utilisateur(idUtilisateur).then((utilisateur) => {
-          reponse.json({ utilisateur: utilisateur.toJSON() });
-        });
-      } else reponse.status(401).send("Pas d'utilisateur courant");
-    }
-  );
+  routes.get('/utilisateurCourant', (requete, reponse) => {
+    const idUtilisateur = requete.idUtilisateurCourant;
+    if (idUtilisateur) {
+      depotDonnees.utilisateur(idUtilisateur).then((utilisateur) => {
+        reponse.json({ utilisateur: utilisateur.toJSON() });
+      });
+    } else reponse.status(401).send("Pas d'utilisateur courant");
+  });
 
   routes.post(
     '/autorisation',

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -18,6 +18,7 @@ const ServiceTracking = require('../../tracking/serviceTracking');
 const Utilisateur = require('../../modeles/utilisateur');
 const objetGetServices = require('../../modeles/objetsApi/objetGetServices');
 const objetGetIndicesCyber = require('../../modeles/objetsApi/objetGetIndicesCyber');
+const { DUREE_SESSION } = require('../../http/configurationServeur');
 
 const routesApiPrivee = ({
   middleware,
@@ -301,6 +302,10 @@ const routesApiPrivee = ({
         reponse.json({ utilisateur: utilisateur.toJSON() });
       });
     } else reponse.status(401).send("Pas d'utilisateur courant");
+  });
+
+  routes.get('/dureeSession', (_requete, reponse) => {
+    reponse.send({ dureeSession: DUREE_SESSION });
   });
 
   routes.post(

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const { DUREE_SESSION } = require('../../http/configurationServeur');
 const Utilisateur = require('../../modeles/utilisateur');
 const { valeurBooleenne } = require('../../utilitaires/aseptisation');
 const {
@@ -174,10 +173,6 @@ const routesApiPublique = ({
         }
       })
       .catch(suite);
-  });
-
-  routes.get('/dureeSession', (_requete, reponse) => {
-    reponse.send({ dureeSession: DUREE_SESSION });
   });
 
   routes.get('/annuaire/suggestions', (requete, reponse) => {

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -134,6 +134,9 @@ const middlewareFantaisie = {
     requete.idUtilisateurCourant = idUtilisateurCourant;
     requete.cguAcceptees = cguAcceptees;
     verificationCGUMenee = true;
+    // Réplique le comportement du middleware CGU de PROD,
+    // qui appelle le middleware de vérification JWT.
+    verificationJWTMenee = true;
     suite();
   },
 

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -17,6 +17,15 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
   afterEach(testeur.arrete);
 
+  it("vérifie que l'utilisateur est authentifié sur toutes les routes", (done) => {
+    // On vérifie une seule route privée.
+    // Par construction, les autres seront protégées aussi puisque la protection est ajoutée comme middleware
+    // devant le routeur dédié aux routes privées.
+    testeur
+      .middleware()
+      .verifieRequeteExigeJWT('http://localhost:1234/api/services', done);
+  });
+
   describe('quand requête GET sur `/api/services`', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       testeur
@@ -330,15 +339,6 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         Promise.resolve(utilisateur);
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
-        .middleware()
-        .verifieRequeteExigeJWT(
-          { method: 'put', url: 'http://localhost:1234/api/motDePasse' },
-          done
-        );
-    });
-
     it('aseptise les paramètres de la requête', (done) => {
       testeur.middleware().verifieAseptisationParametres(
         ['cguAcceptees'],
@@ -573,17 +573,6 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       depotDonnees.utilisateur = () => Promise.resolve(utilisateur);
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeJWT(
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/utilisateur',
-          data: donneesRequete,
-        },
-        done
-      );
-    });
-
     it('aseptise les paramètres de la requête', (done) => {
       testeur.middleware().verifieAseptisationParametres(
         [
@@ -750,16 +739,6 @@ describe('Le serveur MSS des routes privées /api/*', () => {
   });
 
   describe('quand requête GET sur `/api/utilisateurCourant`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeJWT(
-        {
-          method: 'get',
-          url: 'http://localhost:1234/api/utilisateurCourant',
-        },
-        done
-      );
-    });
-
     it("renvoie l'utilisateur correspondant à l'identifiant", (done) => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -779,6 +779,21 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
   });
 
+  describe('quand requête GET sur `/api/dureeSession`', () => {
+    it('renvoie la durée de session', (done) => {
+      axios
+        .get('http://localhost:1234/api/dureeSession')
+        .then((reponse) => {
+          expect(reponse.status).to.equal(200);
+
+          const { dureeSession } = reponse.data;
+          expect(dureeSession).to.equal(3600000);
+          done();
+        })
+        .catch((e) => done(e.response?.data || e));
+    });
+  });
+
   describe('quand requête POST sur `/api/autorisation`', () => {
     const autorisation = { id: '111' };
     const utilisateur = {

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -524,21 +524,6 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
   });
 
-  describe('quand requête GET sur `/api/dureeSession`', () => {
-    it('renvoie la durée de session', (done) => {
-      axios
-        .get('http://localhost:1234/api/dureeSession')
-        .then((reponse) => {
-          expect(reponse.status).to.equal(200);
-
-          const { dureeSession } = reponse.data;
-          expect(dureeSession).to.equal(3600000);
-          done();
-        })
-        .catch((e) => done(e.response?.data || e));
-    });
-  });
-
   describe('quand requête GET sur `/api/annuaire/suggestions`', () => {
     beforeEach(() => {
       testeur.referentiel().estCodeDepartement = () => true;


### PR DESCRIPTION
Plutôt que de demander à chaque route privée de penser à positionner le middleware `verifieJWT`, on passe à une sécurité par construction où le middleware est positionné devant le routeur privé au global.

Faite en binôme cc @ThibaudMZN 