### PR TITLE
Rubrique `HOMOLOGUER` en lecture seule

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -818,8 +818,18 @@ module.exports = {
     { numero: 2, libelle: 'Avis', id: 'avis' },
     { numero: 3, libelle: 'Documents', id: 'documents' },
     { numero: 4, libelle: 'Décision', id: 'dateTelechargement' },
-    { numero: 5, libelle: 'Date', id: 'decision' },
-    { numero: 6, libelle: 'Récapitulatif', id: 'recapitulatif' },
+    {
+      numero: 5,
+      libelle: 'Date',
+      id: 'decision',
+      reserveePeutHomologuer: true,
+    },
+    {
+      numero: 6,
+      libelle: 'Récapitulatif',
+      id: 'recapitulatif',
+      reserveePeutHomologuer: true,
+    },
   ],
 
   etapeNecessairePourDossierDecision: 'dateTelechargement',

--- a/public/assets/styles/etapesDossier.css
+++ b/public/assets/styles/etapesDossier.css
@@ -171,7 +171,7 @@ section.autorite {
 .boutons {
   display: flex;
   flex: 1;
-  justify-content: space-between;
+  justify-content: end;
   align-items: center;
   margin-left: 7em;
 }

--- a/public/assets/styles/modules/selectize.css
+++ b/public/assets/styles/modules/selectize.css
@@ -190,3 +190,16 @@
   transform: translateY(3px);
   visibility: visible;
 }
+
+.selectize-control .selectize-input.disabled {
+  opacity: 1 !important;
+  background: #dbecf1 !important;
+}
+
+.selectize-control .selectize-input.disabled .item {
+  padding: 0.4em !important;
+}
+
+.selectize-control .selectize-input.disabled .remove {
+  display: none !important;
+}

