### PR TITLE
Retire l'info 'En attente de création de compte MSS'

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionContributeurs.mjs
+++ b/public/modules/tableauDeBord/actions/ActionContributeurs.mjs
@@ -61,22 +61,13 @@ class ActionContributeurs extends ActionAbstraite {
     super.initialise();
     const [idService] = args;
     const service = this.tableauDesServices.donneesDuService(idService);
-    const $listeContributeursActifs = $('.contributeurs-actifs');
-    const $listeContributeursEnAttente = $('.contributeurs-attente-activation');
+    const $listeContributeurs = $('.contributeurs-actifs');
 
-    $listeContributeursActifs.empty();
-    $listeContributeursEnAttente.empty();
-    $listeContributeursActifs.append(metEnFormeProprietaire(service.createur));
+    $listeContributeurs.empty();
+    $listeContributeurs.append(metEnFormeProprietaire(service.createur));
 
-    $('.titre-contributeurs-attente-activation').toggleClass(
-      'invisible',
-      service.contributeurs.length === 0
-    );
     service.contributeurs.forEach((contributeur) => {
-      const $conteneur = contributeur.cguAcceptees
-        ? $listeContributeursActifs
-        : $listeContributeursEnAttente;
-      $conteneur.append(
+      $listeContributeurs.append(
         metEnFormeContributeur(
           service.permissions.suppressionContributeur,
           contributeur,

--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -23,7 +23,6 @@ const donnees = (services, idUtilisateur, referentiel) => ({
         id: c.id,
         prenomNom: c.prenomNom,
         initiales: c.initiales,
-        cguAcceptees: c.cguAcceptees,
         poste: c.posteDetaille,
       })),
       statutHomologation: {

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -110,8 +110,6 @@ block main
           form.conteneur-formulaire
             h3.titre-liste.titre-contributeurs-actifs Ajouté(s) au service
             ul.liste-contributeurs.contributeurs-actifs
-            h3.titre-liste.titre-contributeurs-attente-activation En attente d'activation du compte MonServiceSécurisé
-            ul.liste-contributeurs.contributeurs-attente-activation
           .conteneur-confirmation
             p.entete 
               span Souhaitez-vous vraiment retirer les accès de 

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -66,7 +66,6 @@ describe("L'objet d'API de `GET /services`", () => {
             id: 'B',
             prenomNom: 'Jean',
             initiales: 'J',
-            cguAcceptees: false,
             poste: 'Maire',
           },
         ],


### PR DESCRIPTION
Afin de ne pas donner d'information sur le statut des comptes sur MSS, on supprime cette distinction dans le tiroir contributeur.

<img src='https://github.com/betagouv/mon-service-securise/assets/1643465/aa2a57c6-8501-4175-b939-885d9c4a5cbb' height=500/>

_La partie En attente d'activation du compte MonServiceSécurisé n'est plus présente_