### PR TITLE
[CORRECTION] Abonnement aux emails marketing

### DIFF
--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -12,7 +12,7 @@ const enteteJSON = {
   },
 };
 const urlBase = process.env.SENDINBLUE_EMAIL_API_URL_BASE;
-const idListeEmailsTransactionnels = Number(
+const idListeEmailsMarketing = Number(
   process.env.SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE
 );
 
@@ -39,7 +39,7 @@ const creeContact = (
   destinataire,
   prenom,
   nom,
-  bloqueEmails,
+  bloqueNewsletter,
   bloqueMarketing
 ) =>
   axios
@@ -47,9 +47,9 @@ const creeContact = (
       `${urlBase}/contacts`,
       {
         email: destinataire,
-        emailBlacklisted: bloqueEmails,
+        emailBlacklisted: bloqueNewsletter,
         attributes: { PRENOM: decode(prenom), NOM: decode(nom) },
-        ...(!bloqueMarketing && { listIds: [idListeEmailsTransactionnels] }),
+        ...(!bloqueMarketing && { listIds: [idListeEmailsMarketing] }),
       },
       enteteJSON
     )
@@ -66,7 +66,7 @@ const creeContact = (
 const inscrisEmailsTransactionnels = async (destinataire) => {
   // https://developers.brevo.com/reference/addcontacttolist-1
   const url = new URL(
-    `${urlBase}/contacts/lists/${idListeEmailsTransactionnels}/contacts/add`
+    `${urlBase}/contacts/lists/${idListeEmailsMarketing}/contacts/add`
   );
 
   try {
@@ -88,7 +88,7 @@ const inscrisEmailsTransactionnels = async (destinataire) => {
 const desinscrisEmailsTransactionnels = async (destinataire) => {
   // https://developers.brevo.com/reference/removecontactfromlist
   const url = new URL(
-    `${urlBase}/contacts/lists/${idListeEmailsTransactionnels}/contacts/remove`
+    `${urlBase}/contacts/lists/${idListeEmailsMarketing}/contacts/remove`
   );
 
   try {

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -35,7 +35,13 @@ const desinscrisInfolettre = (destinataire) =>
 const inscrisInfolettre = (destinataire) =>
   basculeInfolettre(destinataire, false);
 
-const creeContact = (destinataire, prenom, nom, bloqueEmails) =>
+const creeContact = (
+  destinataire,
+  prenom,
+  nom,
+  bloqueEmails,
+  bloqueMarketing
+) =>
   axios
     .post(
       `${urlBase}/contacts`,
@@ -43,7 +49,7 @@ const creeContact = (destinataire, prenom, nom, bloqueEmails) =>
         email: destinataire,
         emailBlacklisted: bloqueEmails,
         attributes: { PRENOM: decode(prenom), NOM: decode(nom) },
-        listIds: [idListeEmailsTransactionnels],
+        ...(!bloqueMarketing && { listIds: [idListeEmailsTransactionnels] }),
       },
       enteteJSON
     )

--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -39,7 +39,7 @@ const ajoutContributeurSurServices = ({
       email,
       infolettreAcceptee: false,
     });
-    await adaptateurMail.creeContact(email, '', '', true);
+    await adaptateurMail.creeContact(email, '', '', true, true);
     return utilisateur;
   };
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -162,7 +162,8 @@ const routesApiPrivee = ({
         .metsAJourMotDePasse(idUtilisateur, motDePasse)
         .then(depotDonnees.valideAcceptationCGUPourUtilisateur)
         .then(depotDonnees.supprimeIdResetMotDePassePourUtilisateur)
-        .then((utilisateur) => {
+        .then(async (utilisateur) => {
+          await adaptateurMail.inscrisEmailsTransactionnels(utilisateur.email);
           requete.session.token = utilisateur.genereToken();
           reponse.json({ idUtilisateur });
         })

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -40,7 +40,8 @@ const routesApiPublique = ({
             utilisateur.email,
             utilisateur.prenom ?? '',
             utilisateur.nom ?? '',
-            !utilisateur.infolettreAcceptee
+            !utilisateur.infolettreAcceptee,
+            false
           ),
           utilisateur
         );

--- a/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
+++ b/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
@@ -12,7 +12,7 @@
 
   const envoiEvenement = createEventDispatcher();
 
-  const REGEX_EMAIL = /^[\w-.]+@[\w-.]{2,}\.\w{2,}$/i;
+  const REGEX_EMAIL = /^[\w+-.]+@[\w-.]{2,}\.\w{2,}$/i;
   $: proposeAjout = REGEX_EMAIL.test(saisie);
   $: suggestionsVisibles = saisie && (suggestions.length > 0 || proposeAjout);
 

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -246,15 +246,22 @@ describe("L'ajout d'un contributeur sur des services", () => {
       expect(emailAjoute).to.be('jean.dupont@mail.fr');
     });
 
-    it('crée un contact email', async () => {
+    it('crée un contact email (qui refuse les emails marketing pour le moment)', async () => {
       let contactCree;
       adaptateurMail.creeContact = async (
         destinataire,
         prenom,
         nom,
-        bloqueEmails
+        bloqueEmails,
+        bloqueMarketing
       ) => {
-        contactCree = { destinataire, prenom, nom, bloqueEmails };
+        contactCree = {
+          destinataire,
+          prenom,
+          nom,
+          bloqueEmails,
+          bloqueMarketing,
+        };
       };
 
       await ajoutContributeurSurServices({
@@ -267,6 +274,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       expect(contactCree.prenom).to.be('');
       expect(contactCree.nom).to.be('');
       expect(contactCree.bloqueEmails).to.be(true);
+      expect(contactCree.bloqueMarketing).to.be(true);
     });
 
     it("envoie un mail d'invitation au contributeur créé", async () => {

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -455,6 +455,28 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         .catch((e) => done(e.response?.data || e));
     });
 
+    it("ajoute l'utilisateur à la liste marketing Brevo via l'adaptateur", async () => {
+      let inscriptionEffectuee;
+
+      testeur.depotDonnees().supprimeIdResetMotDePassePourUtilisateur =
+        async () => ({
+          id: '123',
+          email: 'jean.dujardin@beta.gouv.fr',
+          genereToken: () => 'un token',
+        });
+      testeur.adaptateurMail().inscrisEmailsTransactionnels = async (
+        emailUtilisateur
+      ) => {
+        inscriptionEffectuee = emailUtilisateur;
+      };
+
+      await axios.put('http://localhost:1234/api/motDePasse', {
+        motDePasse: 'mdp_ABC12345',
+      });
+
+      expect(inscriptionEffectuee).to.equal('jean.dujardin@beta.gouv.fr');
+    });
+
     it("invalide l'identifiant de réinitialisation de mot de passe", (done) => {
       let idResetSupprime = false;
 

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -178,12 +178,14 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         destinataire,
         prenom,
         nom,
-        bloqueEmails
+        bloqueEmails,
+        bloqueMarketing
       ) => {
         expect(destinataire).to.equal('jean.dupont@mail.fr');
         expect(prenom).to.equal('Jean');
         expect(nom).to.equal('Dupont');
         expect(bloqueEmails).to.equal(true);
+        expect(bloqueMarketing).to.be(false);
         return Promise.resolve();
       };
 


### PR DESCRIPTION
Pour ne pas abonner les personnes seulement sur la base d'une invitation, cette PR corrige le workflow déclenchant un abonnement Brevo.

### AVANT
 - A invite B
 - B se retrouve immédiatement abonné aux emails marketing Brevo

### APRÈS
 - A invite B
 - Brevo n'est pas sollicité
 - C'est seulement lorsque B se connecte (le lien de connexion est dans le mail d'invitation) et accepte les CGU que Brevo est sollicité