### PR TITLE
Composant « Vue seulement » des résumés de niveau de droit par contributeur

### DIFF
--- a/public/assets/images/icone_contributeurs_actifs.svg
+++ b/public/assets/images/icone_contributeurs_actifs.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22.6426C17.5 22.6426 22 18.1426 22 12.6426C22 7.14258 17.5 2.64258 12 2.64258C6.5 2.64258 2 7.14258 2 12.6426C2 18.1426 6.5 22.6426 12 22.6426Z" stroke="#0E972B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.75 12.6425L10.58 15.4725L16.25 9.8125" stroke="#0E972B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/public/assets/images/icone_contributeurs_attente_activation.svg
+++ b/public/assets/images/icone_contributeurs_attente_activation.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M22 12.6426C22 18.1626 17.52 22.6426 12 22.6426C6.48 22.6426 2 18.1626 2 12.6426C2 7.12258 6.48 2.64258 12 2.64258C17.52 2.64258 22 7.12258 22 12.6426Z" stroke="#0079D0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M15.7109 15.8223L12.6109 13.9723C12.0709 13.6523 11.6309 12.8823 11.6309 12.2523V8.15234" stroke="#0079D0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -198,7 +198,7 @@
 .contenu-tiroir .conteneur-actions {
   display: flex;
   justify-content: end;
-  gap: 1em;
+  gap: 10px;
 }
 
 #contenu-suppression p {
@@ -325,9 +325,8 @@
 }
 
 #contenu-contributeurs .liste-contributeurs li {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  column-gap: 1em;
+  display: flex;
+  justify-content: space-between;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
   padding: 1em;
@@ -338,7 +337,6 @@
   display: flex;
   align-items: center;
   gap: 1em;
-  grid-column: 1 / 6;
 }
 
 #contenu-contributeurs .initiales {
@@ -370,7 +368,6 @@
   line-height: 0.9em;
   padding: 0.4em 0.5em;
   align-self: center;
-  grid-column: 6 / 7;
 }
 
 #contenu-contributeurs .declencheur-menu-flottant {

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -303,46 +303,6 @@
   height: 2.8em;
 }
 
-#contenu-contributeurs .liste-contributeurs {
-  list-style: none;
-  padding-left: 0;
-}
-
-#contenu-contributeurs .liste-contributeurs li {
-  display: flex;
-  justify-content: space-between;
-  border: 1px solid #cbd5e1;
-  border-radius: 8px;
-  padding: 1em;
-  margin-bottom: 0.5em;
-}
-
-#contenu-contributeurs .contenu-nom-prenom {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-#contenu-contributeurs .nom-contributeur {
-  font-weight: 500;
-  word-break: break-word;
-}
-
-#contenu-contributeurs .poste-contributeur {
-  font-weight: 500;
-  color: #667892;
-}
-
-#contenu-contributeurs .role {
-  border-radius: 4px;
-  font-weight: bold;
-  color: #ffffff;
-  font-size: 0.9em;
-  line-height: 0.9em;
-  padding: 0.4em 0.5em;
-  align-self: center;
-}
-
 #contenu-contributeurs .declencheur-menu-flottant {
   border-radius: 4px;
   border: 1px solid #cbd5e1;

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -134,7 +134,7 @@
   margin-top: 0.5em;
   display: flex;
   align-items: center;
-  gap: 0.5em;
+  gap: 8px;
 }
 
 #contenu-contributeurs
@@ -166,33 +166,17 @@
   border-color: var(--liseres) !important;
 }
 
-#contenu-contributeurs .option .initiales {
-  min-width: 1.5em;
-  min-height: 1.5em;
-  font-size: 0.8em;
-  padding: 0.4em;
-  margin-right: 1em;
-}
-
 #contenu-contributeurs .option.suggestion-contributeur {
   display: flex;
   align-items: center;
   padding: 0.6em;
   cursor: pointer;
   font-weight: normal;
+  column-gap: 8px;
 }
 
 #contenu-contributeurs .option:hover {
   background-color: var(--fond-gris-pale);
