### PR TITLE
Utilise une variable d'environnement pour l'URL de l'API Brevo

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,6 +8,7 @@ NOM_UTILISATEUR_DEMO= # nom de l'utilisateur de démonstration
 EMAIL_UTILISATEUR_DEMO= # adresse mail de l'utilisateur de démonstration
 MOT_DE_PASSE_UTILISATEUR_DEMO= # mot de passe de l'utilisateur de démonstration
 
+SENDINBLUE_EMAIL_API_URL_BASE= # URL de base de l'API brevo utilisée pour envoi des mails
 SENDINBLUE_EMAIL_CLEF_API= # clef d'API sendinblue utilisée pour envoi des mails
 SENDINBLUE_TRACKING_CLEF_API= # clef d'API sendinblue utilisée pour les événements de tracking
 SENDINBLUE_TEMPLATE_FINALISATION_INSCRIPTION= # id de template

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -11,7 +11,7 @@ const enteteJSON = {
     'content-type': 'application/json',
   },
 };
-const urlBase = 'https://api.brevo.com/v3';
+const urlBase = process.env.SENDINBLUE_EMAIL_API_URL_BASE;
 const idListeEmailsTransactionnels = Number(
   process.env.SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE
 );


### PR DESCRIPTION
... afin de pouvoir le modifier facilement, suite à l'incident avec le DNS Brevo / Sendinblue.

### :warning: Afin d'avoir un fix temporaire pour Brevo, on utilise l'ancienne URL d'api : `https://api.sendinblue.com/v3`