--- a/public/service/homologation/formulaireEtape.js
+++ b/public/service/homologation/formulaireEtape.js
@@ -6,6 +6,7 @@ import {
 let formulaireDejaSoumis = false;
 
 const brancheComportemenFormulaireEtape = (actionSoumission) => {
+  const { estLectureSeule } = JSON.parse($('#autorisations-homologuer').text());
   const $boutonSuivant = $('.bouton#suivant');
 
   const selecteurFormulaire = 'form';
@@ -14,18 +15,22 @@ const brancheComportemenFormulaireEtape = (actionSoumission) => {
 
   brancheValidation(selecteurFormulaire);
 
+  const versEtapeSuivante = () =>
+    (window.location = idEtapeSuivante
+      ? `/service/${idService}/homologation/edition/etape/${idEtapeSuivante}`
+      : `/service/${idService}/dossiers`);
+
   $(selecteurFormulaire).on('submit', (e) => {
     e.preventDefault();
 
+    if (estLectureSeule) {
+      versEtapeSuivante();
+      return;
+    }
+
     if (!formulaireDejaSoumis) {
       formulaireDejaSoumis = true;
-
-      actionSoumission(idService, selecteurFormulaire).then(
-        () =>
-          (window.location = idEtapeSuivante
-            ? `/service/${idService}/homologation/edition/etape/${idEtapeSuivante}`
-            : `/service/${idService}/dossiers`)
-      );
+      actionSoumission(idService, selecteurFormulaire).then(versEtapeSuivante);
     }
   });
 

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -207,15 +207,22 @@ const middleware = (configuration = {}) => {
     depotDonnees
       .autorisationPour(requete.idUtilisateurCourant, requete.homologation.id)
       .then((autorisation) => {
-        reponse.locals.autorisationsService = Object.fromEntries(
-          Object.entries(autorisation.droits).map(([rubrique, niveau]) => [
-            [rubrique],
-            {
+        const droitsRubriques = Object.entries(autorisation.droits).reduce(
+          (droits, [rubrique, niveau]) => ({
+            ...droits,
+            [rubrique]: {
               estLectureSeule: niveau === LECTURE,
               estMasque: niveau === INVISIBLE,
             },
-          ])
+          }),
+          {}
         );
+
+        reponse.locals.autorisationsService = {
+          ...droitsRubriques,
+          peutHomologuer: autorisation.peutHomologuer(),
+        };
+
         suite();
       });
   };

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -1,6 +1,6 @@
 const Base = require('../base');
 const {
-  Rubriques: { DECRIRE, SECURISER, RISQUES, HOMOLOGUER },
+  Rubriques: { DECRIRE, SECURISER, RISQUES, HOMOLOGUER, CONTACTS },
   Permissions: { LECTURE, ECRITURE },
   Rubriques,
   Permissions,
@@ -40,6 +40,10 @@ class AutorisationBase extends Base {
     );
   }
 
+  peutHomologuer() {
+    return this.aLesPermissions(AutorisationBase.DROITS_HOMOLOGUER);
+  }
+
   resumeNiveauDroit() {
     const tousNiveaux = Object.values(Permissions).reduce(
       (acc, niveau) => ({ ...acc, [niveau]: 0 }),
@@ -65,6 +69,14 @@ class AutorisationBase extends Base {
     ECRITURE: 'ECRITURE',
     LECTURE: 'LECTURE',
     PERSONNALISE: 'PERSONNALISE',
+  };
+
+  static DROITS_HOMOLOGUER = {
+    [DECRIRE]: ECRITURE,
+    [SECURISER]: ECRITURE,
+    [HOMOLOGUER]: ECRITURE,
+    [RISQUES]: ECRITURE,
+    [CONTACTS]: ECRITURE,
   };
 
   static DROITS_ANNEXES_PDF = {

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -60,8 +60,11 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     ids
       ?.map((id) => descriptionDonneesCaracterePersonnel(id))
       .filter((id) => id !== undefined);
-  const etapesParcoursHomologation = () =>
-    donnees.etapesParcoursHomologation || [];
+  const etapesParcoursHomologation = (peutHomologuer = true) => {
+    const etapes = donnees.etapesParcoursHomologation || [];
+    if (peutHomologuer) return etapes;
+    return etapes.filter((etape) => !etape.reserveePeutHomologuer);
+  };
   const identifiantsEcheancesRenouvellement = () =>
     Object.keys(echeancesRenouvellement());
   const estIdentifiantEcheanceRenouvellementConnu = (idEcheance) =>

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -194,6 +194,19 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     return numeroEtapeCourante >= numeroEtapeSuffisante;
   };
 
+  const etapeDossierAutorisee = (idEtape, peutHomologuer) => {
+    if (peutHomologuer) return idEtape;
+    const etapesDisponibles = etapesParcoursHomologation(peutHomologuer);
+    const numeroMaxDisponible = Math.max(
+      ...etapesDisponibles.map((e) => e.numero)
+    );
+    const numeroEtapeAutorisee = Math.min(
+      numeroEtape(idEtape),
+      numeroMaxDisponible
+    );
+    return etapesDisponibles.find((e) => e.numero === numeroEtapeAutorisee)?.id;
+  };
+
   const valideDonnees = () => {
     const sommeCoefficients =
       coefficientIndiceCyberMesuresIndispensables() +
@@ -260,6 +273,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     estDocumentHomologation,
     estIdentifiantEcheanceRenouvellementConnu,
     estIdentifiantStatutAvisDossierHomologationConnu,
+    etapeDossierAutorisee,
     etapeExiste,
     etapesParcoursHomologation,
     etapeSuffisantePourDossierDecision,

--- a/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutablesAvis.pug
@@ -1,6 +1,6 @@
 include ../inputChoix
 
-mixin zoneSaisieUnAvis(donneesUnAvis = {}, index = 0, indexAvis = index + 1)
+mixin zoneSaisieUnAvis({donneesUnAvis = {}, index = 0, indexAvis = index + 1, lectureSeule = false})
   div(id = `element-un-avis-${index}`)
     .cartouche: h3 Avis n°#{indexAvis}
     .contenu
@@ -11,7 +11,8 @@ mixin zoneSaisieUnAvis(donneesUnAvis = {}, index = 0, indexAvis = index + 1)
             name = `collaborateurs-un-avis-${index}`,
             placeholder = 'ex: Louis Martin',
             required,
-            multiple
+            multiple,
+            disabled = lectureSeule
           )
             each collaborateur in donneesUnAvis.collaborateurs || []
               option(value!= collaborateur, selected) !{collaborateur}
@@ -29,6 +30,7 @@ mixin zoneSaisieUnAvis(donneesUnAvis = {}, index = 0, indexAvis = index + 1)
             requis: true,
             messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
             objetDonnees: donneesUnAvis,
+            lectureSeule: lectureSeule
           })
 
       - donneesUnAvis[`dureeValidite-un-avis-${index}`] = donneesUnAvis.dureeValidite
@@ -41,6 +43,7 @@ mixin zoneSaisieUnAvis(donneesUnAvis = {}, index = 0, indexAvis = index + 1)
             requis: true,
             messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
             objetDonnees: donneesUnAvis,
+            lectureSeule: lectureSeule
           })
 
       label.texte-libre Commentaires et recommandations
@@ -49,19 +52,21 @@ mixin zoneSaisieUnAvis(donneesUnAvis = {}, index = 0, indexAvis = index + 1)
           id = `commentaires-un-avis-${index}`,
           name = `commentaires-un-avis-${index}`,
           placeholder = 'ex : favorable pour la mise en ligne sous réserve que certaines mesures soient réalisées dans 1 mois.',
+          readonly = lectureSeule
         )!= donneesUnAvis.commentaires
 
-mixin unAvis(donneesUnAvis = {}, index = 0)
+mixin unAvis(donneesUnAvis = {}, index = 0, lectureSeule = false)
   .item-ajoute
-    .icone-suppression
-    +zoneSaisieUnAvis(donneesUnAvis, index)
+    if(!lectureSeule)
+        .icone-suppression
+    +zoneSaisieUnAvis({donneesUnAvis, index, lectureSeule})
 
-mixin elementsAjoutablesAvis(donneesAvis = [])
+mixin elementsAjoutablesAvis(donneesAvis = [], lectureSeule = false)
   .elements-ajoutables#avis
     #element-ajoutable-template.invisible
-      +zoneSaisieUnAvis({}, 'INDEX', 'INDEX_AVIS')
+      +zoneSaisieUnAvis({donneesUnAvis:{}, index:'INDEX', indexAvis: 'INDEX_AVIS'})
 
     each donneesUnAvis, index in donneesAvis 
-      +unAvis(donneesUnAvis, index)
+      +unAvis(donneesUnAvis, index, lectureSeule)
 
   script(type = 'module', src = '/statique/modules/elementsAjoutables.js')

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -6,6 +6,7 @@ mixin dossier({ statut, dossier, idService })
     const etapeCourante = dossier.etapeCourante()
     const numeroDerniereEtapeCompletee = referentiel.numeroEtape(etapeCourante) - 1
     const nombreTotalEtapes = referentiel.derniereEtapeParcours().numero
+    const estLectureSeule = autorisationsService.HOMOLOGUER.estLectureSeule
 
   .dossier
     .contenu-dossier
@@ -15,7 +16,8 @@ mixin dossier({ statut, dossier, idService })
           div= `Durée : ${dossier.descriptionDureeValidite()}`
           div= `Prochaine homologation : ${dossier.descriptionProchaineDateHomologation()}`
         else
-          div= `Étapes complétées : ${numeroDerniereEtapeCompletee} / ${nombreTotalEtapes}`
+          if(!estLectureSeule)
+            div= `Étapes complétées : ${numeroDerniereEtapeCompletee} / ${nombreTotalEtapes}`
     if idService
       nav
         a(href = `/service/${idService}/homologation/edition/etape/${etapeCourante}`) Consulter
@@ -46,9 +48,12 @@ block formulaire
     script(type = "module", src = "/statique/service/homologation/dossiers.js")
 
 block bouton-etape
-  - const etapeSuivante = dossierCourant?.etapeCourante() ?? premiereEtapeParcours.id
+  -
+    const etapeSuivante = dossierCourant?.etapeCourante() ?? premiereEtapeParcours.id
+    const estLectureSeule = autorisationsService.HOMOLOGUER.estLectureSeule
 
-  button.bouton#suivant(
-    data-id-homologation = service.id,
-    data-id-etape-suivante = etapeSuivante
-    ) Nouvelle homologation
+  if(!estLectureSeule)
+    button.bouton#suivant(
+      data-id-homologation = service.id,
+      data-id-etape-suivante = etapeSuivante
+      ) Nouvelle homologation

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -3,7 +3,7 @@ include ../fragments/texteTronque
 
 mixin dossier({ statut, dossier, idService })
   -
