### PR TITLE
Ajout des droits lecture/écriture/invisible dans le modèle `Autorisation`

### DIFF
--- a/migrations/20230912144944_ajouteDroitsEnEcriture.js
+++ b/migrations/20230912144944_ajouteDroitsEnEcriture.js
@@ -1,0 +1,35 @@
+exports.up = async (knex) => {
+  const autorisations = await knex('autorisations');
+
+  const misesAJour = autorisations.map(({ id, donnees }) =>
+    knex('autorisations')
+      .where({ id })
+      .update({
+        donnees: {
+          ...donnees,
+          droits: {
+            DECRIRE: 2,
+            SECURISER: 2,
+            HOMOLOGUER: 2,
+            RISQUES: 2,
+            CONTACTS: 2,
+          },
+        },
+      })
+  );
+
+  await Promise.all(misesAJour);
+};
+
+exports.down = async (knex) => {
+  const autorisations = await knex('autorisations');
+
+  const misesAJour = autorisations.map(
+    ({ id, donnees: { droits, ...autreDonnees } }) =>
+      knex('autorisations').where({ id }).update({
+        donnees: autreDonnees,
+      })
+  );
+
+  await Promise.all(misesAJour);
+};

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -10,6 +10,9 @@ const {
 } = require('../erreurs');
 const AutorisationCreateur = require('../modeles/autorisations/autorisationCreateur');
 const FabriqueAutorisation = require('../modeles/autorisations/fabriqueAutorisation');
+const {
+  toutDroitsEnEcriture,
+} = require('../modeles/autorisations/gestionDroits');
 
 const creeDepot = (config = {}) => {
   const {
@@ -78,6 +81,7 @@ const creeDepot = (config = {}) => {
           idHomologation,
           idService: idHomologation,
           type: 'contributeur',
+          droits: toutDroitsEnEcriture(),
         })
       );
   };

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -14,6 +14,9 @@ const EvenementNouvelleHomologationCreee = require('../modeles/journalMSS/evenem
 const EvenementServiceSupprime = require('../modeles/journalMSS/evenementServiceSupprime');
 const { avecPMapPourChaqueElement } = require('../utilitaires/pMap');
 const { fabriqueServiceTracking } = require('../tracking/serviceTracking');
+const {
+  toutDroitsEnEcriture,
+} = require('../modeles/autorisations/gestionDroits');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -357,6 +360,7 @@ const creeDepot = (config = {}) => {
           idHomologation,
           idService: idHomologation,
           type: 'createur',
+          droits: toutDroitsEnEcriture(),
         })
       )
       .then(() => p.lis.une(idHomologation))

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -8,6 +8,7 @@ class AutorisationBase extends Base {
         'idUtilisateur',
         'idHomologation',
         'idService',
+        'droits',
       ],
     });
     this.renseigneProprietes(donnees);
@@ -15,6 +16,10 @@ class AutorisationBase extends Base {
     this.permissionAjoutContributeur = false;
     this.permissionSuppressionContributeur = false;
     this.permissionSuppressionService = false;
+  }
+
+  aLaPermission(niveau, rubrique) {
+    return this.droits[rubrique] >= niveau;
   }
 }
 

--- a/src/modeles/autorisations/gestionDroits.js
+++ b/src/modeles/autorisations/gestionDroits.js
@@ -12,4 +12,10 @@ const Rubriques = {
   CONTACTS: 'CONTACTS',
 };
 
-module.exports = { Permissions, Rubriques };
+const toutDroitsEnEcriture = () =>
+  Object.values(Rubriques).reduce(
+    (droits, rubrique) => ({ ...droits, [rubrique]: Permissions.ECRITURE }),
+    {}
+  );
+
+module.exports = { Permissions, Rubriques, toutDroitsEnEcriture };

