### PR TITLE
Implémente la version 2 du menu de navigation

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -66,19 +66,17 @@ module.exports = {
     descriptionService: {
       position: 0,
       description: 'Décrire',
-      sousTitre: 'Présentez les caractéristiques de votre service.',
+      sousTitre: 'Évaluer les besoins de sécurité',
     },
     mesures: {
       position: 1,
       description: 'Sécuriser',
-      sousTitre:
-        'Mettez en œuvre les mesures de sécurité adaptées à votre service.',
+      sousTitre: "Mesurer et renforcer l'indice cyber",
     },
     dossiers: {
       position: 2,
       description: 'Homologuer',
-      sousTitre:
-        'Complétez et téléchargez les documents pour homologuer le service.',
+      sousTitre: "Générer un dossier d'homologation",
     },
   },
 

--- a/public/assets/images/actionsSaisie/descriptionService.svg
+++ b/public/assets/images/actionsSaisie/descriptionService.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="edit-2">
+<path id="Vector" d="M13.2594 4.10022L5.04936 12.7902C4.73936 13.1202 4.43936 13.7702 4.37936 14.2202L4.00936 17.4602C3.87936 18.6302 4.71936 19.4302 5.87936 19.2302L9.09936 18.6802C9.54936 18.6002 10.1794 18.2702 10.4894 17.9302L18.6994 9.24022C20.1194 7.74022 20.7594 6.03022 18.5494 3.94022C16.3494 1.87022 14.6794 2.60022 13.2594 4.10022Z" stroke="#0C5C98" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M11.8906 5.5498C12.3206 8.3098 14.5606 10.4198 17.3406 10.6998" stroke="#0C5C98" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M3 22.5H21" stroke="#0C5C98" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/public/assets/images/actionsSaisie/dossiers.svg
+++ b/public/assets/images/actionsSaisie/dossiers.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="medal">
+<path id="Vector" d="M12 15.5C15.7279 15.5 18.75 12.5899 18.75 9C18.75 5.41015 15.7279 2.5 12 2.5C8.27208 2.5 5.25 5.41015 5.25 9C5.25 12.5899 8.27208 15.5 12 15.5Z" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M7.5217 14.0198L7.51172 21.3998C7.51172 22.2998 8.14172 22.7398 8.92172 22.3698L11.6017 21.0998C11.8217 20.9898 12.1917 20.9898 12.4117 21.0998L15.1017 22.3698C15.8717 22.7298 16.5117 22.2998 16.5117 21.3998V13.8398" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/public/assets/images/actionsSaisie/mesures.svg
+++ b/public/assets/images/actionsSaisie/mesures.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 20H21" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 13H21" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 6H21" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 6L4 7L7 4" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 13L4 14L7 11" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 20L4 21L7 18" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/images/fleche_retour.svg
+++ b/public/assets/images/fleche_retour.svg
@@ -1,0 +1,11 @@
+<svg width="9" height="8" viewBox="0 0 9 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Frame 1631" clip-path="url(#clip0_11825_12055)">
+<path id="Vector" d="M8.13807 4.07031H2.01562" stroke="#667892" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M4.06122 1L1 4.06122L4.06122 7.12245" stroke="#667892" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_11825_12055">
+<rect width="9" height="8" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/assets/images/icone_retour.svg
+++ b/public/assets/images/icone_retour.svg
@@ -1,6 +1,0 @@
-<svg width="20" height="21" viewBox="0 0 20 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="undo">
-<path id="Vector" d="M5.94141 16.1848H12.6081C14.9081 16.1848 16.7748 14.3164 16.7748 12.0143C16.7748 9.71216 14.9081 7.84375 12.6081 7.84375H3.44141" stroke="white" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
-<path id="Vector_2" d="M5.35794 9.92875L3.22461 7.79349L5.35794 5.6582" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
-</svg>

--- a/public/assets/styles/deuxColonnes.css
+++ b/public/assets/styles/deuxColonnes.css
@@ -6,6 +6,17 @@ header {
   max-width: unset;
 }
 
