### PR TITLE
Stockage des `services` dans le store Svelte

### DIFF
--- a/svelte/lib/GestionContributeurs.svelte
+++ b/svelte/lib/GestionContributeurs.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import { gestionContributeursStore } from './gestionContributeurs.store';
+  import { store } from './gestionContributeurs.store';
   import InvitationContributeur from './InvitationContributeur.svelte';
   import LigneContributeur from './LigneContributeur.svelte';
   import SuppressionContributeur from './SuppressionContributeur.svelte';
 
-  $: surServiceUnique = $gestionContributeursStore.services.length === 1;
-  $: serviceUnique = $gestionContributeursStore.services[0];
+  $: surServiceUnique = $store.services.length === 1;
+  $: serviceUnique = $store.services[0];
   $: contributeurs = serviceUnique.contributeurs;
 </script>
 
-{#if $gestionContributeursStore.etapeCourante === 'SuppressionContributeur'}
+{#if $store.etapeCourante === 'SuppressionContributeur'}
   <SuppressionContributeur />
 {:else}
   <InvitationContributeur />
-  {#if $gestionContributeursStore.etapeCourante !== 'InvitationContributeurs' && surServiceUnique}
+  {#if $store.etapeCourante !== 'InvitationContributeurs' && surServiceUnique}
     <h3 class="titre-liste titre-contributeurs-actifs">Ajouté(s) au service</h3>
     <ul class="liste-contributeurs contributeurs-actifs">
       <LigneContributeur

--- a/svelte/lib/GestionContributeurs.svelte
+++ b/svelte/lib/GestionContributeurs.svelte
@@ -12,7 +12,9 @@
 {#if $store.etapeCourante === 'SuppressionContributeur'}
   <SuppressionContributeur />
 {:else}
-  <InvitationContributeur />
+  {#if $store.services.every((s) => s.estCreateur)}
+    <InvitationContributeur />
+  {/if}
   {#if $store.etapeCourante !== 'InvitationContributeurs' && surServiceUnique}
     <h3 class="titre-liste titre-contributeurs-actifs">Ajouté(s) au service</h3>
     <ul class="liste-contributeurs contributeurs-actifs">

--- a/svelte/lib/GestionContributeurs.svelte
+++ b/svelte/lib/GestionContributeurs.svelte
@@ -1,26 +1,19 @@
 <script lang="ts">
-  import type { Service, Utilisateur } from './gestionContributeurs.d';
-
   import { gestionContributeursStore } from './gestionContributeurs.store';
   import InvitationContributeur from './InvitationContributeur.svelte';
   import LigneContributeur from './LigneContributeur.svelte';
   import SuppressionContributeur from './SuppressionContributeur.svelte';
 
-  export let services: Service[];
-  $: serviceUnique = services[0];
+  $: surServiceUnique = $gestionContributeursStore.services.length === 1;
+  $: serviceUnique = $gestionContributeursStore.services[0];
   $: contributeurs = serviceUnique.contributeurs;
-
-  const supprimeContributeur = (evenement: CustomEvent<Utilisateur>) => {
-    contributeurs = contributeurs.filter((c) => c.id != evenement.detail.id);
-    document.body.dispatchEvent(new CustomEvent('jquery-recharge-services'));
-  };
 </script>
 
 {#if $gestionContributeursStore.etapeCourante === 'SuppressionContributeur'}
-  <SuppressionContributeur service={serviceUnique} on:suppressionEffectuee={supprimeContributeur} />
+  <SuppressionContributeur />
 {:else}
-  <InvitationContributeur {services} />
-  {#if $gestionContributeursStore.etapeCourante !== 'InvitationContributeurs' && services.length === 1}
+  <InvitationContributeur />
+  {#if $gestionContributeursStore.etapeCourante !== 'InvitationContributeurs' && surServiceUnique}
     <h3 class="titre-liste titre-contributeurs-actifs">Ajouté(s) au service</h3>
     <ul class="liste-contributeurs contributeurs-actifs">
       <LigneContributeur

--- a/svelte/lib/InvitationContributeur.svelte
+++ b/svelte/lib/InvitationContributeur.svelte
@@ -117,16 +117,5 @@
       alt="Icône envoi email"
     />
     <p>Un e-mail d'invitation a bien été envoyé.</p>
-    <button
-      class="bouton"
-      id="retour-liste-contributeurs"
-      type="button"
-      on:click={() => {
-        etapeCourante = 'Ajout';
-        store.afficheEtapeListe();
-      }}
-    >
-      Revenir à la liste des contributeurs
-    </button>
   </div>
 {/if}

--- a/svelte/lib/InvitationContributeur.svelte
+++ b/svelte/lib/InvitationContributeur.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import type { Service, Utilisateur } from './gestionContributeurs.d';
+  import type { Utilisateur } from './gestionContributeurs.d';
 
-  import { gestionContributeursStore } from './gestionContributeurs.store';
+  import { store } from './gestionContributeurs.store';
   import ChampAvecSuggestions from './ChampAvecSuggestions.svelte';
 
   type Etape = 'Ajout' | 'EnvoiEnCours' | 'Rapport';
@@ -9,9 +9,9 @@
   let contributeursAInviter: Utilisateur[] = [];
   let etapeCourante: Etape = 'Ajout';
 
-  $: services = $gestionContributeursStore.services;
+  $: services = $store.services;
   $: afficheLesBoutonsAction =
-    $gestionContributeursStore.etapeCourante === 'InvitationContributeurs';
+    $store.etapeCourante === 'InvitationContributeurs';
 
   const rechercheContributeurs = async (recherche: string) => {
     const reponse = await axios.get('/api/annuaire/contributeurs', {
@@ -22,7 +22,7 @@
   };
 
   const ajouteInvitation = (evenement: CustomEvent<Utilisateur>) => {
-    gestionContributeursStore.afficheEtapeInvitation();
+    store.afficheEtapeInvitation();
     if (!contributeursAInviter.find((c) => c.email === evenement.detail.email))
       contributeursAInviter = [...contributeursAInviter, evenement.detail];
   };
@@ -86,7 +86,7 @@
           type="button"
           on:click={() => {
             contributeursAInviter = [];
-            gestionContributeursStore.afficheEtapeListe();
+            store.afficheEtapeListe();
           }}
         >
           Annuler
@@ -123,7 +123,7 @@
       type="button"
       on:click={() => {
         etapeCourante = 'Ajout';
-        gestionContributeursStore.afficheEtapeListe();
+        store.afficheEtapeListe();
       }}
     >
       Revenir à la liste des contributeurs

--- a/svelte/lib/InvitationContributeur.svelte
+++ b/svelte/lib/InvitationContributeur.svelte
@@ -6,12 +6,12 @@
 
   type Etape = 'Ajout' | 'EnvoiEnCours' | 'Rapport';
 
-  export let services: Service[];
-
   let contributeursAInviter: Utilisateur[] = [];
   let etapeCourante: Etape = 'Ajout';
 
-  $: afficheLesBoutonsAction = $gestionContributeursStore.etapeCourante === 'InvitationContributeurs';
+  $: services = $gestionContributeursStore.services;
+  $: afficheLesBoutonsAction =
+    $gestionContributeursStore.etapeCourante === 'InvitationContributeurs';
 
   const rechercheContributeurs = async (recherche: string) => {
     const reponse = await axios.get('/api/annuaire/contributeurs', {
@@ -81,10 +81,14 @@
     </label>
     {#if afficheLesBoutonsAction}
       <div class="conteneur-actions">
-        <button class="bouton bouton-secondaire fermeture-tiroir" type="button" on:click={() => {
-          contributeursAInviter = [];
-          gestionContributeursStore.afficheEtapeListe()
-        }}>
+        <button
+          class="bouton bouton-secondaire fermeture-tiroir"
+          type="button"
+          on:click={() => {
+            contributeursAInviter = [];
+            gestionContributeursStore.afficheEtapeListe();
+          }}
+        >
           Annuler
         </button>
         {#if contributeursAInviter.length}

--- a/svelte/lib/LigneContributeur.svelte
+++ b/svelte/lib/LigneContributeur.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Utilisateur } from './gestionContributeurs.d';
-  import { gestionContributeursStore } from './gestionContributeurs.store';
+  import { store } from './gestionContributeurs.store';
   import MenuFlottant from './ui/MenuFlottant.svelte';
 
   export let estProprietaire: boolean;
@@ -30,8 +30,7 @@
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <li
           class="action-suppression-contributeur"
-          on:click={() =>
-            gestionContributeursStore.afficheEtapeSuppression(utilisateur)}
+          on:click={() => store.afficheEtapeSuppression(utilisateur)}
         >
           Retirer du service
         </li>

--- a/svelte/lib/SuppressionContributeur.svelte
+++ b/svelte/lib/SuppressionContributeur.svelte
@@ -1,21 +1,20 @@
 <script lang="ts">
-  import type { Service, Utilisateur } from './gestionContributeurs.d';
+  import type { Utilisateur } from './gestionContributeurs.d';
 
-  import { createEventDispatcher } from 'svelte';
   import { gestionContributeursStore } from './gestionContributeurs.store';
 
-  export let service: Service;
+  $: service = $gestionContributeursStore.services[0];
 
-  $: utilisateur = $gestionContributeursStore.utilisateurEnCoursDeSuppression as Utilisateur;
-
-  const envoiEvenement = createEventDispatcher();
+  $: utilisateur =
+    $gestionContributeursStore.utilisateurEnCoursDeSuppression as Utilisateur;
 
   const supprimeContributeur = async () => {
     await axios.delete('/api/autorisation', {
       params: { idHomologation: service.id, idContributeur: utilisateur.id },
     });
+    gestionContributeursStore.supprimeContributeur(utilisateur);
+    document.body.dispatchEvent(new CustomEvent('jquery-recharge-services'));
     gestionContributeursStore.afficheEtapeListe();
-    envoiEvenement('suppressionEffectuee', { ...utilisateur });
   };
 </script>
 

--- a/svelte/lib/SuppressionContributeur.svelte
+++ b/svelte/lib/SuppressionContributeur.svelte
@@ -1,20 +1,17 @@
 <script lang="ts">
   import type { Utilisateur } from './gestionContributeurs.d';
+  import { store } from './gestionContributeurs.store';
 
-  import { gestionContributeursStore } from './gestionContributeurs.store';
-
-  $: service = $gestionContributeursStore.services[0];
-
-  $: utilisateur =
-    $gestionContributeursStore.utilisateurEnCoursDeSuppression as Utilisateur;
+  $: service = $store.services[0];
+  $: utilisateur = $store.utilisateurEnCoursDeSuppression as Utilisateur;
 
   const supprimeContributeur = async () => {
     await axios.delete('/api/autorisation', {
       params: { idHomologation: service.id, idContributeur: utilisateur.id },
     });
-    gestionContributeursStore.supprimeContributeur(utilisateur);
+    store.supprimeContributeur(utilisateur);
     document.body.dispatchEvent(new CustomEvent('jquery-recharge-services'));
-    gestionContributeursStore.afficheEtapeListe();
+    store.afficheEtapeListe();
   };
 </script>
 
@@ -38,7 +35,7 @@
     <button
       class="bouton bouton-secondaire"
       type="button"
-      on:click={() => gestionContributeursStore.afficheEtapeListe()}
+      on:click={() => store.afficheEtapeListe()}
     >
       Annuler
     </button>

--- a/svelte/lib/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs.d.ts
@@ -11,10 +11,9 @@ export type GestionContributeursProps = {
 export type Service = {
   id: string;
   createur: Utilisateur;
+  estCreateur: boolean;
   contributeurs: Utilisateur[];
-  permissions: {
-    suppressionContributeur: boolean;
-  };
+  permissions: { suppressionContributeur: boolean };
   nomService: string;
 };
 

--- a/svelte/lib/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs.store.ts
@@ -21,7 +21,7 @@ const valeurParDefaut: EtatGestionContributeursStore = {
 const { subscribe, update, set } =
   writable<EtatGestionContributeursStore>(valeurParDefaut);
 
-export const gestionContributeursStore = {
+export const store = {
   subscribe,
   afficheEtapeSuppression: (utilisateur: Utilisateur) => {
     update((etat) => ({

--- a/svelte/lib/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs.store.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import type { Utilisateur } from './gestionContributeurs.d';
+import type { Service, Utilisateur } from './gestionContributeurs.d';
 
 type Etape =
   | 'ListeContributeurs'
@@ -9,11 +9,13 @@ type Etape =
 type EtatGestionContributeursStore = {
   etapeCourante: Etape;
   utilisateurEnCoursDeSuppression: Utilisateur | null;
+  services: Service[];
 };
 
 const valeurParDefaut: EtatGestionContributeursStore = {
   etapeCourante: 'ListeContributeurs',
   utilisateurEnCoursDeSuppression: null,
+  services: [],
 };
 
 const { subscribe, update, set } =
@@ -36,10 +38,16 @@ export const gestionContributeursStore = {
     }));
   },
   afficheEtapeInvitation: () => {
-    update((valeurActuelle) => ({
-      ...valeurActuelle,
-      etapeCourante: 'InvitationContributeurs',
-    }));
+    update((etat) => ({ ...etat, etapeCourante: 'InvitationContributeurs' }));
   },
-  reinitialise: () => set(valeurParDefaut),
+  supprimeContributeur: (contributeur: Utilisateur) => {
+    update((etat) => {
+      const [serviceUnique] = etat.services;
+      serviceUnique.contributeurs = serviceUnique.contributeurs.filter(
+        (c) => c.id != contributeur.id
+      );
+      return { ...etat, services: [serviceUnique] };
+    });
+  },
+  reinitialise: (services: Service[]) => set({ ...valeurParDefaut, services }),
 };

--- a/svelte/lib/gestionContributeurs.ts
+++ b/svelte/lib/gestionContributeurs.ts
@@ -1,5 +1,8 @@
 import GestionContributeurs from './GestionContributeurs.svelte';
-import type { GestionContributeursProps } from './gestionContributeurs.d';
+import type {
+  GestionContributeursProps,
+  Service,
+} from './gestionContributeurs.d';
 import { gestionContributeursStore } from './gestionContributeurs.store';
 
 document.body.addEventListener(
@@ -9,16 +12,15 @@ document.body.addEventListener(
 
 let app: GestionContributeurs;
 
-const reinitialiseStore = () => {
-  gestionContributeursStore.reinitialise();
+const reinitialiseStore = (services: Service[]) => {
+  gestionContributeursStore.reinitialise(services);
 };
 
 const rechargeApp = (props: GestionContributeursProps) => {
   app?.$destroy();
-  reinitialiseStore();
+  reinitialiseStore(props.services);
   app = new GestionContributeurs({
-    target: document.getElementById('conteneur-gestion-contributeurs'),
-    props,
+    target: document.getElementById('conteneur-gestion-contributeurs')!,
   });
 };
 

--- a/svelte/lib/gestionContributeurs.ts
+++ b/svelte/lib/gestionContributeurs.ts
@@ -3,7 +3,7 @@ import type {
   GestionContributeursProps,
   Service,
 } from './gestionContributeurs.d';
-import { gestionContributeursStore } from './gestionContributeurs.store';
+import { store } from './gestionContributeurs.store';
 
 document.body.addEventListener(
   'svelte-recharge-contributeurs',
@@ -13,7 +13,7 @@ document.body.addEventListener(
 let app: GestionContributeurs;
 
 const reinitialiseStore = (services: Service[]) => {
-  gestionContributeursStore.reinitialise(services);
+  store.reinitialise(services);
 };
 
 const rechargeApp = (props: GestionContributeursProps) => {


### PR DESCRIPTION
… au lieu d'utiliser le composant racine `<GestionContributeurs>`.

Ça allège le code.

Au passage on corrige un bug où on affichait l'invitation pour les services dont l'utilisateur n'est pas propriétaire.