### PR TITLE
Route `GET /api/service/:id` 

### DIFF
--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -1,0 +1,33 @@
+const Dossiers = require('../dossiers');
+
+const donnees = (service, idUtilisateur, referentiel) => ({
+  id: service.id,
+  nomService: service.nomService(),
+  organisationsResponsables:
+    service.descriptionService.organisationsResponsables ?? [],
+  createur: {
+    id: service.createur.id,
+    prenomNom: service.createur.prenomNom(),
+    initiales: service.createur.initiales(),
+    poste: service.createur.posteDetaille(),
+  },
+  contributeurs: service.contributeurs.map((c) => ({
+    id: c.id,
+    prenomNom: c.prenomNom(),
+    initiales: c.initiales(),
+    poste: c.posteDetaille(),
+  })),
+  statutHomologation: {
+    id: service.dossiers.statutHomologation(),
+    enCoursEdition: service.dossiers.statutSaisie() === Dossiers.A_COMPLETER,
+    ...referentiel.statutHomologation(service.dossiers.statutHomologation()),
+  },
+  nombreContributeurs: service.contributeurs.length + 1,
+  estCreateur: service.createur.id === idUtilisateur,
+  documentsPdfDisponibles: service.documentsPdfDisponibles(),
+  permissions: {
+    suppressionContributeur: service.createur.id === idUtilisateur,
+  },
+});
+
+module.exports = { donnees };

--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -1,42 +1,10 @@
 const Dossiers = require('../dossiers');
+const objetGetService = require('./objetGetService');
 
 const donnees = (services, idUtilisateur, referentiel) => ({
-  services: services
-    .map((s) => ({
-      ...s.toJSON(),
-      organisationsResponsables: s.descriptionService.organisationsResponsables,
-      statutHomologation: s.dossiers.statutHomologation(),
-      statutSaisie: s.dossiers.statutSaisie(),
-      documentsPdfDisponibles: s.documentsPdfDisponibles(),
-    }))
-    .map((json) => ({
-      id: json.id,
-      nomService: json.nomService,
-      organisationsResponsables: json.organisationsResponsables ?? [],
-      createur: {
-        id: json.createur.id,
-        prenomNom: json.createur.prenomNom,
-        initiales: json.createur.initiales,
-        poste: json.createur.posteDetaille,
-      },
-      contributeurs: json.contributeurs.map((c) => ({
-        id: c.id,
-        prenomNom: c.prenomNom,
-        initiales: c.initiales,
-        poste: c.posteDetaille,
-      })),
-      statutHomologation: {
-        id: json.statutHomologation,
-        enCoursEdition: json.statutSaisie === Dossiers.A_COMPLETER,
-        ...referentiel.statutHomologation(json.statutHomologation),
-      },
-      nombreContributeurs: json.contributeurs.length + 1,
-      estCreateur: json.createur.id === idUtilisateur,
-      documentsPdfDisponibles: json.documentsPdfDisponibles,
-      permissions: {
-        suppressionContributeur: json.createur.id === idUtilisateur,
-      },
-    })),
+  services: services.map((s) =>
+    objetGetService.donnees(s, idUtilisateur, referentiel)
+  ),
   resume: {
     nombreServices: services.length,
     nombreServicesHomologues: services.filter(

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -23,6 +23,7 @@ const RisquesSpecifiques = require('../../modeles/risquesSpecifiques');
 const RolesResponsabilites = require('../../modeles/rolesResponsabilites');
 const { dateInvalide } = require('../../utilitaires/date');
 const { valeurBooleenne } = require('../../utilitaires/aseptisation');
+const objetGetService = require('../../modeles/objetsApi/objetGetService');
 
 const routesApiService = (
   middleware,
@@ -111,6 +112,20 @@ const routesApiService = (
             reponse.status(422).send(e.message);
           } else suite(e);
         });
+    }
+  );
+
+  routes.get(
+    '/:id',
+    middleware.aseptise('id'),
+    middleware.trouveService,
+    async (requete, reponse) => {
+      const donnees = objetGetService.donnees(
+        requete.homologation,
+        requete.idUtilisateurCourant,
+        referentiel
+      );
+      reponse.json(donnees);
     }
   );
 

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -1,0 +1,103 @@
+const expect = require('expect.js');
+
+const Service = require('../../../src/modeles/service');
+const objetGetService = require('../../../src/modeles/objetsApi/objetGetService');
+const Referentiel = require('../../../src/referentiel');
+
+describe("L'objet d'API de `GET /service`", () => {
+  const referentiel = Referentiel.creeReferentiel({
+    statutsHomologation: {
+      nonRealisee: { libelle: 'Non réalisée', ordre: 1 },
+    },
+  });
+
+  const unService = new Service({
+    id: '123',
+    descriptionService: {
+      nomService: 'Un service',
+      organisationsResponsables: ['Une organisation'],
+    },
+    createur: {
+      id: 'A',
+      email: 'email.createur@mail.fr',
+      prenom: 'Jacques',
+      postes: ['RSSI'],
+    },
+    contributeurs: [
+      {
+        id: 'B',
+        email: 'email.contributeur1@mail.fr',
+        prenom: 'Jean',
+        postes: ['Maire'],
+      },
+    ],
+  });
+
+  it('fournit les données nécessaires', () => {
+    expect(objetGetService.donnees(unService, 'A', referentiel)).to.eql({
+      id: '123',
+      nomService: 'Un service',
+      organisationsResponsables: ['Une organisation'],
+      createur: {
+        id: 'A',
+        prenomNom: 'Jacques',
+        initiales: 'J',
+        poste: 'RSSI',
+      },
+      contributeurs: [
+        {
+          id: 'B',
+          prenomNom: 'Jean',
+          initiales: 'J',
+          poste: 'Maire',
+        },
+      ],
+      statutHomologation: {
+        enCoursEdition: false,
+        libelle: 'Non réalisée',
+        id: 'nonRealisee',
+        ordre: 1,
+      },
+      nombreContributeurs: 1 + 1,
+      estCreateur: true,
+      documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
+      permissions: {
+        suppressionContributeur: true,
+      },
+    });
+  });
+
+  describe('sur demande des permissions', () => {
+    it("autorise la suppression de contributeur si l'utilisateur est créateur", () => {
+      const unServiceDontAestCreateur = new Service({
+        id: '123',
+        descriptionService: { nomService: 'Un service' },
+        createur: { id: 'A', email: 'email.createur@mail.fr' },
+      });
+      expect(
+        objetGetService.donnees(unServiceDontAestCreateur, 'A', referentiel)
+          .permissions
+      ).to.eql({
+        suppressionContributeur: true,
+      });
+    });
+
+    it("n'autorise pas la suppression de contributeur si l'utilisateur est contributeur", () => {
+      const unServiceDontAestCreateur = new Service({
+        id: '123',
+        descriptionService: { nomService: 'Un service' },
+        createur: { id: 'A', email: 'email.createur@mail.fr' },
+      });
+      const idUtilisateur = 'un autre ID';
+      expect(
+        objetGetService.donnees(
+          unServiceDontAestCreateur,
+          idUtilisateur,
+          referentiel
+        ).permissions
+      ).to.eql({
+        suppressionContributeur: false,
+      });
+    });
+  });
+});

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -95,37 +95,4 @@ describe("L'objet d'API de `GET /services`", () => {
       nombreServicesHomologues: 2,
     });
   });
