### PR TITLE
[CORRECTION] Wording du nom de fichier

### DIFF
--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -110,7 +110,7 @@ const routesApiServicePdf = (
                 homologation,
                 homologation.dossierCourant()
               ),
-            nom: () => 'DossierDecison.pdf',
+            nom: () => 'DossierDecision.pdf',
           },
           syntheseSecurite: {
             pdf: () => generePdfSyntheseSecurite(homologation),

--- a/test/routes/privees/routesApiServicePdf.spec.js
+++ b/test/routes/privees/routesApiServicePdf.spec.js
@@ -251,7 +251,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
             buffer: 'PDF B',
           });
           expect(fichiers[2]).to.eql({
-            nom: 'DossierDecison.pdf',
+            nom: 'DossierDecision.pdf',
             buffer: 'PDF C',
           });
           adaptateurZipAppele = true;


### PR DESCRIPTION
Le fichier dans l'archive ZIP avait une typo: `DossierDecison` -> `DossierDecision`