### PR TITLE
Sécurisation de certaines routes d'API

### DIFF
--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -27,10 +27,16 @@ const creeDepot = (config = {}) => {
       .autorisations(idUtilisateur)
       .then((as) => as.map((a) => FabriqueAutorisation.fabrique(a)));
 
-  const accesAutorise = (idUtilisateur, idHomologation) =>
-    autorisations(idUtilisateur).then((as) =>
-      as.some((a) => a.idHomologation === idHomologation)
+  const accesAutorise = async (idUtilisateur, idHomologation, droitsRequis) => {
+    const as = await autorisations(idUtilisateur);
+    const autorisationPourService = as.find(
+      (a) => a.idHomologation === idHomologation
     );
+
+    if (!autorisationPourService) return false;
+
+    return autorisationPourService.aLesPermissions(droitsRequis);
+  };
 
   const autorisation = (id) =>
     adaptateurPersistance

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -1,5 +1,6 @@
 class EchecAutorisation extends Error {}
 class EchecEnvoiMessage extends Error {}
+class ErreurDroitsIncoherents extends Error {}
 class ErreurModele extends Error {}
 class ErreurAutorisationExisteDeja extends ErreurModele {}
 class ErreurAutorisationInexistante extends ErreurModele {}
@@ -71,6 +72,7 @@ module.exports = {
   ErreurDossierNonFinalisable,
   ErreurDossierNonFinalise,
   ErreurDossiersInvalides,
+  ErreurDroitsIncoherents,
   ErreurDureeValiditeInvalide,
   ErreurEmailManquant,
   ErreurHomologationInexistante,

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -21,6 +21,12 @@ class AutorisationBase extends Base {
   aLaPermission(niveau, rubrique) {
     return this.droits[rubrique] >= niveau;
   }
+
+  aLesPermissions(droits) {
+    return Object.entries(droits).every(([rubrique, niveau]) =>
+      this.aLaPermission(niveau, rubrique)
+    );
+  }
 }
 
 module.exports = AutorisationBase;

--- a/src/modeles/autorisations/gestionDroits.js
+++ b/src/modeles/autorisations/gestionDroits.js
@@ -18,4 +18,16 @@ const toutDroitsEnEcriture = () =>
     {}
   );
 
-module.exports = { Permissions, Rubriques, toutDroitsEnEcriture };
+const verifieCoherenceDesDroits = (droits) =>
+  Object.entries(droits).every(([rubrique, niveau]) => {
+    const rubriqueExiste = Object.values(Rubriques).includes(rubrique);
+    const niveauExiste = Object.values(Permissions).includes(niveau);
+    return rubriqueExiste && niveauExiste;
+  });
+
+module.exports = {
+  Permissions,
+  Rubriques,
+  toutDroitsEnEcriture,
+  verifieCoherenceDesDroits,
+};

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -182,9 +182,9 @@ const routesApiPrivee = ({
 
   routes.put(
     '/utilisateur',
-    middleware.aseptise([
-      ...Utilisateur.nomsProprietesBase().filter((nom) => nom !== 'email'),
-    ]),
+    middleware.aseptise(
+      ...Utilisateur.nomsProprietesBase().filter((nom) => nom !== 'email')
+    ),
     (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       const donnees = obtentionDonneesDeBaseUtilisateur(requete.body);

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -25,6 +25,14 @@ const { dateInvalide } = require('../../utilitaires/date');
 const { valeurBooleenne } = require('../../utilitaires/aseptisation');
 const objetGetService = require('../../modeles/objetsApi/objetGetService');
 
+const {
+  Permissions,
+  Rubriques,
+} = require('../../modeles/autorisations/gestionDroits');
+
+const { ECRITURE, LECTURE } = Permissions;
+const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
+
 const routesApiService = (
   middleware,
   depotDonnees,
@@ -80,10 +88,9 @@ const routesApiService = (
         });
     }
   );
-
   routes.put(
     '/:id',
-    middleware.trouveService,
+    middleware.trouveService({ [DECRIRE]: ECRITURE }),
     middleware.aseptise('nomService', 'organisationsResponsables.*'),
     middleware.aseptiseListes([
       { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
@@ -118,7 +125,7 @@ const routesApiService = (
   routes.get(
     '/:id',
     middleware.aseptise('id'),
-    middleware.trouveService,
+    middleware.trouveService({ [DECRIRE]: LECTURE }),
     async (requete, reponse) => {
       const donnees = objetGetService.donnees(
         requete.homologation,
@@ -131,7 +138,7 @@ const routesApiService = (
 
   routes.post(
     '/:id/mesures',
-    middleware.trouveService,
+    middleware.trouveService({ [SECURISER]: ECRITURE }),
     middleware.aseptise(
       'mesuresGenerales.*.statut',
       'mesuresGenerales.*.modalites',
@@ -173,7 +180,7 @@ const routesApiService = (
 
   routes.post(
     '/:id/rolesResponsabilites',
-    middleware.trouveService,
+    middleware.trouveService({ [CONTACTS]: ECRITURE }),
     middleware.aseptiseListes([
       {
         nom: 'acteursHomologation',
@@ -198,7 +205,7 @@ const routesApiService = (
 
   routes.post(
     '/:id/risques',
-    middleware.trouveService,
+    middleware.trouveService({ [RISQUES]: ECRITURE }),
     middleware.aseptise(
       '*',
       'risquesSpecifiques.*.description',
@@ -258,7 +265,7 @@ const routesApiService = (
 
   routes.put(
     '/:id/homologation/autorite',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     middleware.trouveDossierCourant,
     middleware.aseptise('nom', 'fonction'),
     (requete, reponse, suite) => {
@@ -277,7 +284,7 @@ const routesApiService = (
 
   routes.put(
     '/:id/homologation/decision',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     middleware.trouveDossierCourant,
     middleware.aseptise('dateHomologation', 'dureeValidite'),
     (requete, reponse, suite) => {
@@ -306,7 +313,7 @@ const routesApiService = (
 
   routes.put(
     '/:id/homologation/telechargement',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     middleware.trouveDossierCourant,
     (requete, reponse, suite) => {
       const { homologation, dossierCourant } = requete;
@@ -322,7 +329,7 @@ const routesApiService = (
 
   routes.put(
     '/:id/homologation/avis',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     middleware.trouveDossierCourant,
     middleware.aseptiseListes([
       {
@@ -358,7 +365,7 @@ const routesApiService = (
 
   routes.put(
     '/:id/homologation/documents',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     middleware.trouveDossierCourant,
     middleware.aseptise('documents.*', 'avecDocuments'),
     (requete, reponse, suite) => {
@@ -385,7 +392,7 @@ const routesApiService = (
 
   routes.post(
     '/:id/homologation/finalise',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 

--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -1,6 +1,13 @@
 const express = require('express');
 const { genereGradientConique } = require('../../pdf/graphiques/camembert');
 const { dateYYYYMMDD } = require('../../utilitaires/date');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../modeles/autorisations/gestionDroits');
+
+const { LECTURE } = Permissions;
+const { HOMOLOGUER, RISQUES, SECURISER, DECRIRE } = Rubriques;
 
 const routesApiServicePdf = (
   middleware,
@@ -54,10 +61,13 @@ const routesApiServicePdf = (
 
     return adaptateurPdf.genereSyntheseSecurite(donnees);
   };
-
   routes.get(
     '/:id/pdf/annexes.pdf',
-    middleware.trouveService,
+    middleware.trouveService({
+      [DECRIRE]: LECTURE,
+      [SECURISER]: LECTURE,
+      [RISQUES]: LECTURE,
+    }),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 
@@ -69,7 +79,7 @@ const routesApiServicePdf = (
 
   routes.get(
     '/:id/pdf/dossierDecision.pdf',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: LECTURE }),
     middleware.trouveDossierCourant,
     (requete, reponse, suite) => {
       const { homologation, dossierCourant } = requete;
@@ -82,7 +92,7 @@ const routesApiServicePdf = (
 
   routes.get(
     '/:id/pdf/syntheseSecurite.pdf',
-    middleware.trouveService,
+    middleware.trouveService({ [SECURISER]: LECTURE, [DECRIRE]: LECTURE }),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 
@@ -94,7 +104,7 @@ const routesApiServicePdf = (
 
   routes.get(
     '/:id/pdf/documentsHomologation.zip',
-    middleware.trouveService,
+    middleware.trouveService({}),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -6,6 +6,14 @@ const InformationsHomologation = require('../../modeles/informationsHomologation
 const ObjetApiStatutHomologation = require('../../modeles/objetsApi/objetApiStatutHomologation');
 const ActionSaisie = require('../../modeles/actionSaisie');
 
+const {
+  Permissions,
+  Rubriques,
+} = require('../../modeles/autorisations/gestionDroits');
+
+const { LECTURE } = Permissions;
+const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
+
 const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   const routes = express.Router();
 
@@ -42,14 +50,17 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
         .catch(suite);
     }
   );
-
-  routes.get('/:id', middleware.trouveService, (requete, reponse) => {
-    reponse.redirect(`/service/${requete.params.id}/descriptionService`);
-  });
+  routes.get(
+    '/:id',
+    middleware.trouveService({ [DECRIRE]: LECTURE }),
+    (requete, reponse) => {
+      reponse.redirect(`/service/${requete.params.id}/descriptionService`);
+    }
+  );
 
   routes.get(
     '/:id/descriptionService',
-    middleware.trouveService,
+    middleware.trouveService({ [DECRIRE]: LECTURE }),
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;
@@ -65,7 +76,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
 
   routes.get(
     '/:id/mesures',
-    middleware.trouveService,
+    middleware.trouveService({ [SECURISER]: LECTURE }),
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;
@@ -87,7 +98,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
 
   routes.get(
     '/:id/rolesResponsabilites',
-    middleware.trouveService,
+    middleware.trouveService({ [CONTACTS]: LECTURE }),
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;
@@ -103,7 +114,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
 
   routes.get(
     '/:id/risques',
-    middleware.trouveService,
+    middleware.trouveService({ [RISQUES]: LECTURE }),
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;
@@ -119,7 +130,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
 
   routes.get(
     '/:id/dossiers',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: LECTURE }),
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;
@@ -136,7 +147,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
 
   routes.get(
     '/:id/homologation/edition/etape/:idEtape',
-    middleware.trouveService,
+    middleware.trouveService({ [HOMOLOGUER]: LECTURE }),
     middleware.chargePreferencesUtilisateur,
     (requete, reponse, suite) => {
       const { homologation } = requete;

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -155,7 +155,7 @@ const routesApiPublique = ({
 
   routes.get(
     '/annuaire/organisations',
-    middleware.aseptise(['recherche', 'departement']),
+    middleware.aseptise('recherche', 'departement'),
     (requete, reponse) => {
       const { recherche = '', departement = null } = requete.query;
 

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -36,6 +36,7 @@ const verifieRequeteChangeEtat = (donneesEtat, requete, done) => {
 
 let cguAcceptees;
 let challengeMotDePasseEffectue = false;
+let droitVerifie = [];
 let expirationCookieRepoussee = false;
 let headersAvecNoncePositionnes = false;
 let headersPositionnes = false;
@@ -45,7 +46,6 @@ let listesAseptisees = [];
 let listeAdressesIPsAutorisee = [];
 let parametresAseptises = [];
 let preferencesChargees = false;
-let rechercheServiceEffectuee = false;
 let rechercheDossierCourantEffectuee = false;
 let suppressionCookieEffectuee = false;
 let verificationJWTMenee = false;
@@ -61,6 +61,7 @@ const middlewareFantaisie = {
     }),
   }) => {
     cguAcceptees = acceptationCGU;
+    droitVerifie = [];
     expirationCookieRepoussee = false;
     headersAvecNoncePositionnes = false;
     headersPositionnes = false;
@@ -70,7 +71,6 @@ const middlewareFantaisie = {
     listeAdressesIPsAutorisee = [];
     parametresAseptises = [];
     preferencesChargees = false;
-    rechercheServiceEffectuee = false;
     rechercheDossierCourantEffectuee = false;
     suppressionCookieEffectuee = false;
     verificationJWTMenee = false;
@@ -125,11 +125,14 @@ const middlewareFantaisie = {
     suite();
   },
 
-  trouveService: () => (requete, _reponse, suite) => {
+  trouveService: (listeDroits) => (requete, _reponse, suite) => {
+    droitVerifie = Object.entries(listeDroits).map(([rubrique, niveau]) => ({
+      niveau,
+      rubrique,
+    }));
     requete.idUtilisateurCourant = idUtilisateurCourant;
     requete.cguAcceptees = cguAcceptees;
     requete.homologation = homologationTrouvee;
-    rechercheServiceEffectuee = true;
     suite();
   },
 
@@ -196,9 +199,13 @@ const middlewareFantaisie = {
     );
   },
 
-  verifieRechercheService: (...params) => {
+  verifieRechercheService: (droitsAttendus, ...params) => {
     verifieRequeteChangeEtat(
-      { lectureEtat: () => rechercheServiceEffectuee },
+      {
+        lectureEtat: () => droitVerifie,
+        etatInitial: [],
+        etatFinal: droitsAttendus,
+      },
       ...params
     );
   },

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -4,10 +4,11 @@ const expect = require('expect.js');
 const Homologation = require('../../src/modeles/homologation');
 
 const verifieRequeteChangeEtat = (donneesEtat, requete, done) => {
-  const verifieEgalite = (valeurConstatee, valeurReference, ...diagnostics) =>
-    expect(`${[valeurConstatee, ...diagnostics].join(' ')}`).to.eql(
-      `${[valeurReference, ...diagnostics].join(' ')}`
-    );
+  const verifieEgalite = (valeurConstatee, valeurReference, ...diagnostics) => {
+    expect(
+      `${[JSON.stringify(valeurConstatee), ...diagnostics].join(' ')}`
+    ).to.eql(`${[JSON.stringify(valeurReference), ...diagnostics].join(' ')}`);
+  };
 
   const { lectureEtat, etatInitial = false, etatFinal = true } = donneesEtat;
   const suffixeLectureEtat = `(sur appel à ${lectureEtat.toString()})`;
@@ -124,7 +125,7 @@ const middlewareFantaisie = {
     suite();
   },
 
-  trouveService: (requete, _reponse, suite) => {
+  trouveService: () => (requete, _reponse, suite) => {
     requete.idUtilisateurCourant = idUtilisateurCourant;
     requete.cguAcceptees = cguAcceptees;
     requete.homologation = homologationTrouvee;

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -13,6 +13,13 @@ const {
 const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
 const AutorisationCreateur = require('../../../src/modeles/autorisations/autorisationCreateur');
 const Homologation = require('../../../src/modeles/homologation');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../../src/modeles/autorisations/gestionDroits');
+
+const { ECRITURE, LECTURE } = Permissions;
+const { RISQUES, DECRIRE, SECURISER, CONTACTS, HOMOLOGUER } = Rubriques;
 
 describe('Le serveur MSS des routes /api/service/*', () => {
   const testeur = testeurMSS();
@@ -168,6 +175,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: DECRIRE }],
           { method: 'put', url: 'http://localhost:1234/api/service/456' },
           done
         );
@@ -292,6 +300,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: SECURISER }],
         {
           method: 'post',
           url: 'http://localhost:1234/api/service/456/mesures',
@@ -454,6 +463,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: CONTACTS }],
         {
           method: 'post',
           url: 'http://localhost:1234/api/service/456/rolesResponsabilites',
@@ -529,6 +539,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: RISQUES }],
         {
           method: 'post',
           url: 'http://localhost:1234/api/service/456/risques',
@@ -673,6 +684,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
         {
           url: 'http://localhost:1234/api/service/456/homologation/autorite',
           method: 'put',
@@ -740,6 +752,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
         {
           url: 'http://localhost:1234/api/service/456/homologation/decision',
           method: 'put',
@@ -839,6 +852,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
         {
           url: 'http://localhost:1234/api/service/456/homologation/telechargement',
           method: 'put',
@@ -902,6 +916,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
         {
           url: 'http://localhost:1234/api/service/456/homologation/avis',
           method: 'put',
@@ -1042,6 +1057,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
         {
           url: 'http://localhost:1234/api/service/456/homologation/documents',
           method: 'put',
@@ -1154,6 +1170,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("recherche l'homologation correspondante", (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
         {
           url: 'http://localhost:1234/api/service/456/homologation/finalise',
           method: 'post',
@@ -1433,6 +1450,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('recherche le service correspondant', (done) => {
       testeur.middleware().verifieRechercheService(
+        [{ niveau: LECTURE, rubrique: DECRIRE }],
         {
           method: 'get',
           url: 'http://localhost:1234/api/service/456',

--- a/test/routes/privees/routesApiServicePdf.spec.js
+++ b/test/routes/privees/routesApiServicePdf.spec.js
@@ -10,6 +10,13 @@ const {
 const { unDossier } = require('../../constructeurs/constructeurDossier');
 const Homologation = require('../../../src/modeles/homologation');
 const Referentiel = require('../../../src/referentiel');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../../src/modeles/autorisations/gestionDroits');
+
+const { LECTURE } = Permissions;
+const { SECURISER, RISQUES, DECRIRE, HOMOLOGUER } = Rubriques;
 
 describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
   const testeur = testeurMSS();
@@ -20,12 +27,15 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
 
   describe('quand requête GET sur `/api/service/:id/pdf/annexes.pdf`', () => {
     it('recherche le service correspondant', (done) => {
-      testeur
-        .middleware()
-        .verifieRechercheService(
-          'http://localhost:1234/api/service/456/pdf/annexes.pdf',
-          done
-        );
+      testeur.middleware().verifieRechercheService(
+        [
+          { niveau: LECTURE, rubrique: DECRIRE },
+          { niveau: LECTURE, rubrique: SECURISER },
+          { niveau: LECTURE, rubrique: RISQUES },
+        ],
+        'http://localhost:1234/api/service/456/pdf/annexes.pdf',
+        done
+      );
     });
 
     it('sert un fichier de type pdf', (done) => {
@@ -87,6 +97,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: HOMOLOGUER }],
           'http://localhost:1234/api/service/456/pdf/dossierDecision.pdf',
           done
         );
@@ -154,12 +165,14 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
     });
 
     it('recherche le service correspondant', (done) => {
-      testeur
-        .middleware()
-        .verifieRechercheService(
-          'http://localhost:1234/api/service/456/pdf/syntheseSecurite.pdf',
-          done
-        );
+      testeur.middleware().verifieRechercheService(
+        [
+          { niveau: LECTURE, rubrique: SECURISER },
+          { niveau: LECTURE, rubrique: DECRIRE },
+        ],
+        'http://localhost:1234/api/service/456/pdf/syntheseSecurite.pdf',
+        done
+      );
     });
 
     it('sert un fichier de type pdf', (done) => {
@@ -213,6 +226,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [],
           'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip',
           done
         );

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -3,6 +3,13 @@ const expect = require('expect.js');
 
 const testeurMSS = require('../testeurMSS');
 const Homologation = require('../../../src/modeles/homologation');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../../src/modeles/autorisations/gestionDroits');
+
+const { LECTURE } = Permissions;
+const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 
 describe('Le serveur MSS des routes /service/*', () => {
   const testeur = testeurMSS();
@@ -58,7 +65,11 @@ describe('Le serveur MSS des routes /service/*', () => {
     it('recherche le service correspondant', (done) => {
       testeur
         .middleware()
-        .verifieRechercheService('http://localhost:1234/service/456', done);
+        .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: DECRIRE }],
+          'http://localhost:1234/service/456',
+          done
+        );
     });
 
     it('redirige vers la page de description du service', async () => {
@@ -75,6 +86,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: DECRIRE }],
           'http://localhost:1234/service/456/descriptionService',
           done
         );
@@ -102,6 +114,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: SECURISER }],
           'http://localhost:1234/service/456/mesures',
           done
         );
@@ -141,6 +154,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: CONTACTS }],
           'http://localhost:1234/service/456/rolesResponsabilites',
           done
         );
@@ -161,6 +175,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: RISQUES }],
           'http://localhost:1234/service/456/risques',
           done
         );
@@ -186,6 +201,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: HOMOLOGUER }],
           'http://localhost:1234/service/456/dossiers',
           done
         );
@@ -226,6 +242,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       testeur
         .middleware()
         .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: HOMOLOGUER }],
           'http://localhost:1234/service/456/homologation/edition/etape/dateTelechargement',
           done
         );


### PR DESCRIPTION
On utilise maintenant les droits contenu dans `autorisation` pour autoriser ou non l'accès à toute les routes existantes.