### PR TITLE
[CORRECTION] Le chiffre dans le camembert « À remplir »

### DIFF
--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -116,6 +116,9 @@ class StatistiquesMesures {
     );
 
     resultat.restant = resultat.total - resultat.fait;
+    resultat.aRemplir =
+      resultat.total - resultat.fait - resultat.enCours - resultat.nonFait;
+
     return resultat;
   }
 

--- a/src/pdf/graphiques/camembert.js
+++ b/src/pdf/graphiques/camembert.js
@@ -7,7 +7,7 @@ const detailAngle = (debut, fin) => ({
 });
 
 const recalculPourFin360 = (angles) => {
-  const { fait, enCours, nonFait, restant } = angles;
+  const { fait, enCours, nonFait, aRemplir } = angles;
 
   const depassement = fait.fin - 360;
   const nbAnglesAModifier = Object.values(angles)
@@ -23,7 +23,7 @@ const recalculPourFin360 = (angles) => {
   const valeurRevisees = {
     enCours: valeurRevisee(enCours),
     nonFait: valeurRevisee(nonFait),
-    restant: valeurRevisee(restant),
+    aRemplir: valeurRevisee(aRemplir),
     fait: valeurRevisee(fait),
   };
 
@@ -32,19 +32,19 @@ const recalculPourFin360 = (angles) => {
     enCoursRevise.fin,
     enCoursRevise.fin + valeurRevisees.nonFait
   );
-  const restantRevise = detailAngle(
+  const aRemplirRevise = detailAngle(
     nonFaitRevise.fin,
-    nonFaitRevise.fin + valeurRevisees.restant
+    nonFaitRevise.fin + valeurRevisees.aRemplir
   );
   const faitRevise = detailAngle(
-    restantRevise.fin,
-    restantRevise.fin + valeurRevisees.fait
+    aRemplirRevise.fin,
+    aRemplirRevise.fin + valeurRevisees.fait
   );
 
   return {
     enCours: enCoursRevise,
     nonFait: nonFaitRevise,
-    restant: restantRevise,
+    aRemplir: aRemplirRevise,
     fait: faitRevise,
   };
 };
@@ -54,7 +54,7 @@ const genereGradientConique = (statistiques) => {
     const total =
       statistiques.enCours +
       statistiques.nonFait +
-      statistiques.restant +
+      statistiques.aRemplir +
       statistiques.fait;
 
     const valeurBrute = (uneStatistique / total) * 360;
@@ -63,16 +63,16 @@ const genereGradientConique = (statistiques) => {
 
   const enCours = avecAngleMinimum(statistiques.enCours);
   const nonFait = avecAngleMinimum(statistiques.nonFait);
-  const restant = avecAngleMinimum(statistiques.restant);
+  const aRemplir = avecAngleMinimum(statistiques.aRemplir);
   const fait = avecAngleMinimum(statistiques.fait);
 
   const anglesInitiaux = {
     enCours: detailAngle(0, enCours),
     nonFait: detailAngle(enCours, enCours + nonFait),
-    restant: detailAngle(enCours + nonFait, enCours + nonFait + restant),
+    aRemplir: detailAngle(enCours + nonFait, enCours + nonFait + aRemplir),
     fait: detailAngle(
-      enCours + nonFait + restant,
-      enCours + nonFait + restant + fait
+      enCours + nonFait + aRemplir,
+      enCours + nonFait + aRemplir + fait
     ),
   };
 
@@ -84,7 +84,7 @@ const genereGradientConique = (statistiques) => {
   const seulementStatistiquesConcernes = {
     enCours: statistiques.enCours,
     nonFait: statistiques.nonFait,
-    restant: statistiques.restant,
+    aRemplir: statistiques.aRemplir,
     fait: statistiques.fait,
   };
   const contientUneValeurUnique =

--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -781,7 +781,7 @@ p {
   color: white;
 }
 
-.synthese-securite .graphique-camemberts .chiffre:is(.non-fait, .restant) {
+.synthese-securite .graphique-camemberts .chiffre:is(.non-fait, .a-remplir) {
   color: #08416a;
 }
 

--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -6,20 +6,20 @@ mixin chiffre(texte, angle, classe, estUnique)
     .chiffre(class=classe, style=`top: calc(${rayon} * cos(180deg - ${angle}deg)); left: calc(${rayon} * sin(180deg - ${angle}deg));`)!= texte
 
 mixin statistiquesMesures({ id, statistiques = {},  camembert = {}, unique = null})
-  - const { total = 0, enCours = 0, nonFait = 0, fait = 0, restant = 0 } = statistiques
-  - const chaineGradientConique = `background: conic-gradient(#75A1E8 ${camembert.enCours.debut}deg ${camembert.enCours.fin}deg, #D0E0F6 ${camembert.nonFait.debut}deg ${camembert.nonFait.fin}deg, #FFFFFF ${camembert.restant.debut}deg ${camembert.restant.fin}deg, transparent ${camembert.restant.fin}deg 360deg);`;
+  - const { total = 0, enCours = 0, nonFait = 0, fait = 0, restant = 0, aRemplir = 0 } = statistiques
+  - const chaineGradientConique = `background: conic-gradient(#75A1E8 ${camembert.enCours.debut}deg ${camembert.enCours.fin}deg, #D0E0F6 ${camembert.nonFait.debut}deg ${camembert.nonFait.fin}deg, #FFFFFF ${camembert.aRemplir.debut}deg ${camembert.aRemplir.fin}deg, transparent ${camembert.aRemplir.fin}deg 360deg);`;
   - const chaineGradientConiqueFait = `background: conic-gradient(transparent 0deg ${camembert.fait.debut}deg, #0A4C8C ${camembert.fait.debut}deg ${camembert.fait.fin}deg);`;
   - const decalageCamemberFait = '4px'
   - const styleDecalageCamemberFait = `top: calc(${decalageCamemberFait} * cos(180deg - ${camembert.fait.milieu}deg)); left: calc(${decalageCamemberFait} * sin(180deg - ${camembert.fait.milieu}deg));`
   .statistiques-mesures
     .details
       .graphique-camemberts
-        .camembert.bordure-reste-a-faire(style=`background: conic-gradient(#0F7AC7 0deg ${camembert.restant.fin}deg, transparent ${camembert.restant.fin}deg 360deg);`)
+        .camembert.bordure-reste-a-faire(style=`background: conic-gradient(#0F7AC7 0deg ${camembert.aRemplir.fin}deg, transparent ${camembert.aRemplir.fin}deg 360deg);`)
         .camembert.masque-reste-a-faire
         .camembert(style=chaineGradientConique)
         +chiffre(enCours, camembert.enCours.milieu, 'en-cours', unique === 'enCours')
         +chiffre(nonFait, camembert.nonFait.milieu, 'non-fait', unique === 'nonFait')
-        +chiffre(restant, camembert.restant.milieu, 'restant', unique === 'restant')
+        +chiffre(aRemplir, camembert.aRemplir.milieu, 'a-remplir', unique === 'aRemplir')
         .camembert.fait(style=`${chaineGradientConiqueFait}; ${styleDecalageCamemberFait}`)
         +chiffre(fait, camembert.fait.milieu, 'fait', unique == 'fait')
       .fleche

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -333,6 +333,7 @@ describe('Les statistiques sur les mesures de sécurité', () => {
       total: 12 + 15,
       restant: 12 + 15 - (1 + 2),
       nonFait: 8 + 4,
+      aRemplir: 12 + 15 - (1 + 2) - (2 + 3) - (8 + 4),
     });
   });
 
@@ -360,6 +361,7 @@ describe('Les statistiques sur les mesures de sécurité', () => {
       total: 12 + 15,
       restant: 12 + 15 - (1 + 2),
       nonFait: 8 + 4,
+      aRemplir: 12 + 15 - (1 + 2) - (2 + 3) - (8 + 4),
     });
   });
 

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -316,21 +316,24 @@ describe('Les statistiques sur les mesures de sécurité', () => {
         une: {
           misesEnOeuvre: 1,
           retenues: 5,
-          indispensables: { total: 12, enCours: 2, fait: 1 },
+          indispensables: { total: 12, enCours: 2, fait: 1, nonFait: 0 },
         },
         deux: {
           misesEnOeuvre: 2,
           retenues: 5,
-          indispensables: { total: 15, enCours: 3, fait: 2 },
+          indispensables: { total: 15, enCours: 3, fait: 2, nonFait: 0 },
         },
       },
       referentiel
     );
 
-    expect(stats.indispensables().enCours).to.equal(2 + 3);
-    expect(stats.indispensables().fait).to.equal(1 + 2);
-    expect(stats.indispensables().total).to.equal(12 + 15);
-    expect(stats.indispensables().restant).to.equal(12 + 15 - (1 + 2));
+    expect(stats.indispensables()).to.eql({
+      enCours: 2 + 3,
+      fait: 1 + 2,
+      total: 12 + 15,
+      restant: 12 + 15 - (1 + 2),
+      nonFait: 0 + 0,
+    });
   });
 
   elles('peuvent filtrer les totaux par mesures recommandées', () => {
@@ -339,20 +342,25 @@ describe('Les statistiques sur les mesures de sécurité', () => {
         une: {
           misesEnOeuvre: 1,
           retenues: 5,
-          recommandees: { total: 12, enCours: 2, fait: 1 },
+          recommandees: { total: 12, enCours: 2, fait: 1, nonFait: 0 },
         },
         deux: {
           misesEnOeuvre: 2,
           retenues: 5,
-          recommandees: { total: 15, enCours: 3, fait: 2 },
+          recommandees: { total: 15, enCours: 3, fait: 2, nonFait: 0 },
         },
       },
       referentiel
     );
 
-    expect(stats.recommandees().enCours).to.equal(2 + 3);
-    expect(stats.recommandees().fait).to.equal(1 + 2);
-    expect(stats.recommandees().total).to.equal(12 + 15);
+    const recommandees = stats.recommandees();
+    expect(recommandees).to.eql({
+      enCours: 2 + 3,
+      fait: 1 + 2,
+      total: 12 + 15,
+      restant: 12 + 15 - (1 + 2),
+      nonFait: 0 + 0,
+    });
   });
 
   describe('sur demande de la complétude', () => {

--- a/test/modeles/statistiquesMesures.spec.js
+++ b/test/modeles/statistiquesMesures.spec.js
@@ -316,12 +316,12 @@ describe('Les statistiques sur les mesures de sécurité', () => {
         une: {
           misesEnOeuvre: 1,
           retenues: 5,
-          indispensables: { total: 12, enCours: 2, fait: 1, nonFait: 0 },
+          indispensables: { total: 12, enCours: 2, fait: 1, nonFait: 8 },
         },
         deux: {
           misesEnOeuvre: 2,
           retenues: 5,
-          indispensables: { total: 15, enCours: 3, fait: 2, nonFait: 0 },
+          indispensables: { total: 15, enCours: 3, fait: 2, nonFait: 4 },
         },
       },
       referentiel
@@ -332,7 +332,7 @@ describe('Les statistiques sur les mesures de sécurité', () => {
       fait: 1 + 2,
       total: 12 + 15,
       restant: 12 + 15 - (1 + 2),
-      nonFait: 0 + 0,
+      nonFait: 8 + 4,
     });
   });
 
@@ -342,12 +342,12 @@ describe('Les statistiques sur les mesures de sécurité', () => {
         une: {
           misesEnOeuvre: 1,
           retenues: 5,
-          recommandees: { total: 12, enCours: 2, fait: 1, nonFait: 0 },
+          recommandees: { total: 12, enCours: 2, fait: 1, nonFait: 8 },
         },
         deux: {
           misesEnOeuvre: 2,
           retenues: 5,
-          recommandees: { total: 15, enCours: 3, fait: 2, nonFait: 0 },
+          recommandees: { total: 15, enCours: 3, fait: 2, nonFait: 4 },
         },
       },
       referentiel
@@ -359,7 +359,7 @@ describe('Les statistiques sur les mesures de sécurité', () => {
       fait: 1 + 2,
       total: 12 + 15,
       restant: 12 + 15 - (1 + 2),
-      nonFait: 0 + 0,
+      nonFait: 8 + 4,
     });
   });
 

