### PR TITLE
Masquage des statuts d'homologation en fonction des droits

### DIFF
--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -160,7 +160,7 @@ const tableauDesServices = {
             tableauDesServices.nombreServices = data.resume.nombreServices;
             tableauDesServices.donnees = data.services;
             tableauDesServices.donnees.forEach((s) => {
-              s.ordreStatutHomologation = s.statutHomologation.ordre;
+              s.ordreStatutHomologation = s.statutHomologation?.ordre ?? -1;
             });
             tableauDesServices.afficheDonnees();
             tableauDesServices.afficheEtatSelection();
@@ -247,10 +247,10 @@ const tableauDesServices = {
       $ligne.append(
         $(
           `<td><div class='statut-homologation statut-${
-            service.statutHomologation.id
+            service.statutHomologation?.id ?? 'inconnu'
           } ${
-            service.statutHomologation.enCoursEdition ? 'enCoursEdition' : ''
-          }'>${service.statutHomologation.libelle}</div></td>`
+            service.statutHomologation?.enCoursEdition ? 'enCoursEdition' : ''
+          }'>${service.statutHomologation?.libelle ?? '-'}</div></td>`
         )
       );
 

--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -20,7 +20,7 @@ const ligneDuService = (service) =>
     service.nombreContributeurs,
     remplaceBooleen(service.estCreateur),
     Number(service.indiceCyber) ? service.indiceCyber : '-',
-    service.statutHomologation.libelle,
+    service.statutHomologation?.libelle ?? '-',
   ].join(SEPARATEUR);
 
 const genereCsvServices = (tableauServices) => {

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -1,6 +1,10 @@
 const Dossiers = require('../dossiers');
+const { Permissions, Rubriques } = require('../autorisations/gestionDroits');
 
-const donnees = (service, idUtilisateur, referentiel) => ({
+const { LECTURE } = Permissions;
+const { HOMOLOGUER } = Rubriques;
+
+const donnees = (service, autorisation, idUtilisateur, referentiel) => ({
   id: service.id,
   nomService: service.nomService(),
   organisationsResponsables:
@@ -17,11 +21,13 @@ const donnees = (service, idUtilisateur, referentiel) => ({
     initiales: c.initiales(),
     poste: c.posteDetaille(),
   })),
-  statutHomologation: {
-    id: service.dossiers.statutHomologation(),
-    enCoursEdition: service.dossiers.statutSaisie() === Dossiers.A_COMPLETER,
-    ...referentiel.statutHomologation(service.dossiers.statutHomologation()),
-  },
+  ...(autorisation.aLaPermission(LECTURE, HOMOLOGUER) && {
+    statutHomologation: {
+      id: service.dossiers.statutHomologation(),
+      enCoursEdition: service.dossiers.statutSaisie() === Dossiers.A_COMPLETER,
+      ...referentiel.statutHomologation(service.dossiers.statutHomologation()),
+    },
+  }),
   nombreContributeurs: service.contributeurs.length + 1,
   estCreateur: service.createur.id === idUtilisateur,
   documentsPdfDisponibles: service.documentsPdfDisponibles(),

--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -1,16 +1,28 @@
 const Dossiers = require('../dossiers');
 const objetGetService = require('./objetGetService');
+const { Permissions, Rubriques } = require('../autorisations/gestionDroits');
 
-const donnees = (services, idUtilisateur, referentiel) => ({
+const { LECTURE } = Permissions;
+const { HOMOLOGUER } = Rubriques;
+
+const donnees = (services, autorisations, idUtilisateur, referentiel) => ({
   services: services.map((s) =>
-    objetGetService.donnees(s, idUtilisateur, referentiel)
+    objetGetService.donnees(
+      s,
+      autorisations.find((a) => a.idService === s.id),
+      idUtilisateur,
+      referentiel
+    )
   ),
   resume: {
     nombreServices: services.length,
     nombreServicesHomologues: services.filter(
       (s) =>
-        s.dossiers.statutHomologation() === Dossiers.ACTIVEE ||
-        s.dossiers.statutHomologation() === Dossiers.BIENTOT_EXPIREE
+        (s.dossiers.statutHomologation() === Dossiers.ACTIVEE ||
+          s.dossiers.statutHomologation() === Dossiers.BIENTOT_EXPIREE) &&
+        autorisations
+          .find((a) => a.idService === s.id)
+          .aLaPermission(LECTURE, HOMOLOGUER)
     ).length,
   },
 });

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -40,17 +40,20 @@ const routesApiPrivee = ({
   routes.get(
     '/services',
     middleware.verificationAcceptationCGU,
-    (requete, reponse) => {
-      depotDonnees
-        .homologations(requete.idUtilisateurCourant)
-        .then((services) =>
-          objetGetServices.donnees(
-            services,
-            requete.idUtilisateurCourant,
-            referentiel
-          )
-        )
-        .then((donnees) => reponse.json(donnees));
+    async (requete, reponse) => {
+      const services = await depotDonnees.homologations(
+        requete.idUtilisateurCourant
+      );
+      const autorisations = await depotDonnees.autorisations(
+        requete.idUtilisateurCourant
+      );
+      const donnees = objetGetServices.donnees(
+        services,
+        autorisations,
+        requete.idUtilisateurCourant,
+        referentiel
+      );
+      reponse.json(donnees);
     }
   );
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -82,6 +82,7 @@ const routesApiPrivee = ({
       const donneesCsvServices = (services, autorisations) => {
         const servicesSansIndice = objetGetServices.donnees(
           services,
+          autorisations,
           requete.idUtilisateurCourant,
           referentiel
         );

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -30,7 +30,7 @@ const {
   Rubriques,
 } = require('../../modeles/autorisations/gestionDroits');
 
-const { ECRITURE, LECTURE } = Permissions;
+const { ECRITURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
 
 const routesApiService = (
@@ -125,10 +125,15 @@ const routesApiService = (
   routes.get(
     '/:id',
     middleware.aseptise('id'),
-    middleware.trouveService({ [DECRIRE]: LECTURE }),
+    middleware.trouveService({}),
     async (requete, reponse) => {
+      const autorisation = await depotDonnees.autorisationPour(
+        requete.idUtilisateurCourant,
+        requete.homologation.id
+      );
       const donnees = objetGetService.donnees(
         requete.homologation,
+        autorisation,
         requete.idUtilisateurCourant,
         referentiel
       );

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -303,6 +303,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     it('utilise un adaptateur de CSV pour la génération', (done) => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
+      testeur.depotDonnees().autorisations = async () => [
+        uneAutorisation()
+          .deCreateurDeService('123', '456')
+          .avecDroits({})
+          .construis(),
+      ];
+
       testeur.depotDonnees().homologations = () =>
         Promise.resolve([
           new Service({
@@ -324,8 +331,6 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         expect(service.organisationsResponsables).to.eql(['ANSSI']);
         expect(service.nombreContributeurs).to.eql(1);
         expect(service.estCreateur).to.be(true);
-        expect(service.indiceCyber).not.to.be(undefined);
-        expect(service.statutHomologation.libelle).to.be('Non réalisée');
 
         return Promise.resolve('Fichier CSV');
       };

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -48,6 +48,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
+      let donneesPassees = {};
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
       testeur.referentiel().recharge({
         statutsHomologation: {
@@ -56,7 +57,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
 
       testeur.depotDonnees().homologations = (idUtilisateur) => {
-        expect(idUtilisateur).to.equal('123');
+        donneesPassees = { idUtilisateur };
         return Promise.resolve([
           new Service({
             id: '456',
@@ -77,6 +78,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           const { services } = reponse.data;
           expect(services.length).to.equal(1);
           expect(services[0].id).to.equal('456');
+          expect(donneesPassees.idUtilisateur).to.equal('123');
           done();
         })
         .catch(done);
@@ -112,6 +114,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
+      let donneesPassees = {};
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
       testeur.depotDonnees().autorisations = async () => [
@@ -122,7 +125,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       ];
 
       testeur.depotDonnees().homologations = (idUtilisateur) => {
-        expect(idUtilisateur).to.equal('123');
+        donneesPassees = { idUtilisateur };
         return Promise.resolve([
           new Service({
             id: '456',
@@ -143,6 +146,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           const { services } = reponse.data;
           expect(services.length).to.equal(1);
           expect(services[0].id).to.equal('456');
+          expect(donneesPassees.idUtilisateur).to.equal('123');
           done();
         })
         .catch(done);
@@ -204,12 +208,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
-      let depotAppele = false;
+      let donneesPassees = {};
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
       testeur.depotDonnees().homologations = (idUtilisateur) => {
-        expect(idUtilisateur).to.equal('123');
-        depotAppele = true;
+        donneesPassees = { idUtilisateur };
         return Promise.resolve([
           new Service({
             id: '456',
@@ -226,7 +229,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         .get('http://localhost:1234/api/services/export.csv')
         .then((reponse) => {
           expect(reponse.status).to.equal(200);
-          expect(depotAppele).to.be(true);
+          expect(donneesPassees.idUtilisateur).to.equal('123');
           done();
         })
         .catch(done);

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1489,7 +1489,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return uneAutorisation().avecDroits({}).construis();
       };
 
-      const reponse = await axios('http://localhost:1234/api/service/456');
+      await axios('http://localhost:1234/api/service/456');
       expect(donneesPassees.idUtilisateur).to.equal('123');
       expect(donneesPassees.idService).to.equal('456');
     });


### PR DESCRIPTION
On conditionne l'affichage du statut d'homologation sur le front en fonction de la permission sur la rubrique HOMOLOGUER.
Les statuts sont masqués si l'utilisateur n'a pas les droits suffisants.

Ils ne sont aussi pas prit en compte pour le calcul du nombre total de services homologués.
