### PR TITLE
Déplace la MAJ des préférences de communication dans `Utilisateur`

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const adaptateurHorloge = require('./src/adaptateurs/adaptateurHorloge');
 const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
 const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPIEmail()
   ? require('./src/adaptateurs/adaptateurMailSendinblue')
-  : require('./src/adaptateurs/adaptateurMailMemoire');
+  : require('./src/adaptateurs/adaptateurMailMemoire').fabriqueAdaptateurMailMemoire();
 const adaptateurPdf = require('./src/adaptateurs/adaptateurPdf');
 const adaptateurZip = require('./src/adaptateurs/adaptateurZip');
 const {

--- a/src/adaptateurs/adaptateurMailMemoire.js
+++ b/src/adaptateurs/adaptateurMailMemoire.js
@@ -1,64 +1,60 @@
 const adaptateurEnvironnement = require('./adaptateurEnvironnement');
 
-const envoyer = (texte, args) => {
-  const doitLoguer = adaptateurEnvironnement
-    .emailMemoire()
-    .logEmailDansConsole();
+const fabriqueAdaptateurMailMemoire = () => {
+  const envoyer = (texte, args) => {
+    const doitLoguer = adaptateurEnvironnement
+      .emailMemoire()
+      .logEmailDansConsole();
 
-  // eslint-disable-next-line no-console
-  if (doitLoguer) console.log(texte, args);
+    // eslint-disable-next-line no-console
+    if (doitLoguer) console.log(texte, args);
+  };
+
+  const creeContact = async (...args) => {
+    envoyer("Création d'un contact email", args);
+  };
+
+  const desinscrisInfolettre = async (...args) => {
+    envoyer("Désinscription de l'infolettre MSS", args);
+  };
+
+  const inscrisInfolettre = async (...args) => {
+    envoyer("Inscription à l'infolettre MSS", args);
+  };
+
+  const envoieMessageFinalisationInscription = async (...args) => {
+    envoyer("Envoie de l'email de finalisation de l'inscription", args);
+  };
+
+  const envoieMessageInvitationContribution = async (...args) => {
+    envoyer("Envoie de l'email d'invitation à contribuer", args);
+  };
+
+  const envoieMessageInvitationInscription = async (...args) => {
+    envoyer("Envoie de l'email d'invitation à s'inscrire", args);
+  };
+
+  const envoieMessageReinitialisationMotDePasse = async (...args) => {
+    envoyer("Envoie de l'email de réinitialisation du mot de passe", args);
+  };
+
+  const envoieNotificationTentativeReinscription = async (...args) => {
+    envoyer(
+      "Envoie de l'email de notification de tentative de réinscription",
+      args
+    );
+  };
+
+  return {
+    creeContact,
+    desinscrisInfolettre,
+    inscrisInfolettre,
+    envoieMessageFinalisationInscription,
+    envoieMessageInvitationContribution,
+    envoieMessageInvitationInscription,
+    envoieMessageReinitialisationMotDePasse,
+    envoieNotificationTentativeReinscription,
+  };
 };
 
-const creeContact = (...args) => {
-  envoyer("Création d'un contact email", args);
-  return Promise.resolve();
-};
-
-const desinscrisInfolettre = (...args) => {
-  envoyer("Désinscription de l'infolettre MSS", args);
-  return Promise.resolve();
-};
-
-const inscrisInfolettre = (...args) => {
-  envoyer("Inscription à l'infolettre MSS", args);
-  return Promise.resolve();
-};
-
-const envoieMessageFinalisationInscription = (...args) => {
-  envoyer("Envoie de l'email de finalisation de l'inscription", args);
-  return Promise.resolve();
-};
-
-const envoieMessageInvitationContribution = (...args) => {
-  envoyer("Envoie de l'email d'invitation à contribuer", args);
-  return Promise.resolve();
-};
-
-const envoieMessageInvitationInscription = (...args) => {
-  envoyer("Envoie de l'email d'invitation à s'inscrire", args);
-  return Promise.resolve();
-};
-
-const envoieMessageReinitialisationMotDePasse = (...args) => {
-  envoyer("Envoie de l'email de réinitialisation du mot de passe", args);
-  return Promise.resolve();
-};
-
-const envoieNotificationTentativeReinscription = (...args) => {
-  envoyer(
-    "Envoie de l'email de notification de tentative de réinscription",
-    args
-  );
-  return Promise.resolve();
-};
-
-module.exports = {
-  creeContact,
-  desinscrisInfolettre,
-  inscrisInfolettre,
-  envoieMessageFinalisationInscription,
-  envoieMessageInvitationContribution,
-  envoieMessageInvitationInscription,
-  envoieMessageReinitialisationMotDePasse,
-  envoieNotificationTentativeReinscription,
-};
+module.exports = { fabriqueAdaptateurMailMemoire };

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -153,6 +153,16 @@ class Utilisateur extends Base {
     return (this.nom?.trim() ?? '') !== '';
   }
 
+  async changePreferencesCommunication(nouvellesPreferences, adaptateurEmail) {
+    const infolettreActuelle = this.accepteInfolettre();
+    const nouvelleInfolettre = nouvellesPreferences.infolettreAcceptee;
+    const inscrisIL = !infolettreActuelle && nouvelleInfolettre;
+    const desinscrisIL = infolettreActuelle && !nouvelleInfolettre;
+
+    if (inscrisIL) await adaptateurEmail.inscrisInfolettre(this.email);
+    if (desinscrisIL) await adaptateurEmail.desinscrisInfolettre(this.email);
+  }
+
   toJSON() {
     return {
       id: this.id,

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -241,20 +241,12 @@ const routesApiPrivee = ({
 
       depotDonnees
         .utilisateur(idUtilisateur)
-        .then((utilisateur) => {
-          const acceptationInfolettreActuelle = utilisateur.infolettreAcceptee;
-          const nouvelleAcceptationInfolettre = donnees.infolettreAcceptee;
-          const doitInscrire =
-            !acceptationInfolettreActuelle && nouvelleAcceptationInfolettre;
-          const doitDesinscrire =
-            acceptationInfolettreActuelle && !nouvelleAcceptationInfolettre;
-
-          if (doitInscrire)
-            return adaptateurMail.inscrisInfolettre(utilisateur.email);
-          if (doitDesinscrire)
-            return adaptateurMail.desinscrisInfolettre(utilisateur.email);
-          return Promise.resolve();
-        })
+        .then((utilisateur) =>
+          utilisateur.changePreferencesCommunication(
+            { infolettreAcceptee: donnees.infolettreAcceptee },
+            adaptateurMail
+          )
+        )
         .then(() => depotDonnees.metsAJourUtilisateur(idUtilisateur, donnees))
         .then(() => reponse.json({ idUtilisateur }))
         .catch(suite);

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -28,6 +28,16 @@ class ConstructeurUtilisateur {
     return this;
   }
 
+  quiAccepteInfolettre() {
+    this.donnees.infolettreAcceptee = true;
+    return this;
+  }
+
+  quiRefuseInfolettre() {
+    this.donnees.infolettreAcceptee = false;
+    return this;
+  }
+
   construis() {
     return new Utilisateur(this.donnees);
   }

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -10,6 +10,7 @@ const Utilisateur = require('../../src/modeles/utilisateur');
 const {
   fabriqueAdaptateurMailMemoire,
 } = require('../../src/adaptateurs/adaptateurMailMemoire');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
 
 describe('Un utilisateur', () => {
   describe("sur demande d'un profil complet ou non", () => {
@@ -323,6 +324,8 @@ describe('Un utilisateur', () => {
       adaptateurEmail = fabriqueAdaptateurMailMemoire();
     });
 
+    const jeanDupont = () => unUtilisateur().avecEmail('jean.dupont@mail.fr');
+
     it("s'inscrit à l'infolettre s'il passe de « non » à « oui » sur ce canal de communication", async () => {
       let inscriptionEffectuee;
       adaptateurEmail.inscrisInfolettre = async (email) => {
@@ -332,12 +335,8 @@ describe('Un utilisateur', () => {
         throw new Error('Ce test ne devrait pas déclencher de désinscription');
       };
 
-      const utilisateur = new Utilisateur({
-        email: 'jean.dupont@mail.fr',
-        infolettreAcceptee: false,
-      });
-
-      await utilisateur.changePreferencesCommunication(
+      const refusait = jeanDupont().quiRefuseInfolettre().construis();
+      await refusait.changePreferencesCommunication(
         { infolettreAcceptee: true },
         adaptateurEmail
       );
@@ -353,12 +352,9 @@ describe('Un utilisateur', () => {
       adaptateurEmail.inscrisInfolettre = async () => {
         throw new Error("Ce test ne devrait pas déclencher d'inscription");
       };
-      const utilisateur = new Utilisateur({
-        email: 'jean.dupont@mail.fr',
-        infolettreAcceptee: true,
-      });
 
-      await utilisateur.changePreferencesCommunication(
+      const acceptait = jeanDupont().quiAccepteInfolettre().construis();
+      await acceptait.changePreferencesCommunication(
         { infolettreAcceptee: false },
         adaptateurEmail
       );

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -52,7 +52,7 @@ const testeurMss = () => {
   const initialise = (done) => {
     adaptateurAnnuaire = {};
     adaptateurHorloge = adaptateurHorlogeParDefaut;
-    adaptateurMail = adaptateurMailMemoire;
+    adaptateurMail = adaptateurMailMemoire.fabriqueAdaptateurMailMemoire();
     adaptateurPdf = {
       genereAnnexes: () => Promise.resolve('PDF Annexe'),
       genereDossierDecision: () => Promise.resolve('PDF Dossier decision'),


### PR DESCRIPTION
Ça recentre la responsabilité. Et ça va faciliter l'arrivée de la MAJ du canal « email transactionnel ».

Le code de l'API devient trivial, et sera facilement extensible :

```js
    depotDonnees
        .utilisateur(idUtilisateur)
        .then((utilisateur) =>
          utilisateur.changePreferencesCommunication(
            { infolettreAcceptee: donnees.infolettreAcceptee },
            adaptateurMail
          )
        )
        .then(() => depotDonnees.metsAJourUtilisateur(idUtilisateur, donnees))
```