--- a/src/modeles/autorisations/gestionDroits.js
+++ b/src/modeles/autorisations/gestionDroits.js
@@ -1,0 +1,15 @@
+const Permissions = {
+  ECRITURE: 2,
+  LECTURE: 1,
+  INVISIBLE: 0,
+};
+
+const Rubriques = {
+  DECRIRE: 'DECRIRE',
+  SECURISER: 'SECURISER',
+  HOMOLOGUER: 'HOMOLOGUER',
+  RISQUES: 'RISQUES',
+  CONTACTS: 'CONTACTS',
+};
+
+module.exports = { Permissions, Rubriques };

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -16,6 +16,13 @@ const AutorisationCreateur = require('../../src/modeles/autorisations/autorisati
 const {
   unePersistanceMemoire,
 } = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
+const {
+  Rubriques,
+  Permissions,
+} = require('../../src/modeles/autorisations/gestionDroits');
+
+const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
+const { ECRITURE } = Permissions;
 
 describe('Le dépôt de données des autorisations', () => {
   const creeDepot = (adaptateurPersistance, adaptateurUUID) =>
@@ -322,6 +329,13 @@ describe('Le dépôt de données des autorisations', () => {
       expect(a.idHomologation).to.equal('123');
       expect(a.idService).to.equal('123');
       expect(a.idUtilisateur).to.equal('000');
+      expect(a.droits).to.eql({
+        [DECRIRE]: ECRITURE,
+        [SECURISER]: ECRITURE,
+        [HOMOLOGUER]: ECRITURE,
+        [RISQUES]: ECRITURE,
+        [CONTACTS]: ECRITURE,
+      });
     });
   });
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -49,6 +49,14 @@ const {
 } = require('../tracking/constructeurServiceTracking');
 const { unDossier } = require('../constructeurs/constructeurDossier');
 
+const {
+  Rubriques,
+  Permissions,
+} = require('../../src/modeles/autorisations/gestionDroits');
+
+const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
+const { ECRITURE } = Permissions;
+
 describe('Le dépôt de données des homologations', () => {
   it("connaît toutes les homologations d'un utilisateur donné", async () => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
@@ -827,7 +835,7 @@ describe('Le dépôt de données des homologations', () => {
         .catch(done);
     });
 
-    it("déclare un accès entre l'utilisateur et l'homologation", (done) => {
+    it("déclare un accès en écriture entre l'utilisateur et l'homologation", (done) => {
       const depotAutorisations = DepotDonneesAutorisations.creeDepot({
         adaptateurPersistance,
       });
@@ -847,6 +855,13 @@ describe('Le dépôt de données des homologations', () => {
           expect(autorisation.idHomologation).to.equal('unUUID');
           expect(autorisation.idService).to.equal('unUUID');
           expect(autorisation.idUtilisateur).to.equal('123');
+          expect(autorisation.droits).to.eql({
+            [DECRIRE]: ECRITURE,
+            [SECURISER]: ECRITURE,
+            [HOMOLOGUER]: ECRITURE,
+            [RISQUES]: ECRITURE,
+            [CONTACTS]: ECRITURE,
+          });
           done();
         })
         .catch(done);

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -1,6 +1,13 @@
 const expect = require('expect.js');
 
 const AutorisationBase = require('../../../src/modeles/autorisations/autorisationBase');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../../src/modeles/autorisations/gestionDroits');
+
+const { ECRITURE, LECTURE, INVISIBLE } = Permissions;
+const { DECRIRE, SECURISER } = Rubriques;
 
 describe('Une autorisation de base', () => {
   it("ne permet pas d'ajouter un contributeur", () => {
@@ -16,5 +23,56 @@ describe('Une autorisation de base', () => {
   it('ne permet pas de supprimer un service', () => {
     const autorisation = new AutorisationBase();
     expect(autorisation.permissionSuppressionService).to.be(false);
+  });
+
+  it("permet de savoir s'il y a une permission en lecture sur une rubrique", () => {
+    const autorisation = new AutorisationBase({
+      droits: { [DECRIRE]: LECTURE },
+    });
+
+    expect(autorisation.aLaPermission(LECTURE, DECRIRE)).to.be(true);
+  });
+
+  it("permet de savoir s'il y a une permission en écriture sur une rubrique", () => {
+    const autorisation = new AutorisationBase({
+      droits: { [DECRIRE]: ECRITURE },
+    });
+
+    expect(autorisation.aLaPermission(ECRITURE, DECRIRE)).to.be(true);
+  });
+
+  it("autorise la lecture sur une rubrique avec droits d'écriture", () => {
+    const autorisationEcriture = new AutorisationBase({
+      droits: { [DECRIRE]: ECRITURE },
+    });
+
+    const peutLire = autorisationEcriture.aLaPermission(LECTURE, DECRIRE);
+
+    expect(peutLire).to.be(true);
+  });
+
+  it("n'autorise pas l'accès à une rubrique non référencée", () => {
+    const autorisationSecuriser = new AutorisationBase({
+      droits: { [SECURISER]: ECRITURE },
+    });
+
+    const peutLireDecrire = autorisationSecuriser.aLaPermission(
+      LECTURE,
+      DECRIRE
+    );
+
+    expect(peutLireDecrire).to.be(false);
+  });
+
+  it("n'autorise aucun accès pour un niveau invisible", () => {
+    const niveauInvisible = new AutorisationBase({
+      droits: { [DECRIRE]: INVISIBLE },
+    });
+
+    const peutLire = niveauInvisible.aLaPermission(LECTURE, DECRIRE);
+    const peutEcrire = niveauInvisible.aLaPermission(ECRITURE, DECRIRE);
+
+    expect(peutLire).to.be(false);
+    expect(peutEcrire).to.be(false);
   });
 });


### PR DESCRIPTION
En vue de préparer l'intégration des droits de contributions, on ajoute au modèle `autorisation` une donnée permettant de gérer les niveaux des droits pour chacune des 5 rubriques de MSS (Décrire, Sécuriser, Homologuer, Risques et Contacts utiles).

Par la suite, ces droits seront challengés sur chaque opération portant sur un service (GET, PUT et POST) afin de savoir si l'action est permise.
Ils permettront aussi de conditionner l'affichage du front.