### PR TITLE
Pilotage des droits accordés par la couche API

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -88,7 +88,7 @@ const creeDepot = (config = {}) => {
 
   const {
     accesAutorise,
-    ajouteContributeurAHomologation,
+    ajouteContributeurAuService,
     autorisation,
     autorisationExiste,
     autorisationPour,
@@ -103,7 +103,7 @@ const creeDepot = (config = {}) => {
 
   return {
     accesAutorise,
-    ajouteContributeurAHomologation,
+    ajouteContributeurAuService,
     ajouteDescriptionServiceAHomologation,
     ajouteDossierCourantSiNecessaire,
     ajouteMesuresAHomologation,

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -10,9 +10,6 @@ const {
 } = require('../erreurs');
 const AutorisationCreateur = require('../modeles/autorisations/autorisationCreateur');
 const FabriqueAutorisation = require('../modeles/autorisations/fabriqueAutorisation');
-const {
-  toutDroitsEnEcriture,
-} = require('../modeles/autorisations/gestionDroits');
 
 const creeDepot = (config = {}) => {
   const {

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -3,7 +3,7 @@ const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateur
 const {
   ErreurAutorisationExisteDeja,
   ErreurAutorisationInexistante,
-  ErreurHomologationInexistante,
+  ErreurServiceInexistant,
   ErreurTentativeSuppressionCreateur,
   ErreurTranfertVersUtilisateurSource,
   ErreurUtilisateurInexistant,
@@ -56,7 +56,7 @@ const creeDepot = (config = {}) => {
   const autorisationExiste = (...params) =>
     autorisationPour(...params).then((a) => !!a);
 
-  const ajouteContributeurAHomologation = async (nouvelleAutorisation) => {
+  const ajouteContributeurAuService = async (nouvelleAutorisation) => {
     const verifieUtilisateurExiste = async (id) => {
       const existe = await depotUtilisateurs.utilisateurExiste(id);
       if (!existe)
@@ -70,9 +70,7 @@ const creeDepot = (config = {}) => {
         nouvelleAutorisation.idService
       );
       if (!h)
-        throw new ErreurHomologationInexistante(
-          `L'homologation "${id}" n'existe pas`
-        );
+        throw new ErreurServiceInexistant(`Le service "${id}" n'existe pas`);
     };
 
     const verifieAutorisationInexistante = async (...params) => {
@@ -103,7 +101,7 @@ const creeDepot = (config = {}) => {
       autorisationExiste(idContributeur, idHomologation).then((existe) => {
         if (!existe) {
           throw new ErreurAutorisationInexistante(
-            `L'utilisateur "${idContributeur}" n'est pas contributeur de l'homologation "${idHomologation}"`
+            `L'utilisateur "${idContributeur}" n'est pas contributeur du service "${idHomologation}"`
           );
         }
       });
@@ -112,7 +110,7 @@ const creeDepot = (config = {}) => {
       autorisationPour(idContributeur, idHomologation).then((a) => {
         if (a.constructor.name === AutorisationCreateur.name) {
           throw new ErreurTentativeSuppressionCreateur(
-            `Suppression impossible : l'utilisateur "${idContributeur}" est le propriétaire de l'homologation "${idHomologation}"`
+            `Suppression impossible : l'utilisateur "${idContributeur}" est le propriétaire du service "${idHomologation}"`
           );
         }
       });
@@ -152,7 +150,7 @@ const creeDepot = (config = {}) => {
 
   return {
     accesAutorise,
-    ajouteContributeurAHomologation,
+    ajouteContributeurAuService,
     autorisation,
     autorisationExiste,
     autorisationPour,

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -56,7 +56,7 @@ const creeDepot = (config = {}) => {
   const autorisationExiste = (...params) =>
     autorisationPour(...params).then((a) => !!a);
 
-  const ajouteContributeurAHomologation = (idContributeur, idHomologation) => {
+  const ajouteContributeurAHomologation = (nouvelleAutorisation) => {
     const verifieUtilisateurExiste = (id) =>
       depotUtilisateurs.utilisateurExiste(id).then((existe) => {
         if (!existe)
@@ -66,12 +66,14 @@ const creeDepot = (config = {}) => {
       });
 
     const verifieHomologationExiste = (id) =>
-      depotHomologations.homologation(idHomologation).then((h) => {
-        if (!h)
-          throw new ErreurHomologationInexistante(
-            `L'homologation "${id}" n'existe pas`
-          );
-      });
+      depotHomologations
+        .homologation(nouvelleAutorisation.idService)
+        .then((h) => {
+          if (!h)
+            throw new ErreurHomologationInexistante(
+              `L'homologation "${id}" n'existe pas`
+            );
+        });
 
     const verifieAutorisationInexistante = (...params) =>
       autorisationExiste(...params).then((existe) => {
@@ -81,16 +83,19 @@ const creeDepot = (config = {}) => {
 
     const idAutorisation = adaptateurUUID.genereUUID();
 
-    return verifieUtilisateurExiste(idContributeur)
-      .then(() => verifieHomologationExiste(idHomologation))
+    return verifieUtilisateurExiste(nouvelleAutorisation.idUtilisateur)
+      .then(() => verifieHomologationExiste(nouvelleAutorisation.idService))
       .then(() =>
-        verifieAutorisationInexistante(idContributeur, idHomologation)
+        verifieAutorisationInexistante(
+          nouvelleAutorisation.idUtilisateur,
+          nouvelleAutorisation.idService
+        )
       )
       .then(() =>
         adaptateurPersistance.ajouteAutorisation(idAutorisation, {
-          idUtilisateur: idContributeur,
-          idHomologation,
-          idService: idHomologation,
+          idUtilisateur: nouvelleAutorisation.idUtilisateur,
+          idHomologation: nouvelleAutorisation.idService,
+          idService: nouvelleAutorisation.idService,
           type: 'contributeur',
           droits: toutDroitsEnEcriture(),
         })

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -87,13 +87,10 @@ const creeDepot = (config = {}) => {
       nouvelleAutorisation.idUtilisateur,
       nouvelleAutorisation.idService
     );
-    await adaptateurPersistance.ajouteAutorisation(idAutorisation, {
-      idUtilisateur: nouvelleAutorisation.idUtilisateur,
-      idHomologation: nouvelleAutorisation.idService,
-      idService: nouvelleAutorisation.idService,
-      type: 'contributeur',
-      droits: toutDroitsEnEcriture(),
-    });
+    await adaptateurPersistance.ajouteAutorisation(
+      idAutorisation,
+      nouvelleAutorisation.donneesAPersister()
+    );
   };
 
   const supprimeContributeur = (...params) => {

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -15,7 +15,7 @@ const EvenementServiceSupprime = require('../modeles/journalMSS/evenementService
 const { avecPMapPourChaqueElement } = require('../utilitaires/pMap');
 const { fabriqueServiceTracking } = require('../tracking/serviceTracking');
 const {
-  toutDroitsEnEcriture,
+  tousDroitsEnEcriture,
 } = require('../modeles/autorisations/gestionDroits');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
@@ -360,7 +360,7 @@ const creeDepot = (config = {}) => {
           idHomologation,
           idService: idHomologation,
           type: 'createur',
-          droits: toutDroitsEnEcriture(),
+          droits: tousDroitsEnEcriture(),
         })
       )
       .then(() => p.lis.une(idHomologation))

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -2,7 +2,7 @@ const adaptateurChiffrementParDefaut = require('../adaptateurs/adaptateurChiffre
 const fabriqueAdaptateurTracking = require('../adaptateurs/fabriqueAdaptateurTracking');
 const {
   ErreurDonneesObligatoiresManquantes,
-  ErreurHomologationInexistante,
+  ErreurServiceInexistant,
   ErreurNomServiceDejaExistant,
 } = require('../erreurs');
 const DescriptionService = require('../modeles/descriptionService');
@@ -176,7 +176,7 @@ const creeDepot = (config = {}) => {
     p.lis.une(idHomologation).then((h) => {
       if (typeof h === 'undefined') {
         return Promise.reject(
-          new ErreurHomologationInexistante(
+          new ErreurServiceInexistant(
             `Homologation "${idHomologation}" non trouvée`
           )
         );
@@ -465,8 +465,8 @@ const creeDepot = (config = {}) => {
       .then((h) =>
         typeof h === 'undefined'
           ? Promise.reject(
-              new ErreurHomologationInexistante(
-                `Homologation "${idHomologation}" non trouvée`
+              new ErreurServiceInexistant(
+                `Service "${idHomologation}" non trouvé`
               )
             )
           : h

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -30,7 +30,7 @@ class ErreurDossierNonFinalise extends ErreurModele {}
 class ErreurDossiersInvalides extends ErreurModele {}
 class ErreurDureeValiditeInvalide extends ErreurModele {}
 class ErreurEmailManquant extends ErreurModele {}
-class ErreurHomologationInexistante extends ErreurModele {}
+class ErreurServiceInexistant extends ErreurModele {}
 class ErreurIdentifiantActionSaisieInvalide extends ErreurModele {}
 class ErreurIdentifiantActionSaisieManquant extends ErreurModele {}
 class ErreurLocalisationDonneesInvalide extends ErreurModele {}
@@ -77,7 +77,6 @@ module.exports = {
   ErreurDroitsIncoherents,
   ErreurDureeValiditeInvalide,
   ErreurEmailManquant,
-  ErreurHomologationInexistante,
   ErreurIdentifiantActionSaisieInvalide,
   ErreurIdentifiantActionSaisieManquant,
   ErreurLocalisationDonneesInvalide,
@@ -88,6 +87,7 @@ module.exports = {
   ErreurNomServiceDejaExistant,
   ErreurProprieteManquante,
   ErreurRisqueInconnu,
+  ErreurServiceInexistant,
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,
   ErreurSuppressionImpossible,

--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -87,7 +87,7 @@ const ajoutContributeurSurServices = ({
 
   const ajouteContributeur = async (contributeur, services) => {
     const ajouteAuService = async (s) => {
-      await depotDonnees.ajouteContributeurAHomologation(
+      await depotDonnees.ajouteContributeurAuService(
         new AutorisationBase({
           idUtilisateur: contributeur.id,
           idService: s.id,

--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -1,6 +1,7 @@
 const { EchecAutorisation, EchecEnvoiMessage } = require('../../erreurs');
 const { fabriqueServiceTracking } = require('../../tracking/serviceTracking');
-const AutorisationBase = require('./autorisationBase');
+const AutorisationContributeur = require('./autorisationContributeur');
+const { toutDroitsEnEcriture } = require('./gestionDroits');
 
 const ajoutContributeurSurServices = ({
   depotDonnees,
@@ -88,9 +89,10 @@ const ajoutContributeurSurServices = ({
   const ajouteContributeur = async (contributeur, services) => {
     const ajouteAuService = async (s) => {
       await depotDonnees.ajouteContributeurAuService(
-        new AutorisationBase({
+        new AutorisationContributeur({
           idUtilisateur: contributeur.id,
           idService: s.id,
+          droits: toutDroitsEnEcriture(),
         })
       );
     };

--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -1,7 +1,6 @@
 const { EchecAutorisation, EchecEnvoiMessage } = require('../../erreurs');
 const { fabriqueServiceTracking } = require('../../tracking/serviceTracking');
 const AutorisationContributeur = require('./autorisationContributeur');
-const { toutDroitsEnEcriture } = require('./gestionDroits');
 
 const ajoutContributeurSurServices = ({
   depotDonnees,
@@ -86,13 +85,13 @@ const ajoutContributeurSurServices = ({
   const recupereParEmail = async (emailContributeur) =>
     depotDonnees.utilisateurAvecEmail(emailContributeur);
 
-  const ajouteContributeur = async (contributeur, services) => {
+  const ajouteContributeur = async (contributeur, services, droits) => {
     const ajouteAuService = async (s) => {
       await depotDonnees.ajouteContributeurAuService(
         new AutorisationContributeur({
           idUtilisateur: contributeur.id,
           idService: s.id,
-          droits: toutDroitsEnEcriture(),
+          droits,
         })
       );
     };
@@ -101,7 +100,7 @@ const ajoutContributeurSurServices = ({
   };
 
   return {
-    executer: async (emailContributeur, services, emetteur) => {
+    executer: async (emailContributeur, services, droits, emetteur) => {
       await verifiePermission(emetteur.id, services);
       const utilisateur = await recupereParEmail(emailContributeur);
 
@@ -118,7 +117,7 @@ const ajoutContributeurSurServices = ({
         ? utilisateur
         : await creeUtilisateur(emailContributeur);
 
-      await ajouteContributeur(contributeur, cibles);
+      await ajouteContributeur(contributeur, cibles, droits);
       await informeContributeur(contributeur, dejaInscrit, emetteur, cibles);
       await envoieTracking(emetteur);
     },

--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -1,5 +1,6 @@
 const { EchecAutorisation, EchecEnvoiMessage } = require('../../erreurs');
 const { fabriqueServiceTracking } = require('../../tracking/serviceTracking');
+const AutorisationBase = require('./autorisationBase');
 
 const ajoutContributeurSurServices = ({
   depotDonnees,
@@ -86,7 +87,12 @@ const ajoutContributeurSurServices = ({
 
   const ajouteContributeur = async (contributeur, services) => {
     const ajouteAuService = async (s) => {
-      await depotDonnees.ajouteContributeurAHomologation(contributeur.id, s.id);
+      await depotDonnees.ajouteContributeurAHomologation(
+        new AutorisationBase({
+          idUtilisateur: contributeur.id,
+          idService: s.id,
+        })
+      );
     };
 
     await Promise.all(services.map(ajouteAuService));

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -69,6 +69,16 @@ class AutorisationBase extends Base {
     return RESUME_NIVEAU_DROIT.PERSONNALISE;
   }
 
+  donneesAPersister() {
+    return {
+      id: this.id,
+      idService: this.idService,
+      idHomologation: this.idService,
+      idUtilisateur: this.idUtilisateur,
+      droits: this.droits,
+    };
+  }
+
   static RESUME_NIVEAU_DROIT = {
     PROPRIETAIRE: 'PROPRIETAIRE',
     ECRITURE: 'ECRITURE',

--- a/src/modeles/autorisations/autorisationContributeur.js
+++ b/src/modeles/autorisations/autorisationContributeur.js
@@ -1,5 +1,9 @@
 const AutorisationBase = require('./autorisationBase');
 
-class AutorisationContributeur extends AutorisationBase {}
+class AutorisationContributeur extends AutorisationBase {
+  donneesAPersister() {
+    return { ...super.donneesAPersister(), type: 'contributeur' };
+  }
+}
 
 module.exports = AutorisationContributeur;

--- a/src/modeles/autorisations/gestionDroits.js
+++ b/src/modeles/autorisations/gestionDroits.js
@@ -27,7 +27,7 @@ const premiereRouteDisponible = (autorisation) => {
   )?.route;
 };
 
-const toutDroitsEnEcriture = () =>
+const tousDroitsEnEcriture = () =>
   Object.values(Rubriques).reduce(
     (droits, rubrique) => ({ ...droits, [rubrique]: Permissions.ECRITURE }),
     {}
@@ -44,6 +44,6 @@ module.exports = {
   Permissions,
   Rubriques,
   premiereRouteDisponible,
-  toutDroitsEnEcriture,
+  tousDroitsEnEcriture,
   verifieCoherenceDesDroits,
 };

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -22,6 +22,9 @@ const {
   messageErreurDonneesUtilisateur,
   obtentionDonneesDeBaseUtilisateur,
 } = require('../mappeur/utilisateur');
+const {
+  toutDroitsEnEcriture,
+} = require('../../modeles/autorisations/gestionDroits');
 
 const routesApiPrivee = ({
   middleware,
@@ -262,6 +265,7 @@ const routesApiPrivee = ({
         await procedures.ajoutContributeurSurServices(
           emailContributeur,
           services,
+          toutDroitsEnEcriture(),
           emetteur
         );
         reponse.send('');

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -23,7 +23,7 @@ const {
   obtentionDonneesDeBaseUtilisateur,
 } = require('../mappeur/utilisateur');
 const {
-  toutDroitsEnEcriture,
+  tousDroitsEnEcriture,
 } = require('../../modeles/autorisations/gestionDroits');
 
 const routesApiPrivee = ({
@@ -265,7 +265,7 @@ const routesApiPrivee = ({
         await procedures.ajoutContributeurSurServices(
           emailContributeur,
           services,
-          toutDroitsEnEcriture(),
+          tousDroitsEnEcriture(),
           emetteur
         );
         reponse.send('');

--- a/src/routes/procedures.js
+++ b/src/routes/procedures.js
@@ -10,14 +10,14 @@ const fabriqueProcedures = ({
   ajoutContributeurSurServices: async (
     emailContributeur,
     service,
+    droits,
     emetteur
-  ) => {
-    await ajoutContributeurSurServices({
+  ) =>
+    ajoutContributeurSurServices({
       depotDonnees,
       adaptateurMail,
       adaptateurTracking,
-    }).executer(emailContributeur, service, emetteur);
-  },
+    }).executer(emailContributeur, service, droits, emetteur),
 });
 
 module.exports = { fabriqueProcedures };

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -1,5 +1,5 @@
 const {
-  toutDroitsEnEcriture,
+  tousDroitsEnEcriture,
 } = require('../../src/modeles/autorisations/gestionDroits');
 const AutorisationCreateur = require('../../src/modeles/autorisations/autorisationCreateur');
 const AutorisationContributeur = require('../../src/modeles/autorisations/autorisationContributeur');
@@ -38,7 +38,7 @@ class ConstructeurAutorisation {
   }
 
   avecTousDroitsEcriture() {
-    this.donnees.droits = toutDroitsEnEcriture();
+    this.donnees.droits = tousDroitsEnEcriture();
     return this;
   }
 

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -23,6 +23,7 @@ const {
 const {
   uneAutorisation,
 } = require('../constructeurs/constructeurAutorisation');
+const AutorisationBase = require('../../src/modeles/autorisations/autorisationBase');
 
 const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 const { ECRITURE, LECTURE } = Permissions;
@@ -284,7 +285,9 @@ describe('Le dépôt de données des autorisations', () => {
       const depot = creeDepot(adaptateurPersistance);
 
       try {
-        await depot.ajouteContributeurAHomologation('000', '123');
+        await depot.ajouteContributeurAHomologation(
+          new AutorisationBase({ idUtilisateur: '000', idService: '123' })
+        );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
         expect(erreur).to.be.a(ErreurUtilisateurInexistant);
@@ -301,7 +304,9 @@ describe('Le dépôt de données des autorisations', () => {
       const depot = creeDepot(adaptateurPersistance);
 
       try {
-        await depot.ajouteContributeurAHomologation('000', '123');
+        await depot.ajouteContributeurAHomologation(
+          new AutorisationBase({ idUtilisateur: '000', idService: '123' })
+        );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
         expect(erreur).to.be.a(ErreurHomologationInexistante);
@@ -327,7 +332,9 @@ describe('Le dépôt de données des autorisations', () => {
       const depot = creeDepot(adaptateurPersistance);
 
       try {
-        await depot.ajouteContributeurAHomologation('999', '123');
+        await depot.ajouteContributeurAHomologation(
+          new AutorisationBase({ idUtilisateur: '999', idService: '123' })
+        );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
         expect(erreur).to.be.a(ErreurAutorisationExisteDeja);
@@ -354,7 +361,9 @@ describe('Le dépôt de données des autorisations', () => {
       adaptateurUUID.genereUUID = () => '789';
       const depot = creeDepot(adaptateurPersistance, adaptateurUUID);
 
-      await depot.ajouteContributeurAHomologation('000', '123');
+      await depot.ajouteContributeurAHomologation(
+        new AutorisationBase({ idUtilisateur: '000', idService: '123' })
+      );
 
       const a = await depot.autorisation('789');
       expect(a).to.be.a(AutorisationContributeur);

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -6,7 +6,7 @@ const DepotDonneesUtilisateurs = require('../../src/depots/depotDonneesUtilisate
 const {
   ErreurAutorisationExisteDeja,
   ErreurAutorisationInexistante,
-  ErreurHomologationInexistante,
+  ErreurServiceInexistant,
   ErreurTentativeSuppressionCreateur,
   ErreurTranfertVersUtilisateurSource,
   ErreurUtilisateurInexistant,
@@ -264,7 +264,7 @@ describe('Le dépôt de données des autorisations', () => {
     });
   });
 
-  describe("sur demande d'ajout d'un contributeur à une homologation", () => {
+  describe("sur demande d'ajout d'un contributeur à un service", () => {
     const adaptateurUUID = { genereUUID: () => {} };
 
     it('lève une erreur si le contributeur est inexistant', async () => {
@@ -285,7 +285,7 @@ describe('Le dépôt de données des autorisations', () => {
       const depot = creeDepot(adaptateurPersistance);
 
       try {
-        await depot.ajouteContributeurAHomologation(
+        await depot.ajouteContributeurAuService(
           new AutorisationBase({ idUtilisateur: '000', idService: '123' })
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
@@ -295,7 +295,7 @@ describe('Le dépôt de données des autorisations', () => {
       }
     });
 
-    it("lève une erreur si l'homologation est inexistante", async () => {
+    it('lève une erreur si le service est inexistant', async () => {
       const adaptateurPersistance = unePersistanceMemoire()
         .ajouteUnUtilisateur({ id: '999', email: 'jean.dupont@mail.fr' })
         .ajouteUnUtilisateur({ id: '000', email: 'contributeur@mail.fr' })
@@ -304,13 +304,13 @@ describe('Le dépôt de données des autorisations', () => {
       const depot = creeDepot(adaptateurPersistance);
 
       try {
-        await depot.ajouteContributeurAHomologation(
+        await depot.ajouteContributeurAuService(
           new AutorisationBase({ idUtilisateur: '000', idService: '123' })
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
-        expect(erreur).to.be.a(ErreurHomologationInexistante);
-        expect(erreur.message).to.equal('L\'homologation "123" n\'existe pas');
+        expect(erreur).to.be.a(ErreurServiceInexistant);
+        expect(erreur.message).to.equal('Le service "123" n\'existe pas');
       }
     });
 
@@ -332,7 +332,7 @@ describe('Le dépôt de données des autorisations', () => {
       const depot = creeDepot(adaptateurPersistance);
 
       try {
-        await depot.ajouteContributeurAHomologation(
+        await depot.ajouteContributeurAuService(
           new AutorisationBase({ idUtilisateur: '999', idService: '123' })
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
@@ -361,7 +361,7 @@ describe('Le dépôt de données des autorisations', () => {
       adaptateurUUID.genereUUID = () => '789';
       const depot = creeDepot(adaptateurPersistance, adaptateurUUID);
 
-      await depot.ajouteContributeurAHomologation(
+      await depot.ajouteContributeurAuService(
         new AutorisationBase({ idUtilisateur: '000', idService: '123' })
       );
 
@@ -380,7 +380,7 @@ describe('Le dépôt de données des autorisations', () => {
     });
   });
 
-  it("connaît l'autorisation pour un utilisateur et une homologation donnée", async () => {
+  it("connaît l'autorisation pour un utilisateur et un service donnés", async () => {
     const adaptateurPersistance = unePersistanceMemoire()
       .ajouteUnUtilisateur({ id: '999', email: 'jean.dupont@mail.fr' })
       .ajouteUnService({
@@ -455,12 +455,12 @@ describe('Le dépôt de données des autorisations', () => {
       } catch (e) {
         expect(e).to.be.an(ErreurAutorisationInexistante);
         expect(e.message).to.equal(
-          'L\'utilisateur "000" n\'est pas contributeur de l\'homologation "123"'
+          'L\'utilisateur "000" n\'est pas contributeur du service "123"'
         );
       }
     });
 
-    it("vérifie qu'il s'agit bien d'un contributeur et non du créateur de l'homologation", async () => {
+    it("vérifie qu'il s'agit bien d'un contributeur et non du créateur du service", async () => {
       const adaptateurPersistance = unePersistanceMemoire()
         .ajouteUnUtilisateur({ id: '999', email: 'jean.dupont@mail.fr' })
         .ajouteUnService({
@@ -483,7 +483,7 @@ describe('Le dépôt de données des autorisations', () => {
       } catch (e) {
         expect(e).to.be.an(ErreurTentativeSuppressionCreateur);
         expect(e.message).to.equal(
-          'Suppression impossible : l\'utilisateur "999" est le propriétaire de l\'homologation "123"'
+          'Suppression impossible : l\'utilisateur "999" est le propriétaire du service "123"'
         );
       }
     });

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -19,7 +19,7 @@ const {
 const {
   Rubriques,
   Permissions,
-  toutDroitsEnEcriture,
+  tousDroitsEnEcriture,
 } = require('../../src/modeles/autorisations/gestionDroits');
 const {
   uneAutorisation,
@@ -374,7 +374,7 @@ describe('Le dépôt de données des autorisations', () => {
         new AutorisationContributeur({
           idUtilisateur: '000',
           idService: '123',
-          droits: toutDroitsEnEcriture(),
+          droits: tousDroitsEnEcriture(),
         })
       );
 

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -19,11 +19,11 @@ const {
 const {
   Rubriques,
   Permissions,
+  toutDroitsEnEcriture,
 } = require('../../src/modeles/autorisations/gestionDroits');
 const {
   uneAutorisation,
 } = require('../constructeurs/constructeurAutorisation');
-const AutorisationBase = require('../../src/modeles/autorisations/autorisationBase');
 
 const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 const { ECRITURE, LECTURE } = Permissions;
@@ -286,7 +286,10 @@ describe('Le dépôt de données des autorisations', () => {
 
       try {
         await depot.ajouteContributeurAuService(
-          new AutorisationBase({ idUtilisateur: '000', idService: '123' })
+          new AutorisationContributeur({
+            idUtilisateur: '000',
+            idService: '123',
+          })
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
@@ -305,7 +308,10 @@ describe('Le dépôt de données des autorisations', () => {
 
       try {
         await depot.ajouteContributeurAuService(
-          new AutorisationBase({ idUtilisateur: '000', idService: '123' })
+          new AutorisationContributeur({
+            idUtilisateur: '000',
+            idService: '123',
+          })
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
@@ -333,7 +339,10 @@ describe('Le dépôt de données des autorisations', () => {
 
       try {
         await depot.ajouteContributeurAuService(
-          new AutorisationBase({ idUtilisateur: '999', idService: '123' })
+          new AutorisationContributeur({
+            idUtilisateur: '999',
+            idService: '123',
+          })
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
@@ -362,10 +371,15 @@ describe('Le dépôt de données des autorisations', () => {
       const depot = creeDepot(adaptateurPersistance, adaptateurUUID);
 
       await depot.ajouteContributeurAuService(
-        new AutorisationBase({ idUtilisateur: '000', idService: '123' })
+        new AutorisationContributeur({
+          idUtilisateur: '000',
+          idService: '123',
+          droits: toutDroitsEnEcriture(),
+        })
       );
 
       const a = await depot.autorisation('789');
+
       expect(a).to.be.a(AutorisationContributeur);
       expect(a.idHomologation).to.equal('123');
       expect(a.idService).to.equal('123');

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -4,7 +4,7 @@ const uneDescriptionValide = require('../constructeurs/constructeurDescriptionSe
 
 const {
   ErreurDonneesObligatoiresManquantes,
-  ErreurHomologationInexistante,
+  ErreurServiceInexistant,
   ErreurNomServiceDejaExistant,
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
@@ -1349,7 +1349,7 @@ describe('Le dépôt de données des homologations', () => {
           done("La tentative d'ajout de dossier aurait dû lever une exception")
         )
         .catch((e) => {
-          expect(e).to.be.an(ErreurHomologationInexistante);
+          expect(e).to.be.an(ErreurServiceInexistant);
           expect(e.message).to.equal('Homologation "999" non trouvée');
           done();
         })
@@ -1678,8 +1678,8 @@ describe('Le dépôt de données des homologations', () => {
           done('La tentative de duplication aurait dû lever une exception')
         )
         .catch((e) => {
-          expect(e).to.be.an(ErreurHomologationInexistante);
-          expect(e.message).to.equal('Homologation "id-invalide" non trouvée');
+          expect(e).to.be.an(ErreurServiceInexistant);
+          expect(e.message).to.equal('Service "id-invalide" non trouvé');
           done();
         })
         .catch(done);

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -16,7 +16,7 @@ const {
 const { unService } = require('../../constructeurs/constructeurService');
 const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
 const {
-  toutDroitsEnEcriture,
+  tousDroitsEnEcriture,
 } = require('../../../src/modeles/autorisations/gestionDroits');
 
 describe("L'ajout d'un contributeur sur des services", () => {
@@ -71,7 +71,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
     }).executer(
       'jean.dupont@mail.fr',
       [leService('123'), leService('888')],
-      toutDroitsEnEcriture(),
+      tousDroitsEnEcriture(),
       unEmetteur('456')
     );
 
@@ -93,7 +93,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       }).executer(
         'jean.dupont@mail.fr',
         [leService('123')],
-        toutDroitsEnEcriture(),
+        tousDroitsEnEcriture(),
         unEmetteur()
       );
 
@@ -132,7 +132,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
         }).executer(
           'jean.dupont@mail.fr',
           [leService('123'), [leService('888')]],
-          toutDroitsEnEcriture(),
+          tousDroitsEnEcriture(),
           unEmetteur()
         );
 
@@ -166,7 +166,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
         }).executer(
           'jean.dupont@mail.fr',
           [leService('123')],
-          toutDroitsEnEcriture(),
+          tousDroitsEnEcriture(),
           unEmetteur()
         );
 
@@ -198,7 +198,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       }).executer(
         'jean.dupont@mail.fr',
         deuxServices,
-        toutDroitsEnEcriture(),
+        tousDroitsEnEcriture(),
         unEmetteur()
       );
 
@@ -230,7 +230,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       }).executer(
         'jean.dupont@mail.fr',
         deuxServices,
-        toutDroitsEnEcriture(),
+        tousDroitsEnEcriture(),
         unEmetteur()
       );
 
@@ -271,7 +271,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       }).executer(
         'jean.dupont@mail.fr',
         [leService('123')],
-        toutDroitsEnEcriture(),
+        tousDroitsEnEcriture(),
         unEmetteur()
       );
 
@@ -303,7 +303,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       }).executer(
         'jean.dupont@mail.fr',
         [leService('123')],
-        toutDroitsEnEcriture(),
+        tousDroitsEnEcriture(),
         unEmetteur()
       );
 
@@ -338,7 +338,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       }).executer(
         'jean.dupont@mail.fr',
         [leService('123'), leService('888')],
-        toutDroitsEnEcriture(),
+        tousDroitsEnEcriture(),
         unEmetteur()
       );
 
@@ -364,7 +364,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
     }).executer(
       'jean.dupont@mail.fr',
       [leService('123'), leService('888')],
-      toutDroitsEnEcriture(),
+      tousDroitsEnEcriture(),
       unEmetteur()
     );
 
@@ -402,7 +402,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
     }).executer(
       'contributeur@mail.fr',
       [leService('123')],
-      toutDroitsEnEcriture(),
+      tousDroitsEnEcriture(),
       unEmetteur('888')
     );
 

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -14,6 +14,7 @@ const {
   unUtilisateur,
 } = require('../../constructeurs/constructeurUtilisateur');
 const { unService } = require('../../constructeurs/constructeurService');
+const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
 
 describe("L'ajout d'un contributeur sur des services", () => {
   const unEmetteur = (idUtilisateur) =>
@@ -332,8 +333,10 @@ describe("L'ajout d'un contributeur sur des services", () => {
 
     expect(autorisations.length).to.be(2);
     const [a1, a2] = autorisations;
+    expect(a1).to.be.an(AutorisationContributeur);
     expect(a1.idUtilisateur).to.be('999');
     expect(a1.idService).to.be('123');
+    expect(a2).to.be.an(AutorisationContributeur);
     expect(a2.idUtilisateur).to.be('999');
     expect(a2.idService).to.be('888');
   });

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -39,7 +39,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
     depotDonnees.autorisationExiste = async () => false;
     depotDonnees.autorisationPour = async () => autorisation;
     depotDonnees.utilisateurAvecEmail = async () => utilisateur;
-    depotDonnees.ajouteContributeurAHomologation = async () => {};
+    depotDonnees.ajouteContributeurAuService = async () => {};
 
     const utilisateurCourant = { prenomNom: () => '' };
     depotDonnees.utilisateur = async () => utilisateurCourant;
@@ -168,7 +168,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       depotDonnees.autorisationExiste = existePour123MaisPas888;
 
       const autorisations = [];
-      depotDonnees.ajouteContributeurAHomologation = async (
+      depotDonnees.ajouteContributeurAuService = async (
         nouvelleAutorisation
       ) => {
         autorisations.push(nouvelleAutorisation);
@@ -316,9 +316,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
 
   it("demande au dépôt de données d'ajouter les autorisations", async () => {
     const autorisations = [];
-    depotDonnees.ajouteContributeurAHomologation = async (
-      nouvelleAutorisation
-    ) => {
+    depotDonnees.ajouteContributeurAuService = async (nouvelleAutorisation) => {
       autorisations.push(nouvelleAutorisation);
     };
 

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -164,14 +164,14 @@ describe("L'ajout d'un contributeur sur des services", () => {
     it('ajoute le contributeur seulement sur les services manquants', async () => {
       const existePour123MaisPas888 = async (_, idService) =>
         idService === '123';
+
       depotDonnees.autorisationExiste = existePour123MaisPas888;
 
       const autorisations = [];
       depotDonnees.ajouteContributeurAHomologation = async (
-        idContributeur,
-        idService
+        nouvelleAutorisation
       ) => {
-        autorisations.push({ idContributeur, idService });
+        autorisations.push(nouvelleAutorisation);
       };
 
       const deuxServices = [leService('123'), leService('888')];
@@ -181,9 +181,10 @@ describe("L'ajout d'un contributeur sur des services", () => {
         adaptateurTracking,
       }).executer('jean.dupont@mail.fr', deuxServices, unEmetteur());
 
-      expect(autorisations).to.eql([
-        { idContributeur: '999', idService: '888' },
-      ]);
+      expect(autorisations.length).to.be(1);
+      const [a] = autorisations;
+      expect(a.idUtilisateur).to.be('999');
+      expect(a.idService).to.be('888');
     });
 
     it('envoie un email ne mentionnant que les nouveaux services ciblés', async () => {
@@ -316,10 +317,9 @@ describe("L'ajout d'un contributeur sur des services", () => {
   it("demande au dépôt de données d'ajouter les autorisations", async () => {
     const autorisations = [];
     depotDonnees.ajouteContributeurAHomologation = async (
-      idContributeur,
-      idService
+      nouvelleAutorisation
     ) => {
-      autorisations.push({ idContributeur, idService });
+      autorisations.push(nouvelleAutorisation);
     };
 
     await ajoutContributeurSurServices({
@@ -332,10 +332,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
       unEmetteur()
     );
 
-    expect(autorisations).to.eql([
-      { idContributeur: '999', idService: '123' },
-      { idContributeur: '999', idService: '888' },
-    ]);
+    expect(autorisations.length).to.be(2);
+    const [a1, a2] = autorisations;
+    expect(a1.idUtilisateur).to.be('999');
+    expect(a1.idService).to.be('123');
+    expect(a2.idUtilisateur).to.be('999');
+    expect(a2.idService).to.be('888');
   });
 
   it("envoie un événement d'invitation contributeur via l'adaptateur de tracking", async () => {

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -15,6 +15,9 @@ const {
 } = require('../../constructeurs/constructeurUtilisateur');
 const { unService } = require('../../constructeurs/constructeurService');
 const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
+const {
+  toutDroitsEnEcriture,
+} = require('../../../src/modeles/autorisations/gestionDroits');
 
 describe("L'ajout d'un contributeur sur des services", () => {
   const unEmetteur = (idUtilisateur) =>
@@ -68,6 +71,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
     }).executer(
       'jean.dupont@mail.fr',
       [leService('123'), leService('888')],
+      toutDroitsEnEcriture(),
       unEmetteur('456')
     );
 
@@ -86,7 +90,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
         depotDonnees,
         adaptateurMail,
         adaptateurTracking,
-      }).executer('jean.dupont@mail.fr', [leService('123')], unEmetteur());
+      }).executer(
+        'jean.dupont@mail.fr',
+        [leService('123')],
+        toutDroitsEnEcriture(),
+        unEmetteur()
+      );
 
       expect().to.fail("L'ajout aurait dû lever une exception");
     } catch (e) {
@@ -123,6 +132,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
         }).executer(
           'jean.dupont@mail.fr',
           [leService('123'), [leService('888')]],
+          toutDroitsEnEcriture(),
           unEmetteur()
         );
 
@@ -153,7 +163,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
           depotDonnees,
           adaptateurMail,
           adaptateurTracking,
-        }).executer('jean.dupont@mail.fr', [leService('123')], unEmetteur());
+        }).executer(
+          'jean.dupont@mail.fr',
+          [leService('123')],
+          toutDroitsEnEcriture(),
+          unEmetteur()
+        );
 
         expect(emailEnvoye.inscription).to.be(false);
         expect(emailEnvoye.contribution).to.be(false);
@@ -180,7 +195,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
         depotDonnees,
         adaptateurMail,
         adaptateurTracking,
-      }).executer('jean.dupont@mail.fr', deuxServices, unEmetteur());
+      }).executer(
+        'jean.dupont@mail.fr',
+        deuxServices,
+        toutDroitsEnEcriture(),
+        unEmetteur()
+      );
 
       expect(autorisations.length).to.be(1);
       const [a] = autorisations;
@@ -207,7 +227,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
         depotDonnees,
         adaptateurMail,
         adaptateurTracking,
-      }).executer('jean.dupont@mail.fr', deuxServices, unEmetteur());
+      }).executer(
+        'jean.dupont@mail.fr',
+        deuxServices,
+        toutDroitsEnEcriture(),
+        unEmetteur()
+      );
 
       expect(nbServicesMentionnes).to.be(1);
     });
@@ -243,7 +268,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
         depotDonnees,
         adaptateurMail,
         adaptateurTracking,
-      }).executer('jean.dupont@mail.fr', [leService('123')], unEmetteur());
+      }).executer(
+        'jean.dupont@mail.fr',
+        [leService('123')],
+        toutDroitsEnEcriture(),
+        unEmetteur()
+      );
 
       expect(emailAjoute).to.be('jean.dupont@mail.fr');
     });
@@ -270,7 +300,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
         depotDonnees,
         adaptateurMail,
         adaptateurTracking,
-      }).executer('jean.dupont@mail.fr', [leService('123')], unEmetteur());
+      }).executer(
+        'jean.dupont@mail.fr',
+        [leService('123')],
+        toutDroitsEnEcriture(),
+        unEmetteur()
+      );
 
       expect(contactCree.destinataire).to.be('jean.dupont@mail.fr');
       expect(contactCree.prenom).to.be('');
@@ -303,6 +338,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
       }).executer(
         'jean.dupont@mail.fr',
         [leService('123'), leService('888')],
+        toutDroitsEnEcriture(),
         unEmetteur()
       );
 
@@ -328,6 +364,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
     }).executer(
       'jean.dupont@mail.fr',
       [leService('123'), leService('888')],
+      toutDroitsEnEcriture(),
       unEmetteur()
     );
 
@@ -362,7 +399,12 @@ describe("L'ajout d'un contributeur sur des services", () => {
       depotDonnees,
       adaptateurMail,
       adaptateurTracking,
-    }).executer('contributeur@mail.fr', [leService('123')], unEmetteur('888'));
+    }).executer(
+      'contributeur@mail.fr',
+      [leService('123')],
+      toutDroitsEnEcriture(),
+      unEmetteur('888')
+    );
 
     expect(idEmetteur).to.be('888');
     expect(donneesTracking).to.eql({

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -4,6 +4,7 @@ const AutorisationBase = require('../../../src/modeles/autorisations/autorisatio
 const {
   Permissions,
   Rubriques,
+  toutDroitsEnEcriture,
 } = require('../../../src/modeles/autorisations/gestionDroits');
 const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
 const AutorisationCreateur = require('../../../src/modeles/autorisations/autorisationCreateur');
@@ -147,6 +148,30 @@ describe('Une autorisation de base', () => {
       const autorisationCreateur = new AutorisationCreateur();
 
       expect(autorisationCreateur.peutGererContributeurs()).to.be(true);
+    });
+  });
+
+  it('connaît ses données à persister', () => {
+    const autorisationContributeur = new AutorisationContributeur({
+      id: 'uuid',
+      idService: '123',
+      idUtilisateur: '999',
+      droits: toutDroitsEnEcriture(),
+    });
+
+    expect(autorisationContributeur.donneesAPersister()).to.eql({
+      id: 'uuid',
+      idService: '123',
+      idHomologation: '123',
+      idUtilisateur: '999',
+      type: 'contributeur',
+      droits: {
+        CONTACTS: 2,
+        DECRIRE: 2,
+        HOMOLOGUER: 2,
+        RISQUES: 2,
+        SECURISER: 2,
+      },
     });
   });
 });

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -4,7 +4,7 @@ const AutorisationBase = require('../../../src/modeles/autorisations/autorisatio
 const {
   Permissions,
   Rubriques,
-  toutDroitsEnEcriture,
+  tousDroitsEnEcriture,
 } = require('../../../src/modeles/autorisations/gestionDroits');
 const AutorisationContributeur = require('../../../src/modeles/autorisations/autorisationContributeur');
 const AutorisationCreateur = require('../../../src/modeles/autorisations/autorisationCreateur');
@@ -156,7 +156,7 @@ describe('Une autorisation de base', () => {
       id: 'uuid',
       idService: '123',
       idUtilisateur: '999',
-      droits: toutDroitsEnEcriture(),
+      droits: tousDroitsEnEcriture(),
     });
 
     expect(autorisationContributeur.donneesAPersister()).to.eql({

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -870,9 +870,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.procedures().ajoutContributeurSurServices = async (
         emailContributeur,
         services,
+        droits,
         emetteur
       ) => {
-        ajout = { emailContributeur, services, emetteur };
+        ajout = { emailContributeur, services, droits, emetteur };
       };
 
       await axios.post('http://localhost:1234/api/autorisation', {
@@ -882,6 +883,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       expect(ajout.emailContributeur).to.be('jean.dupont@mail.fr');
       expect(ajout.services[0].id).to.be('123');
+      expect(ajout.droits).to.eql({
+        DECRIRE: 2,
+        SECURISER: 2,
+        HOMOLOGUER: 2,
+        RISQUES: 2,
+        CONTACTS: 2,
+      });
       expect(ajout.emetteur.id).to.be('EMETTEUR');
     });
 


### PR DESCRIPTION
Cette PR a pour objectif de donner à l'API la possibilité de piloter les droits qui sont accordés au nouveau contributeur invité.

### L'archi AVANT PR 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/46038e71-50a2-4af5-97a1-42be041e1bf5)

Le choix de mettre les droits en écriture se fait juste au moment d'appeler la persistance.

### L'archi APRÈS PR 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/8bc8fa6b-7921-4b4b-8933-68a441b87a6b)

Plusieurs choses :
 - Le dépôt prend désormais un objet du domaine : une `AutorisationBase` (ou une sous-classe)
 - Il utilise `.donneesAPersister()` pour rester le plus ignorant possible de comment sont gérés les droits
 - Ces droits sont injectés directement dans `procedure.ajoutContributeurSurServices()` qui est appelée par l'API

Dans cette PR, l'API appelle systématiquement avec `tousDroitsEnEcriture()`.
La suite est de prendre en paramètre une indication sur les droits à appliquer : `LECTURE` ou `ECRITURE`.