### PR TITLE
[CORRECTION] Affichage de modale sans contenu

### DIFF
--- a/public/modules/modaleNouvellesFonctionnalites.mjs
+++ b/public/modules/modaleNouvellesFonctionnalites.mjs
@@ -23,7 +23,10 @@ const brancheComportementModaleNouvelleFonctionnalite = ($modale) => {
       $modale[0].close();
     });
 
-    $($modale).on('close', () => supprimeQueryString());
+    $($modale).on('close', () => {
+      supprimeQueryString();
+      $modale.attr('data-page-actuelle', 1);
+    });
 
     $('.bouton.suivant', $modale).on('click', () => {
       const actuelle = parseInt($modale.attr('data-page-actuelle'), 10);


### PR DESCRIPTION
Nous avons détecté un bug en démo, réalisable comme cela :
- ouvrir le carrousel via le bouton 'Nouveautés'
- cliquer sur suivant pour aller à la deuxième page
- fermer le carrousel
- réouvrir le carrousel via le bouton 'Nouveautés'
- aller à la deuxième page, elle ne s'affiche pas

Il s'agissait d'un bug où, à la fermeture, le compteur `data-page-actuelle` n'était pas réinitialisé à `1`, donc le compteur continuait d'incrémenter au delà du nombre de slide.