### PR TITLE
Affiche « Nouveautés » sur le tableau de bord

### DIFF
--- a/src/vues/motDePasse/edition.pug
+++ b/src/vues/motDePasse/edition.pug
@@ -17,6 +17,9 @@ block header-gauche
     .retour-tableau-de-bord
       a(href='/tableauDeBord') Retour au tableau de bord
 
+block bandeau-nouveautes
+  // Pas de « Nouveautés » sur cette page
+
 block main
   form.etroit.mot-de-passe#edition
     .mention champ obligatoire

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -28,8 +28,6 @@ block append scripts
   script(src = "/statique/bibliotheques/selectize-0.15.2.min.js")
   script(src = "/statique/composants-svelte/gestionContributeurs.js", type = "module")
 
-block bandeau-nouveautes
-  // Pas de « Nouveautés » sur le tableau de bord
 
 block header-gauche
   .conteneur-logo

--- a/src/vues/utilisateur/edition.pug
+++ b/src/vues/utilisateur/edition.pug
@@ -10,6 +10,10 @@ block header-gauche
     .retour-tableau-de-bord
       a(href='/tableauDeBord') Retour au tableau de bord
 
+
+block bandeau-nouveautes
+  // Pas de « Nouveautés » sur cette page
+
 block main
   form.etroit.utilisateur#edition
     +formulaireUtilisateur({


### PR DESCRIPTION
Le tableau de bord est la seule page privée où on veut afficher ce bouton des « Nouveautés ».

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/9afa4746-e8d5-4798-b4d9-66e6b96650c1)
