### PR TITLE
[REMANIEMENT] Supprime la duplication de code de mapping

### DIFF
--- a/src/routes/mappeur/utilisateur.js
+++ b/src/routes/mappeur/utilisateur.js
@@ -1,0 +1,30 @@
+const Utilisateur = require('../../modeles/utilisateur');
+const { valeurBooleenne } = require('../../utilitaires/aseptisation');
+
+const obtentionDonneesDeBaseUtilisateur = (corps) => ({
+  prenom: corps.prenom,
+  nom: corps.nom,
+  telephone: corps.telephone,
+  nomEntitePublique: corps.nomEntitePublique,
+  departementEntitePublique: corps.departementEntitePublique,
+  infolettreAcceptee: valeurBooleenne(corps.infolettreAcceptee),
+  postes: corps.postes,
+});
+
+const messageErreurDonneesUtilisateur = (
+  donneesRequete,
+  utilisateurExiste,
+  referentiel
+) => {
+  try {
+    Utilisateur.valideDonnees(donneesRequete, referentiel, utilisateurExiste);
+    return { donneesInvalides: false };
+  } catch (erreur) {
+    return { donneesInvalides: true, messageErreur: erreur.message };
+  }
+};
+
+module.exports = {
+  obtentionDonneesDeBaseUtilisateur,
+  messageErreurDonneesUtilisateur,
+};

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -19,6 +19,10 @@ const Utilisateur = require('../../modeles/utilisateur');
 const objetGetServices = require('../../modeles/objetsApi/objetGetServices');
 const objetGetIndicesCyber = require('../../modeles/objetsApi/objetGetIndicesCyber');
 const { DUREE_SESSION } = require('../../http/configurationServeur');
+const {
+  messageErreurDonneesUtilisateur,
+  obtentionDonneesDeBaseUtilisateur,
+} = require('../mappeur/utilisateur');
 
 const routesApiPrivee = ({
   middleware,
@@ -68,32 +72,6 @@ const routesApiPrivee = ({
         service.id
       )
       .then(() => contributeur);
-
-  const obtentionDonneesDeBaseUtilisateur = (corps) => ({
-    prenom: corps.prenom,
-    nom: corps.nom,
-    telephone: corps.telephone,
-    nomEntitePublique: corps.nomEntitePublique,
-    departementEntitePublique: corps.departementEntitePublique,
-    infolettreAcceptee: valeurBooleenne(corps.infolettreAcceptee),
-    postes: corps.postes,
-  });
-
-  const messageErreurDonneesUtilisateur = (
-    donneesRequete,
-    utilisateurExistant = false
-  ) => {
-    try {
-      Utilisateur.valideDonnees(
-        donneesRequete,
-        referentiel,
-        utilisateurExistant
-      );
-      return { donneesInvalides: false };
-    } catch (erreur) {
-      return { donneesInvalides: true, messageErreur: erreur.message };
-    }
-  };
 
   const routes = express.Router();
 
@@ -261,9 +239,9 @@ const routesApiPrivee = ({
     (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       const donnees = obtentionDonneesDeBaseUtilisateur(requete.body);
-
       const { donneesInvalides, messageErreur } =
-        messageErreurDonneesUtilisateur(donnees, true);
+        messageErreurDonneesUtilisateur(donnees, true, referentiel);
+
       if (donneesInvalides) {
         reponse
           .status(422)

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -6,6 +6,10 @@ const {
   EchecEnvoiMessage,
   ErreurModele,
 } = require('../../erreurs');
+const {
+  messageErreurDonneesUtilisateur,
+  obtentionDonneesDeBaseUtilisateur,
+} = require('../mappeur/utilisateur');
 
 const routesApiPublique = ({
   middleware,
@@ -21,32 +25,6 @@ const routesApiPublique = ({
     '/utilisateur',
     middleware.aseptise(...Utilisateur.nomsProprietesBase()),
     (requete, reponse, suite) => {
-      const obtentionDonneesDeBaseUtilisateur = (corps) => ({
-        prenom: corps.prenom,
-        nom: corps.nom,
-        telephone: corps.telephone,
-        nomEntitePublique: corps.nomEntitePublique,
-        departementEntitePublique: corps.departementEntitePublique,
-        infolettreAcceptee: valeurBooleenne(corps.infolettreAcceptee),
-        postes: corps.postes,
-      });
-
-      const messageErreurDonneesUtilisateur = (
-        donneesRequete,
-        utilisateurExistant = false
-      ) => {
-        try {
-          Utilisateur.valideDonnees(
-            donneesRequete,
-            referentiel,
-            utilisateurExistant
-          );
-          return { donneesInvalides: false };
-        } catch (erreur) {
-          return { donneesInvalides: true, messageErreur: erreur.message };
-        }
-      };
-
       const verifieSuccesEnvoiMessage = (promesseEnvoiMessage, utilisateur) =>
         promesseEnvoiMessage
           .then(() => utilisateur)
@@ -80,9 +58,9 @@ const routesApiPublique = ({
       const donnees = obtentionDonneesDeBaseUtilisateur(requete.body);
       donnees.cguAcceptees = valeurBooleenne(requete.body.cguAcceptees);
       donnees.email = requete.body.email?.toLowerCase();
-
       const { donneesInvalides, messageErreur } =
-        messageErreurDonneesUtilisateur(donnees);
+        messageErreurDonneesUtilisateur(donnees, false, referentiel);
+
       if (donneesInvalides) {
         reponse
           .status(422)


### PR DESCRIPTION
Le code avait été dupliqué lorsque nous avons séparé les routes publiques et privées dans des fichiers distincts.