### PR TITLE
Ajoute la route `PATCH /motDePasse`

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -187,20 +187,22 @@ const middleware = (configuration = {}) => {
       message: 'Non autorisé',
     });
 
-  const verificationMotDePasse = (requete, reponse, suite) => {
+  const challengeMotDePasse = (requete, reponse, suite) => {
     if (!requete.idUtilisateurCourant)
       throw new Error(
         'Un utilisateur courant doit être présent dans la requête. Manque-t-il un appel à `verificationJWT` ?'
       );
 
-    const { motDePasse } = requete.body;
-    if (!motDePasse) {
-      reponse.status(422).send('Le champ "motDePasse" est obligatoire');
+    const { motDePasseChallenge } = requete.body;
+    if (!motDePasseChallenge) {
+      reponse
+        .status(422)
+        .send('Le champ `motDePasseChallenge` est obligatoire');
       return;
     }
 
     depotDonnees
-      .verifieMotDePasse(requete.idUtilisateurCourant, motDePasse)
+      .verifieMotDePasse(requete.idUtilisateurCourant, motDePasseChallenge)
       .then(() => suite())
       .catch(() => reponse.status(401).send('Mot de passe incorrect'));
   };
@@ -218,7 +220,7 @@ const middleware = (configuration = {}) => {
     verificationAcceptationCGU,
     verificationAddresseIP,
     verificationJWT,
-    verificationMotDePasse,
+    challengeMotDePasse,
   };
 };
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -217,6 +217,29 @@ const routesApiPrivee = ({
     }
   );
 
+  routes.patch(
+    '/motDePasse',
+    middleware.challengeMotDePasse,
+    (requete, reponse) => {
+      const idUtilisateur = requete.idUtilisateurCourant;
+      const { motDePasse } = requete.body;
+
+      const mdpInvalide =
+        valideMotDePasse(motDePasse) !== resultatValidation.MOT_DE_PASSE_VALIDE;
+      if (mdpInvalide) {
+        reponse.status(422).send('Mot de passe trop simple');
+        return;
+      }
+
+      depotDonnees
+        .metsAJourMotDePasse(idUtilisateur, motDePasse)
+        .then((utilisateur) => {
+          requete.session.token = utilisateur.genereToken();
+          reponse.json({ idUtilisateur });
+        });
+    }
+  );
+
   routes.put(
     '/utilisateur',
     middleware.aseptise([

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -34,6 +34,7 @@ const verifieRequeteChangeEtat = (donneesEtat, requete, done) => {
 };
 
 let cguAcceptees;
+let challengeMotDePasseEffectue = false;
 let expirationCookieRepoussee = false;
 let headersAvecNoncePositionnes = false;
 let headersPositionnes = false;
@@ -84,6 +85,11 @@ const middlewareFantaisie = {
     listes.forEach(({ nom, proprietes }) =>
       listesAseptisees.push({ nom, proprietes })
     );
+    suite();
+  },
+
+  challengeMotDePasse: (_requete, _reponse, suite) => {
+    challengeMotDePasseEffectue = true;
     suite();
   },
 
@@ -225,6 +231,13 @@ const middlewareFantaisie = {
   verifieRequeteRepousseExpirationCookie: (...params) => {
     verifieRequeteChangeEtat(
       { lectureEtat: () => expirationCookieRepoussee },
+      ...params
+    );
+  },
+
+  verifieChallengeMotDePasse: (...params) => {
+    verifieRequeteChangeEtat(
+      { lectureEtat: () => challengeMotDePasseEffectue },
       ...params
     );
   },


### PR DESCRIPTION
On ajoute une route pour modifier son mot de passe lorsqu'on est connecté.

Cette route reprend le fonctionnement de la route `POST /motDePasse`, sans vérification des CGUs mais avec vérification du mot de passe actuel via le middleware `challengeMotDePasse`