### PR TITLE
Force l'acceptation des emails transactionnels au niveau du dépôt

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -44,6 +44,7 @@ const creeDepot = (config = {}) => {
     donneesUtilisateur.motDePasse = await adaptateurChiffrement.hacheBCrypt(
       adaptateurUUID.genereUUID()
     );
+    donneesUtilisateur.transactionnelAccepte = true;
 
     await adaptateurPersistance.ajouteUtilisateur(id, donneesUtilisateur);
 

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -411,6 +411,18 @@ describe('Le dépôt de données des utilisateurs', () => {
         expect(utilisateur.adaptateurJWT).to.equal(adaptateurJWT);
       });
 
+      it('marque les emails transactionnels comme « acceptés »', async () => {
+        const u = await depot.utilisateur('1');
+        expect(u).to.be(undefined);
+
+        await depot.nouvelUtilisateur({
+          email: 'jean.dupont@mail.fr',
+        });
+
+        const utilisateur = await depot.utilisateur('1');
+        expect(utilisateur.transactionnelAccepte).to.be(true);
+      });
+
       it('utilise la date actuelle comme date de création du nouvel utilisateur', async () => {
         const utilisateur = await depot.nouvelUtilisateur({
           prenom: 'Jean',


### PR DESCRIPTION
De cette façon, tous les nouveaux inscrits ont forcément `transactionnelAccepte = true`. 
Ce qui est le comportement voulu.

Avant ce commit, les utilisateurs ajoutés par une invitation à collaborer (donc qui ne s'inscrivent pas eux-même) n'avaient pas ce booléen.

On met la logique dans le dépôt pour éviter que de futures façons d'inscrire les utilisateurs souffrent à nouveau de ce bug.