+.header-gauche .conteneur-logo {
+  width: var(--menu-largeur);
+}
+
+.header-gauche .titre-page h3 {
+  color: var(--bleu-survol);
+  font-size: 1.55em;
+  font-weight: 700;
+  margin: 0;
+}
+
 .corps {
   display: grid;
   grid-template-columns: 4fr 1fr;

--- a/public/assets/styles/deuxColonnes.css
+++ b/public/assets/styles/deuxColonnes.css
@@ -10,11 +10,32 @@ header {
   width: var(--menu-largeur);
 }
 
+.header-gauche .titre-page {
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+}
+
 .header-gauche .titre-page h3 {
   color: var(--bleu-survol);
   font-size: 1.55em;
   font-weight: 700;
   margin: 0;
+}
+
+.header-gauche .titre-page .retour-tableau-de-bord {
+  cursor: pointer;
+  font-size: 0.75em;
+  font-weight: 500;
+  line-height: 1.35em;
+  background: #f1f5f9;
+  width: fit-content;
+  border-radius: 20px;
+  padding: 1px 8px;
+}
+
+.header-gauche .titre-page .retour-tableau-de-bord a {
+  color: #667892;
 }
 
 .corps {

--- a/public/assets/styles/deuxColonnes.css
+++ b/public/assets/styles/deuxColonnes.css
@@ -1,3 +1,11 @@
+header {
+  justify-content: space-between;
+  margin-left: 15px;
+  margin-right: 15px;
+  width: unset;
+  max-width: unset;
+}
+
 .corps {
   display: grid;
   grid-template-columns: 4fr 1fr;

--- a/public/assets/styles/deuxColonnes.css
+++ b/public/assets/styles/deuxColonnes.css
@@ -6,6 +6,10 @@ header {
   max-width: unset;
 }
 
+main {
+  background-color: white;
+}
+
 .header-gauche .conteneur-logo {
   width: var(--menu-largeur);
 }

--- a/public/assets/styles/deuxColonnes.css
+++ b/public/assets/styles/deuxColonnes.css
@@ -31,11 +31,23 @@ header {
   background: #f1f5f9;
   width: fit-content;
   border-radius: 20px;
-  padding: 1px 8px;
+  padding: 1px 8px 1px 3px;
 }
 
 .header-gauche .titre-page .retour-tableau-de-bord a {
   color: #667892;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  column-gap: 5px;
+}
+
+.header-gauche .titre-page .retour-tableau-de-bord a::before {
+  content: '';
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: white url(../images/fleche_retour.svg) no-repeat center;
 }
 
 .corps {

--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -3,6 +3,15 @@ header {
   column-gap: 1.4em;
   align-items: center;
   padding: 1em 0;
+  justify-content: space-around;
+  margin: auto;
+  width: 100%;
+  max-width: 1440px;
+}
+
+header :is(.header-gauche, .header-droit) {
+  display: flex;
+  align-items: center;
 }
 
 header a {

--- a/public/assets/styles/entete.responsive.css
+++ b/public/assets/styles/entete.responsive.css
@@ -1,8 +1,9 @@
 @media screen and (max-width: 1247px) {
-  header.marges-fixes {
+  header {
     width: 100vw;
     max-width: 90%;
     column-gap: unset;
+    justify-content: space-between;
   }
 
   header nav:not(.visible) {

--- a/public/assets/styles/index.css
+++ b/public/assets/styles/index.css
@@ -1,7 +1,3 @@
-main {
-  padding-bottom: 0;
-}
-
 .introduction {
   display: flex;
   column-gap: 1em;

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -9,15 +9,18 @@
   top: 0;
   left: 0;
   z-index: 20;
-  width: 21em;
+  width: 19em;
   height: 100vh;
   display: flex;
   flex-direction: column;
-  box-shadow: -10px 0 34px 0 #00000026;
+  row-gap: 1em;
+  background: #f1f5f9;
+
+  transition: width 0.2s cubic-bezier(0.05, 1.13, 0.81, 0.99);
 }
 
 .menu-navigation > * {
-  padding: 15px 30px;
+  padding: 15px 24px;
 }
 
 :is(.menu-navigation, .menu-navigation a) {
@@ -27,93 +30,43 @@
 .menu-navigation a:hover {
   color: var(--menu-couleur-survol);
 }
-.menu-navigation a:hover .chevron {
-  background-color: var(--menu-couleur-survol);
-}
-.menu-navigation a:hover .position,
-.menu-navigation .lien-tableau-de-bord:hover > div,
-.menu-navigation .lien-deconnexion:hover > div {
+.menu-navigation a:hover .position {
   border-color: var(--menu-couleur-survol);
 }
 .menu-navigation a.actif:hover .position {
   background-color: var(--menu-couleur-survol) !important;
 }
-.menu-navigation .lien-contacts-utiles:hover img,
-.menu-navigation .lien-risques:hover img {
-  /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) saturate(100%) invert(34%) sepia(49%) saturate(7011%)
-    hue-rotate(189deg) brightness(96%) contrast(100%);
-}
-.menu-navigation .lien-tableau-de-bord:hover img {
-  /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) saturate(100%) invert(23%) sepia(53%) saturate(2687%)
-    hue-rotate(187deg) brightness(94%) contrast(91%);
-}
-
-.menu-navigation .outils-complementaires a.actif > div {
-  background-color: var(--menu-couleur-repos);
-}
-.menu-navigation .outils-complementaires a.actif:active > div {
-  background-color: var(--menu-couleur-actif) !important;
-}
-.menu-navigation .outils-complementaires a.actif img {
-  filter: brightness(0) saturate(100%) invert(100%);
-}
-.menu-navigation .outils-complementaires a.actif:hover > div {
-  background-color: var(--menu-couleur-survol);
-}
 
 .menu-navigation a:active {
   color: var(--menu-couleur-actif);
 }
-.menu-navigation a:active .chevron {
-  background-color: var(--menu-couleur-actif);
-}
-.menu-navigation a:active .position,
-.menu-navigation .lien-tableau-de-bord:active > div,
-.menu-navigation .lien-deconnexion:active > div {
+.menu-navigation a:active .position {
   border-color: var(--menu-couleur-actif);
 }
 .menu-navigation a.actif:active .position {
   background-color: var(--menu-couleur-actif) !important;
 }
-.menu-navigation .lien-contacts-utiles:active img,
-.menu-navigation .lien-risques:active img,
-.menu-navigation .lien-tableau-de-bord:active img {
-  /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) saturate(100%) invert(16%) sepia(31%) saturate(4479%)
-    hue-rotate(186deg) brightness(96%) contrast(94%);
-}
 
-.menu-navigation .accueil {
+.menu-navigation .actions {
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
-  align-items: center;
-  background: #ebf4f7;
 }
 
-.menu-navigation .accueil a {
-  display: block;
-  width: 120px;
-  height: 45px;
-  background: url(../images/logo_mss.svg) no-repeat center;
-  background-size: contain;
-}
-
-.menu-navigation .accueil .repli-menu {
+.menu-navigation .repli-menu {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: white;
+  background: #dbecf1;
   border: none;
   border-radius: 100%;
   width: 2.1em;
   height: 2.1em;
   cursor: pointer;
+  position: absolute;
+  right: -1em;
 }
 
-.menu-navigation .accueil .repli-menu img {
+.menu-navigation .repli-menu img {
   width: 1em;
   height: 1em;
   rotate: 180deg;
@@ -123,31 +76,7 @@
   transform: translateX(1px);
 }
 
-.menu-navigation .nom-service {
-  background: #dbecf1;
-  text-align: center;
-  font-size: 1.15em;
-  font-weight: 700;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1em;
-}
-
-.menu-navigation :is(.parcours, .lien-tableau-de-bord, .lien-deconnexion) {
-  background: #f8fafc;
-}
-
-.menu-navigation .parcours {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-evenly;
-  flex: 1;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-.menu-navigation .parcours ul {
+.menu-navigation ul {
   display: flex;
   flex-direction: column;
   row-gap: 24px;
@@ -157,29 +86,49 @@
   text-align: left;
 }
 
-.menu-navigation .parcours ul li {
+.menu-navigation ul li {
   display: flex;
   flex-direction: column;
 }
 
-.menu-navigation .parcours a {
+.menu-navigation a > div,
+.menu-navigation .autres-liens a {
   display: flex;
   flex-direction: row;
-  column-gap: 10px;
+  column-gap: 8px;
 }
 
-.menu-navigation .parcours .etapes a {
+.menu-navigation .autres-liens a.actif > div {
+  background-color: var(--menu-couleur-repos);
+}
+.menu-navigation .autres-liens a.actif > span {
+  color: var(--menu-couleur-repos);
+}
+.menu-navigation .autres-liens a.actif:hover > span {
+  color: var(--menu-couleur-survol);
+}
+.menu-navigation .autres-liens a.actif img {
+  filter: brightness(0) saturate(100%) invert(100%);
+}
+.menu-navigation .autres-liens a.actif:active > div {
+  background-color: var(--menu-couleur-actif) !important;
+}
+.menu-navigation .autres-liens a.actif:hover > div {
+  background-color: var(--menu-couleur-survol);
+}
+
+.menu-navigation .etapes a > div {
   font-size: 1.15em;
   font-weight: 700;
   align-items: baseline;
 }
 
-.menu-navigation .parcours a.actif .position {
+.menu-navigation a.actif .position {
   color: white;
   background: var(--menu-couleur-repos);
 }
 
-.menu-navigation .parcours .position {
+.menu-navigation .position {
   width: 1.3em;
   height: 1.3em;
   border: 1.5px solid var(--menu-couleur-repos);
@@ -191,7 +140,7 @@
   text-align: center;
 }
 
-.menu-navigation .parcours .statut-saisie {
+.menu-navigation .statut-saisie {
   margin-left: auto;
   width: 1em;
   height: 1em;
@@ -200,154 +149,74 @@
   background-position: center;
 }
 
-.menu-navigation .parcours .statut-saisie.faite {
+.menu-navigation .statut-saisie.faite {
   background-image: url(../images/icone_ok_pastille_verte.svg);
   background-size: contain;
 }
 
-.menu-navigation .parcours .statut-saisie.en-cours {
+.menu-navigation .statut-saisie.en-cours {
   background-image: url(../images/icone_crayon_pastille_bleue.svg);
   background-size: contain;
 }
 
-.menu-navigation .parcours .chevron {
-  content: '';
-  display: block;
-  flex-shrink: 0;
-  width: 1em;
-  height: 1em;
-  align-self: center;
-  -webkit-mask-size: contain;
-  mask-size: contain;
-  -webkit-mask: url(../images/forme_chevron_blanc.svg) no-repeat center;
-  mask: url(../images/forme_chevron_blanc.svg) no-repeat center;
-  background: var(--menu-couleur-repos);
-  rotate: 90deg;
-}
-
-.menu-navigation .parcours a.actif .chevron {
-  rotate: -90deg;
-}
-
-.menu-navigation .parcours .sous-titre {
+.menu-navigation .sous-titre {
+  display: inline-block;
   font-size: 0.85em;
   margin-left: 3.3em;
+  padding-right: 20px;
 }
 
-.menu-navigation :is(.outils-complementaires, .documents-telechargeables) {
+.menu-navigation .autres-liens {
   display: flex;
   flex-direction: column;
   row-gap: 15px;
   font-size: 0.98em;
 }
 
-.menu-navigation :is(.outils-complementaires, .documents-telechargeables) h4 {
-  text-align: left;
-  color: var(--menu-couleur-repos);
-  font-weight: 400;
-  text-transform: uppercase;
-  margin: 0;
+.menu-navigation .autres-liens .pastille {
+  width: 30px;
+  height: 30px;
+  border-radius: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-.menu-navigation :is(.outils-complementaires, .documents-telechargeables) ul {
+.menu-navigation .autres-liens ul {
   row-gap: 14px;
   font-weight: 500;
   font-size: 1.13em;
 }
 
-.menu-navigation :is(.outils-complementaires, .documents-telechargeables) a {
+.menu-navigation .autres-liens a {
   align-items: center;
-}
-
-.menu-navigation .documents-telechargeables a {
   color: var(--bleu-mise-en-avant);
   font-weight: 500;
+  font-size: 0.95em;
 }
-.menu-navigation .documents-telechargeables a:hover {
+.menu-navigation .autres-liens a:hover {
   color: #0c5c98;
 }
-.menu-navigation .documents-telechargeables a:active {
+.menu-navigation .autres-liens a:active {
   color: #08416a;
 }
 
-:is(
-    .menu-navigation .lien-tableau-de-bord,
-    .menu-navigation .lien-deconnexion
-  ) {
-  display: flex;
-  align-items: center;
-  column-gap: 10px;
-  border-top: 1px solid var(--menu-couleur-repos);
-}
-
-.menu-navigation .lien-tableau-de-bord {
-  font-size: 1.12em;
-  font-weight: 500;
-  padding-top: 15px;
-  padding-bottom: 15px;
-}
-.menu-navigation .lien-deconnexion {
-  font-weight: 500;
-}
-
-.menu-navigation .lien-deconnexion {
-  padding-top: 12px;
-  padding-bottom: 12px;
-}
-
-.menu-navigation .lien-contacts-utiles > div,
-.menu-navigation .lien-risques > div,
-.menu-navigation .lien-pdf > div {
-  width: 1.9em;
-  height: 1.9em;
-  border-radius: 100%;
-}
-.menu-navigation .lien-deconnexion > div,
-.menu-navigation .lien-tableau-de-bord > div {
-  width: 1.7em;
-  height: 1.7em;
-  border-radius: 100%;
-}
-
-.menu-navigation .lien-contacts-utiles img,
-.menu-navigation .lien-risques img,
-.menu-navigation .documents-telechargeables img {
-  width: 1.35em;
-}
-.menu-navigation .lien-deconnexion img {
-  width: 1.65em;
-}
-
-.menu-navigation .lien-tableau-de-bord > div {
-  border: 1.5px solid var(--menu-couleur-repos);
-}
-.menu-navigation .lien-contacts-utiles > div,
-.menu-navigation .lien-risques > div,
-.menu-navigation .lien-tableau-de-bord > div,
-.menu-navigation .lien-pdf > div,
-.menu-navigation .lien-deconnexion > div {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-.menu-navigation .lien-contacts-utiles img,
-.menu-navigation .lien-risques img,
-.menu-navigation .lien-tableau-de-bord img,
-.menu-navigation .lien-deconnexion img {
+.menu-navigation .autres-liens a:not(.actif):hover img {
   /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) saturate(100%) invert(15%) sepia(60%) saturate(5222%)
-    hue-rotate(193deg) brightness(98%) contrast(91%);
+  filter: brightness(0) invert(17%) sepia(100%) saturate(2297%)
+    hue-rotate(190deg) brightness(98%) contrast(91%);
 }
-
-.menu-navigation .lien-pdf:hover {
+.menu-navigation .autres-liens a:not(.actif):active img {
   /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) saturate(100%) invert(22%) sepia(94%) saturate(1432%)
-    hue-rotate(186deg) brightness(95%) contrast(91%);
+  filter: brightness(0) invert(15%) sepia(76%) saturate(1769%)
+    hue-rotate(184deg) brightness(96%) contrast(94%);
 }
-.menu-navigation .lien-pdf:active {
+.menu-navigation .autres-liens a img {
+  width: 20px;
+  height: 20px;
   /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) saturate(100%) invert(16%) sepia(28%) saturate(3895%)
-    hue-rotate(184deg) brightness(102%) contrast(94%);
+  filter: brightness(0) invert(29%) sepia(96%) saturate(1526%)
+    hue-rotate(185deg) brightness(95%) contrast(101%);
 }
 
 /* MENU FERMÉ */
@@ -365,29 +234,15 @@
 .menu-navigation.ferme .none-si-ferme {
   display: none !important;
 }
-.menu-navigation.ferme .accueil {
-  position: relative;
-}
-.menu-navigation.ferme .accueil a {
-  width: 57px;
-  height: 45px;
-  background-size: 100px;
-  background-position: 15px;
-}
-.menu-navigation.ferme .repli-menu {
-  position: absolute;
-  left: 4.9em;
-}
 .menu-navigation.ferme .repli-menu img {
   rotate: 0deg;
   transition: rotate 0.2s;
 }
-.menu-navigation.ferme .parcours a,
-.menu-navigation.ferme .lien-tableau-de-bord,
-.menu-navigation.ferme .lien-deconnexion {
+.menu-navigation.ferme a {
   justify-content: center;
 }
 
+/* GÉRER CONTRIBUTEURS */
 .menu-navigation #gerer-contributeurs {
   width: 52px;
   height: 30px;
@@ -407,6 +262,14 @@
 
 .menu-navigation #gerer-contributeurs:active {
   background: #08416a;
+}
+
+.menu-navigation.ferme #gerer-contributeurs {
+  width: auto;
+}
+.menu-navigation.ferme .actions,
+.menu-navigation.ferme .etapes div {
+  justify-content: center;
 }
 
 .menu-navigation:not(.ferme) #gerer-contributeurs:hover {

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -10,6 +10,7 @@
   top: 0;
   left: 0;
   width: var(--menu-largeur);
+  min-width: var(--menu-largeur);
   height: 100%;
   max-height: 100vh;
   display: flex;
@@ -31,21 +32,19 @@
 .menu-navigation a:hover {
   color: var(--menu-couleur-survol);
 }
-.menu-navigation a:hover .position {
-  border-color: var(--menu-couleur-survol);
-}
-.menu-navigation a.actif:hover .position {
-  background-color: var(--menu-couleur-survol) !important;
-}
 
 .menu-navigation a:active {
   color: var(--menu-couleur-actif);
 }
-.menu-navigation a:active .position {
-  border-color: var(--menu-couleur-actif);
-}
-.menu-navigation a.actif:active .position {
+
+.menu-navigation a:active .action-saisie,
+.menu-navigation a.actif:active .action-saisie {
   background-color: var(--menu-couleur-actif) !important;
+}
+
+.menu-navigation a:hover .action-saisie,
+.menu-navigation a.actif:hover .action-saisie {
+  background-color: var(--menu-couleur-survol) !important;
 }
 
 .menu-navigation .actions {
@@ -118,53 +117,69 @@
   background-color: var(--menu-couleur-survol);
 }
 
-.menu-navigation .etapes a > div {
-  font-size: 1.15em;
-  font-weight: 700;
-  align-items: baseline;
+.menu-navigation .etapes li a {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
 }
 
-.menu-navigation a.actif .position {
-  color: white;
+.menu-navigation .etapes li div {
+  display: flex;
+  flex-direction: column;
+}
+
+.menu-navigation .etapes #descriptionService {
+  -webkit-mask: url(../images/actionsSaisie/descriptionService.svg) no-repeat
+    center;
+  mask: url(../images/actionsSaisie/descriptionService.svg) no-repeat center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+.menu-navigation .etapes #mesures {
+  -webkit-mask: url(../images/actionsSaisie/mesures.svg) no-repeat center;
+  mask: url(../images/actionsSaisie/mesures.svg) no-repeat center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+.menu-navigation .etapes #dossiers {
+  -webkit-mask: url(../images/actionsSaisie/dossiers.svg) no-repeat center;
+  mask: url(../images/actionsSaisie/dossiers.svg) no-repeat center;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+
+.menu-navigation .action-saisie {
   background: var(--menu-couleur-repos);
+  width: 24px;
+  height: 24px;
+  margin-right: 8px;
 }
 
-.menu-navigation .position {
-  width: 1.3em;
-  height: 1.3em;
-  border: 1.5px solid var(--menu-couleur-repos);
-  padding: 4px;
-  font-size: 0.9em;
+.menu-navigation .etapes .nom-action {
+  font-weight: 700;
+  font-size: 1.1em;
+}
+.menu-navigation .etapes .sous-titre {
   font-weight: 400;
-  line-height: 1.1em;
-  border-radius: 100%;
-  text-align: center;
+  font-size: 0.85em;
+  padding-right: 10px;
 }
 
 .menu-navigation .statut-saisie {
-  margin-left: auto;
-  width: 1em;
-  height: 1em;
-  align-self: center;
-  background-repeat: no-repeat;
-  background-position: center;
+  width: 16px;
+  height: 16px;
 }
 
 .menu-navigation .statut-saisie.faite {
   background-image: url(../images/icone_ok_pastille_verte.svg);
-  background-size: contain;
+  background-size: cover;
 }
 
 .menu-navigation .statut-saisie.en-cours {
   background-image: url(../images/icone_crayon_pastille_bleue.svg);
-  background-size: contain;
-}
-
-.menu-navigation .sous-titre {
-  display: inline-block;
-  font-size: 0.85em;
-  margin-left: 3.3em;
-  padding-right: 20px;
+  background-size: cover;
 }
 
 .menu-navigation .autres-liens {
@@ -248,7 +263,7 @@
   width: 52px;
   height: 30px;
   padding: 0;
-  background-image: url('/statique/assets/images/bouton_inviter_collaborateur_fond_ouvert.svg');
+  background-image: url(../images/bouton_inviter_collaborateur_fond_ouvert.svg);
   background-repeat: no-repeat;
   background-size: cover;
   display: flex;

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -135,6 +135,7 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
+  column-gap: 8px;
 }
 
 .menu-navigation .etapes li div {
@@ -168,7 +169,6 @@
   background: var(--menu-couleur-repos);
   width: 24px;
   height: 24px;
-  margin-right: 8px;
 }
 
 .menu-navigation .etapes .nom-action {
@@ -178,7 +178,6 @@
 .menu-navigation .etapes .sous-titre {
   font-weight: 400;
   font-size: 0.85em;
-  padding-right: 10px;
 }
 
 .menu-navigation .statut-saisie {
@@ -205,13 +204,14 @@
   font-size: 0.98em;
 }
 
-.menu-navigation .autres-liens .pastille {
+.menu-navigation .pastille {
   width: 30px;
   height: 30px;
   border-radius: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .menu-navigation .autres-liens ul {
@@ -228,8 +228,8 @@
 }
 
 .menu-navigation .autres-liens a img {
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   /* https://codepen.io/sosuke/pen/Pjoqqp */
   filter: brightness(0) invert(29%) sepia(96%) saturate(1526%)
     hue-rotate(185deg) brightness(95%) contrast(101%);

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -33,18 +33,14 @@
   color: var(--menu-couleur-survol);
 }
 
+.menu-navigation a:hover .action-saisie {
+  background-color: var(--menu-couleur-survol);
+}
 .menu-navigation a:active {
   color: var(--menu-couleur-actif);
 }
-
-.menu-navigation a:active .action-saisie,
-.menu-navigation a.actif:active .action-saisie {
-  background-color: var(--menu-couleur-actif) !important;
-}
-
-.menu-navigation a:hover .action-saisie,
-.menu-navigation a.actif:hover .action-saisie {
-  background-color: var(--menu-couleur-survol) !important;
+.menu-navigation a:active .action-saisie {
+  background-color: var(--menu-couleur-actif);
 }
 
 .menu-navigation .actions {
@@ -98,6 +94,22 @@
   column-gap: 8px;
 }
 
+.menu-navigation .autres-liens a:hover > span {
+  color: var(--menu-couleur-repos);
+}
+.menu-navigation .autres-liens a:active > span {
+  color: var(--menu-couleur-actif);
+}
+.menu-navigation .autres-liens a:hover img {
+  /* https://codepen.io/sosuke/pen/Pjoqqp */
+  filter: brightness(0) invert(17%) sepia(100%) saturate(2297%)
+    hue-rotate(190deg) brightness(98%) contrast(91%);
+}
+.menu-navigation .autres-liens a:active img {
+  /* https://codepen.io/sosuke/pen/Pjoqqp */
+  filter: brightness(0) invert(15%) sepia(76%) saturate(1769%)
+    hue-rotate(184deg) brightness(96%) contrast(94%);
+}
 .menu-navigation .autres-liens a.actif > div {
   background-color: var(--menu-couleur-repos);
 }
@@ -112,6 +124,9 @@
 }
 .menu-navigation .autres-liens a.actif:active > div {
   background-color: var(--menu-couleur-actif) !important;
+}
+.menu-navigation .autres-liens a.actif:active > span {
+  color: var(--menu-couleur-actif);
 }
 .menu-navigation .autres-liens a.actif:hover > div {
   background-color: var(--menu-couleur-survol);
@@ -210,23 +225,7 @@
   font-weight: 500;
   font-size: 0.95em;
 }
-.menu-navigation .autres-liens a:hover {
-  color: #0c5c98;
-}
-.menu-navigation .autres-liens a:active {
-  color: #08416a;
-}
 
-.menu-navigation .autres-liens a:not(.actif):hover img {
-  /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) invert(17%) sepia(100%) saturate(2297%)
-    hue-rotate(190deg) brightness(98%) contrast(91%);
-}
-.menu-navigation .autres-liens a:not(.actif):active img {
-  /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) invert(15%) sepia(76%) saturate(1769%)
-    hue-rotate(184deg) brightness(96%) contrast(94%);
-}
 .menu-navigation .autres-liens a img {
   width: 20px;
   height: 20px;

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -185,6 +185,7 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  transform: translateY(2px);
 }
 
 .menu-navigation .statut-saisie.faite {

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -310,7 +310,3 @@
   white-space: nowrap;
   transform: translateY(-2px);
 }
-
-.corps.marges-fixes + .tiroir {
-  position: fixed;
-}

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -10,14 +10,13 @@
   top: 0;
   left: 0;
   width: var(--menu-largeur);
-  min-width: var(--menu-largeur);
   height: 100%;
   max-height: 100vh;
   display: flex;
   flex-direction: column;
   row-gap: 1em;
+  flex-shrink: 0;
   background: #f1f5f9;
-
   transition: width 0.2s cubic-bezier(0.05, 1.13, 0.81, 0.99);
 }
 
@@ -242,10 +241,7 @@
   padding-left: 0;
   padding-right: 0;
 }
-.menu-navigation.ferme .hidden-si-ferme {
-  visibility: hidden !important;
-  white-space: nowrap;
-}
+
 .menu-navigation.ferme .none-si-ferme {
   display: none !important;
 }

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -5,12 +5,12 @@
 }
 
 .menu-navigation {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
-  z-index: 20;
   width: 19em;
-  height: 100vh;
+  height: 100%;
+  max-height: 100vh;
   display: flex;
   flex-direction: column;
   row-gap: 1em;

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -2,13 +2,14 @@
   --menu-couleur-repos: var(--bleu-survol);
   --menu-couleur-survol: var(--bleu-mise-en-avant);
   --menu-couleur-actif: var(--bleu-anssi);
+  --menu-largeur: 19em;
 }
 
 .menu-navigation {
   position: sticky;
   top: 0;
   left: 0;
-  width: 19em;
+  width: var(--menu-largeur);
   height: 100%;
   max-height: 100vh;
   display: flex;

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -184,6 +184,7 @@
 .menu-navigation .statut-saisie {
   width: 16px;
   height: 16px;
+  flex-shrink: 0;
 }
 
 .menu-navigation .statut-saisie.faite {

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -21,8 +21,10 @@ body {
 }
 
 main {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
   flex-grow: 1;
-  padding-bottom: 5em;
   border-top: solid 1px var(--liseres);
   border-bottom: solid 2px var(--systeme-design-etat-bleu);
   background: var(--fond-pale);

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -50,16 +50,6 @@ section:last-of-type {
   border-bottom: solid 1px var(--liseres);
 }
 
-.retour {
-  display: flex;
-  flex-direction: column;
-  margin-top: 1.5em;
-}
-
-.retour:empty {
-  display: none;
-}
-
 .invisible {
   display: none;
 }

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -3,7 +3,8 @@
 }
 
 main {
-  padding-bottom: 0;
+  background-image: url('/statique/assets/images/fond_entete_tableau_de_bord.svg');
+  background-repeat: no-repeat;
 }
 
 .bandeau-maj-profil {
@@ -52,8 +53,6 @@ main {
 }
 
 .entete-suivi-services {
-  background-image: url('/statique/assets/images/fond_entete_tableau_de_bord.svg');
-  background-repeat: no-repeat;
   padding-bottom: 1em;
 }
 

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -9,6 +9,7 @@
   box-shadow: -10px 0px 34px 0px #00000026;
   background: #fff;
   visibility: hidden;
+  z-index: 20;
 }
 
 .tiroir.ouvert {

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -1,7 +1,7 @@
 .tiroir {
   height: 100%;
   min-width: 33em;
-  position: absolute;
+  position: fixed;
   left: 100vw;
   top: 0;
   overflow-y: scroll;

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -14,8 +14,8 @@ block append scripts
   script(type = 'module', src = '/statique/scripts/menuNavigation.js')
   script(type = 'module', src = '/statique/composants-svelte/gestionContributeurs.js')
 
-block header
-  // Pas de header sur les pages 2 colonnes
+block header-gauche
+  a.logo-mss(href='/tableauDeBord')
 
 block main
   include ./fragments/menuNavigation

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -21,6 +21,9 @@ block header-gauche
     .retour-tableau-de-bord
       a(href='/tableauDeBord') Retour au tableau de bord
 
+block bandeau-nouveautes
+  // Pas de « Nouveautés » sur les pages de service
+
 block main
   include ./fragments/menuNavigation
 

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -1,5 +1,4 @@
 extends mssConnecte
-include ./fragments/texteTronque
 include ./tiroirs/tiroir.pug
 
 block append styles
@@ -15,7 +14,10 @@ block append scripts
   script(type = 'module', src = '/statique/composants-svelte/gestionContributeurs.js')
 
 block header-gauche
-  a.logo-mss(href='/tableauDeBord')
+  .conteneur-logo
+    a.logo-mss(href='/tableauDeBord')
+  .titre-page
+    block header-titre-page
 
 block main
   include ./fragments/menuNavigation

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -18,6 +18,8 @@ block header-gauche
     a.logo-mss(href='/tableauDeBord')
   .titre-page
     block header-titre-page
+    .retour-tableau-de-bord
+      a(href='/tableauDeBord') Retour au tableau de bord
 
 block main
   include ./fragments/menuNavigation

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -38,16 +38,18 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut })
   if !estSurCreationDeService
     .autres-liens
       ul
-        li
-          a(href = `/service/${service.id}/risques`, class = etapeActive === 'risques' ? 'actif' : '')
-            .pastille
-              img(src = '/statique/assets/images/icone_risques.svg' alt="Icône d'un panneau « Danger »")
-            span.none-si-ferme Risques
-        li
-          a(href = `/service/${service.id}/rolesResponsabilites`, class = etapeActive === 'contactsUtiles' ? 'actif' : '')
-            .pastille
-              img(src = '/statique/assets/images/icone_contacts_utiles.svg' alt="Icône d'un livre ouvert")
-            span.none-si-ferme Contacts utiles
+        if !autorisationsService.RISQUES.estMasque
+          li
+            a(href = `/service/${service.id}/risques`, class = etapeActive === 'risques' ? 'actif' : '')
+              .pastille
+                img(src = '/statique/assets/images/icone_risques.svg' alt="Icône d'un panneau « Danger »")
+              span.none-si-ferme Risques
+        if !autorisationsService.CONTACTS.estMasque
+          li
+            a(href = `/service/${service.id}/rolesResponsabilites`, class = etapeActive === 'contactsUtiles' ? 'actif' : '')
+              .pastille
+                img(src = '/statique/assets/images/icone_contacts_utiles.svg' alt="Icône d'un livre ouvert")
+              span.none-si-ferme Contacts utiles
         li
           a(
             href = `/api/service/${service.id}/pdf/syntheseSecurite.pdf`,

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -13,12 +13,12 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut })
 
   li
     a(href = estSurCreationDeService ? '#' : url, class = estActive ? 'actif' : '')
+      span.action-saisie(id = id)
       div
-        span.position
-          !=(position+1)
-        span.none-si-ferme!= description
-        span.statut-saisie.none-si-ferme(class = statutSaisie(statut))
-      span.sous-titre.hidden-si-ferme!= sousTitre
+        span.nom-action.none-si-ferme!= description
+        span.sous-titre.hidden-si-ferme!= sousTitre
+      .statut-saisie.none-si-ferme(class = statutSaisie(statut))
+
 
 .menu-navigation(class = preferencesUtilisateur.etatMenuNavigation === 'ferme' ? 'ferme' : '')
   .actions

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -14,9 +14,9 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut })
   li
     a(href = estSurCreationDeService ? '#' : url, class = estActive ? 'actif' : '')
       span.action-saisie(id = id)
-      div
-        span.nom-action.none-si-ferme!= description
-        span.sous-titre.hidden-si-ferme!= sousTitre
+      .none-si-ferme
+        span.nom-action!= description
+        span.sous-titre!= sousTitre
       .statut-saisie.none-si-ferme(class = statutSaisie(statut))
 
 

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -13,7 +13,8 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut })
 
   li
     a(href = estSurCreationDeService ? '#' : url, class = estActive ? 'actif' : '')
-      span.action-saisie(id = id)
+      .pastille
+        span.action-saisie(id = id)
       .none-si-ferme
         span.nom-action!= description
         span.sous-titre!= sousTitre

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -13,78 +13,56 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut })
 
   li
     a(href = estSurCreationDeService ? '#' : url, class = estActive ? 'actif' : '')
-      span.position
-        !=(position+1)
-      span.none-si-ferme!=description
-      span.chevron.none-si-ferme
-      span.statut-saisie.none-si-ferme(class = statutSaisie(statut))
-    if estActive
-      span.sous-titre.none-si-ferme
-        !=sousTitre
+      div
+        span.position
+          !=(position+1)
+        span.none-si-ferme!= description
+        span.statut-saisie.none-si-ferme(class = statutSaisie(statut))
+      span.sous-titre.hidden-si-ferme!= sousTitre
 
 .menu-navigation(class = preferencesUtilisateur.etatMenuNavigation === 'ferme' ? 'ferme' : '')
-  .accueil
-    a(href="/" title="Naviguer vers la page d'acceuil")
-    button.repli-menu
-      img(src = '/statique/assets/images/forme_chevron_blanc.svg' alt='Chevron vers la gauche')
-
-  if !estSurCreationDeService
-    .nom-service
-      .none-si-ferme
-        +texteTronque({texte: service.nomService() || ''})
+  .actions
+    if !estSurCreationDeService
       button#gerer-contributeurs
         img(src = '/statique/assets/images/bouton_inviter_collaborateur_persona.svg')
-        span.nombre-contributeurs= service.contributeurs.length + 1
+        span.none-si-ferme.nombre-contributeurs= service.contributeurs.length + 1
         span.inviter-contributeurs Gérer les contributeurs
+    button.repli-menu
+      img(src = '/statique/assets/images/forme_chevron_blanc.svg' alt='Chevron vers la gauche')
 
   .parcours
     ul.etapes
       each actionSaisie in actionsSaisie
         +etapeParcours(actionSaisie)
 
-    if !estSurCreationDeService
-      .outils-complementaires
-        h4.hidden-si-ferme Outils complémentaires
-        ul
-          li
-            a.lien-risques(href = `/service/${service.id}/risques`, class = etapeActive === 'risques' ? 'actif' : '')
-              div
-                img(src = '/statique/assets/images/icone_risques.svg' alt="Icône d'un panneau « Danger »")
-              span.none-si-ferme Risques
-          li
-            a.lien-contacts-utiles(href = `/service/${service.id}/rolesResponsabilites`, class = etapeActive === 'contactsUtiles' ? 'actif' : '')
-              div
-                img(src = '/statique/assets/images/icone_contacts_utiles.svg' alt="Icône d'un livre ouvert")
-              span.none-si-ferme Contacts utiles
-
-      .documents-telechargeables
-        h4.hidden-si-ferme Documents à télécharger
-        ul
-          li
-            a.lien-pdf(
-              href = `/api/service/${service.id}/pdf/syntheseSecurite.pdf`,
-              target = '_blank',
-              rel = 'noopener'
-              title= 'Télécharger le PDF de synthèse de sécurité dans une nouvelle fenêtre')
-              div
-                img(src = '/statique/assets/images/icone_action_telechargement.svg' alt='Icône de fichier PDF')
-              span.none-si-ferme Synthèse de sécurité
-          li
-            a.lien-pdf(
-              href = `/api/service/${service.id}/pdf/annexes.pdf`,
-              target = '_blank',
-              rel = 'noopener'
-              title= 'Télécharger les annexes PDF dans une nouvelle fenêtre')
-              div
-                img(src = '/statique/assets/images/icone_action_telechargement.svg' alt='Icône de fichier PDF')
-              span.none-si-ferme Annexes
-
-
-  a.lien-tableau-de-bord(href="/tableauDeBord" title="Retour au tableau de bord")
-    div
-      img(src = '/statique/assets/images/icone_retour.svg' alt="Icône d'une flèche pointant vers la gauche")
-    span.none-si-ferme Tableau de bord
-  a.lien-deconnexion(href="/connexion" title="Déconnexion")
-    div
-      img(src = '/statique/assets/images/icone_deconnecter.svg' alt="Icône d'une croix")
-    span.none-si-ferme Se déconnecter
+  if !estSurCreationDeService
+    .autres-liens
+      ul
+        li
+          a(href = `/service/${service.id}/risques`, class = etapeActive === 'risques' ? 'actif' : '')
+            .pastille
+              img(src = '/statique/assets/images/icone_risques.svg' alt="Icône d'un panneau « Danger »")
+            span.none-si-ferme Risques
+        li
+          a(href = `/service/${service.id}/rolesResponsabilites`, class = etapeActive === 'contactsUtiles' ? 'actif' : '')
+            .pastille
+              img(src = '/statique/assets/images/icone_contacts_utiles.svg' alt="Icône d'un livre ouvert")
+            span.none-si-ferme Contacts utiles
+        li
+          a(
+            href = `/api/service/${service.id}/pdf/syntheseSecurite.pdf`,
+            target = '_blank',
+            rel = 'noopener'
+            title= 'Télécharger le PDF de synthèse de sécurité dans une nouvelle fenêtre')
+            .pastille
+              img(src = '/statique/assets/images/icone_action_telechargement.svg' alt='Icône de fichier PDF')
+            span.none-si-ferme Synthèse de sécurité
+        li
+          a(
+            href = `/api/service/${service.id}/pdf/annexes.pdf`,
+            target = '_blank',
+            rel = 'noopener'
+            title= 'Télécharger les annexes PDF dans une nouvelle fenêtre')
+            .pastille
+              img(src = '/statique/assets/images/icone_action_telechargement.svg' alt='Icône de fichier PDF')
+            span.none-si-ferme Annexes

--- a/src/vues/motDePasse/edition.pug
+++ b/src/vues/motDePasse/edition.pug
@@ -7,14 +7,6 @@ block append styles
   link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
 
-block retour
-  nav.fil-ariane
-    a.avec-chevron(href = '/tableauDeBord') Tableau de bord
-    if afficheChallengeMotDePasse
-      div Changez votre mot de passe
-    else
-      div Créez votre mot de passe
-
 block main
   form.etroit.mot-de-passe#edition
     if afficheChallengeMotDePasse

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -34,8 +34,6 @@ block page
     include csrf.pug
 
   main
-    .retour.marges-fixes
-      block retour
     block main
     .bom
       .bom-vignette

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -18,17 +18,22 @@ block page
   title MonServiceSécurisé
 
   block header
-    header.marges-fixes
-      .bloc-marque
-        .marianne
-        .republique-francaise RÉPUBLIQUE<br>FRANÇAISE
-        .devise
-      a.logo-anssi(href='https://www.ssi.gouv.fr')
-      a.logo-mss(href='/')
-      .sandwich
-      nav
-        .bouton-fermer Fermer
-        block navigation
+    header
+      block header-gauche
+        .header-gauche
+          .bloc-marque
+            .marianne
+            .republique-francaise RÉPUBLIQUE<br>FRANÇAISE
+            .devise
+          a.logo-anssi(href='https://www.ssi.gouv.fr')
+          a.logo-mss(href='/')
+
+      block header-droit
+        .header-droit
+          .sandwich
+          nav
+            .bouton-fermer Fermer
+            block navigation
 
   block session
     include csrf.pug

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -19,8 +19,8 @@ block page
 
   block header
     header
-      block header-gauche
-        .header-gauche
+      .header-gauche
+        block header-gauche
           .bloc-marque
             .marianne
             .republique-francaise RÉPUBLIQUE<br>FRANÇAISE
@@ -28,8 +28,8 @@ block page
           a.logo-anssi(href='https://www.ssi.gouv.fr')
           a.logo-mss(href='/')
 
-      block header-droit
-        .header-droit
+      .header-droit
+        block header-droit
           .sandwich
           nav
             .bouton-fermer Fermer

--- a/src/vues/mssConnecte.pug
+++ b/src/vues/mssConnecte.pug
@@ -4,10 +4,11 @@ block append styles
   link(href = '/statique/assets/styles/modale.css', rel = 'stylesheet')
 
 block navigation
-  .bandeau-nouveautes
-    img(src='/statique/assets/images/bandeau_nouveautes_decoration.svg', alt='Décoration du bouton des nouveautés')
-    p.
-      Nouveautés
+  block bandeau-nouveautes
+    .bandeau-nouveautes
+      img(src='/statique/assets/images/bandeau_nouveautes_decoration.svg', alt='Décoration du bouton des nouveautés')
+      p.
+        Nouveautés
 
   .utilisateur-courant
 

--- a/src/vues/service/descriptionService.pug
+++ b/src/vues/service/descriptionService.pug
@@ -1,5 +1,10 @@
 extends ./decrire
+include ../fragments/texteTronque
 include ../fragments/formulaireDescriptionService
+
+block header-titre-page
+  h3
+    +texteTronque({texte: service.nomService() || ''})
 
 block formulaire
   +formulaireDescriptionService(service.id)

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -1,4 +1,5 @@
 extends ./formulaireEtapier
+include ../fragments/texteTronque
 
 mixin dossier({ statut, dossier, idService })
   -
@@ -24,6 +25,10 @@ mixin dossierFinalise({ dossier })
 
 mixin dossierCourant({ ...donnees })
   +dossier({ statut: 'Homologation en cours', ...donnees })
+
+block header-titre-page
+  h3
+    +texteTronque({texte: service.nomService() || ''})
 
 block formulaire
   -

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -1,6 +1,7 @@
 extends ./formulaire
 include ../fragments/inputChoix
 include ../fragments/cartesInformations
+include ../fragments/texteTronque
 include ../cartes/statutHomologation
 include ../cartes/indiceCyber
 include ../cartes/recommandationsANSSI
@@ -18,6 +19,10 @@ mixin inputMesure({ nom, titre, indispensable, lectureSeule = false })
 block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
+
+block header-titre-page
+  h3
+    +texteTronque({texte: service.nomService() || ''})
 
 block formulaire
   - const estLectureSeule  = autorisationsService.SECURISER.estLectureSeule

--- a/src/vues/service/risques.pug
+++ b/src/vues/service/risques.pug
@@ -1,9 +1,14 @@
 extends ./formulaire
 include ../fragments/carteInformations
 include ../fragments/cartesInformations
+include ../fragments/texteTronque
 
 block append styles
   link(href = '/statique/assets/styles/homologation/risques.css', rel = 'stylesheet')
+
+block header-titre-page
+  h3
+    +texteTronque({texte: service.nomService() || ''})
 
 block formulaire
   - const estLectureSeule  = autorisationsService.RISQUES.estLectureSeule

--- a/src/vues/service/rolesResponsabilites.pug
+++ b/src/vues/service/rolesResponsabilites.pug
@@ -1,11 +1,16 @@
 extends ./formulaire
 include ../fragments/inputIdentite
 include ../fragments/inputPartiePrenante
+include ../fragments/texteTronque
 include ../fragments/elementsAjoutables/elementsAjoutablesActeurHomologation
 include ../fragments/elementsAjoutables/elementsAjoutablesPartiePrenante
 
 block append styles
   link(href = '/statique/assets/styles/homologation/rolesResponsabilites.css', rel = 'stylesheet')
+
+block header-titre-page
+  h3
+    +texteTronque({texte: service.nomService() || ''})
 
 block formulaire
   - const estLectureSeule  = autorisationsService.CONTACTS.estLectureSeule

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -95,12 +95,13 @@ block main
                 +actionAvecIcone('/statique/assets/images/icone_dupliquer_service.svg', 'Dupliquer', 'duplication')
                 +actionAvecIcone('/statique/assets/images/icone_supprimer.svg', 'Supprimer', 'suppression')
         tbody.contenu-tableau-services
-    +tiroir
-      include ./tiroirs/tiroirContributeurs
-      include ./tiroirs/tiroirExport
-      include ./tiroirs/tiroirDuplication
-      include ./tiroirs/tiroirSuppression
-      include ./tiroirs/tiroirTelechargement
+
+  +tiroir
+    include ./tiroirs/tiroirContributeurs
+    include ./tiroirs/tiroirExport
+    include ./tiroirs/tiroirDuplication
+    include ./tiroirs/tiroirSuppression
+    include ./tiroirs/tiroirTelechargement
 
 
   script(type = 'module', src = '/statique/tableauDeBord.js')

--- a/src/vues/utilisateur/edition.pug
+++ b/src/vues/utilisateur/edition.pug
@@ -5,11 +5,6 @@ include ../fragments/formulaireUtilisateur
 block append styles
   link(href = '/statique/assets/styles/filAriane.css', rel = 'stylesheet')
 
-block retour
-  nav.fil-ariane
-    a.avec-chevron(href = '/tableauDeBord') Tableau de bord
-    div Profil
-
 block main
   form.etroit.utilisateur#edition
     h1 Profil


### PR DESCRIPTION
### PARKING D'IDÉES
- [ ] Le header sur les pages connectée autre que « Service » : on fait quoi ?

### PR suivante
- [ ] Afficher « Documents » qui ouvre le tiroir des PDF, à la place des PDFs eux-mêmes
- [ ] Masquer les étapes du parcours inaccessibles 

### PR
Cette PR relooke le menu pour qu'il soit en v2 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/73300aaa-c5ac-4d85-bd4c-ac1b11ca58b4)

