### PR TITLE
Ajoute un conteneur docker 'Vault' pour gérer le chiffrement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,20 @@ services:
       - '${PORT_MSS}:3000'
     depends_on:
       - mss-db
+      - mss-crypto
+
+  mss-crypto:
+    image: hashicorp/vault:1.14
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=root # Mot de passe de connexion sur l'UI Vault locale
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+    networks:
+      - mss-network
+    ports:
+      - '8200:8200'
+    volumes:
+      - ./scripts/init-mss-crypto.sh:/init-mss-crypto.sh
+    entrypoint: sh -c "/init-mss-crypto.sh"
 
 networks:
   mss-network:

--- a/scripts/init-mss-crypto.sh
+++ b/scripts/init-mss-crypto.sh
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+# Ce script configure Vault pour que MSS puisse chiffrer/déchiffrer via l'API Vault
+# avec un token et une clé de chiffrement statique
+vault server -dev &
+SERVER_PID=$!
+
+
+export VAULT_ADDR=http://mss-crypto:8200
+
+sleep 3
+
+vault login root
+
+vault secrets enable transit
+
+# Cette clé AES256 est hardcodé pour la conserver entre les reboots du conteneur Docker Vault
+# Elle n'est utilisée qu'en DEV LOCAL
+vault transit import transit/keys/cle-mss '3MYMjS/qJzQ8M7mMgoQcxof+StJbGQl8Pbp7VdUyu1Y=' type=aes256-gcm96
+
+vault policy write app-mss -<<EOF
+path "transit/encrypt/cle-mss" {
+   capabilities = [ "update" ]
+}
+path "transit/decrypt/cle-mss" {
+   capabilities = [ "update" ]
+}
+EOF
+
+vault write auth/token/create policies=app-mss id='vault-token-mss-local'
+
+wait $SERVER_PID


### PR DESCRIPTION
On ajoute un conteneur [Hashicorp Vault](https://www.vaultproject.io/) pour gérer le chiffrement/déchiffrement des données de MSS en local.
On utilise une clé d'encryption 'statique' afin qu'elle soit la même à chaque redémarrage du conteneur, mais aussi qu'elle soit partagé entre le pôle dev pour une meilleur facilité à chiffrer/déchiffrer les données de la même manière.

### :warning: Pour l'instant MSS n'utilise pas encore ce service, qu'il faudra mettre derrière un `feature flag` pour ne pas l'activer en prod