### PR TITLE
Ajoute champ mailing transactionnel - Utilisateur

### DIFF
--- a/migrations/20230719132333_ajouteChampTransactionnelAccepte.js
+++ b/migrations/20230719132333_ajouteChampTransactionnelAccepte.js
@@ -1,0 +1,25 @@
+exports.up = (knex) =>
+  knex('utilisateurs').then((lignes) => {
+    const misesAJour = lignes.map(({ id, donnees }) =>
+      knex('utilisateurs')
+        .where({ id })
+        .update({
+          donnees: {
+            ...donnees,
+            transactionnelAccepte: true,
+          },
+        })
+    );
+
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) =>
+  knex('utilisateurs').then((lignes) => {
+    const misesAJour = lignes.map(
+      ({ id, donnees: { transactionnelAccepte: _, ...autresDonnees } }) =>
+        knex('utilisateurs').where({ id }).update({ donnees: autresDonnees })
+    );
+
+    return Promise.all(misesAJour);
+  });

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -29,6 +29,7 @@ class Utilisateur extends Base {
         'nomEntitePublique',
         'departementEntitePublique',
         'infolettreAcceptee',
+        'transactionnelAccepte',
       ],
     });
     valide(donnees);
@@ -91,7 +92,10 @@ class Utilisateur extends Base {
       'nomEntitePublique',
       'departementEntitePublique',
     ]);
-    validePresenceProprietesBooleenes(['infolettreAcceptee']);
+    validePresenceProprietesBooleenes([
+      'infolettreAcceptee',
+      'transactionnelAccepte',
+    ]);
     validePresenceProprieteListes(['postes']);
     valideDepartement(donnees.departementEntitePublique, referentiel);
   }
@@ -116,6 +120,10 @@ class Utilisateur extends Base {
 
   accepteInfolettre() {
     return !!this.infolettreAcceptee;
+  }
+
+  accepteTransactionnel() {
+    return !!this.transactionnelAccepte;
   }
 
   genereToken(callback) {
@@ -158,6 +166,7 @@ class Utilisateur extends Base {
       departementEntitePublique: this.departementEntitePublique || '',
       profilEstComplet: this.profilEstComplet(),
       infolettreAcceptee: this.accepteInfolettre(),
+      transactionnelAccepte: this.accepteTransactionnel(),
     };
   }
 }

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -248,6 +248,7 @@ const routesApiPrivee = ({
     (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       const donnees = obtentionDonneesDeBaseUtilisateur(requete.body);
+      donnees.transactionnelAccepte = true;
       const { donneesInvalides, messageErreur } =
         messageErreurDonneesUtilisateur(donnees, true, referentiel);
 

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -58,6 +58,7 @@ const routesApiPublique = ({
       const donnees = obtentionDonneesDeBaseUtilisateur(requete.body);
       donnees.cguAcceptees = valeurBooleenne(requete.body.cguAcceptees);
       donnees.email = requete.body.email?.toLowerCase();
+      donnees.transactionnelAccepte = true;
       const { donneesInvalides, messageErreur } =
         messageErreurDonneesUtilisateur(donnees, false, referentiel);
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -95,6 +95,7 @@ describe('Une homologation', () => {
         departementEntitePublique: '',
         profilEstComplet: true,
         infolettreAcceptee: false,
+        transactionnelAccepte: false,
       },
       contributeurs: [
         {
@@ -109,6 +110,7 @@ describe('Une homologation', () => {
           departementEntitePublique: '',
           profilEstComplet: true,
           infolettreAcceptee: false,
+          transactionnelAccepte: false,
         },
       ],
     });

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -84,6 +84,7 @@ describe('Un utilisateur', () => {
       nomEntitePublique: 'Ville de Paris',
       departementEntitePublique: '75',
       infolettreAcceptee: true,
+      transactionnelAccepte: true,
     });
 
     expect(utilisateur.toJSON()).to.eql({
@@ -98,6 +99,7 @@ describe('Un utilisateur', () => {
       departementEntitePublique: '75',
       profilEstComplet: true,
       infolettreAcceptee: true,
+      transactionnelAccepte: true,
     });
   });
 
@@ -139,6 +141,17 @@ describe('Un utilisateur', () => {
 
     const autreUtilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
     expect(autreUtilisateur.accepteCGU()).to.be(false);
+  });
+
+  it('sait détecter si le transactionnel a été acceptée', () => {
+    const utilisateur = new Utilisateur({
+      email: 'jean.dupont@mail.fr',
+      transactionnelAccepte: true,
+    });
+    expect(utilisateur.accepteTransactionnel()).to.be(true);
+
+    const autreUtilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
+    expect(autreUtilisateur.accepteTransactionnel()).to.be(false);
   });
 
   it("sait détecter si l'infolettre a été acceptée", () => {
@@ -224,6 +237,7 @@ describe('Un utilisateur', () => {
         nomEntitePublique: 'Ville de Paris',
         departementEntitePublique: '75',
         infolettreAcceptee: true,
+        transactionnelAccepte: true,
       };
     });
 

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -684,6 +684,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           expect(donnees.telephone).to.equal('0100000000');
           expect(donnees.nomEntitePublique).to.equal('Ville de Paris');
           expect(donnees.departementEntitePublique).to.equal('75');
+          expect(donnees.infolettreAcceptee).to.equal(true);
+          expect(donnees.transactionnelAccepte).to.equal(true);
           expect(donnees.postes).to.eql([
             'RSSI',
             "Chargé des systèmes d'informations",

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -127,6 +127,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
           ...donneesRequete,
           cguAcceptees: true,
           infolettreAcceptee: true,
+          transactionnelAccepte: true,
         };
         expect(donneesUtilisateur).to.eql(donneesAttendues);
         return Promise.resolve(utilisateur);


### PR DESCRIPTION
On ajoute le champ `transactionnelAccepte` sur `Utilisateur`.

Ce champ est à `true` par défaut.
Il est forcé à `true` sur les routes d'inscription et de modification de profil.
Il n'est pas possible de le modifier pour l'instant.