### PR TITLE
Cesse de lancer `npm test` dans la tâche de `build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": "9"
   },
   "scripts": {
-    "build": "knex migrate:latest && npm test && npm run cree-utilisateur-demo && npx vite build --config svelte/vite.config.mts",
+    "build": "knex migrate:latest && npm run cree-utilisateur-demo && npx vite build --config svelte/vite.config.mts",
     "cree-utilisateur-demo": "node creeUtilisateurDemo.js",
     "test": "eslint . && mocha",
     "test:mocha": "mocha",


### PR DESCRIPTION
Suite à des recherches de @bbougon nous comprenons que lancer les `tests` dans notre step de `build` va induire l'installation des `devDependencies` (car elles sont nécessaires aux tests) chez Scalingo.

On choisit de ne plus lancer les tests au moment du `build` puisqu'ils sont déjà exécutés par la CI.

Cela nous permet :
 - de raccourcir le temps de build chez Scalingo
 - ET SURTOUT de ne plus installer les `devDependencies` chez Scalingo : donc la taille de notre image est réduite.