### PR TITLE
[REMANIEMENT] Regroupe toutes les routes privée dans `routes/privees`

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -7,7 +7,7 @@ const {
 const routesApiPrivee = require('./routes/privees/routesApiPrivee');
 const routesApiPublique = require('./routes/publiques/routesApiPublique');
 const { routesBibliotheques } = require('./routes/routesBibliotheques');
-const routesService = require('./routes/routesService');
+const routesService = require('./routes/privees/routesService');
 const routesStyles = require('./routes/routesStyles');
 
 require('dotenv').config();
@@ -192,12 +192,13 @@ const creeServeur = (
     })
   );
 
-  app.use('/bibliotheques', routesBibliotheques());
-
   app.use(
     '/service',
+    middleware.verificationJWT,
     routesService(middleware, referentiel, depotDonnees, moteurRegles)
   );
+
+  app.use('/bibliotheques', routesBibliotheques());
 
   app.use('/styles', routesStyles());
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -13,7 +13,7 @@ const {
   ErreurAutorisationExisteDeja,
   ErreurModele,
 } = require('../../erreurs');
-const routesApiService = require('../routesApiService');
+const routesApiService = require('./routesApiService');
 const ServiceTracking = require('../../tracking/serviceTracking');
 const Utilisateur = require('../../modeles/utilisateur');
 const objetGetServices = require('../../modeles/objetsApi/objetGetServices');

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -6,24 +6,24 @@ const {
   ErreurModele,
   ErreurDonneesObligatoiresManquantes,
   ErreurNomServiceDejaExistant,
-} = require('../erreurs');
-const ActeursHomologation = require('../modeles/acteursHomologation');
-const AutorisationCreateur = require('../modeles/autorisations/autorisationCreateur');
-const Avis = require('../modeles/avis');
-const AvisExpertCyber = require('../modeles/avisExpertCyber');
-const DescriptionService = require('../modeles/descriptionService');
-const FonctionnalitesSpecifiques = require('../modeles/fonctionnalitesSpecifiques');
-const DonneesSensiblesSpecifiques = require('../modeles/donneesSensiblesSpecifiques');
-const MesureGenerale = require('../modeles/mesureGenerale');
-const MesureSpecifique = require('../modeles/mesureSpecifique');
-const MesuresSpecifiques = require('../modeles/mesuresSpecifiques');
-const PartiesPrenantes = require('../modeles/partiesPrenantes/partiesPrenantes');
-const PointsAcces = require('../modeles/pointsAcces');
-const RisqueGeneral = require('../modeles/risqueGeneral');
-const RisquesSpecifiques = require('../modeles/risquesSpecifiques');
-const RolesResponsabilites = require('../modeles/rolesResponsabilites');
-const { dateInvalide } = require('../utilitaires/date');
-const { valeurBooleenne } = require('../utilitaires/aseptisation');
+} = require('../../erreurs');
+const ActeursHomologation = require('../../modeles/acteursHomologation');
+const AutorisationCreateur = require('../../modeles/autorisations/autorisationCreateur');
+const Avis = require('../../modeles/avis');
+const AvisExpertCyber = require('../../modeles/avisExpertCyber');
+const DescriptionService = require('../../modeles/descriptionService');
+const FonctionnalitesSpecifiques = require('../../modeles/fonctionnalitesSpecifiques');
+const DonneesSensiblesSpecifiques = require('../../modeles/donneesSensiblesSpecifiques');
+const MesureGenerale = require('../../modeles/mesureGenerale');
+const MesureSpecifique = require('../../modeles/mesureSpecifique');
+const MesuresSpecifiques = require('../../modeles/mesuresSpecifiques');
+const PartiesPrenantes = require('../../modeles/partiesPrenantes/partiesPrenantes');
+const PointsAcces = require('../../modeles/pointsAcces');
+const RisqueGeneral = require('../../modeles/risqueGeneral');
+const RisquesSpecifiques = require('../../modeles/risquesSpecifiques');
+const RolesResponsabilites = require('../../modeles/rolesResponsabilites');
+const { dateInvalide } = require('../../utilitaires/date');
+const { valeurBooleenne } = require('../../utilitaires/aseptisation');
 
 const routesApiService = (
   middleware,

--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -1,6 +1,6 @@
 const express = require('express');
-const { genereGradientConique } = require('../pdf/graphiques/camembert');
-const { dateYYYYMMDD } = require('../utilitaires/date');
+const { genereGradientConique } = require('../../pdf/graphiques/camembert');
+const { dateYYYYMMDD } = require('../../utilitaires/date');
 
 const routesApiServicePdf = (
   middleware,

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -1,9 +1,9 @@
 const express = require('express');
 
-const ActionsSaisie = require('../modeles/actionsSaisie');
-const Homologation = require('../modeles/homologation');
-const InformationsHomologation = require('../modeles/informationsHomologation');
-const ObjetApiStatutHomologation = require('../modeles/objetsApi/objetApiStatutHomologation');
+const ActionsSaisie = require('../../modeles/actionsSaisie');
+const Homologation = require('../../modeles/homologation');
+const InformationsHomologation = require('../../modeles/informationsHomologation');
+const ObjetApiStatutHomologation = require('../../modeles/objetsApi/objetApiStatutHomologation');
 
 const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   const routes = express.Router();

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1,17 +1,17 @@
 const axios = require('axios');
 const expect = require('expect.js');
 
-const testeurMSS = require('./testeurMSS');
+const testeurMSS = require('../testeurMSS');
 
-const uneDescriptionValide = require('../constructeurs/constructeurDescriptionService');
-const { unDossier } = require('../constructeurs/constructeurDossier');
+const uneDescriptionValide = require('../../constructeurs/constructeurDescriptionService');
+const { unDossier } = require('../../constructeurs/constructeurDossier');
 const {
   ErreurDonneesObligatoiresManquantes,
   ErreurNomServiceDejaExistant,
-} = require('../../src/erreurs');
-const AutorisationContributeur = require('../../src/modeles/autorisations/autorisationContributeur');
-const AutorisationCreateur = require('../../src/modeles/autorisations/autorisationCreateur');
-const Homologation = require('../../src/modeles/homologation');
+} = require('../../../src/erreurs');
+const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
+const AutorisationCreateur = require('../../../src/modeles/autorisations/autorisationCreateur');
+const Homologation = require('../../../src/modeles/homologation');
 
 describe('Le serveur MSS des routes /api/service/*', () => {
   const testeur = testeurMSS();

--- a/test/routes/privees/routesApiServicePdf.spec.js
+++ b/test/routes/privees/routesApiServicePdf.spec.js
@@ -1,15 +1,15 @@
 const expect = require('expect.js');
 const axios = require('axios');
 
-const testeurMSS = require('./testeurMSS');
+const testeurMSS = require('../testeurMSS');
 const {
   verifieNomFichierServi,
   verifieTypeFichierServiEstPDF,
   verifieTypeFichierServiEstZIP,
-} = require('../aides/verifieFichierServi');
-const { unDossier } = require('../constructeurs/constructeurDossier');
-const Homologation = require('../../src/modeles/homologation');
-const Referentiel = require('../../src/referentiel');
+} = require('../../aides/verifieFichierServi');
+const { unDossier } = require('../../constructeurs/constructeurDossier');
+const Homologation = require('../../../src/modeles/homologation');
+const Referentiel = require('../../../src/referentiel');
 
 describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
   const testeur = testeurMSS();

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -1,8 +1,8 @@
 const axios = require('axios');
 const expect = require('expect.js');
 
-const testeurMSS = require('./testeurMSS');
-const Homologation = require('../../src/modeles/homologation');
+const testeurMSS = require('../testeurMSS');
+const Homologation = require('../../../src/modeles/homologation');
 
 describe('Le serveur MSS des routes /service/*', () => {
   const testeur = testeurMSS();


### PR DESCRIPTION
Pour assurer la cohérence de la base de code, on déplace ces routes.