### PR TITLE
Ajoute les inscrits MSS aux destinataires des emails transactionnels de relance

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,6 +15,7 @@ SENDINBLUE_TEMPLATE_INVITATION_CONTRIBUTION= # id de template
 SENDINBLUE_TEMPLATE_INVITATION_INSCRIPTION= # id de template
 SENDINBLUE_TEMPLATE_REINITIALISATION_MOT_DE_PASSE= # id de template
 SENDINBLUE_TEMPLATE_TENTATIVE_REINSCRIPTION= # id de template
+SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE= # l'ID de la liste de contacts utilisée pour les mails transactionnels de relance
 
 SENTRY_DSN= # Le « DSN » du projet Sentry sur lequel envoyer les exceptions. Laisser commenté pour ne pas utiliser Sentry.
 SENTRY_ENVIRONNEMENT= # L'environnement Sentry auquel seront associées les exceptions loguées, si Sentry est utilisé.

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -40,6 +40,12 @@ const creeContact = (destinataire, prenom, nom, bloqueEmails) =>
         email: destinataire,
         emailBlacklisted: bloqueEmails,
         attributes: { PRENOM: decode(prenom), NOM: decode(nom) },
+        listIds: [
+          Number(
+            process.env
+              .SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE
+          ),
+        ],
       },
       enteteJSON
     )


### PR DESCRIPTION
De cette façon, nous pourrons utiliser Sendinblue pour inviter les utilisateurs à revenir sur MSS pour finir leur travail démarré.

L'attribut `listIds` est détaillé [sur la page de doc de l'API `createContact`](https://developers.brevo.com/reference/createcontact#form-body-createContact)

💻  Il faut créer la variable d'env. `SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE ` chez Scalingo