### PR TITLE
Création d'un conteneur de procédures

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,8 +11,6 @@ const {
   fabriqueAdaptateurGestionErreur,
 } = require('./src/adaptateurs/fabriqueAdaptateurGestionErreur');
 const fabriqueAdaptateurTracking = require('./src/adaptateurs/fabriqueAdaptateurTracking');
-
-const adaptateurGestionErreur = fabriqueAdaptateurGestionErreur();
 const adaptateurHorloge = require('./src/adaptateurs/adaptateurHorloge');
 const adaptateurJWT = require('./src/adaptateurs/adaptateurJWT');
 const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPIEmail()
@@ -23,7 +21,9 @@ const adaptateurZip = require('./src/adaptateurs/adaptateurZip');
 const {
   adaptateurProtection,
 } = require('./src/adaptateurs/adaptateurProtection');
+const { fabriqueProcedures } = require('./src/routes/procedures');
 
+const adaptateurGestionErreur = fabriqueAdaptateurGestionErreur();
 const adaptateurTracking = fabriqueAdaptateurTracking();
 
 const port = process.env.PORT || 3000;
@@ -36,6 +36,7 @@ const middleware = Middleware({
   adaptateurJWT,
   depotDonnees,
 });
+const procedures = fabriqueProcedures();
 
 const serveur = MSS.creeServeur(
   depotDonnees,
@@ -50,7 +51,8 @@ const serveur = MSS.creeServeur(
   adaptateurCsv,
   adaptateurZip,
   adaptateurTracking,
-  adaptateurProtection
+  adaptateurProtection,
+  procedures
 );
 
 serveur.ecoute(port, () => {

--- a/src/adaptateurs/adaptateurTrackingMemoire.js
+++ b/src/adaptateurs/adaptateurTrackingMemoire.js
@@ -11,8 +11,8 @@ const fabriqueAdaptateurTrackingMemoire = () => {
       .logEvenementsTrackingEnConsole();
 
     if (doitLoguer) {
-      // eslint-disable-next-line no-console
       const donnees = JSON.stringify(donneesEvenement);
+      // eslint-disable-next-line no-console
       console.log(
         `EVENEMENT DE TRACKING: destinataire ${destinataire}, ${typeEvenement}, ${donnees} }`
       );

--- a/src/mss.js
+++ b/src/mss.js
@@ -28,6 +28,7 @@ const creeServeur = (
   adaptateurZip,
   adaptateurTracking,
   adaptateurProtection,
+  procedures,
   avecCookieSecurise = process.env.NODE_ENV === 'production',
   avecPageErreur = process.env.NODE_ENV === 'production'
 ) => {
@@ -211,6 +212,7 @@ const creeServeur = (
       adaptateurCsv,
       adaptateurZip,
       adaptateurTracking,
+      procedures,
     })
   );
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -34,6 +34,7 @@ const routesApiPrivee = ({
   adaptateurCsv,
   adaptateurZip,
   adaptateurTracking,
+  procedures,
 }) => {
   const verifieSuccesEnvoiMessage = (promesseEnvoiMessage, utilisateur) =>
     promesseEnvoiMessage
@@ -272,7 +273,9 @@ const routesApiPrivee = ({
     '/autorisation',
     middleware.verificationAcceptationCGU,
     middleware.aseptise('idHomologation', 'emailContributeur'),
-    (requete, reponse, suite) => {
+    async (requete, reponse, suite) => {
+      await procedures.neFaitRien();
+
       const idUtilisateur = requete.idUtilisateurCourant;
       const { idHomologation } = requete.body;
       const emailContributeur = requete.body.emailContributeur?.toLowerCase();

--- a/src/routes/procedures.js
+++ b/src/routes/procedures.js
@@ -1,0 +1,5 @@
+const fabriqueProcedures = () => ({
+  neFaitRien: async () => {},
+});
+
+module.exports = { fabriqueProcedures };

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -742,6 +742,19 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         Promise.resolve();
     });
 
+    it('appelle une procédure qui ne fait rien, seulement pour prouver que le mécanisme fonctionne', async () => {
+      let bouchonAppele;
+
+      testeur.procedures().neFaitRien = () => (bouchonAppele = true);
+
+      await axios.post('http://localhost:1234/api/autorisation', {
+        emailContributeur: 'jean.dupont@mail.fr',
+        idHomologation: '123',
+      });
+
+      expect(bouchonAppele).to.be(true);
+    });
+
     it('aseptise les paramètres de la requête', (done) => {
       testeur
         .middleware()

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -8,8 +8,8 @@ const adaptateurMailMemoire = require('../../src/adaptateurs/adaptateurMailMemoi
 const MoteurRegles = require('../../src/moteurRegles');
 const MSS = require('../../src/mss');
 const Referentiel = require('../../src/referentiel');
-
 const middleware = require('../mocks/middleware');
+const { fabriqueProcedures } = require('../../src/routes/procedures');
 
 const testeurMss = () => {
   let adaptateurAnnuaire;
@@ -23,6 +23,7 @@ const testeurMss = () => {
   let depotDonnees;
   let moteurRegles;
   let referentiel;
+  let procedures;
   let serveur;
 
   const verifieJetonDepose = (reponse, suite) => {
@@ -72,6 +73,7 @@ const testeurMss = () => {
     };
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();
+    procedures = fabriqueProcedures();
     moteurRegles = new MoteurRegles(referentiel);
     depotVide()
       .then((depot) => {
@@ -90,6 +92,7 @@ const testeurMss = () => {
           adaptateurZip,
           adaptateurTracking,
           adaptateurProtection,
+          procedures,
           false,
           false
         );
@@ -112,6 +115,7 @@ const testeurMss = () => {
     middleware: () => middleware,
     moteurRegles: () => moteurRegles,
     referentiel: () => referentiel,
+    procedures: () => procedures,
     arrete,
     initialise,
     verifieRequeteGenereErreurHTTP,


### PR DESCRIPTION
L'objectif est de déporter certaines logiques portées par les routes d'API dans des procédures isolées de la couche HTTP.

En créant un conteneur de procédures, on pourra bouchonner les procédures appelées dans les tests.

Dans l'immédiat c'est #1038 qui va être le premier utilisateur de ce conteneur.