### PR TITLE
Route d'annuaire de suggestions des contributeurs

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironneme
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./src/adaptateurs/fabriqueAdaptateurGestionErreur');
+const fabriqueAdaptateurPersistance = require('./src/adaptateurs/fabriqueAdaptateurPersistance');
 const adaptateurRechercheEntrepriseAPI = require('./src/adaptateurs/adaptateurRechercheEntrepriseAPI');
 const fabriqueAdaptateurTracking = require('./src/adaptateurs/fabriqueAdaptateurTracking');
 const adaptateurHorloge = require('./src/adaptateurs/adaptateurHorloge');
@@ -18,6 +19,10 @@ const adaptateurMail = adaptateurEnvironnement.sendinblue().clefAPIEmail()
   ? require('./src/adaptateurs/adaptateurMailSendinblue')
   : require('./src/adaptateurs/adaptateurMailMemoire').fabriqueAdaptateurMailMemoire();
 const adaptateurPdf = require('./src/adaptateurs/adaptateurPdf');
+
+const adaptateurPersistance = fabriqueAdaptateurPersistance(
+  process.env.NODE_ENV
+);
 const adaptateurZip = require('./src/adaptateurs/adaptateurZip');
 const {
   adaptateurProtection,
@@ -28,6 +33,7 @@ const adaptateurGestionErreur = fabriqueAdaptateurGestionErreur();
 const adaptateurTracking = fabriqueAdaptateurTracking();
 const serviceAnnuaire = fabriqueAnnuaire({
   adaptateurRechercheEntreprise: adaptateurRechercheEntrepriseAPI,
+  adaptateurPersistance,
 });
 
 const port = process.env.PORT || 3000;

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -294,6 +294,26 @@ const nouvelAdaptateur = (
     else dejaConnu.donnees = donneesParcoursUtilisateur;
   };
 
+  const rechercheContributeurs = async (idUtilisateur, recherche) => {
+    const idServices = donnees.autorisations
+      .filter((a) => a.idUtilisateur === idUtilisateur && a.type === 'createur')
+      .map((a) => a.idService);
+    const idUniquesContributeurs = donnees.autorisations.filter(
+      (a) => idServices.includes(a.idService) && a.type !== 'createur'
+    );
+    const tousContributeurs = donnees.utilisateurs.filter((u) =>
+      idUniquesContributeurs.includes(u.id)
+    );
+
+    const rechercheMinuscule = recherche.toLowerCase();
+    return tousContributeurs.filter(
+      (c) =>
+        c.email.toLowerCase().includes(rechercheMinuscule) ||
+        c.prenom?.toLowerCase().includes(rechercheMinuscule) ||
+        c.nom?.toLowerCase().includes(rechercheMinuscule)
+    );
+  };
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -307,6 +327,7 @@ const nouvelAdaptateur = (
     lisParcoursUtilisateur,
     metsAJourUtilisateur,
     nbAutorisationsCreateur,
+    rechercheContributeurs,
     sauvegardeParcoursUtilisateur,
     sauvegardeHomologation,
     sauvegardeService,

--- a/src/annuaire/serviceAnnuaire.js
+++ b/src/annuaire/serviceAnnuaire.js
@@ -1,5 +1,19 @@
-const fabriqueAnnuaire = ({ adaptateurRechercheEntreprise }) => ({
-  rechercheOrganisation: adaptateurRechercheEntreprise.rechercheOrganisation,
+const Utilisateur = require('../modeles/utilisateur');
+
+const fabriqueAnnuaire = ({
+  adaptateurRechercheEntreprise,
+  adaptateurPersistance,
+}) => ({
+  rechercheOrganisation: async (terme, departement) =>
+    adaptateurRechercheEntreprise.rechercheOrganisation(terme, departement),
+  rechercheContributeurs: async (idUtilisateur, recherche) => {
+    const contributeurs = await adaptateurPersistance.rechercheContributeurs(
+      idUtilisateur,
+      recherche
+    );
+
+    return contributeurs.map((c) => new Utilisateur(c));
+  },
 });
 
 module.exports = { fabriqueAnnuaire };

--- a/src/mss.js
+++ b/src/mss.js
@@ -215,6 +215,7 @@ const creeServeur = (
       adaptateurCsv,
       adaptateurZip,
       procedures,
+      serviceAnnuaire,
     })
   );
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -33,6 +33,7 @@ const routesApiPrivee = ({
   adaptateurCsv,
   adaptateurZip,
   procedures,
+  serviceAnnuaire,
 }) => {
   const routes = express.Router();
 
@@ -334,6 +335,24 @@ const routesApiPrivee = ({
       reponse.render(
         `nouvellesFonctionnalites/${nouvelleFonctionnalite.fichierPug}`
       );
+    }
+  );
+
+  routes.get(
+    '/annuaire/contributeurs',
+    middleware.verificationAcceptationCGU,
+    middleware.aseptise('recherche'),
+    (requete, reponse) => {
+      const { recherche = '' } = requete.query;
+
+      if (recherche === '') {
+        reponse.status(400).send('Le terme de recherche ne peut pas être vide');
+        return;
+      }
+
+      serviceAnnuaire
+        .rechercheContributeurs(requete.idUtilisateurCourant, recherche)
+        .then((suggestions) => reponse.status(200).json({ suggestions }));
     }
   );
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -342,7 +342,7 @@ const routesApiPrivee = ({
     '/annuaire/contributeurs',
     middleware.verificationAcceptationCGU,
     middleware.aseptise('recherche'),
-    (requete, reponse) => {
+    async (requete, reponse) => {
       const { recherche = '' } = requete.query;
 
       if (recherche === '') {
@@ -350,9 +350,18 @@ const routesApiPrivee = ({
         return;
       }
 
-      serviceAnnuaire
-        .rechercheContributeurs(requete.idUtilisateurCourant, recherche)
-        .then((suggestions) => reponse.status(200).json({ suggestions }));
+      const contributeurs = await serviceAnnuaire.rechercheContributeurs(
+        requete.idUtilisateurCourant,
+        recherche
+      );
+
+      reponse.status(200).json({
+        suggestions: contributeurs.map((c) => ({
+          prenomNom: c.prenomNom(),
+          email: c.email,
+          initiales: c.initiales(),
+        })),
+      });
     }
   );
 

--- a/test/annuaire/serviceAnnuaire.spec.js
+++ b/test/annuaire/serviceAnnuaire.spec.js
@@ -1,0 +1,24 @@
+const expect = require('expect.js');
+const Utilisateur = require('../../src/modeles/utilisateur');
+const { fabriqueAnnuaire } = require('../../src/annuaire/serviceAnnuaire');
+
+describe("Le service d'annuaire", () => {
+  describe('sur demande de contributeurs', () => {
+    it('retourne des Utilisateurs du domaine', async () => {
+      const bouchonPersistance = {
+        rechercheContributeurs: async () => [
+          { id: '123', email: 'jean.dujardin@beta.gouv.fr' },
+        ],
+      };
+
+      const annuaire = fabriqueAnnuaire({
+        adaptateurPersistance: bouchonPersistance,
+      });
+
+      const contributeurs = await annuaire.rechercheContributeurs('X', 'Y');
+
+      expect(contributeurs.length).to.be(1);
+      expect(contributeurs[0]).to.be.an(Utilisateur);
+    });
+  });
+});

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -29,6 +29,13 @@ class ConstructeurUtilisateur {
     return this;
   }
 
+  quiSAppelle(prenomNom) {
+    const [prenom, nom] = prenomNom.split(' ');
+    this.donnees.prenom = prenom;
+    this.donnees.nom = nom;
+    return this;
+  }
+
   quiAccepteInfolettre() {
     this.donnees.infolettreAcceptee = true;
     return this;

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -1089,8 +1089,12 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       ) => {
         appelDepot.idUtilisateur = idUtilisateur;
         appelDepot.recherche = recherche;
+
         return [
-          { nomPrenom: 'Jean Dujardin', email: 'jean.dujardin@beta.gouv.fr' },
+          unUtilisateur()
+            .avecEmail('jean.dujardin@beta.gouv.fr')
+            .quiSAppelle('Jean Dujardin')
+            .construis(),
         ];
       };
 
@@ -1101,7 +1105,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       expect(appelDepot).to.eql({ idUtilisateur: '123', recherche: 'jean' });
       expect(reponse.status).to.be(200);
       expect(reponse.data.suggestions).to.eql([
-        { nomPrenom: 'Jean Dujardin', email: 'jean.dujardin@beta.gouv.fr' },
+        {
+          prenomNom: 'Jean Dujardin',
+          email: 'jean.dujardin@beta.gouv.fr',
+          initiales: 'JD',
+        },
       ]);
     });
   });


### PR DESCRIPTION
On ajoute une route qui permet de rechercher un contributeur dans tous les services dont je suis propriétaire, en fonction d'un chaine de recherche.
On se base sur les champs `email`, `prenom` et `nom`.