### PR TITLE
[CORRECTION] REGEX pour l'invitation par email des contributeurs

### DIFF
--- a/svelte/lib/ChampAvecSuggestions.svelte
+++ b/svelte/lib/ChampAvecSuggestions.svelte
@@ -12,7 +12,7 @@
 
   const envoiEvenement = createEventDispatcher();
 
-  const REGEX_EMAIL = /[\w-.]+@[\w-.]{2,}\.\w{2,}/i;
+  const REGEX_EMAIL = /^[\w-.]+@[\w-.]{2,}\.\w{2,}$/i;
   $: proposeAjout = REGEX_EMAIL.test(saisie);
   $: suggestionsVisibles = saisie && (suggestions.length > 0 || proposeAjout);
 


### PR DESCRIPTION
Le REGEX `^$` permet de contraindre l'intégralité d'une chaine pour la fonction `String.test()`