--- a/test/pdf/graphiques/camembert.spec.js
+++ b/test/pdf/graphiques/camembert.spec.js
@@ -6,13 +6,13 @@ const {
 describe('Les graphiques camembert', () => {
   describe('quand ils sont générés via un gradient conique', () => {
     it('retournent un angle proportionel à la valeur du statut', () => {
-      const statistiques = { enCours: 5, nonFait: 5, fait: 5, restant: 5 };
+      const statistiques = { enCours: 5, nonFait: 5, fait: 5, aRemplir: 5 };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
           enCours: { debut: 0, milieu: 45, fin: 90 },
           nonFait: { debut: 90, milieu: 135, fin: 180 },
-          restant: { debut: 180, milieu: 225, fin: 270 },
+          aRemplir: { debut: 180, milieu: 225, fin: 270 },
           fait: { debut: 270, milieu: 315, fin: 360 },
         },
         unique: null,
@@ -20,13 +20,13 @@ describe('Les graphiques camembert', () => {
     });
 
     it("retournent un seul angle valant 360 degrés quand il n'y a qu'un seul statut possédant une valeur", () => {
-      const statistiques = { enCours: 0, nonFait: 5, fait: 0, restant: 0 };
+      const statistiques = { enCours: 0, nonFait: 5, fait: 0, aRemplir: 0 };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
           enCours: { debut: 0, milieu: 0, fin: 0 },
           nonFait: { debut: 0, milieu: 180, fin: 360 },
-          restant: { debut: 360, milieu: 360, fin: 360 },
+          aRemplir: { debut: 360, milieu: 360, fin: 360 },
           fait: { debut: 360, milieu: 360, fin: 360 },
         },
         unique: 'nonFait',
@@ -41,25 +41,25 @@ describe('Les graphiques camembert', () => {
       };
 
       verifieAngleMinimum(
-        { enCours: 1, nonFait: 0, fait: 100, restant: 0 },
+        { enCours: 1, nonFait: 0, fait: 100, aRemplir: 0 },
         'enCours'
       );
       verifieAngleMinimum(
-        { enCours: 0, nonFait: 1, fait: 100, restant: 0 },
+        { enCours: 0, nonFait: 1, fait: 100, aRemplir: 0 },
         'nonFait'
       );
       verifieAngleMinimum(
-        { enCours: 0, nonFait: 0, fait: 100, restant: 1 },
-        'restant'
+        { enCours: 0, nonFait: 0, fait: 100, aRemplir: 1 },
+        'aRemplir'
       );
       verifieAngleMinimum(
-        { enCours: 0, nonFait: 0, fait: 1, restant: 100 },
+        { enCours: 0, nonFait: 0, fait: 1, aRemplir: 100 },
         'fait'
       );
     });
 
     it("s'assurent que les « débuts » et « fins » des angles minimum ne se chevauchent pas", () => {
-      const statistiques = { enCours: 1, nonFait: 1, restant: 1, fait: 47 };
+      const statistiques = { enCours: 1, nonFait: 1, aRemplir: 1, fait: 47 };
 
       const { angles } = genereGradientConique(statistiques);
 
@@ -70,17 +70,17 @@ describe('Les graphiques camembert', () => {
 
       verifieDebutFin(0, 20, 'enCours');
       verifieDebutFin(20, 40, 'nonFait');
-      verifieDebutFin(40, 60, 'restant');
+      verifieDebutFin(40, 60, 'aRemplir');
     });
 
     it("s'assurent de ne pas dépasser 360 degrés, même en cas d'utilisation d'angle(s) minimum(s) au début du camembert", () => {
-      const statistiques = { enCours: 1, nonFait: 1, restant: 1, fait: 47 };
+      const statistiques = { enCours: 1, nonFait: 1, aRemplir: 1, fait: 47 };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
           enCours: { debut: 0, milieu: 10, fin: 20 },
           nonFait: { debut: 20, milieu: 30, fin: 40 },
-          restant: { debut: 40, milieu: 50, fin: 60 },
+          aRemplir: { debut: 40, milieu: 50, fin: 60 },
           fait: { debut: 60, milieu: 210, fin: 360 },
         },
         unique: null,
@@ -88,13 +88,13 @@ describe('Les graphiques camembert', () => {
     });
 
     it("s'assurent de ne pas dépasser 360 degrés, même en cas d'utilisation d'angle(s) minimum(s) à la fin du camembert", () => {
-      const statistiques = { enCours: 47, nonFait: 1, restant: 2, fait: 2 };
+      const statistiques = { enCours: 47, nonFait: 1, aRemplir: 2, fait: 2 };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
           enCours: { debut: 0, milieu: 150, fin: 300 },
           nonFait: { debut: 300, milieu: 310, fin: 320 },
-          restant: { debut: 320, milieu: 330, fin: 340 },
+          aRemplir: { debut: 320, milieu: 330, fin: 340 },
           fait: { debut: 340, milieu: 350, fin: 360 },
         },
         unique: null,
@@ -102,13 +102,13 @@ describe('Les graphiques camembert', () => {
     });
 
     it("s'assurent que le champs 'unique' est null si il y a au moins 2 portions non nulles", () => {
-      const statistiques = { enCours: 1, nonFait: 1, restant: 0, fait: 0 };
+      const statistiques = { enCours: 1, nonFait: 1, aRemplir: 0, fait: 0 };
 
       expect(genereGradientConique(statistiques).unique).to.equal(null);
     });
 
     it("s'assurent que le champs 'unique' porte la clé de la portion si une seule portion est présente", () => {
-      const statistiques = { enCours: 1, nonFait: 0, restant: 0, fait: 0 };
+      const statistiques = { enCours: 1, nonFait: 0, aRemplir: 0, fait: 0 };
 
       expect(genereGradientConique(statistiques).unique).to.equal('enCours');
     });


### PR DESCRIPTION
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/1098d5e3-4c5f-42fa-a3c1-208b8f57ba47)


### Reproduction 
 - Créer un service
 - Afficher sa synthèse PDF
 - Voir qu'on a (pour cet exemple) 25 mesures « À remplir » dans la section blanche du Camembert « Indispensable »
 - Retourner sur « Sécuriser » et cocher à « Faite » 1 mesure indispensable
 - Ré-afficher la synthèse PDF

Attendu : le chiffre dans le camembert blanc est maintenant 24, puisqu'on a coché 1 mesure.
Observé : le chiffre est toujours à 25, alors qu'on voit apparaître la section « Faites » qui a le chiffre 1.

### Explication 
Une régression est apparue au moment où on a passé la synthèse PDF en Puppeteer.
Dans la version avant Puppeteer, le calcul des `aRemplir` était fait dans un `.js` côté client.
Et ce calcul n'a pas été porté dans la version Puppeteer.

On peut voir ce calcul dans le commit https://github.com/betagouv/mon-service-securise/commit/3077113689617600eb87a8ed5754067e64a669a2 fichier `public/scripts/statistiquesMesures.js:15`

### Correction 
Les statistiques côté serveur incluent désormais le calcul de `aRemplir`.
Cette valeur est utilisée par le `pug` là où avant on utilisait à tort la valeur `restant`.
Dans le calcul des angles du camembert, on ne s'intéresse pas du tout à `restant` : c'est remplacé par `aRemplir`.

La valeur `restant` est seulement utilisée dans l'encart à droite des camemberts : « Il reste X mesures à mettre en œuvre ».