### PR TITLE
Utilisation d'un tiroir pour télécharger les PDF

### DIFF
--- a/public/assets/images/icone_telechargement_fichier.svg
+++ b/public/assets/images/icone_telechargement_fichier.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="document-download">
+<path id="Vector" d="M9 11.5V17.5L11 15.5" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M9 17.5L7 15.5" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M22 10.5V15.5C22 20.5 20 22.5 15 22.5H9C4 22.5 2 20.5 2 15.5V9.5C2 4.5 4 2.5 9 2.5H14" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_4" d="M22 10.5H18C15 10.5 14 9.5 14 6.5V2.5L22 10.5Z" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/public/modules/tableauDeBord/actions/ActionTelechargement.mjs
+++ b/public/modules/tableauDeBord/actions/ActionTelechargement.mjs
@@ -6,9 +6,9 @@ class ActionTelechargement extends ActionAbstraite {
     this.appliqueContenu({
       titre: 'Télécharger les PDF',
       texteSimple:
-        "Obtenir les documents utiles à la sécurisation et à l'homologation des services sélectionnés.",
-      texteMultiple:
         "Obtenir les documents utiles à la sécurisation et à l'homologation du service sélectionné.",
+      texteMultiple:
+        "Obtenir les documents utiles à la sécurisation et à l'homologation des services sélectionnés.",
     });
   }
 

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -23,7 +23,7 @@ $(() => {
     ouvrir: () => cookie().supprimer(),
   };
 
-  const rechargeDonneesDuService = async () => {
+  const rechargeNbContributeurs = async () => {
     const reponse = await axios.get(`/api/service/${idService}`);
     donneesService = reponse.data;
     $('.nombre-contributeurs', '#gerer-contributeurs').text(
@@ -34,18 +34,15 @@ $(() => {
   const brancheComportementTiroirContributeurs = () => {
     gestionnaireTiroir.brancheComportement();
 
-    if (idService) rechargeDonneesDuService();
+    if (idService) rechargeNbContributeurs();
 
     $(document.body).on('jquery-recharge-services', async () => {
-      await rechargeDonneesDuService();
+      await rechargeNbContributeurs();
     });
 
     $('#gerer-contributeurs').on('click', () => {
       gestionnaireTiroir.afficheContenuAction(
-        {
-          action: contributeurs,
-          estSelectionMulitple: false,
-        },
+        { action: contributeurs, estSelectionMulitple: false },
         { donneesServices: [donneesService] }
       );
     });

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -1,5 +1,6 @@
 import { gestionnaireTiroir } from '../modules/tableauDeBord/gestionnaireTiroir.mjs';
 import ActionContributeurs from '../modules/tableauDeBord/actions/ActionContributeurs.mjs';
+import ActionTelechargement from '../modules/tableauDeBord/actions/ActionTelechargement.mjs';
 
 const tiroirContributeur = (idService) => {
   const contributeurs = new ActionContributeurs();
@@ -14,8 +15,6 @@ const tiroirContributeur = (idService) => {
 
   return {
     brancheComportement: () => {
-      gestionnaireTiroir.brancheComportement();
-
       if (idService) rechargeNbContributeurs();
 
       $(document.body).on('jquery-recharge-services', async () => {
@@ -26,6 +25,24 @@ const tiroirContributeur = (idService) => {
         gestionnaireTiroir.afficheContenuAction(
           { action: contributeurs, estSelectionMulitple: false },
           { donneesServices: [donneesService] }
+        );
+      });
+    },
+  };
+};
+
+const tiroirTelechargement = (idService) => {
+  const telechargement = new ActionTelechargement();
+  const chargeDonneesService = async () =>
+    (await axios.get(`/api/service/${idService}`)).data;
+
+  return {
+    brancheComportement: () => {
+      $('#voir-telechargement').on('click', async () => {
+        const donneesService = await chargeDonneesService();
+        gestionnaireTiroir.afficheContenuAction(
+          { action: telechargement, estSelectionMulitple: false },
+          { idService, donneesService }
         );
       });
     },
@@ -66,10 +83,12 @@ const repliMenu = () => {
     },
   };
 };
-
 $(() => {
   const idService = $('.page-service').data('id-service');
 
   repliMenu().brancheComportement();
+
+  gestionnaireTiroir.brancheComportement();
   tiroirContributeur(idService).brancheComportement();
+  tiroirTelechargement(idService).brancheComportement();
 });

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -1,12 +1,41 @@
 import { gestionnaireTiroir } from '../modules/tableauDeBord/gestionnaireTiroir.mjs';
 import ActionContributeurs from '../modules/tableauDeBord/actions/ActionContributeurs.mjs';
 
+const tiroirContributeur = (idService) => {
+  const contributeurs = new ActionContributeurs();
+  let donneesService;
+  const rechargeNbContributeurs = async () => {
+    const reponse = await axios.get(`/api/service/${idService}`);
+    donneesService = reponse.data;
+    $('.nombre-contributeurs', '#gerer-contributeurs').text(
+      donneesService.contributeurs.length + 1
+    );
+  };
+
+  return {
+    brancheComportement: () => {
+      gestionnaireTiroir.brancheComportement();
+
+      if (idService) rechargeNbContributeurs();
+
+      $(document.body).on('jquery-recharge-services', async () => {
+        await rechargeNbContributeurs();
+      });
+
+      $('#gerer-contributeurs').on('click', () => {
+        gestionnaireTiroir.afficheContenuAction(
+          { action: contributeurs, estSelectionMulitple: false },
+          { donneesServices: [donneesService] }
+        );
+      });
+    },
+  };
+};
+
 $(() => {
   const $menu = $('.menu-navigation');
   const $repliMenu = $('.repli-menu', $menu);
   const idService = $('.page-service').data('id-service');
-  let donneesService;
-  const contributeurs = new ActionContributeurs();
 
   const cookie = () => {
     const cookieAvecAge = (ageEnSecondes) =>
@@ -23,31 +52,6 @@ $(() => {
     ouvrir: () => cookie().supprimer(),
   };
 
-  const rechargeNbContributeurs = async () => {
-    const reponse = await axios.get(`/api/service/${idService}`);
-    donneesService = reponse.data;
-    $('.nombre-contributeurs', '#gerer-contributeurs').text(
-      donneesService.contributeurs.length + 1
-    );
-  };
-
-  const brancheComportementTiroirContributeurs = () => {
-    gestionnaireTiroir.brancheComportement();
-
-    if (idService) rechargeNbContributeurs();
-
-    $(document.body).on('jquery-recharge-services', async () => {
-      await rechargeNbContributeurs();
-    });
-
-    $('#gerer-contributeurs').on('click', () => {
-      gestionnaireTiroir.afficheContenuAction(
-        { action: contributeurs, estSelectionMulitple: false },
-        { donneesServices: [donneesService] }
-      );
-    });
-  };
-
   $repliMenu.on('click', () => {
     const menuOuvert = !$menu.hasClass('ferme');
     if (menuOuvert) {
@@ -59,5 +63,5 @@ $(() => {
     }
   });
 
-  brancheComportementTiroirContributeurs();
+  tiroirContributeur(idService).brancheComportement();
 });

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -32,10 +32,9 @@ const tiroirContributeur = (idService) => {
   };
 };
 
-$(() => {
+const repliMenu = () => {
   const $menu = $('.menu-navigation');
   const $repliMenu = $('.repli-menu', $menu);
-  const idService = $('.page-service').data('id-service');
 
   const cookie = () => {
     const cookieAvecAge = (ageEnSecondes) =>
@@ -52,16 +51,25 @@ $(() => {
     ouvrir: () => cookie().supprimer(),
   };
 
-  $repliMenu.on('click', () => {
-    const menuOuvert = !$menu.hasClass('ferme');
-    if (menuOuvert) {
-      $menu.addClass('ferme');
-      persistance.fermer();
-    } else {
-      $menu.removeClass('ferme');
-      persistance.ouvrir();
-    }
-  });
+  return {
+    brancheComportement: () => {
+      $repliMenu.on('click', () => {
+        const menuOuvert = !$menu.hasClass('ferme');
+        if (menuOuvert) {
+          $menu.addClass('ferme');
+          persistance.fermer();
+        } else {
+          $menu.removeClass('ferme');
+          persistance.ouvrir();
+        }
+      });
+    },
+  };
+};
 
+$(() => {
+  const idService = $('.page-service').data('id-service');
+
+  repliMenu().brancheComportement();
   tiroirContributeur(idService).brancheComportement();
 });

--- a/src/vues/deuxColonnes.pug
+++ b/src/vues/deuxColonnes.pug
@@ -35,3 +35,4 @@ block main
 
   +tiroir
     include ./tiroirs/tiroirContributeurs
+    include ./tiroirs/tiroirTelechargement

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -54,20 +54,8 @@ mixin etapeParcours({ id, position, url, description, sousTitre, statut, rubriqu
                 img(src = '/statique/assets/images/icone_contacts_utiles.svg' alt="Icône d'un livre ouvert")
               span.none-si-ferme Contacts utiles
         li
-          a(
-            href = `/api/service/${service.id}/pdf/syntheseSecurite.pdf`,
-            target = '_blank',
-            rel = 'noopener'
-            title= 'Télécharger le PDF de synthèse de sécurité dans une nouvelle fenêtre')
+          a#voir-telechargement(href = '#')
             .pastille
-              img(src = '/statique/assets/images/icone_action_telechargement.svg' alt='Icône de fichier PDF')
-            span.none-si-ferme Synthèse de sécurité
-        li
-          a(
-            href = `/api/service/${service.id}/pdf/annexes.pdf`,
-            target = '_blank',
-            rel = 'noopener'
-            title= 'Télécharger les annexes PDF dans une nouvelle fenêtre')
-            .pastille
-              img(src = '/statique/assets/images/icone_action_telechargement.svg' alt='Icône de fichier PDF')
-            span.none-si-ferme Annexes
+              img(src = '/statique/assets/images/icone_telechargement_fichier.svg' alt='Icône de téléchargement de fichier')
+            span.none-si-ferme Télécharger les PDF
+

--- a/src/vues/tiroirs/tiroirTelechargement.pug
+++ b/src/vues/tiroirs/tiroirTelechargement.pug
@@ -13,4 +13,4 @@ mixin documentTelechargeable(nom, description, type, idLien, peutEtreIndisponibl
     +documentTelechargeable('Synthèse de la sécurité du service', "Ce PDF résume en 1 page l'état de la sécurité du service.", 'PDF', 'lien-synthese')
     +documentTelechargeable('Annexes', 'Ce PDF détaille toutes les informations renseignées sur la sécurité du service.', 'PDF', 'lien-annexes')
     +documentTelechargeable("Décision d'homologation de sécurité", "Ce PDF est le document de décision pouvant être signé par l'autorité d'homologation.", 'PDF', 'lien-decision')
-    +documentTelechargeable('Tous les documents', 'Ce fichier .ZIP contient les <span id="nbPdfDisponibles"></span> PDF à télécharger.', 'ZIP', 'lien-archive')
+    +documentTelechargeable('Tous les documents', 'Ce fichier .ZIP contient les <span id="nbPdfDisponibles"></span> PDF.', 'ZIP', 'lien-archive')


### PR DESCRIPTION
Cette PDF supprime les liens directs vers les PDF 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/a7417ef7-2392-482f-bb9b-1b1bc1be5087)


… et les remplace par le tiroir « Télécharger les PDF » 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/02e299f8-ce32-4301-aee9-342664943d23)

`public/scripts/menuNavigation.js` est refactoré pour extraire des petits objets à forte cohésion.