-}
-
-#contenu-contributeurs .initiales.persona::before {
-  content: '';
-  width: 1.5em;
-  height: 1.5em;
-  background-image: url('/statique/assets/images/persona_invitation_contributeur.svg');
-  background-repeat: no-repeat;
-  background-size: contain;
 }
 
 .contenu-tiroir .conteneur-actions {
@@ -336,18 +320,7 @@
 #contenu-contributeurs .contenu-nom-prenom {
   display: flex;
   align-items: center;
-  gap: 1em;
-}
-
-#contenu-contributeurs .initiales {
-  border-radius: 50%;
-  min-width: 2.5em;
-  min-height: 2.5em;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  color: #ffffff;
+  gap: 8px;
 }
 
 #contenu-contributeurs .nom-contributeur {

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -352,14 +352,6 @@
   color: #ffffff;
 }
 
-#contenu-contributeurs .initiales.proprietaire {
-  background: #c19616;
-}
-
-#contenu-contributeurs .initiales.contributeur {
-  background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
-}
-
 #contenu-contributeurs .nom-contributeur {
   font-weight: 500;
   word-break: break-word;
@@ -379,14 +371,6 @@
   padding: 0.4em 0.5em;
   align-self: center;
   grid-column: 6 / 7;
-}
-
-#contenu-contributeurs .role.proprietaire {
-  background: #c19616;
-}
-
-#contenu-contributeurs .role.contributeur {
-  background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
 }
 
 #contenu-contributeurs .declencheur-menu-flottant {
@@ -479,24 +463,9 @@
   font-size: 1em;
 }
 
