### PR TITLE
Crée une route dédiée à l'initialisation du mot de passe

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -85,7 +85,7 @@ const middleware = (configuration = {}) => {
 
   const verificationAcceptationCGU = (requete, reponse, suite) => {
     verificationJWT(requete, reponse, () => {
-      if (!requete.cguAcceptees) reponse.redirect('/motDePasse/edition');
+      if (!requete.cguAcceptees) reponse.redirect('/motDePasse/initialisation');
       else suite();
     });
   };

--- a/src/mss.js
+++ b/src/mss.js
@@ -95,6 +95,19 @@ const creeServeur = (
     }
   );
 
+  app.get(
+    '/motDePasse/initialisation',
+    middleware.verificationJWT,
+    (requete, reponse) => {
+      const idUtilisateur = requete.idUtilisateurCourant;
+      depotDonnees
+        .utilisateur(idUtilisateur)
+        .then((utilisateur) =>
+          reponse.render('motDePasse/edition', { utilisateur })
+        );
+    }
+  );
+
   // Pour que les utilisateurs ayant cette page en favoris ne soient pas perdus.
   app.get('/questionsFrequentes', (_requete, reponse) => {
     reponse.redirect('https://aide.monservicesecurise.ssi.gouv.fr');

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -117,7 +117,7 @@ describe('Le middleware MSS', () => {
     const middleware = Middleware({ adaptateurJWT, depotDonnees });
 
     reponse.redirect = (url) => {
-      expect(url).to.equal('/motDePasse/edition');
+      expect(url).to.equal('/motDePasse/initialisation');
       done();
     };
 

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -69,6 +69,20 @@ describe('Le serveur MSS', () => {
     });
   });
 
+  describe('quand GET sur /motDePasse/initialisation', () => {
+    it("vérifie que l'utilisateur est authentifié", (done) => {
+      const utilisateur = { accepteCGU: () => true };
+      testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
+
+      testeur
+        .middleware()
+        .verifieRequeteExigeJWT(
+          'http://localhost:1234/motDePasse/initialisation',
+          done
+        );
+    });
+  });
+
   describe('quand requête GET sur `/reinitialisationMotDePasse`', () => {
     it("déconnecte l'utilisateur courant", (done) => {
       testeur


### PR DESCRIPTION
... car la route d'édition va servir au cas ou l'utilisateur veut modifier un mot de passe existant. On modifie aussi le middleware afin de rediriger vers cette nouvelle route si les CGU n'ont pas été acceptées (Un utilisateur invité qui navigue avant d'avoir accepté les CGUs)