-    const etapeCourante = dossier.etapeCourante()
+    const etapeCourante = referentiel.etapeDossierAutorisee(dossier.etapeCourante(), autorisationsService.peutHomologuer)
     const numeroDerniereEtapeCompletee = referentiel.numeroEtape(etapeCourante) - 1
     const nombreTotalEtapes = referentiel.derniereEtapeParcours().numero
     const estLectureSeule = autorisationsService.HOMOLOGUER.estLectureSeule

--- a/src/vues/service/etapeDossier/autorite.pug
+++ b/src/vues/service/etapeDossier/autorite.pug
@@ -1,7 +1,9 @@
 extends ../formulaireEtapierRecommandation
 
 block formulaire
-  - const dossierCourant = service.dossierCourant()
+  -
+    const dossierCourant = service.dossierCourant()
+    const estLectureSeule  = autorisationsService.HOMOLOGUER.estLectureSeule
 
   section.autorite
     p.
@@ -13,12 +15,12 @@ block formulaire
 
   .requis
     label Prénom Nom
-      input(id = 'nom-prenom' nom = 'nomPrénom', type = 'text', placeholder = 'ex: Louis Martin', required, value != dossierCourant.autorite.nom)
+      input(id = 'nom-prenom' nom = 'nomPrénom', type = 'text', placeholder = 'ex: Louis Martin', required, value != dossierCourant.autorite.nom, readonly = estLectureSeule)
       .message-erreur Le prénom nom est obligatoire. Veuillez renseigner des lettres. Les chiffres ne sont pas autorisés. 
 
   .requis
     label Fonction
