### PR TITLE
[NETTOYAGE] Harmonisation des routes d'annuaire

### DIFF
--- a/public/utilisateur/suggestionEntite.js
+++ b/public/utilisateur/suggestionEntite.js
@@ -17,13 +17,15 @@ const rechercheSuggestions = (recherche, callback) => {
   if (departementSelectionne !== '')
     parametresRequete.params.departement = departementSelectionne;
 
-  axios.get('/api/annuaire/suggestions', parametresRequete).then((reponse) => {
-    const suggestions = reponse.data.suggestions.map(({ departement, nom }) =>
-      uneSuggestion(departement, nom)
-    );
+  axios
+    .get('/api/annuaire/organisations', parametresRequete)
+    .then((reponse) => {
+      const suggestions = reponse.data.suggestions.map(({ departement, nom }) =>
+        uneSuggestion(departement, nom)
+      );
 
-    callback(suggestions);
-  });
+      callback(suggestions);
+    });
 };
 
 $(() => {

--- a/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
+++ b/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
@@ -3,7 +3,7 @@ const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
 
-const rechercheOrganisation = (terme, departement) =>
+const rechercheOrganisations = (terme, departement) =>
   axios
     .get('https://recherche-entreprises.api.gouv.fr/search', {
       params: {
@@ -27,4 +27,4 @@ const rechercheOrganisation = (terme, departement) =>
       return Promise.resolve([]);
     });
 
-module.exports = { rechercheOrganisation };
+module.exports = { rechercheOrganisations };

--- a/src/annuaire/serviceAnnuaire.js
+++ b/src/annuaire/serviceAnnuaire.js
@@ -4,8 +4,8 @@ const fabriqueAnnuaire = ({
   adaptateurRechercheEntreprise,
   adaptateurPersistance,
 }) => ({
-  rechercheOrganisation: async (terme, departement) =>
-    adaptateurRechercheEntreprise.rechercheOrganisation(terme, departement),
+  rechercheOrganisations: async (terme, departement) =>
+    adaptateurRechercheEntreprise.rechercheOrganisations(terme, departement),
   rechercheContributeurs: async (idUtilisateur, recherche) => {
     const contributeurs = await adaptateurPersistance.rechercheContributeurs(
       idUtilisateur,

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -153,7 +153,7 @@ const routesApiPublique = ({
       .catch(suite);
   });
 
-  routes.get('/annuaire/suggestions', (requete, reponse) => {
+  routes.get('/annuaire/organisations', (requete, reponse) => {
     const { recherche = '', departement = null } = requete.query;
 
     if (recherche === '') {

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -166,7 +166,7 @@ const routesApiPublique = ({
     }
 
     serviceAnnuaire
-      .rechercheOrganisation(recherche, departement)
+      .rechercheOrganisations(recherche, departement)
       .then((suggestions) => reponse.status(200).json({ suggestions }));
   });
 

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -153,22 +153,29 @@ const routesApiPublique = ({
       .catch(suite);
   });
 
-  routes.get('/annuaire/organisations', (requete, reponse) => {
-    const { recherche = '', departement = null } = requete.query;
+  routes.get(
+    '/annuaire/organisations',
+    middleware.aseptise(['recherche', 'departement']),
+    (requete, reponse) => {
+      const { recherche = '', departement = null } = requete.query;
 
-    if (recherche === '') {
-      reponse.status(400).send('Le terme de recherche ne peut pas être vide');
-      return;
-    }
-    if (departement !== null && !referentiel.estCodeDepartement(departement)) {
-      reponse.status(400).send('Le département doit être valide (01 à 989)');
-      return;
-    }
+      if (recherche === '') {
+        reponse.status(400).send('Le terme de recherche ne peut pas être vide');
+        return;
+      }
+      if (
+        departement !== null &&
+        !referentiel.estCodeDepartement(departement)
+      ) {
+        reponse.status(400).send('Le département doit être valide (01 à 989)');
+        return;
+      }
 
-    serviceAnnuaire
-      .rechercheOrganisations(recherche, departement)
-      .then((suggestions) => reponse.status(200).json({ suggestions }));
-  });
+      serviceAnnuaire
+        .rechercheOrganisations(recherche, departement)
+        .then((suggestions) => reponse.status(200).json({ suggestions }));
+    }
+  );
 
   routes.post(
     '/desinscriptionInfolettre',

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -527,7 +527,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
   });
 
-  describe('quand requête GET sur `/api/annuaire/suggestions`', () => {
+  describe('quand requête GET sur `/api/annuaire/organisations`', () => {
     beforeEach(() => {
       testeur.referentiel().estCodeDepartement = () => true;
     });
@@ -538,7 +538,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         'Le terme de recherche ne peut pas être vide',
         {
           method: 'get',
-          url: 'http://localhost:1234/api/annuaire/suggestions?departement=75',
+          url: 'http://localhost:1234/api/annuaire/organisations?departement=75',
         },
         done
       );
@@ -551,7 +551,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         'Le département doit être valide (01 à 989)',
         {
           method: 'get',
-          url: 'http://localhost:1234/api/annuaire/suggestions?recherche=mairie&departement=990',
+          url: 'http://localhost:1234/api/annuaire/organisations?recherche=mairie&departement=990',
         },
         done
       );
@@ -571,7 +571,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
 
       axios
         .get(
-          'http://localhost:1234/api/annuaire/suggestions?recherche=mairie&departement=01'
+          'http://localhost:1234/api/annuaire/organisations?recherche=mairie&departement=01'
         )
         .then((reponse) => {
           expect(adaptateurAppele).to.be(true);

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -532,6 +532,17 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       testeur.referentiel().estCodeDepartement = () => true;
     });
 
+    it('aseptise les paramètres de la requête', (done) => {
+      testeur.middleware().verifieAseptisationParametres(
+        ['recherche', 'departement'],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/annuaire/organisations',
+        },
+        done
+      );
+    });
+
     it('retourne une erreur HTTP 400 si le terme de recherche est vide', (done) => {
       testeur.verifieRequeteGenereErreurHTTP(
         400,

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -559,7 +559,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
 
     it("recherche les organisations correspondantes grâce au service d'annuaire", (done) => {
       let adaptateurAppele = false;
-      testeur.serviceAnnuaire().rechercheOrganisation = (
+      testeur.serviceAnnuaire().rechercheOrganisations = (
         terme,
         departement
       ) => {


### PR DESCRIPTION
Après ajout d'une nouvelle route d'annuaire (`/annuaire/contributeurs`), on harmonise les deux routes pour être cohérent.
- Les méthodes du `serviceAnnuaire` sont accordés au pluriel: `rechercheOrganisation` -> `rechercheOrganisations`
- La route de recherche d'organisation hérite du nom de la ressource recherchée: `/annuaire/suggestions` -> `/annuaire/organisations`
- On en profite pour aseptiser les paramètres de la route `/annuaire/organisations` car cela n'avait pas été fait avant.