### PR TITLE
Ajout de la route `/service/:id/autorisations`

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -179,6 +179,9 @@ const nouvelAdaptateur = (
         .map((a) => a.idHomologation)
     );
 
+  const autorisationsDuService = async (idService) =>
+    donnees.autorisations.filter((a) => a.idService === idService);
+
   const autorisationPour = (idUtilisateur, idHomologation) =>
     Promise.resolve(
       donnees.autorisations.find(
@@ -320,6 +323,7 @@ const nouvelAdaptateur = (
     autorisation,
     autorisationPour,
     autorisations,
+    autorisationsDuService,
     homologation,
     homologationAvecNomService,
     homologations,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -204,6 +204,14 @@ const nouvelAdaptateur = (env) => {
       .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
       .then((rows) => rows.map(convertisLigneEnObjet));
 
+  const autorisationsDuService = async (idService) => {
+    const as = await knex('autorisations').whereRaw(
+      "donnees->>'idService'=?",
+      idService
+    );
+    return as.map(convertisLigneEnObjet);
+  };
+
   const idsHomologationsCreeesParUtilisateur = (
     idUtilisateur,
     idsHomologationsAExclure = []
@@ -394,6 +402,7 @@ const nouvelAdaptateur = (env) => {
     autorisation,
     autorisationPour,
     autorisations,
+    autorisationsDuService,
     homologation,
     homologationAvecNomService,
     homologations,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -93,6 +93,7 @@ const creeDepot = (config = {}) => {
     autorisationExiste,
     autorisationPour,
     autorisations,
+    autorisationsDuService,
     supprimeContributeur,
     transfereAutorisations,
   } = depotAutorisations;
@@ -112,6 +113,7 @@ const creeDepot = (config = {}) => {
     autorisationExiste,
     autorisationPour,
     autorisations,
+    autorisationsDuService,
     dupliqueHomologation,
     homologation,
     homologationExiste,

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -43,6 +43,11 @@ const creeDepot = (config = {}) => {
       .autorisation(id)
       .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
 
+  const autorisationsDuService = async (id) => {
+    const as = await adaptateurPersistance.autorisationsDuService(id);
+    return as.map((a) => FabriqueAutorisation.fabrique(a));
+  };
+
   const autorisationPour = (...params) =>
     adaptateurPersistance
       .autorisationPour(...params)
@@ -151,6 +156,7 @@ const creeDepot = (config = {}) => {
     autorisationExiste,
     autorisationPour,
     autorisations,
+    autorisationsDuService,
     supprimeContributeur,
     transfereAutorisations,
   };

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -1,7 +1,9 @@
 const Base = require('../base');
 const {
   Rubriques: { DECRIRE, SECURISER, RISQUES, HOMOLOGUER },
-  Permissions: { LECTURE },
+  Permissions: { LECTURE, ECRITURE },
+  Rubriques,
+  Permissions,
 } = require('./gestionDroits');
 
 class AutorisationBase extends Base {
@@ -31,6 +33,33 @@ class AutorisationBase extends Base {
       this.aLaPermission(niveau, rubrique)
     );
   }
+
+  resumeNiveauDroit() {
+    const tousNiveaux = Object.values(Permissions).reduce(
+      (acc, niveau) => ({ ...acc, [niveau]: 0 }),
+      {}
+    );
+    const toutesRubriques = Object.keys(Rubriques);
+    const totalRubriques = toutesRubriques.length;
+
+    toutesRubriques.forEach((rubrique) => {
+      const droitPourRubrique = this.droits[rubrique];
+      tousNiveaux[droitPourRubrique] += 1;
+    });
+
+    if (tousNiveaux[ECRITURE] === totalRubriques)
+      return AutorisationBase.RESUME_NIVEAU_DROIT.ECRITURE;
+    if (tousNiveaux[LECTURE] === totalRubriques)
+      return AutorisationBase.RESUME_NIVEAU_DROIT.LECTURE;
+
+    return AutorisationBase.RESUME_NIVEAU_DROIT.PERSONNALISE;
+  }
+
+  static RESUME_NIVEAU_DROIT = {
+    ECRITURE: 'ECRITURE',
+    LECTURE: 'LECTURE',
+    PERSONNALISE: 'PERSONNALISE',
+  };
 
   static DROITS_ANNEXES_PDF = {
     [DECRIRE]: LECTURE,

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -34,6 +34,12 @@ class AutorisationBase extends Base {
     );
   }
 
+  peutGererContributeurs() {
+    return (
+      this.permissionAjoutContributeur && this.permissionSuppressionContributeur
+    );
+  }
+
   resumeNiveauDroit() {
     const tousNiveaux = Object.values(Permissions).reduce(
       (acc, niveau) => ({ ...acc, [niveau]: 0 }),

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -478,6 +478,24 @@ const routesApiService = (
     }
   );
 
+  routes.get(
+    '/:id/autorisations',
+    middleware.trouveService({}),
+    middleware.aseptise('id'),
+    async (requete, reponse) => {
+      const { id: idService } = requete.homologation;
+      const autorisations =
+        await depotDonnees.autorisationsDuService(idService);
+
+      reponse.json(
+        autorisations.map((a) => ({
+          idUtilisateur: a.idUtilisateur,
+          resumeNiveauDroit: a.resumeNiveauDroit(),
+        }))
+      );
+    }
+  );
+
   return routes;
 };
 

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -483,9 +483,20 @@ const routesApiService = (
     middleware.trouveService({}),
     middleware.aseptise('id'),
     async (requete, reponse) => {
-      const { id: idService } = requete.homologation;
-      const autorisations =
-        await depotDonnees.autorisationsDuService(idService);
+      const { id: idService, createur } = requete.homologation;
+      let autorisations = await depotDonnees.autorisationsDuService(idService);
+
+      const autorisationUtilisateurCourant = autorisations.find(
+        (a) => a.idUtilisateur === requete.idUtilisateurCourant
+      );
+
+      if (!autorisationUtilisateurCourant.peutGererContributeurs()) {
+        autorisations = autorisations.filter(
+          (a) =>
+            a.idUtilisateur === createur.id ||
+            a.idUtilisateur === requete.idUtilisateurCourant
+        );
+      }
 
       reponse.json(
         autorisations.map((a) => ({

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -1,4 +1,8 @@
-const AutorisationBase = require('../../src/modeles/autorisations/autorisationBase');
+const {
+  toutDroitsEnEcriture,
+} = require('../../src/modeles/autorisations/gestionDroits');
+const AutorisationCreateur = require('../../src/modeles/autorisations/autorisationCreateur');
+const AutorisationContributeur = require('../../src/modeles/autorisations/autorisationContributeur');
 
 class ConstructeurAutorisation {
   constructor() {
@@ -7,7 +11,7 @@ class ConstructeurAutorisation {
       idUtilisateur: '',
       idHomologation: '',
       idService: '',
-      type: '',
+      type: 'contributeur',
       droits: {},
     };
   }
@@ -33,8 +37,15 @@ class ConstructeurAutorisation {
     return this;
   }
 
+  avecTousDroitsEcriture() {
+    this.donnees.droits = toutDroitsEnEcriture();
+    return this;
+  }
+
   construis() {
-    return new AutorisationBase(this.donnees);
+    return this.donnees.type === 'createur'
+      ? new AutorisationCreateur(this.donnees)
+      : new AutorisationContributeur(this.donnees);
   }
 }
 

--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -43,9 +43,13 @@ class ConstructeurService {
     return this;
   }
 
-  avecNContributeurs(combien) {
+  avecNContributeurs(combien, ids = []) {
     for (let i = 0; i < combien; i += 1) {
-      this.donnees.contributeurs.push(unUtilisateur().donnees);
+      let { donnees } = unUtilisateur();
+      if (ids.length) {
+        donnees = unUtilisateur().avecId(ids[i]).donnees;
+      }
+      this.donnees.contributeurs.push(donnees);
     }
     return this;
   }

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -4,7 +4,7 @@ class ConstructeurUtilisateur {
   constructor() {
     this.donnees = {
       dateCreation: '',
-      id: '',
+      id: '999',
       idResetMotDePasse: '',
       prenom: '',
       nom: '',

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -20,6 +20,9 @@ const {
   Rubriques,
   Permissions,
 } = require('../../src/modeles/autorisations/gestionDroits');
+const {
+  uneAutorisation,
+} = require('../constructeurs/constructeurAutorisation');
 
 const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 const { ECRITURE, LECTURE } = Permissions;
@@ -508,5 +511,30 @@ describe('Le dépôt de données des autorisations', () => {
       const apres = await depot.autorisationPour('000', '123');
       expect(apres).to.be(undefined);
     });
+  });
+
+  it('connaît toutes les autorisations pour un service donné', async () => {
+    const adaptateurPersistance = unePersistanceMemoire()
+      .ajouteUnUtilisateur({ id: '888' })
+      .ajouteUnUtilisateur({ id: '999' })
+      .ajouteUnService({
+        id: '123',
+        descriptionService: { nomService: 'Un service' },
+      })
+      .ajouteUneAutorisation(
+        uneAutorisation().deCreateurDeService('888', '123').donnees
+      )
+      .ajouteUneAutorisation(
+        uneAutorisation().deContributeurDeService('999', '123').donnees
+      )
+      .construis();
+
+    const depot = creeDepot(adaptateurPersistance);
+
+    const a = await depot.autorisationsDuService('123');
+
+    expect(a.length).to.be(2);
+    expect(a[0]).to.be.an(AutorisationCreateur);
+    expect(a[1]).to.be.an(AutorisationContributeur);
   });
 });

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -5,6 +5,8 @@ const {
   Permissions,
   Rubriques,
 } = require('../../../src/modeles/autorisations/gestionDroits');
+const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
+const AutorisationCreateur = require('../../../src/modeles/autorisations/autorisationCreateur');
 
 const { ECRITURE, LECTURE, INVISIBLE } = Permissions;
 const { DECRIRE, SECURISER, HOMOLOGUER, RISQUES, CONTACTS } = Rubriques;
@@ -123,6 +125,20 @@ describe('Une autorisation de base', () => {
       expect(autorisationLecture.resumeNiveauDroit()).to.equal(
         AutorisationBase.RESUME_NIVEAU_DROIT.PERSONNALISE
       );
+    });
+  });
+
+  describe('sur demande de permission de gestion des contributeurs', () => {
+    it("retourne 'false' si l'autorisation ne provient pas d'un créateur", () => {
+      const autorisationContributeur = new AutorisationContributeur();
+
+      expect(autorisationContributeur.peutGererContributeurs()).to.be(false);
+    });
+
+    it("retourne 'true' si l'autorisation provient d'un créateur", () => {
+      const autorisationCreateur = new AutorisationCreateur();
+
+      expect(autorisationCreateur.peutGererContributeurs()).to.be(true);
     });
   });
 });

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -7,7 +7,7 @@ const {
 } = require('../../../src/modeles/autorisations/gestionDroits');
 
 const { ECRITURE, LECTURE, INVISIBLE } = Permissions;
-const { DECRIRE, SECURISER } = Rubriques;
+const { DECRIRE, SECURISER, HOMOLOGUER, RISQUES, CONTACTS } = Rubriques;
 
 describe('Une autorisation de base', () => {
   it("ne permet pas d'ajouter un contributeur", () => {
@@ -74,5 +74,55 @@ describe('Une autorisation de base', () => {
 
     expect(peutLire).to.be(false);
     expect(peutEcrire).to.be(false);
+  });
+
+  describe('sur demande de résumé de niveau de droit', () => {
+    it("retourne 'ECRITURE' si tous les droits sont en ECRITURE", () => {
+      const autorisationLecture = new AutorisationBase({
+        droits: {
+          [DECRIRE]: ECRITURE,
+          [SECURISER]: ECRITURE,
+          [HOMOLOGUER]: ECRITURE,
+          [RISQUES]: ECRITURE,
+          [CONTACTS]: ECRITURE,
+        },
+      });
+
+      expect(autorisationLecture.resumeNiveauDroit()).to.equal(
+        AutorisationBase.RESUME_NIVEAU_DROIT.ECRITURE
+      );
+    });
+
+    it("retourne 'LECTURE' si tous les droits sont en LECTURE", () => {
+      const autorisationLecture = new AutorisationBase({
+        droits: {
+          [DECRIRE]: LECTURE,
+          [SECURISER]: LECTURE,
+          [HOMOLOGUER]: LECTURE,
+          [RISQUES]: LECTURE,
+          [CONTACTS]: LECTURE,
+        },
+      });
+
+      expect(autorisationLecture.resumeNiveauDroit()).to.equal(
+        AutorisationBase.RESUME_NIVEAU_DROIT.LECTURE
+      );
+    });
+
+    it("retourne 'PERSONNALISE' si les droits sont mixtes", () => {
+      const autorisationLecture = new AutorisationBase({
+        droits: {
+          [DECRIRE]: LECTURE,
+          [SECURISER]: ECRITURE,
+          [HOMOLOGUER]: LECTURE,
+          [RISQUES]: ECRITURE,
+          [CONTACTS]: ECRITURE,
+        },
+      });
+
+      expect(autorisationLecture.resumeNiveauDroit()).to.equal(
+        AutorisationBase.RESUME_NIVEAU_DROIT.PERSONNALISE
+      );
+    });
   });
 });


### PR DESCRIPTION
On ajoute la route `/service/:id/autorisation` pour pouvoir alimenter par la suite le tiroir contributeurs.

Cette route retourne soit :
- Tout les statuts de droit de tous les utilisateurs du service, si j'en suis créateur
- Uniquement mon statut et celui du propriétaire, si j'en suis contributeur