-      input(id = 'fonction' nom = 'fonction', type = 'text', placeholder = "ex : Maire et membre du conseil communautaire de l'Agglomération de Mansart", required, value != dossierCourant.autorite.fonction)
+      input(id = 'fonction' nom = 'fonction', type = 'text', placeholder = "ex : Maire et membre du conseil communautaire de l'Agglomération de Mansart", required, value != dossierCourant.autorite.fonction, readonly = estLectureSeule)
       .message-erreur La fonction est obligatoire. Veuillez la renseigner. 
 
   script(type = "module", src = "/statique/service/homologation/etapes/autorite.js")

--- a/src/vues/service/etapeDossier/avis.pug
+++ b/src/vues/service/etapeDossier/avis.pug
@@ -15,6 +15,7 @@ block formulaire
   -
     const avis = service.dossierCourant().avis
     const avecAvisRadio = { avecAvis: avis.avecAvis === null ? null : avis.avecAvis ? 1 : 0 }
+    const estLectureSeule  = autorisationsService.HOMOLOGUER.estLectureSeule
 
   +inputChoix({
     type: 'radio',
@@ -23,9 +24,10 @@ block formulaire
     objetDonnees: avecAvisRadio,
     messageErreur: 'Ce champ est obligatoire. Veuillez choisir une option.',
     requis: true,
+    lectureSeule: estLectureSeule
   })
 
