### PR TITLE
Conditionnement des disponibilités des PDF en fonction des droits

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     moment: 'readonly',
   },
   parserOptions: {
-    ecmaVersion: 12,
+    ecmaVersion: 2022,
   },
   ignorePatterns: [
     'public/bibliotheques/*.js',

--- a/public/modules/tableauDeBord/actions/ActionTelechargement.mjs
+++ b/public/modules/tableauDeBord/actions/ActionTelechargement.mjs
@@ -22,19 +22,37 @@ class ActionTelechargement extends ActionAbstraite {
     $('#lien-decision').attr('href', `${urlBase}dossierDecision.pdf`);
     $('#lien-archive').attr('href', `${urlBase}documentsHomologation.zip`);
 
-    const $conteneurDecision = $('#conteneur-lien-decision');
-    const dossierDecisionDisponible =
-      donneesService.documentsPdfDisponibles.includes('dossierDecision');
-    $('.lien-telechargement', $conteneurDecision).toggle(
-      dossierDecisionDisponible
-    );
-    $('.lien-indisponible', $conteneurDecision).toggle(
-      !dossierDecisionDisponible
-    );
+    const listeDocuments = [
+      {
+        cible: 'decision',
+        nomDocument: 'dossierDecision',
+      },
+      {
+        cible: 'annexes',
+        nomDocument: 'annexes',
+      },
+      {
+        cible: 'synthese',
+        nomDocument: 'syntheseSecurite',
+      },
+    ];
 
-    $('#nbPdfDisponibles', '#conteneur-lien-archive').text(
-      donneesService.documentsPdfDisponibles.length
-    );
+    listeDocuments.forEach(({ cible, nomDocument }) => {
+      const $conteneur = $(`#conteneur-lien-${cible}`);
+      const documentDisponible =
+        donneesService.documentsPdfDisponibles.includes(nomDocument);
+      $('.lien-telechargement', $conteneur).toggle(documentDisponible);
+      $('.lien-indisponible', $conteneur).toggle(!documentDisponible);
+    });
+
+    const $conteneurArchive = $('#conteneur-lien-archive');
+    if (donneesService.documentsPdfDisponibles.length === 0) {
+      $conteneurArchive.find('.lien-telechargement').hide();
+      $conteneurArchive.find('.lien-indisponible').show();
+    }
+    $conteneurArchive
+      .find('#nbPdfDisponibles')
+      .text(donneesService.documentsPdfDisponibles.length);
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -1,4 +1,8 @@
 const Base = require('../base');
+const {
+  Rubriques: { DECRIRE, SECURISER, RISQUES, HOMOLOGUER },
+  Permissions: { LECTURE },
+} = require('./gestionDroits');
 
 class AutorisationBase extends Base {
   constructor(donnees = {}) {
@@ -27,6 +31,21 @@ class AutorisationBase extends Base {
       this.aLaPermission(niveau, rubrique)
     );
   }
+
+  static DROITS_ANNEXES_PDF = {
+    [DECRIRE]: LECTURE,
+    [SECURISER]: LECTURE,
+    [RISQUES]: LECTURE,
+  };
+
+  static DROITS_DOSSIER_DECISION_PDF = {
+    [HOMOLOGUER]: LECTURE,
+  };
+
+  static DROIT_SYNTHESE_SECURITE_PDF = {
+    [SECURISER]: LECTURE,
+    [DECRIRE]: LECTURE,
+  };
 }
 
 module.exports = AutorisationBase;

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -12,6 +12,7 @@ const Utilisateur = require('./utilisateur');
 const ObjetPDFAnnexeDescription = require('./objetsPDF/objetPDFAnnexeDescription');
 const ObjetPDFAnnexeMesures = require('./objetsPDF/objetPDFAnnexeMesures');
 const ObjetPDFAnnexeRisques = require('./objetsPDF/objetPDFAnnexeRisques');
+const AutorisationBase = require('./autorisations/autorisationBase');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -110,18 +111,29 @@ class Homologation {
     }, {});
   }
 
