### PR TITLE
Ajoute un fond et un titre sur la case infolettre

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -322,3 +322,27 @@ input[type='checkbox'] + label.label-checkbox {
 .label-mot-de-passe {
   margin-bottom: 0.2em !important;
 }
+
+.conteneur-infolettre {
+  position: relative;
+  background: #eff6ff;
+}
+
+.conteneur-infolettre::before {
+  content: '';
+  background: #eff6ff;
+  border-radius: 10px;
+  position: absolute;
+  height: calc(100% + 2em);
+  width: calc(100% + 2em);
+  top: -1em;
+  left: -1em;
+}
+
+.label-checkbox[for='infolettreAcceptee'] {
+  position: relative;
+}
+
+#infolettreAcceptee:not(:checked) {
+  background: #eff6ff;
+}

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -157,12 +157,13 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule })
             )
             .message-erreur Ce champ est obligatoire. Veuillez sélectionner une ou plusieurs options.
 
-
-      input(
-        id = 'infolettreAcceptee',
-        name = 'infolettreAcceptee',
-        checked = donnees.infolettreAcceptee,
-        type = 'checkbox'
-        class = 'input-checkbox'
-      )
-      label.label-checkbox(for = 'infolettreAcceptee') J'accepte de recevoir la lettre d'information MonServiceSécurisé.
+      label Préférences de communication
+      .conteneur-infolettre
+        input(
+          id = 'infolettreAcceptee',
+          name = 'infolettreAcceptee',
+          checked = donnees.infolettreAcceptee,
+          type = 'checkbox'
+          class = 'input-checkbox'
+        )
+        label.label-checkbox(for = 'infolettreAcceptee') J'accepte de recevoir la lettre d'information MonServiceSécurisé.


### PR DESCRIPTION
Afin de mieux séparer la case infolettre du bloc `Fonction/poste` :point_down: 

<img src='https://github.com/betagouv/mon-service-securise/assets/1643465/f440f989-e556-431a-8f81-434254649ecf' height=400>
