### PR TITLE
Couleurs `hover` et `active` des éléments du menu

### DIFF
--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -6,6 +6,7 @@
   --menu-couleur-autres-survol: #0c5c98;
 
   --menu-couleur-tous-clique: #0c5c98;
+  --menu-couleur-tous-pastille-active: #dbecf1;
 }
 
 .menu-navigation {
@@ -86,12 +87,13 @@
 }
 
 .menu-navigation a.actif .pastille {
-  background-color: var(--menu-couleur-tous-clique);
+  background-color: var(--menu-couleur-tous-pastille-active);
 }
 
 .menu-navigation .autres-liens a.actif img,
 .menu-navigation .etapes a.actif .action-saisie {
-  filter: brightness(0) saturate(100%) invert(100%);
+  filter: brightness(0) saturate(100%) invert(17%) sepia(85%) saturate(2876%)
+    hue-rotate(192deg) brightness(94%) contrast(91%);
 }
 
 .menu-navigation .etapes li a {

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -6,6 +6,7 @@
   --menu-couleur-autres-survol: #0c5c98;
 
   --menu-couleur-tous-clique: #0c5c98;
+  --menu-couleur-tous-pastille-cliquee: #dbecf1;
   --menu-couleur-tous-pastille-active: #dbecf1;
 }
 
@@ -214,16 +215,29 @@
 .menu-navigation a:hover .pastille {
   background-color: transparent;
 }
+.menu-navigation a:active .pastille {
+  background-color: var(--menu-couleur-tous-pastille-active);
+}
 .menu-navigation .etapes a:hover {
   color: var(--menu-couleur-etapes-survol);
+}
+.menu-navigation .etapes a:active {
+  color: var(--menu-couleur-tous-clique);
 }
 
 .menu-navigation .autres-liens a:hover {
   color: var(--menu-couleur-autres-survol);
 }
+.menu-navigation .autres-liens a:active {
+  color: var(--menu-couleur-tous-clique);
+}
 
 .menu-navigation .etapes a:hover .action-saisie {
   background-color: var(--menu-couleur-etapes-survol);
+  filter: unset;
+}
+.menu-navigation .etapes a:active .action-saisie {
+  background-color: var(--menu-couleur-tous-clique);
   filter: unset;
 }
 .menu-navigation a:active {
@@ -264,6 +278,9 @@
 
 .menu-navigation.ferme a:hover .pastille {
   background-color: white;
+}
+.menu-navigation.ferme a:active .pastille {
+  background-color: var(--menu-couleur-tous-pastille-active);
 }
 
 /* GÉRER CONTRIBUTEURS */

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -236,6 +236,10 @@
     hue-rotate(185deg) brightness(95%) contrast(101%);
 }
 
+.menu-navigation #icone-risques {
+  transform: translateY(-1px);
+}
+
 /* MENU FERMÉ */
 .menu-navigation.ferme {
   width: 5.5em;

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -212,27 +212,24 @@
 }
 
 /* HOVER ET ACTIVE */
-.menu-navigation a:hover .pastille {
-  background-color: transparent;
-}
 .menu-navigation a:active .pastille {
   background-color: var(--menu-couleur-tous-pastille-active);
 }
