### PR TITLE
[CORRECTION] Déplace le titre dans `formulaireEtapier`

### DIFF
--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -1,5 +1,4 @@
 extends ./formulaireEtapier
-include ../fragments/texteTronque
 
 mixin dossier({ statut, dossier, idService })
   -
@@ -25,10 +24,6 @@ mixin dossierFinalise({ dossier })
 
 mixin dossierCourant({ ...donnees })
   +dossier({ statut: 'Homologation en cours', ...donnees })
-
-block header-titre-page
-  h3
-    +texteTronque({texte: service.nomService() || ''})
 
 block formulaire
   -

--- a/src/vues/service/formulaireEtapier.pug
+++ b/src/vues/service/formulaireEtapier.pug
@@ -1,4 +1,5 @@
 extends ./formulaire
+include ../fragments/texteTronque
 
 mixin descriptionEtape({ etape })
   .numero-etape= etape.numero
@@ -23,6 +24,10 @@ mixin barre-progression({ numeroEtapeCourante })
 block append styles
   link(href='/statique/assets/styles/etapesDossier.css', rel='stylesheet')
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
+
+block header-titre-page
+  h3
+    +texteTronque({texte: service.nomService() || ''})
 
 block zone-principale
   form.homologation


### PR DESCRIPTION
… afin qu'il soit affiché sur toutes les étapes du parcours d'homologation, et pas seulement sur l'étape qui liste tous les dossiers.