### PR TITLE
Conditionne le parcours `Service` en lecture seule (sauf `HOMOLOGUER`)

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -42,6 +42,37 @@ form input {
   font-family: Marianne;
 }
 
+form :is(input, textarea)[readonly] {
+  background: #dbecf1;
+  user-select: none;
+  cursor: not-allowed;
+}
+
+form input[type='checkbox'][disabled] {
+  background: #dbecf1;
+  cursor: not-allowed;
+  border: none;
+}
+
+form input[type='radio'][disabled] {
+  background: #dbecf1;
+  cursor: not-allowed;
+  border: none;
+}
+
+form input[type='radio'][disabled]:checked {
+  background: white;
+  border: 1px solid #dbecf1;
+}
+
+form input[type='radio'][disabled]:before {
+  filter: brightness(0);
+}
+
+form input[type='checkbox'][disabled]:before {
+  border-color: black;
+}
+
 fieldset {
   margin: 0 0 1em 0;
   padding: 0 0 2em;
@@ -79,20 +110,14 @@ input[type='checkbox'] {
 }
 
 input[type='radio'] {
-  border: 0;
-  background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="45" style="fill: white; stroke: %232f3a43; stroke-width: 0.25em" /></svg>');
-  background-repeat: no-repeat;
-  background-size: contain;
+  border: 1.5px solid black;
+  border-radius: 50%;
+  cursor: pointer;
 }
 
-input[type='checkbox']:focus,
-input[type='radio']:focus {
+input[type='checkbox']:focus {
   outline: 0.5px solid var(--bleu-mise-en-avant);
   outline-offset: 2px;
-}
-
-input[type='radio']:focus {
-  border-radius: 1px;
 }
 
 input[type='checkbox']:checked {
@@ -102,7 +127,7 @@ input[type='checkbox']:checked {
 }
 
 input[type='radio']:checked {
-  background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="45" style="fill: white; stroke: %230f7ac7; stroke-width: 0.50em" /></svg>');
+  border-color: var(--bleu-mise-en-avant);
 }
 
 input[type='checkbox']:checked::before,

--- a/public/assets/styles/homologation/risques.css
+++ b/public/assets/styles/homologation/risques.css
@@ -28,8 +28,19 @@
   gap: 0.4em;
 }
 
-.niveau-gravite .disque:hover {
+.niveau-gravite .disque {
   cursor: pointer;
+}
+
+.niveau-gravite .curseur[readonly='true'] .disque {
+  cursor: not-allowed;
+}
+
+.niveau-gravite .curseur[readonly='true'] .disque:hover {
+  border-color: transparent;
+}
+
+.niveau-gravite .disque:hover {
   border-color: var(--bleu-anssi);
 }
 

--- a/public/assets/styles/modules/validation.css
+++ b/public/assets/styles/modules/validation.css
@@ -62,20 +62,12 @@ form.champ-unique .requis::before {
   margin: 2em 0;
 }
 
-:is(input, select, textarea):not(.intouche):valid {
+:is(input, select, textarea):not(.intouche):not([type='radio']):valid {
   border-color: var(--bleu-mise-en-avant);
-}
-
-input[type='radio']:not(.intouche):valid {
-  background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="45" style="fill: white; stroke: %230f7ac7; stroke-width: 0.50em" /></svg>');
 }
 
 :is(input, select, textarea):not(.intouche):invalid {
   border-color: var(--rose-anssi);
-}
-
-input[type='radio']:not(.intouche):invalid {
-  background-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="45" style="fill: white; stroke: %23ff6584; stroke-width: 0.50em" /></svg>');
 }
 
 :is(input, select, textarea):not(.intouche):invalid:focus {

--- a/public/modules/elementsDom/saisieRisqueSpecifique.js
+++ b/public/modules/elementsDom/saisieRisqueSpecifique.js
@@ -3,24 +3,31 @@ import {
   metsAJourAffichageNiveauGravite,
 } from '../interactions/saisieNiveauGravite.js';
 
-const $inputDescription = (index, description) =>
+const $inputDescription = (index, description, lectureSeule) =>
   $(`
 <input id="description-risque-specifique-${index}"
      name="description-risque-specifique-${index}"
      placeholder="Description du risque"
+     ${lectureSeule ? 'readonly' : ''}
      value="${description}">
   `);
 
 const $disque = (niveau) =>
   $(`<div class="disque" data-niveau="${niveau}"></div>`);
 
-const $curseur = (niveaux) =>
+const $curseur = (niveaux, lectureSeule) =>
   Object.keys(niveaux).reduce(
     ($acc, n) => $acc.append($disque(n)),
-    $('<div class="curseur"></div>')
+    $(`<div class="curseur" ${lectureSeule ? 'readonly' : ''}></div>`)
   );
 
-const $saisieNiveauGravite = (index, niveauGravite, niveaux, couleurs) => {
+const $saisieNiveauGravite = (
+  index,
+  niveauGravite,
+  niveaux,
+  couleurs,
+  lectureSeule
+) => {
   const $conteneurSaisie = $(`
 <div class="niveau-gravite">
 <input id="niveauGravite-risque-specifique-${index}"
@@ -29,8 +36,12 @@ const $saisieNiveauGravite = (index, niveauGravite, niveaux, couleurs) => {
        value="${niveauGravite}">
 </div>
   `);
-  $conteneurSaisie.append($curseur(niveaux), $('<div class="legende"></div>'));
-  brancheComportementSaisieNiveauGravite($conteneurSaisie, niveaux, couleurs);
+  $conteneurSaisie.append(
+    $curseur(niveaux, lectureSeule),
+    $('<div class="legende"></div>')
+  );
+  if (!lectureSeule)
+    brancheComportementSaisieNiveauGravite($conteneurSaisie, niveaux, couleurs);
 
   if (niveauGravite) {
     const { position, description } = niveaux[niveauGravite];
@@ -46,14 +57,21 @@ const $saisieNiveauGravite = (index, niveauGravite, niveaux, couleurs) => {
   return $conteneurSaisie;
 };
 
-const $textareaCommentaire = (index, commentaire) =>
+const $textareaCommentaire = (index, commentaire, lectureSeule) =>
   $(`
 <textarea id="commentaire-risque-specifique-${index}"
         name="commentaire-risque-specifique-${index}"
-        placeholder="Commentaires additionnels (facultatifs)">${commentaire}</textarea>
+        placeholder="Commentaires additionnels (facultatifs)"
+        ${lectureSeule ? 'readonly' : ''}>${commentaire}</textarea>
   `);
 
-const $saisieRisqueSpecifique = (index, niveaux, couleurs, donnees = {}) => {
+const $saisieRisqueSpecifique = (
+  index,
+  niveaux,
+  couleurs,
+  donnees = {},
+  lectureSeule = false
+) => {
   const { description = '', niveauGravite = '', commentaire = '' } = donnees;
 
   const $conteneur = $(
@@ -61,11 +79,11 @@ const $saisieRisqueSpecifique = (index, niveaux, couleurs, donnees = {}) => {
   );
 
   $('.synthese', $conteneur).append(
-    $inputDescription(index, description),
-    $saisieNiveauGravite(index, niveauGravite, niveaux, couleurs)
+    $inputDescription(index, description, lectureSeule),
+    $saisieNiveauGravite(index, niveauGravite, niveaux, couleurs, lectureSeule)
   );
 
-  $conteneur.append($textareaCommentaire(index, commentaire));
+  $conteneur.append($textareaCommentaire(index, commentaire, lectureSeule));
 
   return $conteneur;
 };

--- a/public/modules/saisieListeItems.js
+++ b/public/modules/saisieListeItems.js
@@ -12,11 +12,12 @@ const afficheZoneSaisieItem = (
   selecteur,
   zoneSaisie,
   ordreInverse,
+  lectureSeule,
   actionSurZoneSaisieApresAjout = () => {}
 ) => {
   const $conteneurSaisieItem = $(`
 <label class="item-ajoute">
-  <div class="icone-suppression"></div>
+  ${lectureSeule ? '' : '<div class="icone-suppression"></div>'}
 </label>
   `);
 
@@ -44,6 +45,7 @@ const brancheAjoutItem = (
       selecteurConteneur,
       cbZoneSaisie(index, {}),
       options.ordreInverse,
+      false,
       actionSurZoneSaisieApresAjout
     );
   });
@@ -53,14 +55,15 @@ const peupleListeItems = (
   selecteurConteneur,
   selecteurDonnees,
   cbZoneSaisie,
-  options = { ordreInverse: false }
+  options = { ordreInverse: false, lectureSeule: false }
 ) => {
   const donneesItems = JSON.parse($(selecteurDonnees).text());
   donneesItems.forEach((donnees, index) => {
     afficheZoneSaisieItem(
       selecteurConteneur,
       cbZoneSaisie(index, donnees),
-      options.ordreInverse
+      options.ordreInverse,
+      options.lectureSeule
     );
   });
 

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -16,13 +16,18 @@ import ajouteModalesInformations from '../modules/interactions/modalesInformatio
 
 $(() => {
   let indexMaxMesuresSpecifiques = 0;
+  const { estLectureSeule } = JSON.parse($('#autorisations-securiser').text());
 
   const $conteneurModalites = (nom) => {
     const $conteneur = $('<div class="informations-additionnelles"></div>');
     const $lien = $(
       '<a class="informations-additionnelles">Commentaires (facultatif)</a>'
     );
-    const $zoneSaisie = $(`<textarea id=${nom} name=${nom}></textarea>`);
+    const $zoneSaisie = $(
+      `<textarea id=${nom} name=${nom} ${
+        estLectureSeule ? 'readonly' : ''
+      }></textarea>`
+    );
     $zoneSaisie.hide();
 
     $lien.on('click', () => {
@@ -30,7 +35,10 @@ $(() => {
       if ($zoneSaisie.is(':visible')) $zoneSaisie.focus();
     });
 
-    $conteneur.append($lien, $zoneSaisie);
+    if (!estLectureSeule) {
+      $conteneur.append($lien);
+    }
+    $conteneur.append($zoneSaisie);
     return $conteneur;
   };
 
@@ -73,6 +81,7 @@ $(() => {
        value="${champ}"
        ${champ === valeur ? 'checked' : ''}
        type="radio"
+       ${estLectureSeule ? 'disabled' : ''}
        required>
 <label for="${nomChamp}-${champ}-mesure-specifique-${index}">${
             referentielChamp[champ]
@@ -118,6 +127,7 @@ $(() => {
           name="description-mesure-specifique-${index}"
           placeholder="Description de la mesure"
           value="${description}"
+          ${estLectureSeule ? 'readonly' : ''}
           required>
     <div class="message-erreur">L'intitulé est obligatoire. Veuillez le renseigner.</div>
   </label>
@@ -131,7 +141,9 @@ ${statuts}
   Précisions sur la mesure dans le cadre de votre organisation
   <textarea id="modalites-mesure-specifique-${index}"
             name="modalites-mesure-specifique-${index}"
-            placeholder="Modalités de mise en œuvre (facultatif)">${modalites}</textarea>
+            placeholder="Modalités de mise en œuvre (facultatif)" ${
+              estLectureSeule ? 'readonly' : ''
+            }>${modalites}</textarea>
 </label>
       `;
   };
@@ -155,6 +167,7 @@ ${statuts}
   const peupleMesuresSpecifiques = (...params) =>
     peupleListeItems(...params, zoneSaisieMesureSpecifique, {
       ordreInverse: true,
+      lectureSeule: estLectureSeule,
     });
 
   ajouteModalesInformations();

--- a/public/service/risques.js
+++ b/public/service/risques.js
@@ -15,6 +15,7 @@ import {
 
 $(() => {
   let indexMaxRisquesSpecifiques = 0;
+  const { estLectureSeule } = JSON.parse($('#autorisations-risques').text());
 
   const NIVEAUX_GRAVITE = JSON.parse(
     $('#donnees-referentiel-niveaux-gravite-risque').text()
@@ -25,7 +26,11 @@ $(() => {
 
   const ajouteZoneSaisieCommentairePourRisque = ($r, nom) => {
     const $lien = $('a.informations-additionnelles', $r);
-    const $zoneSaisie = $(`<textarea id=${nom} name=${nom}></textarea>`);
+    const $zoneSaisie = $(
+      `<textarea id=${nom} name=${nom} ${
+        estLectureSeule ? 'readonly' : ''
+      }></textarea>`
+    );
     $zoneSaisie.hide();
     $lien.click(() => $zoneSaisie.toggle());
 
@@ -54,7 +59,13 @@ $(() => {
   };
 
   const zoneSaisieRisqueSpecifique = (index, donnees) =>
-    $saisieRisqueSpecifique(index, NIVEAUX_GRAVITE, COULEURS, donnees);
+    $saisieRisqueSpecifique(
+      index,
+      NIVEAUX_GRAVITE,
+      COULEURS,
+      donnees,
+      estLectureSeule
+    );
 
   const brancheAjoutRisqueSpecifique = (...params) =>
     brancheAjoutItem(
@@ -64,12 +75,15 @@ $(() => {
     );
 
   const peupleRisquesSpecifiques = (...params) =>
-    peupleListeItems(...params, zoneSaisieRisqueSpecifique);
+    peupleListeItems(...params, zoneSaisieRisqueSpecifique, {
+      lectureSeule: estLectureSeule,
+    });
 
   ajouteModalesInformations();
 
   $('.risque').each((_, $r) => {
-    brancheComportementSaisieNiveauGravite($r, NIVEAUX_GRAVITE, COULEURS);
+    if (!estLectureSeule)
+      brancheComportementSaisieNiveauGravite($r, NIVEAUX_GRAVITE, COULEURS);
     ajouteZoneSaisieCommentairePourRisque($r, `commentaire-${$r.id}`);
   });
 

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutables.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutables.pug
@@ -1,4 +1,4 @@
-mixin zoneSaisieElementAjoutable(donneesElement, nom, index)
+mixin zoneSaisieElementAjoutable(donneesElement, nom, index, lectureSeule)
   each valeur, cle in donneesElement
     - var id = cle + '-' + nom + '-' + index;
     if valeur.label
@@ -8,24 +8,27 @@ mixin zoneSaisieElementAjoutable(donneesElement, nom, index)
       name = id,
       type = 'text',
       value != valeur.valeur,
-      placeholder = valeur.valeurExemple
+      placeholder = valeur.valeurExemple,
+      readonly = lectureSeule
     )
 
-mixin zoneSaisie(nom, donneesElement, index)
+mixin zoneSaisie(nom, donneesElement, index, lectureSeule)
   .item-ajoute
-    .icone-suppression
+    if(!lectureSeule)
+      .icone-suppression
     div(id = 'element-' + nom + '-' + index)
-      +zoneSaisieElementAjoutable(donneesElement, nom, index)
+      +zoneSaisieElementAjoutable(donneesElement, nom, index, lectureSeule)
 
-mixin elementsAjoutables({ identifiantConteneur, nom, donneesElements = [], texteLienAjouter = 'Ajouter', zoneSaisieVideVisible = false, structureZoneSaisieVide = {} })
+mixin elementsAjoutables({ identifiantConteneur, nom, donneesElements = [], texteLienAjouter = 'Ajouter', zoneSaisieVideVisible = false, structureZoneSaisieVide = {}, lectureSeule = false })
   div(id = identifiantConteneur class = 'elements-ajoutables')
     if zoneSaisieVideVisible && donneesElements.length === 0
-      +zoneSaisie(nom, structureZoneSaisieVide, 0)
+      +zoneSaisie(nom, structureZoneSaisieVide, 0, lectureSeule)
     each donneesElement, index in donneesElements
-      +zoneSaisie(nom, donneesElement, index)
-  a(
-    class = 'nouvel-item',
-    id = 'ajout-element-' + nom
-  )= texteLienAjouter
+      +zoneSaisie(nom, donneesElement, index, lectureSeule)
+  if(!lectureSeule)
+    a(
+      class = 'nouvel-item',
+      id = 'ajout-element-' + nom
+    )= texteLienAjouter
 
   script(type = 'module', src = '/statique/modules/elementsAjoutables.js')

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesActeurHomologation.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesActeurHomologation.pug
@@ -1,6 +1,6 @@
 include ./elementsAjoutables
 
-mixin elementsAjoutablesActeurHomologation({ donnees = [] })
+mixin elementsAjoutablesActeurHomologation({ donnees = [], lectureSeule = false})
   -
     var donneesElements = donnees.map(({ role, nom, fonction }) => ({
       role: ({ valeur: role, label: 'Rôle au regard du projet' }),
@@ -12,5 +12,6 @@ mixin elementsAjoutablesActeurHomologation({ donnees = [] })
     identifiantConteneur: 'acteurs-homologation',
     nom: 'acteur-homologation',
     donneesElements,
-    texteLienAjouter: 'Ajouter un acteur'
+    texteLienAjouter: 'Ajouter un acteur',
+    lectureSeule
   })

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesDescription.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesDescription.pug
@@ -1,6 +1,6 @@
 include ./elementsAjoutables.pug
 
-mixin elementsAjoutablesDescription({ identifiantConteneur, nom, valeurExemple = '', donnees = [], texteLienAjouter, zoneSaisieVideVisible })
+mixin elementsAjoutablesDescription({ identifiantConteneur, nom, valeurExemple = '', donnees = [], texteLienAjouter, zoneSaisieVideVisible, lectureSeule = false })
   - var donneesElements = donnees.map(donnee => ({ description: ({ valeur: donnee.description, valeurExemple })}))
   +elementsAjoutables({
     identifiantConteneur,
@@ -8,5 +8,6 @@ mixin elementsAjoutablesDescription({ identifiantConteneur, nom, valeurExemple =
     donneesElements,
     texteLienAjouter,
     zoneSaisieVideVisible,
-    structureZoneSaisieVide: ({ description: ({ valeur: '', valeurExemple })})
+    structureZoneSaisieVide: ({ description: ({ valeur: '', valeurExemple })}),
+    lectureSeule
   })

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesPartiePrenante.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesPartiePrenante.pug
@@ -1,6 +1,6 @@
 include ./elementsAjoutables
 
-mixin elementsAjoutablesPartiePrenante({ donnees = [] })
+mixin elementsAjoutablesPartiePrenante({ donnees = [], lectureSeule = false })
   -
     var donneesElements = donnees.map(({ nom, natureAcces, pointContact }) => ({
       nom: ({ valeur: nom, label: "Nom de l'entité" }),
@@ -12,5 +12,6 @@ mixin elementsAjoutablesPartiePrenante({ donnees = [] })
     identifiantConteneur: 'parties-prenantes-specifiques',
     nom: 'partie-prenante-specifique',
     donneesElements,
-    texteLienAjouter: 'Ajouter une partie prenante'
+    texteLienAjouter: 'Ajouter une partie prenante',
+    lectureSeule
   })

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -5,6 +5,8 @@ block append styles
   link(href = '/statique/assets/styles/homologation/descriptionService.css', rel = 'stylesheet')
 
 mixin formulaireDescriptionService(idHomologation)
+  - const estEnCreation = !idHomologation
+  - const estLectureSeule  = estEnCreation ? false : autorisationsService.DECRIRE.estLectureSeule
   form.homologation#homologation
     h1.action Décrire
     p.
@@ -20,6 +22,7 @@ mixin formulaireDescriptionService(idHomologation)
             type = 'text',
             value != service.nomService(),
             required
+            readonly = estLectureSeule
           )
           .message-erreur Le nom est obligatoire. Veuillez le renseigner.
           .message-erreur-specifique#nom-deja-utilise Ce nom est déjà utilisé pour un autre service. Veuillez en saisir un autre.
@@ -34,6 +37,7 @@ mixin formulaireDescriptionService(idHomologation)
             placeholder = 'ex : Agglomération de Mansart',
             value != service.descriptionService.organisationsResponsables.toString(),
             required
+            readonly = estLectureSeule
           )
           .message-erreur Ce champ est obligatoire. Veuillez le renseigner.
 
@@ -46,6 +50,7 @@ mixin formulaireDescriptionService(idHomologation)
           objetDonnees: service.descriptionService,
           messageErreur: 'Ce champ est obligatoire. Veuillez sélectionner une ou plusieurs options.',
           requis: true,
+          lectureSeule: estLectureSeule
         })
 
       .requis
@@ -57,6 +62,7 @@ mixin formulaireDescriptionService(idHomologation)
           objetDonnees: service.descriptionService,
           messageErreur: 'La provenance est obligatoire. Veuillez cocher une option.',
           requis: true,
+          lectureSeule: estLectureSeule
         })
 
       .requis
@@ -68,6 +74,7 @@ mixin formulaireDescriptionService(idHomologation)
           objetDonnees: service.descriptionService,
           messageErreur: 'Le statut est obligatoire. Veuillez cocher une option.',
           requis: true,
+          lectureSeule: estLectureSeule
         })
 
       label Présentation
@@ -75,6 +82,7 @@ mixin formulaireDescriptionService(idHomologation)
           id = 'presentation',
           name = 'presentation',
           placeholder = 'ex : site internet de la médiathèque permettant de créer un compte utilisateur, de réserver, prolonger leur réservation de contenus multimédia.',
+          readonly = estLectureSeule
         )= service.descriptionService.presentation
 
       label Accès
@@ -86,6 +94,7 @@ mixin formulaireDescriptionService(idHomologation)
           donnees: service.descriptionService.pointsAcces.toJSON(),
           texteLienAjouter: 'Ajouter un accès',
           zoneSaisieVideVisible: true,
+          lectureSeule: estLectureSeule
         })
 
     section
@@ -96,6 +105,7 @@ mixin formulaireDescriptionService(idHomologation)
         description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
         items: referentiel.fonctionnalites(),
         objetDonnees: service.descriptionService,
+        lectureSeule: estLectureSeule
       })
 
       +elementsAjoutablesDescription({
@@ -103,6 +113,7 @@ mixin formulaireDescriptionService(idHomologation)
         nom: 'fonctionnalite',
         donnees: service.descriptionService.fonctionnalitesSpecifiques.toJSON(),
         texteLienAjouter: 'Ajouter une fonctionnalité',
+        lectureSeule: estLectureSeule
       })
 
     section
@@ -113,6 +124,7 @@ mixin formulaireDescriptionService(idHomologation)
         description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
         items: referentiel.donneesCaracterePersonnel(),
         objetDonnees: service.descriptionService,
+        lectureSeule: estLectureSeule
       })
 
       +elementsAjoutablesDescription({
@@ -120,6 +132,7 @@ mixin formulaireDescriptionService(idHomologation)
         nom: 'donnees-sensibles',
         donnees: service.descriptionService.donneesSensiblesSpecifiques.toJSON(),
         texteLienAjouter: 'Ajouter des données',
+        lectureSeule: estLectureSeule
       })
 
     section
@@ -132,6 +145,7 @@ mixin formulaireDescriptionService(idHomologation)
           objetDonnees: service.descriptionService,
           messageErreur: 'La localisation des données est obligatoire. Veuillez cocher une option.',
           requis: true,
+          lectureSeule: estLectureSeule
         })
 
       .requis
@@ -143,6 +157,7 @@ mixin formulaireDescriptionService(idHomologation)
           objetDonnees: service.descriptionService,
           messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
           requis: true,
+          lectureSeule: estLectureSeule
         })
       .requis
         +inputOuiNon({
@@ -152,11 +167,13 @@ mixin formulaireDescriptionService(idHomologation)
           exempleOui: "Les mesures de sécurité à mettre en œuvre, proposées dans l'étape suivante « Sécuriser », seront renforcées (ex : réaliser un audit de sécurité approfondi, une analyse de risque Ebios Risk Manager, …).",
           messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
           requis: true,
+          lectureSeule: estLectureSeule
         })
 
-    if idHomologation
-      button.bouton#diagnostic(idHomologation = idHomologation) Enregistrer
-    else
-      button.bouton#diagnostic Valider
+    if !estLectureSeule
+      if !estEnCreation
+        button.bouton#diagnostic(idHomologation = idHomologation) Enregistrer
+      else
+        button.bouton#diagnostic Valider
 
   script(type = 'module', src = '/statique/service/descriptionService.js')

--- a/src/vues/fragments/inputChoix.pug
+++ b/src/vues/fragments/inputChoix.pug
@@ -1,4 +1,4 @@
-mixin inputChoix({ type, nom, titre, description, items, objetDonnees = service, messageErreur, decoration, requis = false })
+mixin inputChoix({ type, nom, titre, description, items, objetDonnees = service, messageErreur, decoration, requis = false, lectureSeule = false })
   - let valeursSelectionnees = objetDonnees[nom]
   - if (typeof valeursSelectionnees === 'boolean') valeursSelectionnees = (valeursSelectionnees ? 'oui' : 'non')
   - const requisGroupe = requis && type === 'checkbox' && Object.keys(items).length > 1
@@ -25,7 +25,8 @@ mixin inputChoix({ type, nom, titre, description, items, objetDonnees = service,
             : identifiant === valeursSelectionnees
         ),
         required = requisChamp,
-        title = ''
+        title = '',
+        disabled = lectureSeule
       )
       label(for = identifiantInput)= description
       br
@@ -34,7 +35,7 @@ mixin inputChoix({ type, nom, titre, description, items, objetDonnees = service,
         br
     .message-erreur=messageErreur
 
-mixin inputOuiNon({ nom, titre, objetDonnees, messageErreur, exempleOui, exempleNon, requis })
+mixin inputOuiNon({ nom, titre, objetDonnees, messageErreur, exempleOui, exempleNon, requis, lectureSeule = false })
   +inputChoix({
     nom,
     titre,
@@ -43,4 +44,5 @@ mixin inputOuiNon({ nom, titre, objetDonnees, messageErreur, exempleOui, exemple
     requis,
     type: 'radio',
     items: { oui: { description: 'Oui', exemple: exempleOui }, non: { description: 'Non', exemple: exempleNon } },
+    lectureSeule
   })

--- a/src/vues/fragments/inputIdentite.pug
+++ b/src/vues/fragments/inputIdentite.pug
@@ -1,15 +1,15 @@
-mixin inputIdentite({ role, nomParametre })
+mixin inputIdentite({ role, nomParametre, lectureSeule = false })
   label(for='aucuneAction')= role
     .saisie-role-responsabilite
       label(for = nomParametre) Prénom / Nom
       input(
         id = nomParametre, name = nomParametre, type = 'text',
-        value != service.rolesResponsabilites[nomParametre]
+        value != service.rolesResponsabilites[nomParametre], readonly=lectureSeule
       )
 
       - const nomParamFonction = `fonction${nomParametre.charAt(0).toUpperCase()}${nomParametre.slice(1)}`
       label(for = nomParamFonction) Fonction
       input(
         id = nomParamFonction, name = nomParamFonction, type = 'text',
-        value = service.rolesResponsabilites[nomParamFonction]
+        value = service.rolesResponsabilites[nomParamFonction], readonly=lectureSeule
       )

--- a/src/vues/fragments/inputPartiePrenante.pug
+++ b/src/vues/fragments/inputPartiePrenante.pug
@@ -1,4 +1,4 @@
-mixin inputPartiePrenante({ categorie, nomParametre, donnees })
+mixin inputPartiePrenante({ categorie, nomParametre, donnees, lectureSeule = false })
   label= categorie
     .saisie-role-responsabilite
       -
@@ -24,5 +24,5 @@ mixin inputPartiePrenante({ categorie, nomParametre, donnees })
         label(for = propriete.parametre)= propriete.libelle
         input(
           id = propriete.parametre, name = propriete.parametre, type = 'text',
-          value != donnees ? donnees[propriete.nom] : ''
+          value != donnees ? donnees[propriete.nom] : '', readonly = lectureSeule
         )

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -5,13 +5,14 @@ include ../cartes/statutHomologation
 include ../cartes/indiceCyber
 include ../cartes/recommandationsANSSI
 
-mixin inputMesure({ nom, titre, indispensable })
+mixin inputMesure({ nom, titre, indispensable, lectureSeule = false })
   +inputChoix({
     type: 'radio',
     nom: nom,
     titre: titre,
     items: service.descriptionStatutsMesures(),
     decoration: indispensable ? '<div class="mention-anssi mesure-indispensable">Indispensable</div>' : '',
+    lectureSeule: lectureSeule
   })
 
 block append styles
@@ -19,6 +20,7 @@ block append styles
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
 
 block formulaire
+  - const estLectureSeule  = autorisationsService.SECURISER.estLectureSeule
   form.homologation#mesures
     h1.action Sécuriser
     p.
@@ -44,6 +46,7 @@ block formulaire
               nom: identifiant,
               titre: donnees.description,
               indispensable: donnees.indispensable,
+              lectureSeule: estLectureSeule
             })
 
             .puce-information
@@ -52,9 +55,10 @@ block formulaire
                   .fermeture-modale
                   h1= donnees.description
                   p!= donnees.descriptionLongue
-    .enregistrement
-      button.bouton.bouton-secondaire.nouvel-item(type = 'button') Ajouter une mesure spécifique
-      button.bouton(idHomologation = service.id) Enregistrer
+    if (!estLectureSeule)
+      .enregistrement
+        button.bouton.bouton-secondaire.nouvel-item(type = 'button') Ajouter une mesure spécifique
+        button.bouton(idHomologation = service.id) Enregistrer
 
   script(id = 'donnees-mesures-generales', type = 'application/json').
     !{JSON.stringify(service.mesures.toJSON().mesuresGenerales || [])}
@@ -67,6 +71,9 @@ block formulaire
 
   script(id = 'referentiel-statuts-mesures', type = 'application/json').
     !{JSON.stringify(referentiel.statutsMesures())}
+
+  script(id = 'autorisations-securiser', type = 'application/json').
+    !{JSON.stringify(autorisationsService.SECURISER)}
 
   script(type = 'module', src = '/statique/service/mesures.js')
 

--- a/src/vues/service/risques.pug
+++ b/src/vues/service/risques.pug
@@ -6,6 +6,7 @@ block append styles
   link(href = '/statique/assets/styles/homologation/risques.css', rel = 'stylesheet')
 
 block formulaire
+  - const estLectureSeule  = autorisationsService.RISQUES.estLectureSeule
   form.homologation#risques
     h1.action Risques de sécurité
     p.
@@ -31,18 +32,21 @@ block formulaire
                 name = `niveauGravite-${identifiant}`,
                 value = '',
               )
-              .curseur
+              .curseur(readonly=`${estLectureSeule}`)
                 each niveau in referentiel.identifiantsNiveauxGravite()
                   .disque(data-niveau = niveau)
               .legende
-          a.informations-additionnelles Commentaires (facultatif)
+          if(!estLectureSeule)
+            a.informations-additionnelles Commentaires (facultatif)
 
     section
       label Risques spécifiques au service numérique
       #risques-specifiques
-      a.nouvel-item Ajouter un risque spécifique
+      if(!estLectureSeule)
+        a.nouvel-item Ajouter un risque spécifique
 
-    .bouton(idHomologation = service.id) Enregistrer &nbsp;&nbsp;›
+    if(!estLectureSeule)
+      .bouton(idHomologation = service.id) Enregistrer &nbsp;&nbsp;›
 
   script(id = 'donnees-referentiel-niveaux-gravite-risque', type = 'application/json').
     !{JSON.stringify(referentiel.niveauxGravite())}
@@ -50,6 +54,8 @@ block formulaire
     !{JSON.stringify(service.risques.toJSON().risquesGeneraux || [])}
   script(id = 'donnees-risques-specifiques', type = 'application/json').
     !{JSON.stringify(service.risques.toJSON().risquesSpecifiques || [])}
+  script(id = 'autorisations-risques', type = 'application/json').
+    !{JSON.stringify(autorisationsService.RISQUES)}
   script(type = 'module', src = '/statique/service/risques.js')
 
 block cartes-informations

--- a/src/vues/service/rolesResponsabilites.pug
+++ b/src/vues/service/rolesResponsabilites.pug
@@ -8,6 +8,7 @@ block append styles
   link(href = '/statique/assets/styles/homologation/rolesResponsabilites.css', rel = 'stylesheet')
 
 block formulaire
+  - const estLectureSeule  = autorisationsService.CONTACTS.estLectureSeule
   form.homologation#roles-responsabilites
     h1.action Rôles et responsabilités
     p.
@@ -22,25 +23,30 @@ block formulaire
         +inputIdentite({
           role: "Autorité d'homologation",
           nomParametre: 'autoriteHomologation',
+          lectureSeule: estLectureSeule
         })
 
         +inputIdentite({
           role: 'Spécialiste cybersécurité',
           nomParametre: 'expertCybersecurite',
+          lectureSeule: estLectureSeule
         })
 
         +inputIdentite({
           role: 'Délégué(e) à la protection des données à caractère personnel',
           nomParametre: 'delegueProtectionDonnees',
+          lectureSeule: estLectureSeule
         })
 
         +inputIdentite({
           role: 'Responsable métier du projet',
           nomParametre: 'piloteProjet',
+          lectureSeule: estLectureSeule
         })
 
         +elementsAjoutablesActeurHomologation({
           donnees: service.rolesResponsabilites.acteursHomologation.toJSON(),
+          lectureSeule: estLectureSeule
         })
 
       .onglet#parties-prenantes
@@ -48,30 +54,36 @@ block formulaire
           categorie: 'Hébergement du service',
           nomParametre: 'hebergement',
           donnees: service.rolesResponsabilites.partiesPrenantes.hebergement(),
+          lectureSeule: estLectureSeule
         })
 
         +inputPartiePrenante({
           categorie: 'Développement / fourniture du service',
           nomParametre: 'developpementFourniture',
           donnees: service.rolesResponsabilites.partiesPrenantes.developpementFourniture(),
+          lectureSeule: estLectureSeule
         })
 
         +inputPartiePrenante({
           categorie: 'Maintenance du service',
           nomParametre: 'maintenanceService',
           donnees: service.rolesResponsabilites.partiesPrenantes.maintenanceService(),
+          lectureSeule: estLectureSeule
         })
 
         +inputPartiePrenante({
           categorie: 'Gestion de la sécurité du service',
           nomParametre: 'securiteService',
           donnees: service.rolesResponsabilites.partiesPrenantes.securiteService(),
+          lectureSeule: estLectureSeule
         })
 
         +elementsAjoutablesPartiePrenante({
           donnees: service.rolesResponsabilites.partiesPrenantes.specifiques(),
+          lectureSeule: estLectureSeule
         })
 
-    .bouton(idHomologation = service.id) Enregistrer &nbsp;&nbsp;›
+    if(!estLectureSeule)
+      .bouton(idHomologation = service.id) Enregistrer &nbsp;&nbsp;›
 
   script(type = 'module', src = '/statique/service/rolesResponsabilites.js')


### PR DESCRIPTION
On conditionne en lecture seule tous les champs à remplir dans les rubriques `DECRIRE`, `SECURISER`, `RISQUES` et `CONTACTS UTILES`.
L'étape `HOMOLOGUER` sera gérée dans une deuxième PR car plus complexe.

Le conditionnement est fait :
- Avec l'attribut `readonly` sur les `input[type="text"]` et `textarea`
- Avec l'attribut `disabled` sur les `checkbox`, `radio` et autre