### PR TITLE
Enlève du menu de navigation les étapes inaccessibles

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -67,16 +67,19 @@ module.exports = {
       position: 0,
       description: 'Décrire',
       sousTitre: 'Évaluer les besoins de sécurité',
+      rubriqueDroit: 'DECRIRE',
     },
     mesures: {
       position: 1,
       description: 'Sécuriser',
       sousTitre: "Mesurer et renforcer l'indice cyber",
+      rubriqueDroit: 'SECURISER',
     },
     dossiers: {
       position: 2,
       description: 'Homologuer',
       sousTitre: "Générer un dossier d'homologation",
+      rubriqueDroit: 'HOMOLOGUER',
     },
   },
 

--- a/src/modeles/actionSaisie.js
+++ b/src/modeles/actionSaisie.js
@@ -30,6 +30,7 @@ class ActionSaisie extends Base {
       sousTitre: donnees.sousTitre,
       position: donnees.position,
       url: `/service/${this.service.id}/${this.id}`,
+      rubriqueDroit: donnees.rubriqueDroit,
     };
   }
 

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -1,8 +1,9 @@
 - const estSurCreationDeService = !!service.id === false
 
-mixin etapeParcours({ id, position, url, description, sousTitre, statut })
+mixin etapeParcours({ id, position, url, description, sousTitre, statut, rubriqueDroit })
   -
     const estActive = etapeActive === id
+    const estVisible = estSurCreationDeService || !(autorisationsService[rubriqueDroit].estMasque)
     const statutSaisie = (s) => {
       switch (s) {
         case InformationsHomologation.COMPLETES: return 'faite';
@@ -11,14 +12,15 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut })
       }
     }
 
-  li
-    a(href = estSurCreationDeService ? '#' : url, class = estActive ? 'actif' : '')
-      .pastille
-        span.action-saisie(id = id)
-      .none-si-ferme
-        span.nom-action!= description
-        span.sous-titre!= sousTitre
-      .statut-saisie.none-si-ferme(class = statutSaisie(statut))
+  if estVisible
+    li
+      a(href = estSurCreationDeService ? '#' : url, class = estActive ? 'actif' : '')
+        .pastille
+          span.action-saisie(id = id)
+        .none-si-ferme
+          span.nom-action!= description
+          span.sous-titre!= sousTitre
+        .statut-saisie.none-si-ferme(class = statutSaisie(statut))
 
 
 .menu-navigation(class = preferencesUtilisateur.etatMenuNavigation === 'ferme' ? 'ferme' : '')

--- a/test/modeles/actionSaisie.spec.js
+++ b/test/modeles/actionSaisie.spec.js
@@ -27,6 +27,7 @@ describe('Une action de saisie', () => {
           position: 0,
           description: 'Une description',
           sousTitre: 'Un sous-titre',
+          rubriqueDroit: 'DECRIRE',
         },
       },
     });
@@ -43,6 +44,7 @@ describe('Une action de saisie', () => {
       sousTitre: 'Un sous-titre',
       statut: InformationsHomologation.A_SAISIR,
       url: `/service/ABC/uneAction`,
+      rubriqueDroit: 'DECRIRE',
     });
   });
 

--- a/test/modeles/actionsSaisie.spec.js
+++ b/test/modeles/actionsSaisie.spec.js
@@ -21,29 +21,17 @@ describe("Les actions de saisie d'un service", () => {
           position: 1,
           description: "Description de l'action suivante",
         },
-        uneAction: { position: 0, description: 'Une description' },
+        uneAction: {
+          position: 0,
+          description: 'Une description',
+        },
       },
     });
 
     const actions = new ActionsSaisie(referentiel, unServiceASaisir());
 
-    expect(actions.toJSON()).to.eql([
-      {
-        id: 'uneAction',
-        position: 0,
-        description: 'Une description',
-        sousTitre: undefined,
-        statut: InformationsHomologation.A_SAISIR,
-        url: '/service/ABC/uneAction',
-      },
-      {
-        id: 'actionSuivante',
-        position: 1,
-        description: "Description de l'action suivante",
-        sousTitre: undefined,
-        statut: InformationsHomologation.A_SAISIR,
-        url: '/service/ABC/actionSuivante',
-      },
-    ]);
+    const [action1, action2] = actions.toJSON();
+    expect(action1.position).to.be(0);
+    expect(action2.position).to.be(1);
   });
 });

--- a/test/referentiel.coherence.spec.js
+++ b/test/referentiel.coherence.spec.js
@@ -1,0 +1,27 @@
+const expect = require('expect.js');
+const { creeReferentiel } = require('../src/referentiel');
+const { Rubriques } = require('../src/modeles/autorisations/gestionDroits');
+
+describe('Les données réelles du référentiel', () => {
+  let referentiel;
+  beforeEach(() => {
+    referentiel = creeReferentiel();
+  });
+
+  describe('sur les actions de saisie', () => {
+    it('référencent des rubriques de droits existantes', () => {
+      const actions = referentiel.actionsSaisie();
+
+      Object.entries(actions).forEach(([id, details]) => {
+        const rubrique = details.rubriqueDroit;
+        try {
+          expect(Rubriques).to.have.key(rubrique);
+        } catch (_) {
+          expect().fail(
+            `L'action de saisie '${id}' référence la rubrique '${rubrique}' qui n'existe pas.`
+          );
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Cette PR permet au menu de navigation de ne contenir que les étapes accessibles à l'utilisateur.

Exemple ici, avec une étape `Décrire` masquée 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/60bf5ee8-ff6c-40b6-8272-1087e388506d)

On ajoute aux `actionsSaisie` du référentiel la connaissance de la rubrique de droits associée.
Au passage on introduit des tests de cohérence du référentiel.