-
-  describe('sur demande des permissions', () => {
-    it("autorise la suppression de contributeur si l'utilisateur est créateur", () => {
-      const unServiceDontAestCreateur = new Service({
-        id: '123',
-        descriptionService: { nomService: 'Un service' },
-        createur: { id: 'A', email: 'email.createur@mail.fr' },
-      });
-      const services = [unServiceDontAestCreateur];
-      expect(
-        objetGetServices.donnees(services, 'A', referentiel).services[0]
-          .permissions
-      ).to.eql({
-        suppressionContributeur: true,
-      });
-    });
-
-    it("n'autorise pas la suppression de contributeur si l'utilisateur est contributeur", () => {
-      const unServiceDontAestCreateur = new Service({
-        id: '123',
-        descriptionService: { nomService: 'Un service' },
-        createur: { id: 'A', email: 'email.createur@mail.fr' },
-      });
-      const idUtilisateur = 'un autre ID';
-      const services = [unServiceDontAestCreateur];
-      expect(
-        objetGetServices.donnees(services, idUtilisateur, referentiel)
-          .services[0].permissions
-      ).to.eql({
-        suppressionContributeur: false,
-      });
-    });
-  });
 });


### PR DESCRIPTION
On ajoute une route `GET /api/service/:id` afin de pouvoir, à tout moment, récupérer les informations d'un service, sous le même format qu'elles sont renvoyées pour le tableau de bord.

Ceci nous permet d'injecter à la demande les données nécessaires pour le bon fonctionnement du compostant `Svelte` du tiroir des contributeurs.

Cela va nous permettre d'afficher simplement le tiroir des contributeurs dans le parcours d'un service.