### PR TITLE
[CORRECTION] Empêche d'inviter la même personne 2 fois

### DIFF
--- a/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
+++ b/svelte/lib/gestionContributeurs/ChampAvecSuggestions.svelte
@@ -50,9 +50,9 @@
         class="create option-ajout"
         on:click={() =>
           choisisContributeur({
-            email: saisie,
+            email: saisie.toLocaleLowerCase('fr'),
             initiales: '',
-            prenomNom: saisie,
+            prenomNom: saisie.toLocaleLowerCase('fr'),
           })}
       >
         Ajouter ce contributeur

--- a/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/InvitationContributeur.svelte
@@ -33,9 +33,14 @@
 
   const ajouteInvitation = (evenement: CustomEvent<Utilisateur>) => {
     store.navigation.afficheEtapeInvitation();
-    const dejaInvite = invitations.find(
-      (c) => c.utilisateur.email === evenement.detail.email
+
+    const memeEmails = (email1: string, email2: string) =>
+      email1.localeCompare(email2, 'fr', { sensitivity: 'accent' }) === 0;
+
+    const dejaInvite = invitations.find((c) =>
+      memeEmails(c.utilisateur.email, evenement.detail.email)
     );
+
     if (!dejaInvite)
       invitations = [
         ...invitations,


### PR DESCRIPTION
… en changeant la casse de l'email.
Avant ce commit, `christophe@beta.gouv.fr` et `CHRISTOPHE@beta.gouv.fr` pouvaient être ajoutés simultanément.