-.menu-navigation .etapes a:hover {
+.menu-navigation .etapes a:not(.actif):hover {
   color: var(--menu-couleur-etapes-survol);
 }
 .menu-navigation .etapes a:active {
   color: var(--menu-couleur-tous-clique);
 }
 
-.menu-navigation .autres-liens a:hover {
+.menu-navigation .autres-liens a:not(.actif):hover {
   color: var(--menu-couleur-autres-survol);
 }
 .menu-navigation .autres-liens a:active {
   color: var(--menu-couleur-tous-clique);
 }
 
-.menu-navigation .etapes a:hover .action-saisie {
+.menu-navigation .etapes a:not(.actif):hover .action-saisie {
   background-color: var(--menu-couleur-etapes-survol);
   filter: unset;
 }
@@ -246,13 +243,13 @@
 .menu-navigation a:active .action-saisie {
   background-color: var(--menu-couleur-tous-clique);
 }
-.menu-navigation .autres-liens a:hover > span {
+.menu-navigation .autres-liens a:not(.actif):hover > span {
   color: var(--menu-couleur-autres-survol);
 }
 .menu-navigation .autres-liens a:active > span {
   color: var(--menu-couleur-tous-clique);
 }
-.menu-navigation .autres-liens a:hover img {
+.menu-navigation .autres-liens a:not(.actif):hover img {
   /* https://codepen.io/sosuke/pen/Pjoqqp */
   filter: brightness(0) invert(17%) sepia(100%) saturate(2297%)
     hue-rotate(190deg) brightness(98%) contrast(91%);
@@ -276,7 +273,7 @@
   transition: rotate 0.2s;
 }
 
-.menu-navigation.ferme a:hover .pastille {
+.menu-navigation.ferme a:not(.actif):hover .pastille {
   background-color: white;
 }
 .menu-navigation.ferme a:active .pastille {

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -1,7 +1,11 @@
 :root {
-  --menu-couleur-repos: var(--bleu-survol);
-  --menu-couleur-survol: var(--bleu-mise-en-avant);
-  --menu-couleur-actif: var(--bleu-anssi);
+  --menu-couleur-etapes-defaut: #0c5c98;
+  --menu-couleur-etapes-survol: #0079d0;
+
+  --menu-couleur-autres-defaut: #0079d0;
+  --menu-couleur-autres-survol: #0c5c98;
+
+  --menu-couleur-tous-clique: #0c5c98;
 }
 
 .menu-navigation {
@@ -23,22 +27,11 @@
   padding: 15px 24px;
 }
 
-:is(.menu-navigation, .menu-navigation a) {
-  color: var(--menu-couleur-repos);
+.menu-navigation .etapes a {
+  color: var(--menu-couleur-etapes-defaut);
 }
-
-.menu-navigation a:hover {
-  color: var(--menu-couleur-survol);
-}
-
-.menu-navigation a:hover .action-saisie {
-  background-color: var(--menu-couleur-survol);
-}
-.menu-navigation a:active {
-  color: var(--menu-couleur-actif);
-}
-.menu-navigation a:active .action-saisie {
-  background-color: var(--menu-couleur-actif);
+.menu-navigation .autres-liens a {
+  color: var(--menu-couleur-autres-defaut);
 }
 
 .menu-navigation .actions {
@@ -92,42 +85,13 @@
   column-gap: 16px;
 }
 
-.menu-navigation .autres-liens a:hover > span {
-  color: var(--menu-couleur-repos);
+.menu-navigation a.actif .pastille {
+  background-color: var(--menu-couleur-tous-clique);
 }
-.menu-navigation .autres-liens a:active > span {
-  color: var(--menu-couleur-actif);
-}
-.menu-navigation .autres-liens a:hover img {
-  /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) invert(17%) sepia(100%) saturate(2297%)
-    hue-rotate(190deg) brightness(98%) contrast(91%);
-}
-.menu-navigation .autres-liens a:active img {
-  /* https://codepen.io/sosuke/pen/Pjoqqp */
-  filter: brightness(0) invert(15%) sepia(76%) saturate(1769%)
-    hue-rotate(184deg) brightness(96%) contrast(94%);
-}
-.menu-navigation .autres-liens a.actif > div {
-  background-color: var(--menu-couleur-repos);
-}
-.menu-navigation .autres-liens a.actif > span {
-  color: var(--menu-couleur-repos);
-}
-.menu-navigation .autres-liens a.actif:hover > span {
-  color: var(--menu-couleur-survol);
-}
-.menu-navigation .autres-liens a.actif img {
+
+.menu-navigation .autres-liens a.actif img,
+.menu-navigation .etapes a.actif .action-saisie {
   filter: brightness(0) saturate(100%) invert(100%);
-}
-.menu-navigation .autres-liens a.actif:active > div {
-  background-color: var(--menu-couleur-actif) !important;
-}
-.menu-navigation .autres-liens a.actif:active > span {
-  color: var(--menu-couleur-actif);
-}
-.menu-navigation .autres-liens a.actif:hover > div {
-  background-color: var(--menu-couleur-survol);
 }
 
 .menu-navigation .etapes li a {
@@ -166,7 +130,7 @@
 }
 
 .menu-navigation .action-saisie {
-  background: var(--menu-couleur-repos);
+  background: var(--menu-couleur-etapes-defaut);
   width: 24px;
   height: 24px;
 }
@@ -236,8 +200,51 @@
     hue-rotate(185deg) brightness(95%) contrast(101%);
 }
 
+.menu-navigation .autres-liens a.actif {
+  color: var(--menu-couleur-tous-clique);
+}
+
 .menu-navigation #icone-risques {
   transform: translateY(-1px);
+}
+
+/* HOVER ET ACTIVE */
+.menu-navigation a:hover .pastille {
+  background-color: transparent;
+}
+.menu-navigation .etapes a:hover {
+  color: var(--menu-couleur-etapes-survol);
+}
+
+.menu-navigation .autres-liens a:hover {
+  color: var(--menu-couleur-autres-survol);
+}
+
+.menu-navigation .etapes a:hover .action-saisie {
+  background-color: var(--menu-couleur-etapes-survol);
+  filter: unset;
+}
+.menu-navigation a:active {
+  color: var(--menu-couleur-tous-clique);
+}
+.menu-navigation a:active .action-saisie {
+  background-color: var(--menu-couleur-tous-clique);
+}
+.menu-navigation .autres-liens a:hover > span {
+  color: var(--menu-couleur-autres-survol);
+}
+.menu-navigation .autres-liens a:active > span {
+  color: var(--menu-couleur-tous-clique);
+}
+.menu-navigation .autres-liens a:hover img {
+  /* https://codepen.io/sosuke/pen/Pjoqqp */
+  filter: brightness(0) invert(17%) sepia(100%) saturate(2297%)
+    hue-rotate(190deg) brightness(98%) contrast(91%);
+}
+.menu-navigation .autres-liens a:active img {
+  /* https://codepen.io/sosuke/pen/Pjoqqp */
+  filter: brightness(0) invert(15%) sepia(76%) saturate(1769%)
+    hue-rotate(184deg) brightness(96%) contrast(94%);
 }
 
 /* MENU FERMÉ */
@@ -251,6 +258,10 @@
 .menu-navigation.ferme .repli-menu img {
   rotate: 0deg;
   transition: rotate 0.2s;
+}
+
+.menu-navigation.ferme a:hover .pastille {
+  background-color: white;
 }
 
 /* GÉRER CONTRIBUTEURS */

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -45,7 +45,7 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut, rubriqu
           li
             a(href = `/service/${service.id}/risques`, class = etapeActive === 'risques' ? 'actif' : '')
               .pastille
-                img(src = '/statique/assets/images/icone_risques.svg' alt="Icône d'un panneau « Danger »")
+                img(src = '/statique/assets/images/icone_risques.svg' alt="Icône d'un panneau « Danger »", id = 'icone-risques')
               span.none-si-ferme Risques
         if !autorisationsService.CONTACTS.estMasque
           li


### PR DESCRIPTION
Cette PR ajoute les `hover` et `active` 👇 

### Menu ouvert 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/7a44380f-350c-448d-86e5-93cf6f363d89)

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/96484a6c-1d1a-4390-ac43-90e1261e2186)

### Menu fermé

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/dae7c370-2450-4e8f-9d99-ef50bd16ece1)

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/bf403ae7-6eb6-4894-8d25-7222b6e4e74c)
