### PR TITLE
[HOTFIX] Utilise l'instruction `@html` pour décoder les données

### DIFF
--- a/svelte/.eslintrc.js
+++ b/svelte/.eslintrc.js
@@ -14,4 +14,10 @@ module.exports = {
       parserOptions: { parser: '@typescript-eslint/parser' },
     },
   ],
+  settings: {
+    svelte: {
+      // On veut parser de la donnée encodée en HTML depuis le back, on doit pouvoir utiliser l'instruction `@html`
+      ignoreWarnings: ['svelte/no-at-html-tags'],
+    },
+  },
 };

--- a/svelte/lib/LigneContributeur.svelte
+++ b/svelte/lib/LigneContributeur.svelte
@@ -16,8 +16,8 @@
       {utilisateur.initiales}
     </div>
     <div class="nom-prenom-poste">
-      <div class="nom-contributeur">{utilisateur.prenomNom}</div>
-      <div class="poste-contributeur">{utilisateur.poste}</div>
+      <div class="nom-contributeur">{@html utilisateur.prenomNom}</div>
+      <div class="poste-contributeur">{@html utilisateur.poste}</div>
     </div>
   </div>
   <div class="role {estProprietaire ? 'proprietaire' : 'contributeur'}">
@@ -26,8 +26,7 @@
   {#if estSupprimable}
     <button
       class="declencheur-menu-flottant"
-      on:click={() =>
-        gestionContributeursStore.ouvrirMenuPour(utilisateur.id)}
+      on:click={() => gestionContributeursStore.ouvrirMenuPour(utilisateur.id)}
     >
       <div
         class="svelte-menu-flottant"
@@ -40,9 +39,7 @@
           <li
             class="action-suppression-contributeur"
             on:click={() =>
-              gestionContributeursStore.afficheEtapeSuppression(
-                utilisateur
-              )}
+              gestionContributeursStore.afficheEtapeSuppression(utilisateur)}
           >
             Retirer du service
           </li>

--- a/svelte/lib/SuppressionContributeur.svelte
+++ b/svelte/lib/SuppressionContributeur.svelte
@@ -20,8 +20,9 @@
 
 <div class="conteneur-confirmation">
   <p class="entete">
-    Souhaitez-vous vraiment retirer les accès de {utilisateur.prenomNom} au service
-    <strong>{service.nomService}</strong> ?
+    Souhaitez-vous vraiment retirer les accès de {@html utilisateur.prenomNom} au
+    service
+    <strong>{@html service.nomService}</strong> ?
   </p>
   <div class="banniere-information">
     <img
@@ -37,8 +38,7 @@
     <button
       class="bouton bouton-secondaire"
       type="button"
-      on:click={() =>
-        gestionContributeursStore.afficheEtapeListe()}
+      on:click={() => gestionContributeursStore.afficheEtapeListe()}
     >
       Annuler
     </button>


### PR DESCRIPTION
Les données stockées en base de données sont au format `HTML`.
Avant, on utilisait le rendu natif de jQuery qui convertit cette données.
Maintenant, nous devons utiliser l'instruction `@html` [de Svelte](https://learn.svelte.dev/tutorial/html-tags).