### PR TITLE
[CORRECTION] Réinitialise le store au montage du composant

### DIFF
--- a/svelte/lib/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs.store.ts
@@ -9,20 +9,17 @@ type EtatGestionContributeursStore = {
   utilisateurEnCoursDeSuppression: Utilisateur;
 };
 
-let { subscribe, update } = writable<EtatGestionContributeursStore>({
+const valeurParDefaut: EtatGestionContributeursStore = {
   idMenuOuvert: null,
   etapeCourante: 'ListeContributeurs',
   utilisateurEnCoursDeSuppression: null,
-});
+};
+
+const { subscribe, update, set } =
+  writable<EtatGestionContributeursStore>(valeurParDefaut);
 
 export const gestionContributeursStore = {
   subscribe,
-  ouvrirMenuPour: (idUtilisateur: string) => {
-    update((valeurActuelle) => ({
-      ...valeurActuelle,
-      idMenuOuvert: idUtilisateur,
-    }));
-  },
   afficheEtapeSuppression: (utilisateur: Utilisateur) => {
     update((valeurActuelle) => ({
       ...valeurActuelle,
@@ -38,4 +35,11 @@ export const gestionContributeursStore = {
       utilisateurEnCoursDeSuppression: null,
     }));
   },
+  ouvrirMenuPour: (idUtilisateur: string) => {
+    update((valeurActuelle) => ({
+      ...valeurActuelle,
+      idMenuOuvert: idUtilisateur,
+    }));
+  },
+  reinitialise: () => set(valeurParDefaut),
 };

--- a/svelte/lib/gestionContributeurs.ts
+++ b/svelte/lib/gestionContributeurs.ts
@@ -1,5 +1,6 @@
 import GestionContributeurs from './GestionContributeurs.svelte';
 import type { GestionContributeursProps } from './gestionContributeurs.d';
+import { gestionContributeursStore } from './gestionContributeurs.store';
 
 document.body.addEventListener(
   'svelte-recharge-contributeurs',
@@ -8,8 +9,13 @@ document.body.addEventListener(
 
 let app: GestionContributeurs;
 
+const reinitialiseStore = () => {
+  gestionContributeursStore.reinitialise();
+};
+
 const rechargeApp = (props: GestionContributeursProps) => {
   app?.$destroy();
+  reinitialiseStore();
   app = new GestionContributeurs({
     target: document.getElementById('conteneur-gestion-contributeurs'),
     props,


### PR DESCRIPTION
On remarque que même si le composant `Svelte` est détruit puis ré-instancié à chaque demande depuis le tableau de bord, le `store` garde son état.
Ceci est visible lorsque l'on change d'étape dans le composant (Suppression d'un contributeur), si le tiroir est fermé puis ré-ouvert, le composant reste à l'étape `Suppression`.

On rajoute donc une méthode pour le réinitialiser. 