### PR TITLE
Retire le `minify` de la commande `build` de vite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   web:
     <<: *configuration-base
-    command: bash -c "export PUPPETEER_EXECUTABLE_PATH=$$(which chromium) && npx knex migrate:latest && npx concurrently \"npx nodemon server.js\" \"npx vite build --watch --config svelte/vite.config.mts\""
+    command: bash -c "export PUPPETEER_EXECUTABLE_PATH=$$(which chromium) && npx knex migrate:latest && npx concurrently \"npx nodemon server.js\" \"npx vite build --watch --minify false --config svelte/vite.config.mts\""
     environment:
       - NODE_ENV=development
       # Sur Mac M1 le téléchargement de Chromium échoue, car aucune version compatible `arm64`.


### PR DESCRIPTION
Afin d'obtenir des messages d'erreurs plus parlant lors du developpement local, on retire [le `minify` du `build`](https://vitejs.dev/config/build-options.html#build-minify) dans le `docker-compose` local.