-#contenu-contributeurs .titre-liste::before {
-  display: inline-block;
-  content: '';
-  width: 1.4em;
-  height: 1.4em;
-  background-image: none;
-  background-repeat: no-repeat;
-  background-size: contain;
-  margin-right: 0.3em;
-  transform: translateY(5px);
-}
-
-#contenu-contributeurs .titre-contributeurs-actifs::before {
-  background-image: url('/statique/assets/images/icone_contributeurs_actifs.svg');
-}
-
-#contenu-contributeurs .titre-contributeurs-attente-activation::before {
-  background-image: url('/statique/assets/images/icone_contributeurs_attente_activation.svg');
+#contenu-contributeurs .sous-titre-liste {
+  margin-top: 0.3em;
+  font-size: 0.9em;
 }
 
 .invisible {

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -45,6 +45,10 @@ class AutorisationBase extends Base {
   }
 
   resumeNiveauDroit() {
+    const { RESUME_NIVEAU_DROIT } = AutorisationBase;
+
+    if (this.estProprietaire) return RESUME_NIVEAU_DROIT.PROPRIETAIRE;
+
     const tousNiveaux = Object.values(Permissions).reduce(
       (acc, niveau) => ({ ...acc, [niveau]: 0 }),
       {}
@@ -58,14 +62,15 @@ class AutorisationBase extends Base {
     });
 
     if (tousNiveaux[ECRITURE] === totalRubriques)
-      return AutorisationBase.RESUME_NIVEAU_DROIT.ECRITURE;
+      return RESUME_NIVEAU_DROIT.ECRITURE;
     if (tousNiveaux[LECTURE] === totalRubriques)
-      return AutorisationBase.RESUME_NIVEAU_DROIT.LECTURE;
+      return RESUME_NIVEAU_DROIT.LECTURE;
 
-    return AutorisationBase.RESUME_NIVEAU_DROIT.PERSONNALISE;
+    return RESUME_NIVEAU_DROIT.PERSONNALISE;
   }
 
   static RESUME_NIVEAU_DROIT = {
+    PROPRIETAIRE: 'PROPRIETAIRE',
     ECRITURE: 'ECRITURE',
     LECTURE: 'LECTURE',
     PERSONNALISE: 'PERSONNALISE',

--- a/src/modeles/autorisations/autorisationCreateur.js
+++ b/src/modeles/autorisations/autorisationCreateur.js
@@ -7,6 +7,7 @@ class AutorisationCreateur extends AutorisationBase {
     this.permissionAjoutContributeur = true;
     this.permissionSuppressionContributeur = true;
     this.permissionSuppressionService = true;
+    this.estProprietaire = true;
   }
 }
 

--- a/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
+++ b/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
@@ -2,6 +2,7 @@
   import type { Utilisateur } from './gestionContributeurs.d';
 
   import { createEventDispatcher } from 'svelte';
+  import Initiales from './Initiales.svelte';
 
   export let callbackDeRecherche: (recherche: string) => Promise<Utilisateur[]>;
   export let dureeDebounceEnMs = 300;
@@ -63,12 +64,7 @@
         class="option suggestion-contributeur"
         on:click={() => choisisContributeur(suggestion)}
       >
-        <div
-          class="initiales contributeur"
-          class:persona={!suggestion.initiales}
-        >
-          {suggestion.initiales}
-        </div>
+        <Initiales valeur={suggestion.initiales} />
         <div>{@html suggestion.prenomNom}</div>
       </div>
     {/each}

--- a/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
+++ b/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
@@ -64,7 +64,7 @@
         class="option suggestion-contributeur"
         on:click={() => choisisContributeur(suggestion)}
       >
-        <Initiales valeur={suggestion.initiales} />
+        <Initiales valeur={suggestion.initiales} resumeNiveauDroit="ECRITURE" />
         <div>{@html suggestion.prenomNom}</div>
       </div>
     {/each}

--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import type { Autorisation, ResumeNiveauDroit } from './gestionContributeurs.d';
+  import type {
+    Autorisation,
+    ResumeNiveauDroit,
+  } from './gestionContributeurs.d';
   import { store } from './gestionContributeurs.store';
   import InvitationContributeur from './InvitationContributeur.svelte';
   import LigneContributeur from './LigneContributeur.svelte';
@@ -35,9 +38,6 @@
   {/if}
   {#if $store.etapeCourante !== 'InvitationContributeurs' && surServiceUnique}
     <h3 class="titre-liste">Liste des contributeurs au service</h3>
-    <p class="sous-titre-liste">
-      Sélectionner une personne pour gérer ses droits d'accès
-    </p>
     <ul class="liste-contributeurs contributeurs-actifs">
       <LigneContributeur
         estSupprimable={false}

--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -1,12 +1,30 @@
 <script lang="ts">
+  import type { Autorisation, ResumeNiveauDroit } from './gestionContributeurs.d';
   import { store } from './gestionContributeurs.store';
   import InvitationContributeur from './InvitationContributeur.svelte';
   import LigneContributeur from './LigneContributeur.svelte';
   import SuppressionContributeur from './SuppressionContributeur.svelte';
+  import { onMount } from 'svelte';
 
+  let autorisations: Record<string, ResumeNiveauDroit> = {};
   $: surServiceUnique = $store.services.length === 1;
   $: serviceUnique = $store.services[0];
   $: contributeurs = serviceUnique.contributeurs;
+
+  onMount(async () => {
+    if (surServiceUnique) {
+      const reponse = await axios.get(
+        `/api/service/${serviceUnique.id}/autorisations`
+      );
+      autorisations = reponse.data.reduce(
+        (acc: Record<string, ResumeNiveauDroit>, v: Autorisation) => ({
+          ...acc,
+          [v.idUtilisateur]: v.resumeNiveauDroit,
+        }),
+        {}
+      );
+    }
+  });
 </script>
 
 {#if $store.etapeCourante === 'SuppressionContributeur'}
@@ -16,18 +34,21 @@
     <InvitationContributeur />
   {/if}
   {#if $store.etapeCourante !== 'InvitationContributeurs' && surServiceUnique}
-    <h3 class="titre-liste titre-contributeurs-actifs">Ajouté(s) au service</h3>
+    <h3 class="titre-liste">Liste des contributeurs au service</h3>
+    <p class="sous-titre-liste">
+      Sélectionner une personne pour gérer ses droits d'accès
+    </p>
     <ul class="liste-contributeurs contributeurs-actifs">
       <LigneContributeur
-        estProprietaire={true}
         estSupprimable={false}
         utilisateur={serviceUnique.createur}
+        resumeNiveauDroit={autorisations[serviceUnique.createur.id]}
       />
       {#each contributeurs as contributeur (contributeur.id)}
         <LigneContributeur
-          estProprietaire={false}
           estSupprimable={serviceUnique.permissions.suppressionContributeur}
           utilisateur={contributeur}
+          resumeNiveauDroit={autorisations[contributeur.id]}
         />
       {/each}
     </ul>

--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -54,3 +54,19 @@
     </ul>
   {/if}
 {/if}
+
+<style>
+  .liste-contributeurs {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  .liste-contributeurs :global(li) {
+    display: flex;
+    justify-content: space-between;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    padding: 1em;
+    margin-bottom: 0.5em;
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/Initiales.svelte
+++ b/svelte/lib/gestionContributeurs/Initiales.svelte
@@ -2,7 +2,7 @@
   import type { ResumeNiveauDroit } from './gestionContributeurs.d';
 
   export let valeur: string;
-  export let resumeNiveauDroit: ResumeNiveauDroit;
+  export let resumeNiveauDroit: ResumeNiveauDroit | undefined;
 </script>
 
 <div

--- a/svelte/lib/gestionContributeurs/Initiales.svelte
+++ b/svelte/lib/gestionContributeurs/Initiales.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type { ResumeNiveauDroit } from './gestionContributeurs.d';
+
+  export let valeur: string;
+  export let resumeNiveauDroit: ResumeNiveauDroit;
+</script>
+
+<div
+  class="initiales contributeur {resumeNiveauDroit || ''}"
+  class:persona={!valeur}
+>
+  {valeur}
+</div>
+
+<style>
+  .initiales {
+    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+    min-width: 36px;
+    min-height: 36px;
+    font-size: 0.9rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: #ffffff;
+  }
+
+  .initiales.persona::before {
+    content: '';
+    width: 1.5rem;
+    height: 1.5rem;
+    background: url('/statique/assets/images/persona_invitation_contributeur.svg')
+      no-repeat;
+    background-size: contain;
+  }
+
+  .ECRITURE {
+    background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
+  }
+
+  .LECTURE {
+    background: linear-gradient(180deg, #a226b8 0%, #8926c9 100%);
+  }
+
+  .PERSONNALISE {
+    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/Initiales.svelte
+++ b/svelte/lib/gestionContributeurs/Initiales.svelte
@@ -35,6 +35,10 @@
     background-size: contain;
   }
 
+  .PROPRIETAIRE {
+    background: #c19616;
+  }
+
   .ECRITURE {
     background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
   }

--- a/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
@@ -4,6 +4,7 @@
   import { store } from './gestionContributeurs.store';
   import ChampAvecSuggestions from './ChampAvecSuggestions.svelte';
   import Initiales from './Initiales.svelte';
+  import TagNiveauDroit from './TagNiveauDroit.svelte';
 
   type Etape = 'Ajout' | 'EnvoiEnCours' | 'Rapport';
 
@@ -62,18 +63,23 @@
       <ul id="liste-ajout-contributeur">
         {#each contributeursAInviter as contributeur (contributeur.email)}
           <li class="contributeur-a-inviter">
-            <Initiales
-              valeur={contributeur.initiales}
-              resumeNiveauDroit="ECRITURE"
-            />
-            <span>{@html contributeur.prenomNom}</span>
-            <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <img
-              class="bouton-suppression-contributeur"
-              src="/statique/assets/images/icone_supprimer_gris.svg"
-              alt="bouton de suppression d'un contributeur"
-              on:click={() => supprimeInvitation(contributeur)}
-            />
+            <div class="contenu-nom-prenom">
+              <Initiales
+                valeur={contributeur.initiales}
+                resumeNiveauDroit="ECRITURE"
+              />
+              <span>{@html contributeur.prenomNom}</span>
+            </div>
+            <div class="conteneur-actions">
+              <TagNiveauDroit niveau="ECRITURE" />
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <img
+                class="bouton-suppression-contributeur"
+                src="/statique/assets/images/icone_supprimer_gris.svg"
+                alt="bouton de suppression d'un contributeur"
+                on:click={() => supprimeInvitation(contributeur)}
+              />
+            </div>
           </li>
         {/each}
       </ul>
@@ -118,3 +124,10 @@
     <p>Un e-mail d'invitation a bien été envoyé.</p>
   </div>
 {/if}
+
+<style>
+  .contributeur-a-inviter {
+    display: flex;
+    justify-content: space-between;
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
@@ -3,6 +3,7 @@
 
   import { store } from './gestionContributeurs.store';
   import ChampAvecSuggestions from './ChampAvecSuggestions.svelte';
+  import Initiales from './Initiales.svelte';
 
   type Etape = 'Ajout' | 'EnvoiEnCours' | 'Rapport';
 
@@ -61,12 +62,7 @@
       <ul id="liste-ajout-contributeur">
         {#each contributeursAInviter as contributeur (contributeur.email)}
           <li class="contributeur-a-inviter">
-            <div
-              class="initiales contributeur"
-              class:persona={!contributeur.initiales}
-            >
-              {contributeur.initiales}
-            </div>
+            <Initiales valeur={contributeur.initiales} />
             <span>{@html contributeur.prenomNom}</span>
             <!-- svelte-ignore a11y-click-events-have-key-events -->
             <img

--- a/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
@@ -130,4 +130,9 @@
     display: flex;
     justify-content: space-between;
   }
+  .contenu-nom-prenom {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
 </style>

--- a/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
@@ -62,7 +62,10 @@
       <ul id="liste-ajout-contributeur">
         {#each contributeursAInviter as contributeur (contributeur.email)}
           <li class="contributeur-a-inviter">
-            <Initiales valeur={contributeur.initiales} />
+            <Initiales
+              valeur={contributeur.initiales}
+              resumeNiveauDroit="ECRITURE"
+            />
             <span>{@html contributeur.prenomNom}</span>
             <!-- svelte-ignore a11y-click-events-have-key-events -->
             <img

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -39,6 +39,20 @@
 </li>
 
 <style>
+  .contenu-nom-prenom {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .nom-contributeur {
+    font-weight: 500;
+    word-break: break-word;
+  }
+  .poste-contributeur {
+    font-weight: 500;
+    color: #667892;
+  }
+
   .conteneur-suppression {
     display: flex;
     align-items: center;

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -21,7 +21,10 @@
     </div>
   </div>
   <div class="conteneur-actions">
-    <TagNiveauDroit niveau={resumeNiveauDroit} />
+    {#if resumeNiveauDroit}
+      <TagNiveauDroit niveau={resumeNiveauDroit} />
+    {/if}
+
     {#if estSupprimable}
       <!--    svelte-ignore a11y-click-events-have-key-events-->
       <div

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -7,6 +7,7 @@
   import Initiales from './Initiales.svelte';
 
   const STATUS_DROITS: Record<ResumeNiveauDroit, string> = {
+    PROPRIETAIRE: 'Propriétaire',
     ECRITURE: 'Édition',
     LECTURE: 'Lecture',
     PERSONNALISE: 'Personnalisé',
@@ -51,6 +52,10 @@
   .role,
   .initiales {
     background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  }
+
+  .PROPRIETAIRE {
+    background: #c19616;
   }
 
   .ECRITURE {

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
-  import type { Utilisateur } from './gestionContributeurs.d';
+  import type { ResumeNiveauDroit, Utilisateur } from './gestionContributeurs.d';
   import { store } from './gestionContributeurs.store';
   import MenuFlottant from '../ui/MenuFlottant.svelte';
 
-  export let estProprietaire: boolean;
+  const STATUS_DROITS: Record<ResumeNiveauDroit, string> = {
+    ECRITURE: 'Édition',
+    LECTURE: 'Lecture',
+    PERSONNALISE: 'Personnalisé',
+  };
+
   export let estSupprimable: boolean;
   export let utilisateur: Utilisateur;
+  export let resumeNiveauDroit: ResumeNiveauDroit;
 </script>
 
 <li class="ligne-contributeur">
   <div class="contenu-nom-prenom">
     <div
-      class="initiales {estProprietaire ? 'proprietaire' : 'contributeur'}
+      class="initiales {resumeNiveauDroit}
     {!utilisateur.initiales ? 'persona' : ''}"
     >
       {utilisateur.initiales}
@@ -21,9 +27,11 @@
       <div class="poste-contributeur">{@html utilisateur.poste}</div>
     </div>
   </div>
-  <div class="role {estProprietaire ? 'proprietaire' : 'contributeur'}">
-    {estProprietaire ? 'Propriétaire' : 'Contributeur'}
-  </div>
+  {#if resumeNiveauDroit}
+    <div class="role {resumeNiveauDroit}">
+      {STATUS_DROITS[resumeNiveauDroit]}
+    </div>
+  {/if}
   {#if estSupprimable}
     <MenuFlottant>
       <ul>
@@ -38,3 +46,22 @@
     </MenuFlottant>
   {/if}
 </li>
+
+<style>
+  .role,
+  .initiales {
+    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  }
+
+  .ECRITURE {
+    background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
+  }
+
+  .LECTURE {
+    background: linear-gradient(180deg, #a226b8 0%, #8926c9 100%);
+  }
+
+  .PERSONNALISE {
+    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -4,7 +4,7 @@
     Utilisateur,
   } from './gestionContributeurs.d';
   import { store } from './gestionContributeurs.store';
-  import MenuFlottant from '../ui/MenuFlottant.svelte';
+  import Initiales from './Initiales.svelte';
 
   const STATUS_DROITS: Record<ResumeNiveauDroit, string> = {
     ECRITURE: 'Édition',
@@ -19,12 +19,7 @@
 
 <li class="ligne-contributeur">
   <div class="contenu-nom-prenom">
-    <div
-      class="initiales {resumeNiveauDroit}
-    {!utilisateur.initiales ? 'persona' : ''}"
-    >
-      {utilisateur.initiales}
-    </div>
+    <Initiales valeur={utilisateur.initiales} {resumeNiveauDroit} />
     <div class="nom-prenom-poste">
       <div class="nom-contributeur">{@html utilisateur.prenomNom}</div>
       <div class="poste-contributeur">{@html utilisateur.poste}</div>

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -45,6 +45,7 @@
         <img
           src="/statique/assets/images/icone_supprimer_gris.svg"
           alt="supression d'un contributeur"
+          title="Supprimer ce contributeur"
         />
       </div>
     {/if}

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import type { ResumeNiveauDroit, Utilisateur } from './gestionContributeurs.d';
+  import type {
+    ResumeNiveauDroit,
+    Utilisateur,
+  } from './gestionContributeurs.d';
   import { store } from './gestionContributeurs.store';
   import MenuFlottant from '../ui/MenuFlottant.svelte';
 
@@ -27,23 +30,25 @@
       <div class="poste-contributeur">{@html utilisateur.poste}</div>
     </div>
   </div>
-  {#if resumeNiveauDroit}
-    <div class="role {resumeNiveauDroit}">
-      {STATUS_DROITS[resumeNiveauDroit]}
-    </div>
-  {/if}
-  {#if estSupprimable}
-    <!--    svelte-ignore a11y-click-events-have-key-events-->
-    <div
-      class="conteneur-suppression"
-      on:click={() => store.afficheEtapeSuppression(utilisateur)}
-    >
-      <img
-        src="/statique/assets/images/icone_supprimer_gris.svg"
-        alt="supression d'un contributeur"
-      />
-    </div>
-  {/if}
+  <div class="conteneur-actions">
+    {#if resumeNiveauDroit}
+      <div class="role {resumeNiveauDroit}">
+        {STATUS_DROITS[resumeNiveauDroit]}
+      </div>
+    {/if}
+    {#if estSupprimable}
+      <!--    svelte-ignore a11y-click-events-have-key-events-->
+      <div
+        class="conteneur-suppression"
+        on:click={() => store.afficheEtapeSuppression(utilisateur)}
+      >
+        <img
+          src="/statique/assets/images/icone_supprimer_gris.svg"
+          alt="supression d'un contributeur"
+        />
+      </div>
+    {/if}
+  </div>
 </li>
 
 <style>
@@ -68,5 +73,6 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    cursor: pointer;
   }
 </style>

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -5,13 +5,7 @@
   } from './gestionContributeurs.d';
   import { store } from './gestionContributeurs.store';
   import Initiales from './Initiales.svelte';
-
-  const STATUS_DROITS: Record<ResumeNiveauDroit, string> = {
-    PROPRIETAIRE: 'Propriétaire',
-    ECRITURE: 'Édition',
-    LECTURE: 'Lecture',
-    PERSONNALISE: 'Personnalisé',
-  };
+  import TagNiveauDroit from './TagNiveauDroit.svelte';
 
   export let estSupprimable: boolean;
   export let utilisateur: Utilisateur;
@@ -27,11 +21,7 @@
     </div>
   </div>
   <div class="conteneur-actions">
-    {#if resumeNiveauDroit}
-      <div class="role {resumeNiveauDroit}">
-        {STATUS_DROITS[resumeNiveauDroit]}
-      </div>
-    {/if}
+    <TagNiveauDroit niveau={resumeNiveauDroit} />
     {#if estSupprimable}
       <!--    svelte-ignore a11y-click-events-have-key-events-->
       <div
@@ -49,27 +39,6 @@
 </li>
 
 <style>
-  .role,
-  .initiales {
-    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
-  }
-
-  .PROPRIETAIRE {
-    background: #c19616;
-  }
-
-  .ECRITURE {
-    background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
-  }
-
-  .LECTURE {
-    background: linear-gradient(180deg, #a226b8 0%, #8926c9 100%);
-  }
-
-  .PERSONNALISE {
-    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
-  }
-
   .conteneur-suppression {
     display: flex;
     align-items: center;

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -33,17 +33,16 @@
     </div>
   {/if}
   {#if estSupprimable}
-    <MenuFlottant>
-      <ul>
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <li
-          class="action-suppression-contributeur"
-          on:click={() => store.afficheEtapeSuppression(utilisateur)}
-        >
-          Retirer du service
-        </li>
-      </ul>
-    </MenuFlottant>
+    <!--    svelte-ignore a11y-click-events-have-key-events-->
+    <div
+      class="conteneur-suppression"
+      on:click={() => store.afficheEtapeSuppression(utilisateur)}
+    >
+      <img
+        src="/statique/assets/images/icone_supprimer_gris.svg"
+        alt="supression d'un contributeur"
+      />
+    </div>
   {/if}
 </li>
 
@@ -63,5 +62,11 @@
 
   .PERSONNALISE {
     background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  }
+
+  .conteneur-suppression {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
   }
 </style>

--- a/svelte/lib/gestionContributeurs/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/TagNiveauDroit.svelte
@@ -17,6 +17,13 @@
 
 <style>
   .role {
+    border-radius: 4px;
+    font-weight: bold;
+    color: #ffffff;
+    font-size: 0.9em;
+    line-height: 0.9em;
+    padding: 0.4em 0.5em;
+    align-self: center;
     background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
   }
 

--- a/svelte/lib/gestionContributeurs/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/TagNiveauDroit.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { ResumeNiveauDroit } from './gestionContributeurs.d';
+
+  const STATUS_DROITS: Record<ResumeNiveauDroit, string> = {
+    PROPRIETAIRE: 'Propriétaire',
+    ECRITURE: 'Édition',
+    LECTURE: 'Lecture',
+    PERSONNALISE: 'Personnalisé',
+  };
+
+  export let niveau: ResumeNiveauDroit;
+</script>
+
+<div class="role {niveau}">
+  {STATUS_DROITS[niveau]}
+</div>
+
+<style>
+  .role {
+    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  }
+
+  .PROPRIETAIRE {
+    background: #c19616;
+  }
+
+  .ECRITURE {
+    background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
+  }
+
+  .LECTURE {
+    background: linear-gradient(180deg, #a226b8 0%, #8926c9 100%);
+  }
+
+  .PERSONNALISE {
+    background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -25,7 +25,11 @@ export type Utilisateur = {
   email: string;
 };
 
-export type ResumeNiveauDroit = 'ECRITURE' | 'LECTURE' | 'PERSONNALISE';
+export type ResumeNiveauDroit =
+  | 'PROPRIETAIRE'
+  | 'ECRITURE'
+  | 'LECTURE'
+  | 'PERSONNALISE';
 
 export type Autorisation = {
   idUtilisateur: string;

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -24,3 +24,10 @@ export type Utilisateur = {
   poste: string;
   email: string;
 };
+
+export type ResumeNiveauDroit = 'ECRITURE' | 'LECTURE' | 'PERSONNALISE';
+
+export type Autorisation = {
+  idUtilisateur: string;
+  resumeNiveauDroit: ResumeNiveauDroit;
+};

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -79,6 +79,14 @@ describe('Une autorisation de base', () => {
   });
 
   describe('sur demande de résumé de niveau de droit', () => {
+    it("retour 'PROPRIETAIRE' si l'utilisateur est créateur du service", async () => {
+      const autorisationCreateur = new AutorisationCreateur();
+
+      expect(autorisationCreateur.resumeNiveauDroit()).to.be(
+        AutorisationBase.RESUME_NIVEAU_DROIT.PROPRIETAIRE
+      );
+    });
+
     it("retourne 'ECRITURE' si tous les droits sont en ECRITURE", () => {
       const autorisationLecture = new AutorisationBase({
         droits: {

--- a/test/modeles/autorisations/autorisationCreateur.spec.js
+++ b/test/modeles/autorisations/autorisationCreateur.spec.js
@@ -17,4 +17,9 @@ describe("Une autorisation d'accès en tant que créateur", () => {
     const autorisation = new AutorisationCreateur();
     expect(autorisation.permissionSuppressionService).to.be(true);
   });
+
+  it("indique que l'utilisateur est propriétaire du service", () => {
+    const autorisation = new AutorisationCreateur();
+    expect(autorisation.estProprietaire).to.be(true);
+  });
 });

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1578,10 +1578,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('Retourne le résumé du niveau de droit pour chaque utilisateur du service', async () => {
       testeur.depotDonnees().autorisationsDuService = async () => [
-        uneAutorisation()
-          .deCreateurDeService('AAA', '456')
-          .avecTousDroitsEcriture()
-          .construis(),
+        uneAutorisation().deCreateurDeService('AAA', '456').construis(),
       ];
 
       const reponse = await axios.get(
@@ -1589,7 +1586,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
 
       expect(reponse.data).to.eql([
-        { idUtilisateur: 'AAA', resumeNiveauDroit: 'ECRITURE' },
+        { idUtilisateur: 'AAA', resumeNiveauDroit: 'PROPRIETAIRE' },
       ]);
     });
 


### PR DESCRIPTION
On affiche désormais, quand ils sont disponibles, les résumé de niveau de droit de chaque utilisateur dans le tiroir contributeurs.

<img src="https://github.com/betagouv/mon-service-securise/assets/1643465/2e67ff9c-f248-40fa-aa3e-89c528a263d6" width=400>

Dans une PR suivante, cela deviendrait le `trigger` pour un Menu flottant.