-  documentsPdfDisponibles() {
-    const documents = ['annexes', 'syntheseSecurite'];
+  documentsPdfDisponibles(autorisation) {
+    const droitAuxAnnexes = autorisation.aLesPermissions(
+      AutorisationBase.DROITS_ANNEXES_PDF
+    );
+    const droitALaSyntheseSecurite = autorisation.aLesPermissions(
+      AutorisationBase.DROIT_SYNTHESE_SECURITE_PDF
+    );
+    const droitAuDossierDecision = autorisation.aLesPermissions(
+      AutorisationBase.DROITS_DOSSIER_DECISION_PDF
+    );
     const dossierCourant = this.dossierCourant();
-    if (
-      dossierCourant &&
+
+    return [
+      ...(droitAuxAnnexes ? ['annexes'] : []),
+      ...(droitALaSyntheseSecurite ? ['syntheseSecurite'] : []),
+      ...(dossierCourant &&
       this.referentiel.etapeSuffisantePourDossierDecision(
         dossierCourant.etapeCourante()
-      )
-    ) {
-      documents.push('dossierDecision');
-    }
-    return documents;
+      ) &&
+      droitAuDossierDecision
+        ? ['dossierDecision']
+        : []),
+    ];
   }
 
   donneesAPersister() {

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -30,7 +30,7 @@ const donnees = (service, autorisation, idUtilisateur, referentiel) => ({
   }),
   nombreContributeurs: service.contributeurs.length + 1,
   estCreateur: service.createur.id === idUtilisateur,
-  documentsPdfDisponibles: service.documentsPdfDisponibles(),
+  documentsPdfDisponibles: service.documentsPdfDisponibles(autorisation),
   permissions: {
     suppressionContributeur: service.createur.id === idUtilisateur,
   },

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -44,13 +44,14 @@ const routesApiService = (
   const routes = express.Router();
 
   routes.use(
-    routesApiServicePdf(
-      middleware,
+    routesApiServicePdf({
       adaptateurHorloge,
       adaptateurPdf,
+      depotDonnees,
       adaptateurZip,
-      referentiel
-    )
+      middleware,
+      referentiel,
+    })
   );
 
   routes.post(

--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -1,13 +1,7 @@
 const express = require('express');
+const AutorisationBase = require('../../modeles/autorisations/autorisationBase');
 const { genereGradientConique } = require('../../pdf/graphiques/camembert');
 const { dateYYYYMMDD } = require('../../utilitaires/date');
-const {
-  Permissions,
-  Rubriques,
-} = require('../../modeles/autorisations/gestionDroits');
-
-const { LECTURE } = Permissions;
-const { HOMOLOGUER, RISQUES, SECURISER, DECRIRE } = Rubriques;
 
 const routesApiServicePdf = (
   middleware,
@@ -63,11 +57,7 @@ const routesApiServicePdf = (
   };
   routes.get(
     '/:id/pdf/annexes.pdf',
-    middleware.trouveService({
-      [DECRIRE]: LECTURE,
-      [SECURISER]: LECTURE,
-      [RISQUES]: LECTURE,
-    }),
+    middleware.trouveService(AutorisationBase.DROITS_ANNEXES_PDF),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 
@@ -79,7 +69,7 @@ const routesApiServicePdf = (
 
   routes.get(
     '/:id/pdf/dossierDecision.pdf',
-    middleware.trouveService({ [HOMOLOGUER]: LECTURE }),
+    middleware.trouveService(AutorisationBase.DROITS_DOSSIER_DECISION_PDF),
     middleware.trouveDossierCourant,
     (requete, reponse, suite) => {
       const { homologation, dossierCourant } = requete;
@@ -92,7 +82,7 @@ const routesApiServicePdf = (
 
   routes.get(
     '/:id/pdf/syntheseSecurite.pdf',
-    middleware.trouveService({ [SECURISER]: LECTURE, [DECRIRE]: LECTURE }),
+    middleware.trouveService(AutorisationBase.DROIT_SYNTHESE_SECURITE_PDF),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 

--- a/src/vues/tiroirs/tiroirTelechargement.pug
+++ b/src/vues/tiroirs/tiroirTelechargement.pug
@@ -7,12 +7,11 @@ mixin documentTelechargeable(nom, description, type, idLien, peutEtreIndisponibl
         p.titre-document= nom
         p.description-document!= description
     a.lien-telechargement.bouton(href='', target='_blank', rel='noopener', id=idLien) Télécharger
-    if (peutEtreIndisponible)
-      p.lien-indisponible Document non disponible
+    p.lien-indisponible Document non disponible
 
 .bloc-contenu#contenu-telechargement
   form.conteneur-formulaire
     +documentTelechargeable('Synthèse de la sécurité du service', "Ce PDF résume en 1 page l'état de la sécurité du service.", 'PDF', 'lien-synthese')
     +documentTelechargeable('Annexes', 'Ce PDF détaille toutes les informations renseignées sur la sécurité du service.', 'PDF', 'lien-annexes')
-    +documentTelechargeable("Décision d'homologation de sécurité", "Ce PDF est le document de décision pouvant être signé par l'autorité d'homologation.", 'PDF', 'lien-decision', true)
+    +documentTelechargeable("Décision d'homologation de sécurité", "Ce PDF est le document de décision pouvant être signé par l'autorité d'homologation.", 'PDF', 'lien-decision')
     +documentTelechargeable('Tous les documents', 'Ce fichier .ZIP contient les <span id="nbPdfDisponibles"></span> PDFs à télécharger.', 'ZIP', 'lien-archive')

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -72,7 +72,7 @@ describe("L'objet d'API de `GET /service`", () => {
       },
       nombreContributeurs: 1 + 1,
       estCreateur: true,
-      documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
+      documentsPdfDisponibles: [],
       permissions: {
         suppressionContributeur: true,
       },

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -98,7 +98,7 @@ describe("L'objet d'API de `GET /services`", () => {
         },
         nombreContributeurs: 1 + 1,
         estCreateur: true,
-        documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
+        documentsPdfDisponibles: [],
         permissions: {
           suppressionContributeur: true,
         },

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1511,7 +1511,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statutHomologation: { id: 'nonRealisee', enCoursEdition: true },
         nombreContributeurs: 1,
         estCreateur: false,
-        documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
+        documentsPdfDisponibles: [],
         permissions: { suppressionContributeur: false },
       });
     });


### PR DESCRIPTION
:warning: Il faut modifier le wording pour l'archive zip avec une phrase statique : 'Ce fichier .ZIP contient tous les PDF'

On conditionne la disponibilité des PDF en fonction des permissions sur les diiférentes rubriques.
Les documents indispnibles sont affichés comme cela dans le tiroir :point_down: 

<img src="https://github.com/betagouv/mon-service-securise/assets/1643465/c876d579-e44e-4cc8-9cc7-5776feb06bf5" width =300>


