### PR TITLE
Utilisation de nouveaux templates Brevo

### DIFF
--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -151,16 +151,16 @@ const envoieMessageInvitationContribution = (
 const envoieMessageInvitationInscription = (
   destinataire,
   prenomNomEmetteur,
-  nomService,
-  idResetMotDePasse
+  idResetMotDePasse,
+  nbServices
 ) =>
   envoieEmail(
     destinataire,
     parseInt(process.env.SENDINBLUE_TEMPLATE_INVITATION_INSCRIPTION, 10),
     {
-      PRENOM: decode(prenomNomEmetteur),
-      NOM_SERVICE: decode(nomService),
-      URL: `${process.env.URL_BASE_MSS}/initialisationMotDePasse/${idResetMotDePasse}`,
+      emetteur: decode(prenomNomEmetteur),
+      nb_services_invitation: Number(nbServices),
+      url: `${process.env.URL_BASE_MSS}/initialisationMotDePasse/${idResetMotDePasse}`,
     }
   );
 

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -136,16 +136,15 @@ const envoieMessageFinalisationInscription = (
 const envoieMessageInvitationContribution = (
   destinataire,
   prenomNomEmetteur,
-  nomService,
-  idService
+  nbServices
 ) =>
   envoieEmail(
     destinataire,
     parseInt(process.env.SENDINBLUE_TEMPLATE_INVITATION_CONTRIBUTION, 10),
     {
-      PRENOM: decode(prenomNomEmetteur),
-      NOM_SERVICE: decode(nomService),
-      URL: `${process.env.URL_BASE_MSS}/service/${idService}`,
+      emetteur: decode(prenomNomEmetteur),
+      nb_services_invitation: Number(nbServices),
+      url: `${process.env.URL_BASE_MSS}/tableauDeBord`,
     }
   );
 

--- a/src/modeles/autorisations/ajoutContributeurSurService.js
+++ b/src/modeles/autorisations/ajoutContributeurSurService.js
@@ -49,8 +49,8 @@ const ajoutContributeurSurService = ({
         await adaptateurMail.envoieMessageInvitationInscription(
           contributeur.email,
           emetteur.prenomNom(),
-          service.nomService(),
-          contributeur.idResetMotDePasse
+          contributeur.idResetMotDePasse,
+          1
         );
       } catch (e) {
         await depotDonnees.supprimeUtilisateur(contributeur.id);

--- a/src/modeles/autorisations/ajoutContributeurSurService.js
+++ b/src/modeles/autorisations/ajoutContributeurSurService.js
@@ -36,15 +36,13 @@ const ajoutContributeurSurService = ({
   const informeContributeur = async (
     contributeur,
     contributeurEstExistant,
-    emetteur,
-    service
+    emetteur
   ) => {
     if (contributeurEstExistant)
       await adaptateurMail.envoieMessageInvitationContribution(
         contributeur.email,
         emetteur.prenomNom(),
-        service.nomService(),
-        service.id
+        1
       );
     else
       try {
@@ -94,7 +92,7 @@ const ajoutContributeurSurService = ({
         : await creeUtilisateur(emailContributeur);
 
       await ajouteContributeur(contributeur, service);
-      await informeContributeur(contributeur, dejaInscrit, emetteur, service);
+      await informeContributeur(contributeur, dejaInscrit, emetteur);
       await envoieTracking(emetteur, emailContributeur);
     },
   };

--- a/test/modeles/autorisations/ajoutContributeurSurService.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurService.spec.js
@@ -107,15 +107,9 @@ describe("L'ajout d'un contributeur sur un service", () => {
         adaptateurMail.envoieMessageInvitationContribution = async (
           destinataire,
           prenomNomEmetteur,
-          nomService,
-          idHomologation
+          nbServices
         ) => {
-          emailEnvoye = {
-            destinataire,
-            prenomNomEmetteur,
-            nomService,
-            idHomologation,
-          };
+          emailEnvoye = { destinataire, prenomNomEmetteur, nbServices };
         };
 
         await ajoutContributeurSurService({
@@ -128,8 +122,7 @@ describe("L'ajout d'un contributeur sur un service", () => {
         expect(emailEnvoye.prenomNomEmetteur).to.be(
           'jean.dujardin@beta.gouv.com'
         );
-        expect(emailEnvoye.nomService).to.be('Nom Service');
-        expect(emailEnvoye.idHomologation).to.be('123');
+        expect(emailEnvoye.nbServices).to.be(1);
       });
     });
 

--- a/test/modeles/autorisations/ajoutContributeurSurService.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurService.spec.js
@@ -251,14 +251,14 @@ describe("L'ajout d'un contributeur sur un service", () => {
       adaptateurMail.envoieMessageInvitationInscription = async (
         destinataire,
         prenomNomEmetteur,
-        nomService,
-        idResetMotDePasse
+        idResetMotDePasse,
+        nbServices
       ) => {
         emailEnvoye = {
           destinataire,
           prenomNomEmetteur,
-          nomService,
           idResetMotDePasse,
+          nbServices,
         };
       };
 
@@ -272,8 +272,8 @@ describe("L'ajout d'un contributeur sur un service", () => {
       expect(emailEnvoye.prenomNomEmetteur).to.be(
         'jean.dujardin@beta.gouv.com'
       );
-      expect(emailEnvoye.nomService).to.be('Nom Service');
       expect(emailEnvoye.idResetMotDePasse).to.be('reset');
+      expect(emailEnvoye.nbServices).to.be(1);
     });
   });
 


### PR DESCRIPTION
Cette PR permet d'utiliser des nouveaux templates d'email Brevo.

⚠️ Il faut changer les IDs de templates dans les `.env` pour permettre le test :
```
SENDINBLUE_TEMPLATE_INVITATION_CONTRIBUTION=…
SENDINBLUE_TEMPLATE_INVITATION_INSCRIPTION=…
```

Le template d'invitation à collaborer 👇 
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/e5cae878-99ec-4d68-af55-4d3edf6c6083)

Le template d'invitation à s'inscrire 👇 
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/7a3bae0d-707b-4b10-9d29-a7d4b27f0eba)
