### PR TITLE
Réparation de la fermeture du menu quand on clic en dehors de celui-ci

### DIFF
--- a/svelte/lib/LigneContributeur.svelte
+++ b/svelte/lib/LigneContributeur.svelte
@@ -5,6 +5,9 @@
   export let estProprietaire: boolean;
   export let estSupprimable: boolean;
   export let utilisateur: Utilisateur;
+
+  let menuOuvert = false;
+  let menuEl;
 </script>
 
 <li class="ligne-contributeur">
@@ -26,14 +29,10 @@
   {#if estSupprimable}
     <button
       class="declencheur-menu-flottant"
-      on:click={() => gestionContributeursStore.ouvrirMenuPour(utilisateur.id)}
+      on:click={() => (menuOuvert = !menuOuvert)}
+      bind:this={menuEl}
     >
-      <div
-        class="svelte-menu-flottant"
-        class:invisible={!(
-          $gestionContributeursStore.idMenuOuvert === utilisateur.id
-        )}
-      >
+      <div class="svelte-menu-flottant" class:invisible={!menuOuvert}>
         <ul>
           <!-- svelte-ignore a11y-click-events-have-key-events -->
           <li
@@ -48,3 +47,10 @@
     </button>
   {/if}
 </li>
+
+<svelte:body
+  on:click={(e) => {
+    const clicSurMenu = e.target === menuEl || menuEl?.contains(e.target);
+    if (!clicSurMenu) menuOuvert = false;
+  }}
+/>

--- a/svelte/lib/LigneContributeur.svelte
+++ b/svelte/lib/LigneContributeur.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
   import type { Utilisateur } from './gestionContributeurs.d';
   import { gestionContributeursStore } from './gestionContributeurs.store';
+  import MenuFlottant from './ui/MenuFlottant.svelte';
 
   export let estProprietaire: boolean;
   export let estSupprimable: boolean;
   export let utilisateur: Utilisateur;
-
-  let menuOuvert = false;
-  let menuEl;
 </script>
 
 <li class="ligne-contributeur">
@@ -27,30 +25,17 @@
     {estProprietaire ? 'Propriétaire' : 'Contributeur'}
   </div>
   {#if estSupprimable}
-    <button
-      class="declencheur-menu-flottant"
-      on:click={() => (menuOuvert = !menuOuvert)}
-      bind:this={menuEl}
-    >
-      <div class="svelte-menu-flottant" class:invisible={!menuOuvert}>
-        <ul>
-          <!-- svelte-ignore a11y-click-events-have-key-events -->
-          <li
-            class="action-suppression-contributeur"
-            on:click={() =>
-              gestionContributeursStore.afficheEtapeSuppression(utilisateur)}
-          >
-            Retirer du service
-          </li>
-        </ul>
-      </div>
-    </button>
+    <MenuFlottant>
+      <ul>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <li
+          class="action-suppression-contributeur"
+          on:click={() =>
+            gestionContributeursStore.afficheEtapeSuppression(utilisateur)}
+        >
+          Retirer du service
+        </li>
+      </ul>
+    </MenuFlottant>
   {/if}
 </li>
-
-<svelte:body
-  on:click={(e) => {
-    const clicSurMenu = e.target === menuEl || menuEl?.contains(e.target);
-    if (!clicSurMenu) menuOuvert = false;
-  }}
-/>

--- a/svelte/lib/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs.store.ts
@@ -21,25 +21,22 @@ const { subscribe, update, set } =
 export const gestionContributeursStore = {
   subscribe,
   afficheEtapeSuppression: (utilisateur: Utilisateur) => {
-    update((valeurActuelle) => ({
-      ...valeurActuelle,
+    update((etat) => ({
+      ...etat,
       etapeCourante: 'SuppressionContributeur',
       utilisateurEnCoursDeSuppression: utilisateur,
       idMenuOuvert: null,
     }));
   },
   afficheEtapeListe: () => {
-    update((valeurActuelle) => ({
-      ...valeurActuelle,
+    update((etat) => ({
+      ...etat,
       etapeCourante: 'ListeContributeurs',
       utilisateurEnCoursDeSuppression: null,
     }));
   },
   ouvrirMenuPour: (idUtilisateur: string) => {
-    update((valeurActuelle) => ({
-      ...valeurActuelle,
-      idMenuOuvert: idUtilisateur,
-    }));
+    update((etat) => ({ ...etat, idMenuOuvert: idUtilisateur }));
   },
   reinitialise: () => set(valeurParDefaut),
 };

--- a/svelte/lib/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs.store.ts
@@ -4,13 +4,11 @@ import type { Utilisateur } from './gestionContributeurs.d';
 type Etape = 'ListeContributeurs' | 'SuppressionContributeur';
 
 type EtatGestionContributeursStore = {
-  idMenuOuvert: string;
   etapeCourante: Etape;
-  utilisateurEnCoursDeSuppression: Utilisateur;
+  utilisateurEnCoursDeSuppression: Utilisateur | null;
 };
 
 const valeurParDefaut: EtatGestionContributeursStore = {
-  idMenuOuvert: null,
   etapeCourante: 'ListeContributeurs',
   utilisateurEnCoursDeSuppression: null,
 };
@@ -25,7 +23,6 @@ export const gestionContributeursStore = {
       ...etat,
       etapeCourante: 'SuppressionContributeur',
       utilisateurEnCoursDeSuppression: utilisateur,
-      idMenuOuvert: null,
     }));
   },
   afficheEtapeListe: () => {
@@ -34,9 +31,6 @@ export const gestionContributeursStore = {
       etapeCourante: 'ListeContributeurs',
       utilisateurEnCoursDeSuppression: null,
     }));
-  },
-  ouvrirMenuPour: (idUtilisateur: string) => {
-    update((etat) => ({ ...etat, idMenuOuvert: idUtilisateur }));
   },
   reinitialise: () => set(valeurParDefaut),
 };

--- a/svelte/lib/ui/MenuFlottant.svelte
+++ b/svelte/lib/ui/MenuFlottant.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  let menuOuvert = false;
+  let menuEl;
+</script>
+
+<button
+  class="declencheur-menu-flottant"
+  on:click={() => (menuOuvert = !menuOuvert)}
+  bind:this={menuEl}
+>
+  <div class="svelte-menu-flottant" class:invisible={!menuOuvert}>
+    <slot />
+  </div>
+</button>
+
+<svelte:body
+  on:click={(e) => {
+    const clicSurMenu = e.target === menuEl || menuEl?.contains(e.target);
+    if (!clicSurMenu) menuOuvert = false;
+  }}
+/>


### PR DESCRIPTION
Cette PR touche à ce menu flottant 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/ee8f0945-ddf1-4ce0-9839-7a87b480a31e)


Le menu ouvert se ferme lorsqu'on clic ailleurs que sur les «…».
De plus, on cesse de gérer l'état d'affichage dans un store : c'est local au composant.