### PR TITLE
Ajoute des cartes sur la page « Sécuriser »

### DIFF
--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -86,6 +86,10 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
       referentiel,
       service: homologation,
       mesures,
+      donneesStatutHomologation: new ObjetApiStatutHomologation(
+        homologation,
+        referentiel
+      ).donnees(),
     });
   });
 

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -54,20 +54,6 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   });
 
   routes.get(
-    '/:id/decision',
-    middleware.trouveService,
-    middleware.positionneHeadersAvecNonce,
-    (requete, reponse) => {
-      const { homologation, nonce } = requete;
-      reponse.render('service/decision', {
-        service: homologation,
-        referentiel,
-        nonce,
-      });
-    }
-  );
-
-  routes.get(
     '/:id/descriptionService',
     middleware.trouveService,
     (requete, reponse) => {

--- a/src/vues/cartes/statutHomologation.pug
+++ b/src/vues/cartes/statutHomologation.pug
@@ -1,0 +1,24 @@
+include ../fragments/carteInformations
+
+mixin statutHomologation({ donneesStatutHomologation })
+  +carteInformations({titre: "Homologation de sécurité"})
+    .statut.statut-homologation(class=donneesStatutHomologation.statut)
+      span= donneesStatutHomologation.libelle
+
+    .informations-complementaires-statut
+      - const liens = donneesStatutHomologation.metadonnees.liens
+      - const validite = donneesStatutHomologation.metadonnees.validite
+      if validite
+        if validite.debut
+          .dates-statut.
+            Active le #{validite.debut}
+        if validite.duree
+          .dates-statut.
+            Durée : #{validite.duree}
+        if validite.fin
+          .dates-statut.
+            #{donneesStatutHomologation.statut === 'expiree' ? 'Expirée depuis le ' : "Valable jusqu'au "} #{validite.fin}
+      if liens
+        for lien in liens
+          a.avec-chevron(href=lien.url)!= lien.libelle
+

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -1,6 +1,7 @@
 extends ./formulaire
 include ../fragments/inputChoix
 include ../fragments/cartesInformations
+include ../cartes/statutHomologation
 include ../cartes/indiceCyber
 include ../cartes/recommandationsANSSI
 
@@ -73,6 +74,8 @@ block formulaire
   script(type = 'module', src = '/statique/service/mesures.js')
 
 block cartes-informations
+  +statutHomologation({ donneesStatutHomologation })
+
   - const indiceCyber = service.indiceCyber()
   +indiceCyber({referentiel, indiceCyber})
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -1,5 +1,8 @@
 extends ./formulaire
 include ../fragments/inputChoix
+include ../fragments/cartesInformations
+include ../cartes/indiceCyber
+include ../cartes/recommandationsANSSI
 
 mixin inputMesure({ nom, titre, indispensable })
   +inputChoix({
@@ -68,3 +71,9 @@ block formulaire
     !{JSON.stringify(referentiel.statutsMesures())}
 
   script(type = 'module', src = '/statique/service/mesures.js')
+
+block cartes-informations
+  - const indiceCyber = service.indiceCyber()
+  +indiceCyber({referentiel, indiceCyber})
+
+  +recommandationsANSSI({referentiel, noteObtenue: indiceCyber.total})

--- a/src/vues/service/synthese.pug
+++ b/src/vues/service/synthese.pug
@@ -1,6 +1,7 @@
 extends ../deuxColonnes
 include ../cartes/indiceCyber
 include ../cartes/recommandationsANSSI
+include ../cartes/statutHomologation
 include ../fragments/cartesInformations
 include ../fragments/texteTronque
 
@@ -75,29 +76,7 @@ block zone-principale
       ) Télécharger les annexes
 
 block cartes-informations
-  - const donneesStatut = donneesStatutHomologation
-
-  +carteInformations({titre: "Homologation de sécurité" })
-    .statut.statut-homologation(class=donneesStatut.statut)
-      span= donneesStatut.libelle
-
-    .informations-complementaires-statut
-      - const liens = donneesStatut.metadonnees.liens
-      - const validite = donneesStatut.metadonnees.validite
-      if validite
-        if validite.debut
-          .dates-statut.
-            Active le #{validite.debut}
-        if validite.duree
-          .dates-statut.
-            Durée : #{validite.duree}
-        if validite.fin
-          .dates-statut.
-            #{donneesStatut.statut === 'expiree' ? 'Expirée depuis le ' : "Valable jusqu'au "} #{validite.fin}
-      if liens
-        for lien in liens
-          a.avec-chevron(href=lien.url)!= lien.libelle
-
+  +statutHomologation({ donneesStatutHomologation })
 
   - const indiceCyber = service.indiceCyber()
   +indiceCyber({ referentiel, indiceCyber })

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -58,6 +58,13 @@ describe('Le serveur MSS des routes /service/*', () => {
   });
 
   describe('quand requête GET sur `/service/:id/mesures`', () => {
+    beforeEach(() => {
+      testeur.referentiel().recharge({
+        statutsHomologation: {},
+        etapesParcoursHomologation: [{ numero: 1 }],
+      });
+    });
+
     it('recherche le service correspondant', (done) => {
       testeur
         .middleware()


### PR DESCRIPTION
On veut les mêmes cartes que sur la page d'accueil du service.

Le résultat 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/a0a696bd-08a6-4a89-a4da-91ee07cf8f5d)


La carte `statutHomologation` était la seule qui n'était pas un mixin indépendant.
C'est chose faite dans cette PR.