### PR TITLE
[NETTOYAGE] Nettoie la validation de mot de passe

### DIFF
--- a/public/motDePasse/validationMotDePasse.mjs
+++ b/public/motDePasse/validationMotDePasse.mjs
@@ -12,8 +12,6 @@ const resultatValidation = {
 };
 
 const valideMotDePasse = (motDePasse) => {
-  if (motDePasse === '') return resultatValidation.MOT_DE_PASSE_VALIDE;
-
   if (motDePasse.length < 12)
     return resultatValidation.ERREUR_MOT_DE_PASSE_TROP_COURT;
   if (!motDePasse.match(/[A-Z]/))

--- a/src/http/validationMotDePasse.js
+++ b/src/http/validationMotDePasse.js
@@ -3,6 +3,7 @@
 // La mutualisation est prévue lorsque le back supportera la syntaxe « import … from »
 
 const resultatValidation = {
+  ERREUR_MOT_DE_PASSE_NON_CHAINE: 'erreurMotDePasseNonChaine',
   ERREUR_MOT_DE_PASSE_TROP_COURT: 'erreurMotDePasseTropCourt',
   ERREUR_PAS_DE_CARACTERE_SPECIAL: 'erreurPasDeCaractereSpecial',
   ERREUR_PAS_DE_CHIFFRE: 'erreurPasDeChiffre',
@@ -12,8 +13,8 @@ const resultatValidation = {
 };
 
 const valideMotDePasse = (motDePasse) => {
-  if (motDePasse === '') return resultatValidation.MOT_DE_PASSE_VALIDE;
-
+  if (typeof motDePasse !== 'string')
+    return resultatValidation.ERREUR_MOT_DE_PASSE_NON_CHAINE;
   if (motDePasse.length < 12)
     return resultatValidation.ERREUR_MOT_DE_PASSE_TROP_COURT;
   if (!motDePasse.match(/[A-Z]/))

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -193,20 +193,6 @@ const routesApiPrivee = ({
       const cguEnCoursDAcceptation = valeurBooleenne(requete.body.cguAcceptees);
       const { motDePasse } = requete.body;
 
-      const pasDeMotDePasse = motDePasse === undefined;
-      if (pasDeMotDePasse) {
-        reponse.status(204).send();
-        return;
-      }
-
-      const motDePasseInvalide = !(
-        typeof motDePasse === 'string' && motDePasse
-      );
-      if (motDePasseInvalide) {
-        reponse.status(422).send('Mot de passe invalide');
-        return;
-      }
-
       if (!cguDejaAcceptees && !cguEnCoursDAcceptation) {
         reponse.status(422).send('CGU non acceptées');
         return;

--- a/test/http/validationMotDePasse.spec.js
+++ b/test/http/validationMotDePasse.spec.js
@@ -5,6 +5,12 @@ const {
 } = require('../../src/http/validationMotDePasse');
 
 describe('Le validateur de mot de passe', () => {
+  it('vérifie que le mot de passe est une chaîne de caractères', () => {
+    expect(valideMotDePasse([])).to.equal(
+      resultatValidation.ERREUR_MOT_DE_PASSE_NON_CHAINE
+    );
+  });
+
   it("vérifie que la taille du mot de passe est d'au moins douze caractères", () => {
     expect(valideMotDePasse('Ab!45678901')).to.equal(
       resultatValidation.ERREUR_MOT_DE_PASSE_TROP_COURT
@@ -58,12 +64,6 @@ describe('Le validateur de mot de passe', () => {
       expect(valideMotDePasse(mdp)).to.equal(
         resultatValidation.MOT_DE_PASSE_VALIDE
       )
-    );
-  });
-
-  it('accepte un mot de passe vide comme valide', () => {
-    expect(valideMotDePasse('')).to.equal(
-      resultatValidation.MOT_DE_PASSE_VALIDE
     );
   });
 });

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -383,35 +383,6 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         .catch((e) => done(e.response?.data || e));
     });
 
-    it("ne fait rien si aucun nouveau mot de passe n'est renseigné (possible tant que le changement de MDP se fait sur la page profil utilisateur)", (done) => {
-      let motDePasseMisAJour = false;
-
-      testeur.depotDonnees().metsAJourMotDePasse = () => {
-        motDePasseMisAJour = true;
-        return Promise.resolve();
-      };
-
-      axios
-        .put('http://localhost:1234/api/motDePasse', { motDePasse: undefined })
-        .then((reponse) => expect(reponse.status).to.equal(204))
-        .then(() => expect(motDePasseMisAJour).to.be(false))
-        .then(() => done())
-        .catch((e) => done(e.response?.data || e));
-    });
-
-    it('retourne une erreur HTTP 422 si le mot de passe est invalide', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
-        422,
-        'Mot de passe invalide',
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/motDePasse',
-          data: { motDePasse: '' },
-        },
-        done
-      );
-    });
-
     it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", (done) => {
       testeur.verifieRequeteGenereErreurHTTP(
         422,

--- a/test_public/motDePasse/validationMotDePasse.spec.mjs
+++ b/test_public/motDePasse/validationMotDePasse.spec.mjs
@@ -60,10 +60,4 @@ describe('Le validateur de mot de passe', () => {
       )
     );
   });
-
-  it('accepte un mot de passe vide comme valide', () => {
-    expect(valideMotDePasse('')).to.equal(
-      resultatValidation.MOT_DE_PASSE_VALIDE
-    );
-  });
 });


### PR DESCRIPTION
La logique qui était pertinente lorsqu'on était en transition vers une page dédiée au changement de mot de passe n'est plus utile. Pendant cette période le code devait gérer des appels depuis la page « Profil utilisateur » (qui avait les champs de changement de MDP) et depuis la nouvelle page « Mot de passe ».

Maintenant : tout passe par la page « Mot de passe ».

Donc on fait les nettoyages suivants :
- Le mot de passe chaîne vide n'est plus valide.
- Appeler l'API sans valeur pour `motDePasse` n'est plus un 204.
- La vérification du type « chaîne » est faite par la fonction de validation, plus par l'API. Par contre, côté front on ne fait pas cette vérification, car le mot de passe est obtenu par ``` const motDePasse = $champMdp.val(); ``` qui renvoie forcément une chaîne.