### PR TITLE
Route `PATCH /autorisations/:idAutorisation`

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -111,6 +111,13 @@ const nouvelAdaptateur = (
   const metsAJourService = (...params) =>
     metsAJourEnregistrement(service, ...params);
 
+  const sauvegardeAutorisation = async (id, donneesAutorisation) => {
+    const dejaConnue = donnees.autorisations.find((a) => a.id === id);
+
+    if (!dejaConnue) donnees.autorisations.push({ id, ...donneesAutorisation });
+    else Object.assign(dejaConnue, { ...donneesAutorisation });
+  };
+
   const sauvegardeHomologation = (id, donneesHomologation) => {
     const dejaConnue =
       donnees.homologations.find((h) => h.id === id) !== undefined;
@@ -332,6 +339,7 @@ const nouvelAdaptateur = (
     metsAJourUtilisateur,
     nbAutorisationsCreateur,
     rechercheContributeurs,
+    sauvegardeAutorisation,
     sauvegardeParcoursUtilisateur,
     sauvegardeHomologation,
     sauvegardeService,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -294,7 +294,7 @@ const nouvelAdaptateur = (
 
     if (!dejaConnu)
       donnees.parcoursUtilisateurs.push({ id, ...donneesParcoursUtilisateur });
-    else dejaConnu.donnees = donneesParcoursUtilisateur;
+    else Object.assign(dejaConnu, { ...donneesParcoursUtilisateur });
   };
 
   const rechercheContributeurs = async (idUtilisateur, recherche) => {

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -266,6 +266,17 @@ const nouvelAdaptateur = (env) => {
     );
   };
 
+  const sauvegardeAutorisation = async (id, donneesAutorisation) => {
+    const ligne = await knex('autorisations')
+      .where('id', id)
+      .select({ id: 'id' })
+      .first();
+
+    const dejaConnue = ligne !== undefined;
+    if (dejaConnue) metsAJourTable('autorisations', id, donneesAutorisation);
+    else ajouteLigneDansTable('autorisations', id, donneesAutorisation);
+  };
+
   const supprimeAutorisation = (idUtilisateur, idHomologation) =>
     knex('autorisations')
       .whereRaw(
@@ -414,6 +425,7 @@ const nouvelAdaptateur = (env) => {
     sauvegardeHomologation,
     sauvegardeService,
     service,
+    sauvegardeAutorisation,
     sauvegardeParcoursUtilisateur,
     supprimeAutorisation,
     supprimeAutorisations,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -94,6 +94,7 @@ const creeDepot = (config = {}) => {
     autorisationPour,
     autorisations,
     autorisationsDuService,
+    sauvegardeAutorisation,
     supprimeContributeur,
     transfereAutorisations,
   } = depotAutorisations;
@@ -127,6 +128,7 @@ const creeDepot = (config = {}) => {
     nouvelUtilisateur,
     reinitialiseMotDePasse,
     remplaceRisquesSpecifiquesPourHomologation,
+    sauvegardeAutorisation,
     sauvegardeParcoursUtilisateur,
     supprimeContributeur,
     supprimeHomologation,

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -40,6 +40,11 @@ const creeDepot = (config = {}) => {
       .autorisation(id)
       .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
 
+  const sauvegardeAutorisation = async (uneAutorisation) => {
+    const { id, ...donnees } = uneAutorisation.donneesAPersister();
+    adaptateurPersistance.sauvegardeAutorisation(id, donnees);
+  };
+
   const autorisationsDuService = async (id) => {
     const as = await adaptateurPersistance.autorisationsDuService(id);
     return as.map((a) => FabriqueAutorisation.fabrique(a));
@@ -150,6 +155,7 @@ const creeDepot = (config = {}) => {
     autorisationPour,
     autorisations,
     autorisationsDuService,
+    sauvegardeAutorisation,
     supprimeContributeur,
     transfereAutorisations,
   };

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -108,6 +108,10 @@ class AutorisationBase extends Base {
     [SECURISER]: LECTURE,
     [DECRIRE]: LECTURE,
   };
+
+  appliqueDroits(nouveauxDroits) {
+    this.droits = { ...this.droits, ...nouveauxDroits };
+  }
 }
 
 module.exports = AutorisationBase;

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -534,7 +534,7 @@ const routesApiService = (
 
       const ciblee = await depotDonnees.autorisation(idAutorisation);
       ciblee.appliqueDroits(nouveauxDroits);
-      await depotDonnees.persisteAutorisation(ciblee);
+      await depotDonnees.sauvegardeAutorisation(ciblee);
 
       reponse.sendStatus(200);
     }

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -533,8 +533,7 @@ const routesApiService = (
       }
 
       const ciblee = await depotDonnees.autorisation(idAutorisation);
-      ciblee.droits = nouveauxDroits;
-
+      ciblee.appliqueDroits(nouveauxDroits);
       await depotDonnees.persisteAutorisation(ciblee);
 
       reponse.sendStatus(200);

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -16,6 +16,11 @@ class ConstructeurAutorisation {
     };
   }
 
+  avecId(id) {
+    this.donnees.id = id;
+    return this;
+  }
+
   deCreateurDeService(idUtilisateur, idService) {
     this.donnees.type = 'createur';
     this.donnees.idUtilisateur = idUtilisateur;

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -560,4 +560,26 @@ describe('Le dépôt de données des autorisations', () => {
     expect(a[0]).to.be.an(AutorisationCreateur);
     expect(a[1]).to.be.an(AutorisationContributeur);
   });
+
+  it('sait sauvegarder une autorisation', async () => {
+    const enEcriture = uneAutorisation()
+      .avecId('uuid-a')
+      .deContributeurDeService('123', '999')
+      .avecTousDroitsEcriture();
+    const depot = creeDepot(
+      unePersistanceMemoire()
+        .ajouteUneAutorisation(enEcriture.donnees)
+        .construis()
+    );
+
+    const avant = await depot.autorisation('uuid-a');
+    expect(avant.droits.HOMOLOGUER).to.be(ECRITURE);
+
+    avant.appliqueDroits({ HOMOLOGUER: LECTURE });
+
+    await depot.sauvegardeAutorisation(avant);
+
+    const apres = await depot.autorisation('uuid-a');
+    expect(apres.droits.HOMOLOGUER).to.be(LECTURE);
+  });
 });

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -79,6 +79,19 @@ describe('Une autorisation de base', () => {
     expect(peutEcrire).to.be(false);
   });
 
+  it('sait appliquer de nouveaux droits', () => {
+    const autorisation = new AutorisationBase({
+      droits: tousDroitsEnEcriture(),
+    });
+    expect(autorisation.aLaPermission(ECRITURE, HOMOLOGUER)).to.be(true);
+
+    const homologuerLecture = { HOMOLOGUER: LECTURE };
+    autorisation.appliqueDroits(homologuerLecture);
+
+    expect(autorisation.aLaPermission(ECRITURE, HOMOLOGUER)).to.be(false);
+    expect(autorisation.aLaPermission(LECTURE, HOMOLOGUER)).to.be(true);
+  });
+
   describe('sur demande de résumé de niveau de droit', () => {
     it("retour 'PROPRIETAIRE' si l'utilisateur est créateur du service", async () => {
       const autorisationCreateur = new AutorisationCreateur();

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1535,7 +1535,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().autorisation = async () =>
         uneAutorisation().avecTousDroitsEcriture().construis();
 
-      testeur.depotDonnees().persisteAutorisation = async () => {};
+      testeur.depotDonnees().sauvegardeAutorisation = async () => {};
     });
 
     it('recherche le service correspondant', (done) => {
@@ -1612,7 +1612,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       };
 
       let autorisationPersistee;
-      testeur.depotDonnees().persisteAutorisation = async (autorisation) => {
+      testeur.depotDonnees().sauvegardeAutorisation = async (autorisation) => {
         autorisationPersistee = autorisation;
       };
 


### PR DESCRIPTION
Cette PR ajoute la route qui permet de modifier une autorisation, avec une requête de la forme :

```http
PATCH /api/service/59398409-5a5b-4555-90ac-40955b6f77d6/autorisations/5f94f7c8-bd00-4abd-80dc-27f60fd7ddba
Content-Type: application/json

{
  "droits": {
    "HOMOLOGUER": 1
  }
}
```

On ajoute au `depotDonneesAutorisations` la capacité de sauvegarder un objet `autorisation` tout entier.