### PR TITLE
Enrichissement de la réponse du serveur pour les routes du parcours du service

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -1,6 +1,7 @@
 class EchecAutorisation extends Error {}
 class EchecEnvoiMessage extends Error {}
 class ErreurDroitsIncoherents extends Error {}
+class ErreurChainageMiddleware extends Error {}
 class ErreurModele extends Error {}
 class ErreurAutorisationExisteDeja extends ErreurModele {}
 class ErreurAutorisationInexistante extends ErreurModele {}
@@ -61,6 +62,7 @@ module.exports = {
   ErreurAutorisationInexistante,
   ErreurAvisInvalide,
   ErreurCategorieInconnue,
+  ErreurChainageMiddleware,
   ErreurDateHomologationInvalide,
   ErreurDateRenouvellementInvalide,
   ErreurDepartementInconnu,

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -8,7 +8,10 @@ const {
   verifieCoherenceDesDroits,
   Permissions: { LECTURE, INVISIBLE },
 } = require('../modeles/autorisations/gestionDroits');
-const { ErreurDroitsIncoherents } = require('../erreurs');
+const {
+  ErreurDroitsIncoherents,
+  ErreurChainageMiddleware,
+} = require('../erreurs');
 
 const middleware = (configuration = {}) => {
   const {
@@ -133,7 +136,7 @@ const middleware = (configuration = {}) => {
 
   const trouveDossierCourant = (requete, reponse, suite) => {
     if (!requete.homologation)
-      throw new Error(
+      throw new ErreurChainageMiddleware(
         'Une homologation doit être présente dans la requête. Manque-t-il un appel à `trouveService` ?'
       );
 
@@ -198,7 +201,7 @@ const middleware = (configuration = {}) => {
 
   const chargeAutorisationsService = (requete, reponse, suite) => {
     if (!requete.idUtilisateurCourant || !requete.homologation)
-      throw new Error(
+      throw new ErreurChainageMiddleware(
         'Un utilisateur courant et un service doivent être présent dans la requête. Manque-t-il un appel à `verificationJWT` et `trouveService` ?'
       );
     depotDonnees
@@ -229,7 +232,7 @@ const middleware = (configuration = {}) => {
 
   const challengeMotDePasse = (requete, reponse, suite) => {
     if (!requete.idUtilisateurCourant)
-      throw new Error(
+      throw new ErreurChainageMiddleware(
         'Un utilisateur courant doit être présent dans la requête. Manque-t-il un appel à `verificationJWT` ?'
       );
 

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -118,6 +118,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   routes.get(
     '/:id/risques',
     middleware.trouveService({ [RISQUES]: LECTURE }),
+    middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -152,6 +152,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   routes.get(
     '/:id/homologation/edition/etape/:idEtape',
     middleware.trouveService({ [HOMOLOGUER]: LECTURE }),
+    middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse, suite) => {
       const { homologation } = requete;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -61,6 +61,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   routes.get(
     '/:id/descriptionService',
     middleware.trouveService({ [DECRIRE]: LECTURE }),
+    middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -78,6 +78,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   routes.get(
     '/:id/mesures',
     middleware.trouveService({ [SECURISER]: LECTURE }),
+    middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -101,6 +101,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   routes.get(
     '/:id/rolesResponsabilites',
     middleware.trouveService({ [CONTACTS]: LECTURE }),
+    middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -135,6 +135,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   routes.get(
     '/:id/dossiers',
     middleware.trouveService({ [HOMOLOGUER]: LECTURE }),
+    middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
       const { homologation } = requete;

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -27,6 +27,11 @@ class ConstructeurAutorisation {
     return this;
   }
 
+  avecDroits(droits) {
+    this.donnees.droits = droits;
+    return this;
+  }
+
   construis() {
     return new AutorisationBase(this.donnees);
   }

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -1,6 +1,9 @@
 const expect = require('expect.js');
 const Middleware = require('../../src/http/middleware');
-const { ErreurDroitsIncoherents } = require('../../src/erreurs');
+const {
+  ErreurDroitsIncoherents,
+  ErreurChainageMiddleware,
+} = require('../../src/erreurs');
 const {
   uneAutorisation,
 } = require('../constructeurs/constructeurAutorisation');
@@ -261,6 +264,7 @@ describe('Le middleware MSS', () => {
       expect(() =>
         middleware.trouveDossierCourant(requete, reponse)
       ).to.throwError((e) => {
+        expect(e).to.be.an(ErreurChainageMiddleware);
         expect(e.message).to.equal(
           'Une homologation doit être présente dans la requête. Manque-t-il un appel à `trouveService` ?'
         );
@@ -600,6 +604,7 @@ describe('Le middleware MSS', () => {
       expect(() =>
         middleware.challengeMotDePasse(requete, reponse)
       ).to.throwError((e) => {
+        expect(e).to.be.an(ErreurChainageMiddleware);
         expect(e.message).to.equal(
           'Un utilisateur courant doit être présent dans la requête. Manque-t-il un appel à `verificationJWT` ?'
         );
@@ -714,6 +719,7 @@ describe('Le middleware MSS', () => {
       expect(() =>
         middleware.chargeAutorisationsService(requete, reponse, () => {})
       ).to.throwError((e) => {
+        expect(e).to.be.an(ErreurChainageMiddleware);
         expect(e.message).to.equal(
           'Un utilisateur courant et un service doivent être présent dans la requête. Manque-t-il un appel à `verificationJWT` et `trouveService` ?'
         );

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -126,6 +126,15 @@ describe('Le serveur MSS des routes /service/*', () => {
         );
     });
 
+    it("charge les autorisations du service pour l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
+          'http://localhost:1234/service/456/mesures',
+          done
+        );
+    });
+
     it("charge les préférences de l'utilisateur", (done) => {
       testeur
         .middleware()

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -240,6 +240,15 @@ describe('Le serveur MSS des routes /service/*', () => {
         );
     });
 
+    it("charge les autorisations du service pour l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
+          'http://localhost:1234/service/456/dossiers',
+          done
+        );
+    });
+
     it("charge les préférences de l'utilisateur", (done) => {
       testeur
         .middleware()

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -4,12 +4,9 @@ const expect = require('expect.js');
 const testeurMSS = require('../testeurMSS');
 const Homologation = require('../../../src/modeles/homologation');
 const {
-  Permissions,
-  Rubriques,
+  Permissions: { LECTURE },
+  Rubriques: { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES },
 } = require('../../../src/modeles/autorisations/gestionDroits');
-
-const { LECTURE } = Permissions;
-const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 
 describe('Le serveur MSS des routes /service/*', () => {
   const testeur = testeurMSS();
@@ -87,6 +84,15 @@ describe('Le serveur MSS des routes /service/*', () => {
         .middleware()
         .verifieRechercheService(
           [{ niveau: LECTURE, rubrique: DECRIRE }],
+          'http://localhost:1234/service/456/descriptionService',
+          done
+        );
+    });
+
+    it("charge les autorisations du service pour l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
           'http://localhost:1234/service/456/descriptionService',
           done
         );

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -175,6 +175,15 @@ describe('Le serveur MSS des routes /service/*', () => {
         );
     });
 
+    it("charge les autorisations du service pour l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
+          'http://localhost:1234/service/456/rolesResponsabilites',
+          done
+        );
+    });
+
     it("charge les préférences de l'utilisateur", (done) => {
       testeur
         .middleware()

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -205,6 +205,15 @@ describe('Le serveur MSS des routes /service/*', () => {
         );
     });
 
+    it("charge les autorisations du service pour l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
+          'http://localhost:1234/service/456/risques',
+          done
+        );
+    });
+
     it("charge les préférences de l'utilisateur", (done) => {
       testeur
         .middleware()

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -281,6 +281,15 @@ describe('Le serveur MSS des routes /service/*', () => {
         );
     });
 
+    it("charge les autorisations du service pour l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
+          'http://localhost:1234/service/456/homologation/edition/etape/dateTelechargement',
+          done
+        );
+    });
+
     it("charge les préférences de l'utilisateur", (done) => {
       testeur
         .middleware()


### PR DESCRIPTION
Pour chaque routes front du parcours service (Décrire, Sécuriser, Homologuer, Risques, Contacts), on enrichit la réponse du serveur avec `autorisationsService`.

Cela est fait dans le middleware.

Cela nous permet de masqué et/ou passer certaines composants du DOM en lecture seule.