### PR TITLE
[CORRECTION] Effacer l'éventuelle pagination existante

### DIFF
--- a/public/modules/modaleNouvellesFonctionnalites.mjs
+++ b/public/modules/modaleNouvellesFonctionnalites.mjs
@@ -1,6 +1,7 @@
 const brancheComportementModaleNouvelleFonctionnalite = ($modale) => {
   const populePagination = (nombrePage) => {
     const $conteneur = $('.pagination', $modale);
+    $conteneur.empty();
     for (let i = 1; i <= nombrePage; i += 1) {
       let classe = 'rond';
       if (i === 1) classe += ' actif';


### PR DESCRIPTION
… avant de populer de nouveau.

Sans ça, cliquer plusieurs fois sur « Nouveautés » sans recharger la page résulte dans une modale qui contient de plus en plus de paginations. Par exemple après 3 clics, l'utilisateur se retrouve avec 3 blocs de pagination adjacents.

Le problème en image 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/78ec0e3b-c3b9-481c-84c9-99528b363ae6)
