### PR TITLE
[CORRECTION] Répare l'affichage en cas de bandeau présent

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -3,6 +3,8 @@
 }
 
 main {
+  flex-direction: column;
+  align-items: center;
   background-image: url('/statique/assets/images/fond_entete_tableau_de_bord.svg');
   background-repeat: no-repeat;
 }
@@ -10,6 +12,7 @@ main {
 .bandeau-maj-profil {
   display: flex;
   height: 2.7em;
+  width: 100%;
   align-items: center;
   color: #fff;
   background-color: var(--bleu-mise-en-avant);


### PR DESCRIPTION
Avant ce commit, le bandeau et le corps de page n'étaient pas en mode colonne 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/e2395f26-12f8-4bb7-a9cd-51e588a42431)


Après correction 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/370fbd77-1c1d-4d7e-8e78-80c775e10890)
