### PR TITLE
Verification du mot de passe sur action critique - Suppression de service

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -780,6 +780,12 @@ label[for='recherche-service'] {
   margin: 0 0 1em 0;
 }
 
+#contenu-suppression
+  :is(.contenu-texte-information, .contenu-texte-avertissement)
+  p {
+  margin: 0;
+}
+
 #contenu-contributeurs .conteneur-confirmation .entete {
   margin: 0 0 1em 0;
 }

--- a/public/modules/tableauDeBord/actions/Action.mjs
+++ b/public/modules/tableauDeBord/actions/Action.mjs
@@ -1,4 +1,18 @@
+import {
+  brancheValidation,
+  declencheValidation,
+} from '../../interactions/validation.mjs';
+
 class ActionAbstraite {
+  get selecteurFormulaire() {
+    return `${this.idConteneur} .conteneur-formulaire`;
+  }
+
+  get formulaireEstValide() {
+    declencheValidation(this.selecteurFormulaire);
+    return $(this.selecteurFormulaire).is(':valid');
+  }
+
   constructor(idConteneur, tableauDesServices) {
     if (this.constructor === ActionAbstraite) {
       throw new TypeError(
@@ -7,6 +21,7 @@ class ActionAbstraite {
     }
     this.tableauDesServices = tableauDesServices;
     this.idConteneur = idConteneur;
+    brancheValidation(this.selecteurFormulaire);
   }
 
   appliqueContenu({ titre, texteSimple, texteMultiple }) {

--- a/public/modules/tableauDeBord/actions/ActionDuplication.mjs
+++ b/public/modules/tableauDeBord/actions/ActionDuplication.mjs
@@ -1,5 +1,4 @@
 import ActionAbstraite from './Action.mjs';
-import { declencheValidation } from '../../interactions/validation.mjs';
 
 const tableauDeLongueur = (longueur) => [...Array(longueur).keys()];
 
@@ -25,10 +24,9 @@ class ActionDuplication extends ActionAbstraite {
   }
 
   execute() {
-    declencheValidation(this.idConteneur);
     const $nombreCopie = $('#nombre-copie');
 
-    if (!$nombreCopie.is(':valid')) return Promise.resolve();
+    if (!this.formulaireEstValide) return Promise.reject();
 
     this.basculeLoader(true);
     $('#action-duplication').hide();

--- a/public/modules/tableauDeBord/actions/ActionInvitation.mjs
+++ b/public/modules/tableauDeBord/actions/ActionInvitation.mjs
@@ -1,5 +1,4 @@
 import ActionAbstraite from './Action.mjs';
-import { declencheValidation } from '../../interactions/validation.mjs';
 
 const estInvitationDejaEnvoyee = (reponseErreur) =>
   reponseErreur.status === 422 &&
@@ -30,10 +29,9 @@ class ActionInvitation extends ActionAbstraite {
   }
 
   execute() {
-    declencheValidation(this.idConteneur);
     const $emailInvite = $('#email-invitation-collaboration');
 
-    if (!$emailInvite.is(':valid')) return Promise.reject();
+    if (!this.formulaireEstValide) return Promise.reject();
 
     this.basculeLoader(true);
     $('#action-invitation').hide();

--- a/public/modules/tableauDeBord/actions/ActionSuppression.mjs
+++ b/public/modules/tableauDeBord/actions/ActionSuppression.mjs
@@ -46,6 +46,8 @@ class ActionSuppression extends ActionAbstraite {
     const $actionSuppression = $('#action-suppression');
     const motDePasseChallenge = $('#mot-de-passe-challenge-suppression').val();
 
+    if (!this.formulaireEstValide) return Promise.reject();
+
     $actionSuppression.hide();
     this.basculeLoader(true);
 

--- a/public/modules/tableauDeBord/gestionnaireEvenements.mjs
+++ b/public/modules/tableauDeBord/gestionnaireEvenements.mjs
@@ -77,7 +77,7 @@ const gestionnaireEvenements = {
     });
 
     $('#action-invitation').on('click', () =>
-      registreDesActions.invitation.execute()
+      registreDesActions.invitation.execute().catch(() => {})
     );
 
     $('#action-export-csv').on('click', () =>

--- a/public/modules/tableauDeBord/gestionnaireEvenements.mjs
+++ b/public/modules/tableauDeBord/gestionnaireEvenements.mjs
@@ -72,7 +72,8 @@ const gestionnaireEvenements = {
     $('#action-suppression').on('click', () => {
       registreDesActions.suppression
         .execute()
-        .then(() => gestionnaireTiroir.basculeOuvert(false));
+        .then(() => gestionnaireTiroir.basculeOuvert(false))
+        .catch(() => {});
     });
 
     $('#action-invitation').on('click', () =>

--- a/public/motDePasse/edition.js
+++ b/public/motDePasse/edition.js
@@ -17,7 +17,7 @@ $(() => {
   const $msgErreurChallenge = $(
     '#mot-de-passe-challenge ~ .message-erreur-specifique'
   );
-  $('#mot-de-passe-challenge').on('change', () => $msgErreurChallenge.hide());
+  $('#mot-de-passe-challenge').on('input', () => $msgErreurChallenge.hide());
 
   $(selecteurFormulaire).on('submit', (e) => {
     e.preventDefault();

--- a/public/tableauDeBord.js
+++ b/public/tableauDeBord.js
@@ -1,7 +1,8 @@
+import brancheChampsMotDePasse from './modules/interactions/brancheChampsMotDePasse.mjs';
 import { brancheModale } from './modules/interactions/modale.mjs';
+import { brancheValidation } from './modules/interactions/validation.mjs';
 import gestionnaireEvenements from './modules/tableauDeBord/gestionnaireEvenements.mjs';
 import tableauDesServices from './modules/tableauDeBord/tableauDesServices.mjs';
-import { brancheValidation } from './modules/interactions/validation.mjs';
 
 const afficheBandeauMajProfil = () =>
   axios
@@ -18,4 +19,6 @@ $(() => {
   brancheValidation('.tiroir form');
   tableauDesServices.recupereServices();
   gestionnaireEvenements.brancheComportement();
+
+  brancheChampsMotDePasse($('.conteneur-formulaire'));
 });

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -403,6 +403,7 @@ const routesApiService = (
   routes.delete(
     '/:id',
     middleware.verificationAcceptationCGU,
+    middleware.challengeMotDePasse,
     (requete, reponse, suite) => {
       const verifiePermissionSuppressionService = (idUtilisateur, idService) =>
         depotDonnees

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -200,6 +200,14 @@ block main
               .contenu-texte-avertissement
                 strong Cette action est irréversible
                 p Les données seront définitivement effacées. Les contributeurs n'auront plus accès à ce service.
+            label.banniere-information
+              img(src='/statique/assets/images/icone_information_suppression.svg')
+              .contenu-texte-information
+                p Pour permettre la suppression, veuillez saisir votre mot de passe actuel.
+            label.requis Mot de passe actuel
+              input(id='mot-de-passe-challenge-suppression', name = 'motDePasseChallengeSuppression', type='password', required)
+              .message-erreur Ce champs est obligatoire. Veuillez le renseigner.
+              .message-erreur-specifique Le mot de passe actuel saisi est incorrect
             .conteneur-loader
               .icone-chargement
               .titre-loader Suppression en cours...

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -72,6 +72,7 @@ const middlewareFantaisie = {
     suppressionCookieEffectuee = false;
     verificationJWTMenee = false;
     verificationCGUMenee = false;
+    challengeMotDePasseEffectue = false;
   },
 
   aseptise:

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1249,6 +1249,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
+    it('utilise le middleware de challenge du mot de passe', (done) => {
+      testeurMSS().middleware().verifieChallengeMotDePasse(
+        {
+          method: 'delete',
+          url: 'http://localhost:1234/api/service/123',
+        },
+        done
+      );
+    });
+
     it("demande au dépôt de vérifier l'autorisation d'accès au service pour l'utilisateur courant", (done) => {
       let autorisationVerifiee = false;
 


### PR DESCRIPTION
On vérifie maintenant l'action de suppression grâce à une 'ré-authentification' : on re-demande le mot de passe de l'utilisateur.

On utilise le middleware `challengeMotDePasse` mit en place précédemment.