### PR TITLE
Rends disponible l'action « Inviter » lorsque plusieurs services sont sélectionnés

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionInvitation.mjs
+++ b/public/modules/tableauDeBord/actions/ActionInvitation.mjs
@@ -24,8 +24,8 @@ class ActionInvitation extends ActionAbstraite {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  estDisponible({ estSelectionMultiple, seulementCreateur }) {
-    return !estSelectionMultiple && seulementCreateur;
+  estDisponible({ seulementCreateur }) {
+    return seulementCreateur;
   }
 
   execute() {
@@ -37,14 +37,12 @@ class ActionInvitation extends ActionAbstraite {
     $('#action-invitation').hide();
 
     const emailContributeur = $emailInvite.val();
-    const invitations = [...this.tableauDesServices.servicesSelectionnes].map(
-      (idService) =>
-        axios.post('/api/autorisation', {
-          emailContributeur,
-          idHomologation: idService,
-        })
-    );
-    return Promise.all(invitations)
+
+    return axios
+      .post('/api/autorisation', {
+        emailContributeur,
+        idServices: [...this.tableauDesServices.servicesSelectionnes],
+      })
       .then(() => {
         this.tableauDesServices.recupereServices();
         this.basculeLoader(false);

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -232,19 +232,21 @@ const routesApiPrivee = ({
   routes.post(
     '/autorisation',
     middleware.verificationAcceptationCGU,
-    middleware.aseptise('idHomologation', 'emailContributeur'),
+    middleware.aseptise('idServices.*', 'emailContributeur'),
     async (requete, reponse, suite) => {
-      const { idHomologation } = requete.body;
+      const { idServices = [] } = requete.body;
       const idUtilisateur = requete.idUtilisateurCourant;
       const emailContributeur = requete.body.emailContributeur?.toLowerCase();
 
-      const service = await depotDonnees.homologation(idHomologation);
+      const services = await Promise.all(
+        idServices.map(depotDonnees.homologation)
+      );
       const emetteur = await depotDonnees.utilisateur(idUtilisateur);
 
       try {
         await procedures.ajoutContributeurSurServices(
           emailContributeur,
-          [service],
+          services,
           emetteur
         );
         reponse.send('');


### PR DESCRIPTION
Cette PR ajoute l'invitation sur plusieurs services côté front 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/2bf2b441-24dd-4b80-a74b-ab0bd97834c0)


C'est la fin de la séquence sur l'invitation multiple : le front et le back supportent désormais l'invitation sur plusieurs services simultanément.