-  +elementsAjoutablesAvis(service.dossierCourant().avis.avis)
+  +elementsAjoutablesAvis(service.dossierCourant().avis.avis, estLectureSeule)
 
   script(type = "module", src = "/statique/service/homologation/etapes/avis.js")
   script(src = "/statique/bibliotheques/selectize-0.15.2.min.js")
@@ -34,10 +36,11 @@ block bouton-etape
     -
       const afficheBoutonAjout = service.dossierCourant().avis.avecAvis === true
       const cssAffichage = afficheBoutonAjout ? '' : 'invisible'
-    a(
-      class = `nouvel-item bouton bouton-secondaire ${cssAffichage}`
-      id = 'ajout-element-un-avis'
-    ) Ajouter un avis
+    if(!estLectureSeule)
+      a(
+        class = `nouvel-item bouton bouton-secondaire ${cssAffichage}`
+        id = 'ajout-element-un-avis'
+      ) Ajouter un avis
     button.bouton#suivant(
       data-id-homologation = service.id,
       data-id-etape = idEtape,

--- a/src/vues/service/etapeDossier/dateTelechargement.pug
+++ b/src/vues/service/etapeDossier/dateTelechargement.pug
@@ -4,37 +4,46 @@ block append styles
   link(href = '/statique/assets/styles/etapesDossier/decision.css', rel = 'stylesheet')
 
 block formulaire
-  - const formatDateCourt = Intl.DateTimeFormat('fr-CA', { year: 'numeric', month: '2-digit', day: '2-digit' });
-  - const formatDateLong = Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeStyle: 'short' });
-  - const maintenant = new Date();
-  - const nomFichier = `MSS_decision_${formatDateCourt.format(maintenant).replaceAll('-', '')}.zip`
-  - const dateTelechargement = service.dossierCourant()?.dateTelechargement.date;
+  -
+    const formatDateCourt = Intl.DateTimeFormat('fr-CA', { year: 'numeric', month: '2-digit', day: '2-digit' });
+    const formatDateLong = Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeStyle: 'short' });
+    const maintenant = new Date();
+    const nomFichier = `MSS_decision_${formatDateCourt.format(maintenant).replaceAll('-', '')}.zip`
+    const dateTelechargement = service.dossierCourant()?.dateTelechargement.date;
+    const peutHomologuer  = autorisationsService.peutHomologuer
 
-  span Voici les étapes à suivre pour finaliser l'homologation de sécurité de votre service :
-  .conteneur-telechargement
-    a.document-homologation(
-      href=`/api/service/${service.id}/pdf/documentsHomologation.zip`
-      data-action-enregistrement=`/api/service/${service.id}/homologation/telechargement`
-      target='_blank'
-      rel='noopener'
-    )= nomFichier
-    if(dateTelechargement)
-      span.date-telechargement= `Dernier téléchargement le : ${formatDateLong.format(new Date(dateTelechargement))}`
-  
-  .validation-telechargement
-    input(type='text', required, value=dateTelechargement)
-    .message-erreur Vous devez télécharger ce fichier .ZIP pour pouvoir passer à l'étape suivante.
-  
-  ul.consignes
-    li Télécharger le fichier .ZIP contenant les 3 PDF : synthèse de sécurité, annexes et décision d'homologation de sécurité.
-    li Présenter, pour signature, la décision d'homologation de sécurité à l'autorité d'homologation ainsi que la synthèse de la sécurité.
-    li Se reconnecter ensuite pour renseigner la date de signature et la durée de validité de l'homologation dans les dernières étapes Date et Récapitulatif.
+  if(peutHomologuer)
+    span Voici les étapes à suivre pour finaliser l'homologation de sécurité de votre service :
+    .conteneur-telechargement
+      a.document-homologation(
+        href=`/api/service/${service.id}/pdf/documentsHomologation.zip`
+        data-action-enregistrement=`/api/service/${service.id}/homologation/telechargement`
+        target='_blank'
+        rel='noopener'
+      )= nomFichier
+      if(dateTelechargement)
+        span.date-telechargement= `Dernier téléchargement le : ${formatDateLong.format(new Date(dateTelechargement))}`
 
-  script(type = "module", src = "/statique/service/homologation/etapes/decision.js")
+    .validation-telechargement
+      input(type='text', required, value=dateTelechargement)
+      .message-erreur Vous devez télécharger ce fichier .ZIP pour pouvoir passer à l'étape suivante.
+
+    ul.consignes
+      li Télécharger le fichier .ZIP contenant les 3 PDF : synthèse de sécurité, annexes et décision d'homologation de sécurité.
+      li Présenter, pour signature, la décision d'homologation de sécurité à l'autorité d'homologation ainsi que la synthèse de la sécurité.
+      li Se reconnecter ensuite pour renseigner la date de signature et la durée de validité de l'homologation dans les dernières étapes Date et Récapitulatif.
+
+    script(type = "module", src = "/statique/service/homologation/etapes/decision.js")
+  else
+    p Le PDF de la décision d’homologation de sécurité est disponible pour le(s) propriétaire(s) du service.
+    p Une fois signée par l’autorité d’homologation, le statut et la durée d’homologation pour ce service apparaîtront dans la liste des homologations et sur votre tableau de bord.
 
 block bouton-etape
-  button.bouton#suivant(
-    data-id-homologation = service.id,
-    data-id-etape = idEtape,
-    data-id-etape-suivante = referentiel.idEtapeSuivante(idEtape)
+  if(peutHomologuer)
+    button.bouton#suivant(
+      data-id-homologation = service.id,
+      data-id-etape = idEtape,
+      data-id-etape-suivante = referentiel.idEtapeSuivante(idEtape)
     ) Suivant
+  else
+    a.bouton(href=`/service/${service.id}/dossiers`) Aller à la liste des homologations

--- a/src/vues/service/etapeDossier/documents.pug
+++ b/src/vues/service/etapeDossier/documents.pug
@@ -14,6 +14,7 @@ block formulaire
   -
     const documents = service.dossierCourant().documents
     const avecDocumentsRadio = { avecDocuments: documents.avecDocuments === null ? null : documents.avecDocuments ? 1 : 0 }
+    const estLectureSeule  = autorisationsService.HOMOLOGUER.estLectureSeule
 
   +inputChoix({
     type: 'radio',
@@ -22,13 +23,15 @@ block formulaire
     objetDonnees: avecDocumentsRadio,
     messageErreur: 'Ce champ est obligatoire. Veuillez choisir une option.',
     requis: true,
+    lectureSeule: estLectureSeule
   })
 
   fieldset#documents
     p.requis Titre et informations utiles
-    .ajout-documents
-      input#champ-titre-document(type='text', placeholder='ex : Analyse Ebios juin 2022')
-      button.bouton.bouton-secondaire#ajout-document(type='button') Ajouter
+    if(!estLectureSeule)
+      .ajout-documents
+        input#champ-titre-document(type='text', placeholder='ex : Analyse Ebios juin 2022')
+        button.bouton.bouton-secondaire#ajout-document(type='button') Ajouter
     div
       input(id='au-moins-un-document', class='invisible', type='text', required, value=documents.documents.length > 0 ? 'OK' : '')
       .message-erreur Ce champ est obligatoire. Veuillez le renseigner. 
@@ -36,7 +39,8 @@ block formulaire
       each document in documents.documents
         li.element-document(data-document=document)
           .contenu!= document
-          .bouton-supprimer
+          if(!estLectureSeule)
+            .bouton-supprimer
 
   script(type = 'module', src = '/statique/service/homologation/etapes/documents.js')
 

--- a/src/vues/service/formulaireEtapier.pug
+++ b/src/vues/service/formulaireEtapier.pug
@@ -6,7 +6,7 @@ mixin descriptionEtape({ etape })
 
 mixin barre-progression({ numeroEtapeCourante })
   .etapes
-    each etape in referentiel.etapesParcoursHomologation()
+    each etape in referentiel.etapesParcoursHomologation(autorisationsService.peutHomologuer)
       -
         let classeEtape = 'courante';
         if (etape.numero < numeroEtapeCourante) classeEtape = 'passee';

--- a/src/vues/service/formulaireEtapier.pug
+++ b/src/vues/service/formulaireEtapier.pug
@@ -42,3 +42,6 @@ block zone-principale
         a(href = `/service/${service.id}`) Revenir à la synthèse
         .boutons-etape
           block bouton-etape
+
+  script(id = 'autorisations-homologuer', type = 'application/json').
+    !{JSON.stringify(autorisationsService.HOMOLOGUER)}

--- a/src/vues/service/formulaireEtapier.pug
+++ b/src/vues/service/formulaireEtapier.pug
@@ -39,7 +39,6 @@ block zone-principale
 
     .enregistrement
       .boutons
-        a(href = `/service/${service.id}`) Revenir à la synthèse
         .boutons-etape
           block bouton-etape
 

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -762,6 +762,7 @@ describe('Le middleware MSS', () => {
             DECRIRE: { estLectureSeule: false, estMasque: false },
             SECURISER: { estLectureSeule: true, estMasque: false },
             HOMOLOGUER: { estLectureSeule: false, estMasque: true },
+            peutHomologuer: false,
           });
           done();
         } catch (e) {

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -109,6 +109,7 @@ const middlewareFantaisie = {
       [HOMOLOGUER]: {},
       [RISQUES]: {},
       [CONTACTS]: {},
+      peutHomologuer: true,
     };
     autorisationsChargees = true;
     suite();

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -518,7 +518,7 @@ describe('Le référentiel', () => {
       expect(positions).to.eql([2, 1]);
     });
 
-    it('inclue les identifiants dans les informations', () => {
+    it('inclut les identifiants dans les informations', () => {
       const referentiel = Referentiel.creeReferentiel({
         niveauxGravite: {
           niveauUn: { position: 0 },
@@ -733,7 +733,7 @@ describe('Le référentiel', () => {
   });
 
   describe("sur demande des etapes du parcours d'homologation", () => {
-    it("inclue toutes les étapes s'il n'y a pas de paramètres", () => {
+    it("inclut toutes les étapes s'il n'y a pas de paramètres", () => {
       const referentiel = Referentiel.creeReferentiel({
         etapesParcoursHomologation: [{ numero: 1 }, { numero: 2 }],
       });
@@ -742,7 +742,7 @@ describe('Le référentiel', () => {
       expect(etapes.length).to.equal(2);
     });
 
-    it('inclue toutes les étapes si `peutHomologuer` est vrai', () => {
+    it('inclut toutes les étapes si `peutHomologuer` est vrai', () => {
       const referentiel = Referentiel.creeReferentiel({
         etapesParcoursHomologation: [{ numero: 1 }, { numero: 2 }],
       });
@@ -752,7 +752,7 @@ describe('Le référentiel', () => {
       expect(etapes.length).to.equal(2);
     });
 
-    it("n'inclue pas les étapes réservée à l'homologation si `peutHomologuer` est faux", () => {
+    it("n'inclut pas les étapes réservée à l'homologation si `peutHomologuer` est faux", () => {
       const referentiel = Referentiel.creeReferentiel({
         etapesParcoursHomologation: [
           { numero: 1 },

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -776,4 +776,44 @@ describe('Le référentiel', () => {
       id: 'nouveauté',
     });
   });
+
+  describe("sur demande de l'étape autorisée du dossier", () => {
+    let referentiel;
+    beforeEach(() => {
+      referentiel = Referentiel.creeReferentiel({
+        etapesParcoursHomologation: [
+          { numero: 1, id: 'id-autorisee-pour-tous' },
+          {
+            numero: 2,
+            id: 'id-autorisee-seulement-homologation',
+            reserveePeutHomologuer: true,
+          },
+        ],
+      });
+    });
+
+    it("renvoie l'id de la même étape s'il s'agit d'un homologateur car il peut voir toutes les étapes", () => {
+      expect(
+        referentiel.etapeDossierAutorisee(
+          'id-autorisee-seulement-homologation',
+          true
+        )
+      ).to.be('id-autorisee-seulement-homologation');
+    });
+
+    it("renvoie l'id de l'étape maximale autorisée s'il s'agit d'un non-homologateur car il n'a pas le droit d'accès aux étapes d'homologation", () => {
+      expect(
+        referentiel.etapeDossierAutorisee(
+          'id-autorisee-seulement-homologation',
+          false
+        )
+      ).to.be('id-autorisee-pour-tous');
+    });
+
+    it("renvoie l'id de la même étape si l'étape demandée n'est pas reservée aux homologateurs", () => {
+      expect(
+        referentiel.etapeDossierAutorisee('id-autorisee-pour-tous', false)
+      ).to.be('id-autorisee-pour-tous');
+    });
+  });
 });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -732,6 +732,41 @@ describe('Le référentiel', () => {
     });
   });
 
+  describe("sur demande des etapes du parcours d'homologation", () => {
+    it("inclue toutes les étapes s'il n'y a pas de paramètres", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        etapesParcoursHomologation: [{ numero: 1 }, { numero: 2 }],
+      });
+
+      const etapes = referentiel.etapesParcoursHomologation();
+      expect(etapes.length).to.equal(2);
+    });
+
+    it('inclue toutes les étapes si `peutHomologuer` est vrai', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        etapesParcoursHomologation: [{ numero: 1 }, { numero: 2 }],
+      });
+      const peutHomologuer = true;
+
+      const etapes = referentiel.etapesParcoursHomologation(peutHomologuer);
+      expect(etapes.length).to.equal(2);
+    });
+
+    it("n'inclue pas les étapes réservée à l'homologation si `peutHomologuer` est faux", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        etapesParcoursHomologation: [
+          { numero: 1 },
+          { numero: 2, reserveePeutHomologuer: true },
+        ],
+      });
+      const nePeutPasHomologuer = false;
+
+      const etapes =
+        referentiel.etapesParcoursHomologation(nePeutPasHomologuer);
+      expect(etapes.length).to.equal(1);
+    });
+  });
+
   it('sait renvoyer une nouvelle fonctionnalité via son id', () => {
     const referentiel = Referentiel.creeReferentiel({
       nouvellesFonctionnalites: [{ id: 'nouveauté' }],


### PR DESCRIPTION
La rubrique `HOMOLOGUER` est différente des autres rubrique dans le cas de la lecture seule.

- D'une part, les champs de saisie sont passés en lecture seule, comme les autres rubriques
<img src="https://github.com/betagouv/mon-service-securise/assets/1643465/6f33e2af-f796-43ce-970f-832211721676" width=300>

- D'autre part, l'étape 4 est modifiée dans le cas où un utilisateur n'a pas la permission `peutHomologuer`
<img src="https://github.com/betagouv/mon-service-securise/assets/1643465/04c24367-9cfb-49e2-9c05-893cd191d728" width=300>

Les boutons `Suivant` n'effectue plus l'action de `POST` en cas de lecture seule.
On en profite pour supprimer le bouton `Revenir à la synthèse` qui n'a plus lieu d'être.

Le résumé des dossiers d'homologation n'indique plus l'étape actuelle en cas de lecture seule.
<img src="https://github.com/betagouv/mon-service-securise/assets/1643465/832f67ed-d518-4dab-85d8-5eb1c4063c10" width=300>

