### PR TITLE
Définition de droits personnalisés à l'invitation et dans la liste des contributeurs

### DIFF
--- a/src/modeles/objetsApi/objetGetAutorisation.js
+++ b/src/modeles/objetsApi/objetGetAutorisation.js
@@ -2,6 +2,7 @@ const donnees = (autorisation) => ({
   idUtilisateur: autorisation.idUtilisateur,
   idAutorisation: autorisation.id,
   resumeNiveauDroit: autorisation.resumeNiveauDroit(),
+  droits: autorisation.droits,
 });
 
 module.exports = { donnees };

--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -4,6 +4,7 @@
   import LigneContributeur from './LigneContributeur.svelte';
   import SuppressionContributeur from './SuppressionContributeur.svelte';
   import { onMount } from 'svelte';
+  import PersonnalisationContributeur from './PersonnalisationContributeur.svelte';
 
   $: surServiceUnique = $store.services.length === 1;
   $: serviceUnique = $store.services[0];
@@ -21,6 +22,8 @@
 
 {#if $store.etapeCourante === 'SuppressionContributeur'}
   <SuppressionContributeur />
+{:else if $store.etapeCourante === 'PersonnalisationContributeur'}
+  <PersonnalisationContributeur />
 {:else}
   {#if $store.services.every((s) => s.estCreateur)}
     <InvitationContributeur />

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -10,6 +10,7 @@
   import { enDroitsSurRubrique } from './gestionContributeurs.d';
 
   export let droitsModifiables: boolean;
+  export let afficheDroits: boolean = true;
   export let utilisateur: Utilisateur;
 
   let serviceUnique: Service;
@@ -40,11 +41,14 @@
     </div>
   </div>
   <div class="conteneur-actions">
-    {#if autorisation?.resumeNiveauDroit}
+    {#if afficheDroits && autorisation?.resumeNiveauDroit}
       <TagNiveauDroit
         niveau={autorisation.resumeNiveauDroit}
         {droitsModifiables}
-        on:droitsChange={(e) => changeDroits(e.detail)}
+        on:droitsChange={({ detail: nouveauxDroits }) =>
+          changeDroits(nouveauxDroits)}
+        on:choixPersonnalisation={() =>
+          store.navigation.affichePersonnalisationContributeur(utilisateur)}
       />
     {/if}
 

--- a/svelte/lib/gestionContributeurs/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/LigneContributeur.svelte
@@ -37,7 +37,9 @@
     />
     <div class="nom-prenom-poste">
       <div class="nom-contributeur">{@html utilisateur.prenomNom}</div>
-      <div class="poste-contributeur">{@html utilisateur.poste}</div>
+      {#if utilisateur.poste}
+        <div class="poste-contributeur">{@html utilisateur.poste}</div>
+      {/if}
     </div>
   </div>
   <div class="conteneur-actions">

--- a/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { store } from './gestionContributeurs.store';
+  import LigneContributeur from './LigneContributeur.svelte';
+
+  $: contributeur = $store.utilisateurEnCoursDePersonnalisation!;
+</script>
+
+<div class="identite-contributeur">
+  <div class="titre">Contributeur sélectionné</div>
+  <ul class="liste-contributeurs">
+    <LigneContributeur
+      utilisateur={contributeur}
+      droitsModifiables={false}
+      afficheDroits={false}
+    />
+  </ul>
+</div>
+<div class="permissions">
+  <div class="titre">Permissions</div>
+  <div>Sélectionner les droits d'accès pour chaque rubrique.</div>
+  <div class="personnalisation">…</div>
+</div>
+<div class="conteneur-actions">
+  <button
+    class="bouton bouton-secondaire"
+    type="button"
+    on:click={() => store.navigation.afficheEtapeListe()}
+  >
+    Annuler
+  </button>
+  <button
+    class="bouton"
+    id="action-invitation"
+    type="button"
+    on:click={() => {}}
+  >
+    Enregistrer
+  </button>
+</div>
+
+<style>
+  .liste-contributeurs {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  .liste-contributeurs :global(li) {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    padding: 1em;
+    margin-bottom: 0.5em;
+  }
+
+  .titre {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+
+  .permissions {
+    margin-top: 32px;
+  }
+
+  .personnalisation {
+    margin: 16px 0 40px 0;
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
@@ -5,29 +5,28 @@
   import TagLectureEcriture from './TagLectureEcriture.svelte';
 
   $: contributeur = $store.utilisateurEnCoursDePersonnalisation!;
-  $: autorisations = $store.autorisations[contributeur.id];
-  $: redefinies = { ...autorisations };
+  $: autorisation = $store.autorisations[contributeur.id];
+  $: redefinis = { ...autorisation.droits };
 
   let rubriques: { id: Rubrique; nom: string; droit: Permission }[];
   $: rubriques = [
-    { id: 'DECRIRE', nom: 'Décrire', droit: redefinies.droits.DECRIRE },
-    { id: 'SECURISER', nom: 'Sécuriser', droit: redefinies.droits.SECURISER },
-    {
-      id: 'HOMOLOGUER',
-      nom: 'Homologuer',
-      droit: redefinies.droits.HOMOLOGUER,
-    },
-    {
-      id: 'RISQUES',
-      nom: 'Risques de sécurité',
-      droit: redefinies.droits.RISQUES,
-    },
-    {
-      id: 'CONTACTS',
-      nom: 'Contacts utiles',
-      droit: redefinies.droits.CONTACTS,
-    },
+    { id: 'DECRIRE', nom: 'Décrire', droit: redefinis.DECRIRE },
+    { id: 'SECURISER', nom: 'Sécuriser', droit: redefinis.SECURISER },
+    { id: 'HOMOLOGUER', nom: 'Homologuer', droit: redefinis.HOMOLOGUER },
+    { id: 'RISQUES', nom: 'Risques de sécurité', droit: redefinis.RISQUES },
+    { id: 'CONTACTS', nom: 'Contacts utiles', droit: redefinis.CONTACTS },
   ];
+
+  const envoyerDroits = async () => {
+    const idService = $store.services[0].id;
+    const idAutorisation = autorisation.idAutorisation;
+    const { data: nouvelleAutorisation } = await axios.patch(
+      `/api/service/${idService}/autorisations/${idAutorisation}`,
+      { droits: redefinis }
+    );
+    store.autorisations.remplace(nouvelleAutorisation);
+    store.navigation.afficheEtapeListe();
+  };
 </script>
 
 <div class="identite-contributeur">
@@ -51,7 +50,7 @@
           {#if droit !== 0}
             <TagLectureEcriture
               {droit}
-              on:droitChange={(e) => (redefinies.droits[id] = e.detail)}
+              on:droitChange={(e) => (redefinis[id] = e.detail)}
             />
           {/if}
         </div>
@@ -71,7 +70,7 @@
     class="bouton"
     id="action-invitation"
     type="button"
-    on:click={() => {}}
+    on:click={() => envoyerDroits()}
   >
     Enregistrer
   </button>

--- a/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
@@ -5,8 +5,8 @@
   import TagLectureEcriture from './TagLectureEcriture.svelte';
 
   $: contributeur = $store.utilisateurEnCoursDePersonnalisation!;
-  $: autorisation = $store.autorisations[contributeur.id];
-  $: redefinis = { ...autorisation.droits };
+  $: originaux = $store.autorisations[contributeur.id];
+  $: redefinis = { ...originaux.droits };
 
   let rubriques: { id: Rubrique; nom: string; droit: Permission }[];
   $: rubriques = [
@@ -19,7 +19,7 @@
 
   const envoyerDroits = async () => {
     const idService = $store.services[0].id;
-    const idAutorisation = autorisation.idAutorisation;
+    const idAutorisation = originaux.idAutorisation;
     const { data: nouvelleAutorisation } = await axios.patch(
       `/api/service/${idService}/autorisations/${idAutorisation}`,
       { droits: redefinis }
@@ -62,7 +62,10 @@
   <button
     class="bouton bouton-secondaire"
     type="button"
-    on:click={() => store.navigation.afficheEtapeListe()}
+    on:click={() => {
+      store.autorisations.remplace(originaux);
+      store.navigation.afficheEtapeListe();
+    }}
   >
     Annuler
   </button>

--- a/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
@@ -1,17 +1,32 @@
 <script lang="ts">
   import { store } from './gestionContributeurs.store';
+  import type { Rubrique, Permission } from './gestionContributeurs.d';
   import LigneContributeur from './LigneContributeur.svelte';
   import TagLectureEcriture from './TagLectureEcriture.svelte';
 
   $: contributeur = $store.utilisateurEnCoursDePersonnalisation!;
   $: autorisations = $store.autorisations[contributeur.id];
+  $: redefinies = { ...autorisations };
 
+  let rubriques: { id: Rubrique; nom: string; droit: Permission }[];
   $: rubriques = [
-    { nom: 'Décrire', droit: autorisations.droits.DECRIRE },
-    { nom: 'Sécuriser', droit: autorisations.droits.SECURISER },
-    { nom: 'Homologuer', droit: autorisations.droits.HOMOLOGUER },
-    { nom: 'Risques de sécurité', droit: autorisations.droits.RISQUES },
-    { nom: 'Contacts utiles', droit: autorisations.droits.CONTACTS },
+    { id: 'DECRIRE', nom: 'Décrire', droit: redefinies.droits.DECRIRE },
+    { id: 'SECURISER', nom: 'Sécuriser', droit: redefinies.droits.SECURISER },
+    {
+      id: 'HOMOLOGUER',
+      nom: 'Homologuer',
+      droit: redefinies.droits.HOMOLOGUER,
+    },
+    {
+      id: 'RISQUES',
+      nom: 'Risques de sécurité',
+      droit: redefinies.droits.RISQUES,
+    },
+    {
+      id: 'CONTACTS',
+      nom: 'Contacts utiles',
+      droit: redefinies.droits.CONTACTS,
+    },
   ];
 </script>
 
@@ -29,12 +44,15 @@
   <div class="titre">Permissions</div>
   <div>Sélectionner les droits d'accès pour chaque rubrique.</div>
   <div class="personnalisation">
-    {#each rubriques as { nom, droit }}
+    {#each rubriques as { id, nom, droit }}
       <div class="rubrique">
         <div class="nom-rubrique">{nom}</div>
         <div>
           {#if droit !== 0}
-            <TagLectureEcriture {droit} />
+            <TagLectureEcriture
+              {droit}
+              on:droitChange={(e) => (redefinies.droits[id] = e.detail)}
+            />
           {/if}
         </div>
       </div>

--- a/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/PersonnalisationContributeur.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
   import { store } from './gestionContributeurs.store';
   import LigneContributeur from './LigneContributeur.svelte';
+  import TagLectureEcriture from './TagLectureEcriture.svelte';
 
   $: contributeur = $store.utilisateurEnCoursDePersonnalisation!;
+  $: autorisations = $store.autorisations[contributeur.id];
+
+  $: rubriques = [
+    { nom: 'Décrire', droit: autorisations.droits.DECRIRE },
+    { nom: 'Sécuriser', droit: autorisations.droits.SECURISER },
+    { nom: 'Homologuer', droit: autorisations.droits.HOMOLOGUER },
+    { nom: 'Risques de sécurité', droit: autorisations.droits.RISQUES },
+    { nom: 'Contacts utiles', droit: autorisations.droits.CONTACTS },
+  ];
 </script>
 
 <div class="identite-contributeur">
@@ -18,7 +28,18 @@
 <div class="permissions">
   <div class="titre">Permissions</div>
   <div>Sélectionner les droits d'accès pour chaque rubrique.</div>
-  <div class="personnalisation">…</div>
+  <div class="personnalisation">
+    {#each rubriques as { nom, droit }}
+      <div class="rubrique">
+        <div class="nom-rubrique">{nom}</div>
+        <div>
+          {#if droit !== 0}
+            <TagLectureEcriture {droit} />
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
 </div>
 <div class="conteneur-actions">
   <button
@@ -57,6 +78,7 @@
   .titre {
     font-weight: 700;
     font-size: 1rem;
+    margin-bottom: 8px;
   }
 
   .permissions {
@@ -65,5 +87,23 @@
 
   .personnalisation {
     margin: 16px 0 40px 0;
+    display: flex;
+    flex-direction: column;
+    row-gap: 20px;
+  }
+
+  .rubrique {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  .rubrique > div {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+  }
+  .rubrique .nom-rubrique {
+    font-weight: 500;
+    color: #08416a;
   }
 </style>

--- a/svelte/lib/gestionContributeurs/PersonnalisationInvitation.svelte
+++ b/svelte/lib/gestionContributeurs/PersonnalisationInvitation.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import { store } from './gestionContributeurs.store';
+  import type {
+    Rubrique,
+    Permission,
+    Utilisateur,
+  } from './gestionContributeurs.d';
+  import LigneContributeur from './LigneContributeur.svelte';
+  import TagLectureEcriture from './TagLectureEcriture.svelte';
+  import { createEventDispatcher } from 'svelte';
+
+  export let invite: Utilisateur;
+  export let droitsOriginaux: Record<Rubrique, Permission>;
+
+  $: redefinis = { ...droitsOriginaux };
+
+  let rubriques: { id: Rubrique; nom: string; droit: Permission }[];
+  $: rubriques = [
+    { id: 'DECRIRE', nom: 'Décrire', droit: redefinis.DECRIRE },
+    { id: 'SECURISER', nom: 'Sécuriser', droit: redefinis.SECURISER },
+    { id: 'HOMOLOGUER', nom: 'Homologuer', droit: redefinis.HOMOLOGUER },
+    { id: 'RISQUES', nom: 'Risques de sécurité', droit: redefinis.RISQUES },
+    { id: 'CONTACTS', nom: 'Contacts utiles', droit: redefinis.CONTACTS },
+  ];
+
+  const dispatch = createEventDispatcher<{
+    annuler: null;
+    valider: Record<Rubrique, Permission>;
+  }>();
+</script>
+
+<div class="identite-contributeur">
+  <div class="titre">Contributeur sélectionné</div>
+  <ul class="liste-contributeurs">
+    <LigneContributeur
+      utilisateur={invite}
+      droitsModifiables={false}
+      afficheDroits={false}
+    />
+  </ul>
+</div>
+<div class="permissions">
+  <div class="titre">Permissions</div>
+  <div>Sélectionner les droits d'accès pour chaque rubrique.</div>
+  <div class="personnalisation">
+    {#each rubriques as { id, nom, droit }}
+      <div class="rubrique">
+        <div class="nom-rubrique">{nom}</div>
+        <div>
+          {#if droit !== 0}
+            <TagLectureEcriture
+              {droit}
+              on:droitChange={(e) => (redefinis[id] = e.detail)}
+            />
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
+</div>
+<div class="conteneur-actions">
+  <button
+    class="bouton bouton-secondaire"
+    type="button"
+    on:click={() => dispatch('annuler')}
+  >
+    Annuler
+  </button>
+  <button
+    class="bouton"
+    id="action-invitation"
+    type="button"
+    on:click={() => dispatch('valider', redefinis)}
+  >
+    Enregistrer
+  </button>
+</div>
+
+<style>
+  .liste-contributeurs {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  .liste-contributeurs :global(li) {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    padding: 1em;
+    margin-bottom: 0.5em;
+  }
+
+  .titre {
+    font-weight: 700;
+    font-size: 1rem;
+    margin-bottom: 8px;
+  }
+
+  .permissions {
+    margin-top: 32px;
+  }
+
+  .personnalisation {
+    margin: 16px 0 40px 0;
+    display: flex;
+    flex-direction: column;
+    row-gap: 20px;
+  }
+
+  .rubrique {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  .rubrique > div {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+  }
+  .rubrique .nom-rubrique {
+    font-weight: 500;
+    color: #08416a;
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/TagLectureEcriture.svelte
+++ b/svelte/lib/gestionContributeurs/TagLectureEcriture.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import MenuFlottant from '../ui/MenuFlottant.svelte';
   import type { Ecriture, Lecture } from './gestionContributeurs.d';
 
   const LIBELLE_DROITS = { [1]: 'Lecture', [2]: 'Édition' };
-  const droitsDisponibles = [
+  const droitsDisponibles: {
+    nom: string;
+    description: string;
+    droit: Lecture | Ecriture;
+  }[] = [
     {
       nom: LIBELLE_DROITS[1],
       description: 'Consulter uniquement les informations',
@@ -17,6 +22,9 @@
   ];
 
   export let droit: Lecture | Ecriture;
+  const dispatch = createEventDispatcher<{
+    droitChange: Lecture | Ecriture;
+  }>();
 </script>
 
 <MenuFlottant>
@@ -34,7 +42,7 @@
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <div
         class="droit-propose"
-        on:click={() => {}}
+        on:click={() => dispatch('droitChange', droit)}
         class:lecture={droit === 1}
         class:ecriture={droit === 2}
       >

--- a/svelte/lib/gestionContributeurs/TagLectureEcriture.svelte
+++ b/svelte/lib/gestionContributeurs/TagLectureEcriture.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import MenuFlottant from '../ui/MenuFlottant.svelte';
+  import type { Ecriture, Lecture } from './gestionContributeurs.d';
+
+  const LIBELLE_DROITS = { [1]: 'Lecture', [2]: 'Édition' };
+  const droitsDisponibles = [
+    {
+      nom: LIBELLE_DROITS[1],
+      description: 'Consulter uniquement les informations',
+      droit: 1,
+    },
+    {
+      nom: LIBELLE_DROITS[2],
+      description: 'Modifier et ajouter des informations',
+      droit: 2,
+    },
+  ];
+
+  export let droit: Lecture | Ecriture;
+</script>
+
+<MenuFlottant>
+  <div
+    slot="declencheur"
+    class="droit"
+    class:lecture={droit === 1}
+    class:ecriture={droit === 2}
+  >
+    {LIBELLE_DROITS[droit]}
+  </div>
+
+  <div class="droits-disponibles">
+    {#each droitsDisponibles as { nom, description, droit }}
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <div
+        class="droit-propose"
+        on:click={() => {}}
+        class:lecture={droit === 1}
+        class:ecriture={droit === 2}
+      >
+        <div class="nom">{nom}</div>
+        <div class="description">{description}</div>
+      </div>
+    {/each}
+  </div>
+</MenuFlottant>
+
+<style>
+  .droit {
+    border-radius: 4px;
+    font-weight: bold;
+    color: #ffffff;
+    font-size: 0.85rem;
+    line-height: 0.85rem;
+    padding: 0.4em 0.5em;
+    align-self: center;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    column-gap: 6px;
+  }
+
+  .droit::after {
+    content: '';
+    width: 12px;
+    height: 12px;
+    background: url('/statique/assets/images/icone_fleche_bas.svg') no-repeat
+      center;
+    background-size: contain;
+    filter: brightness(0) invert(1);
+  }
+
+  .droit.lecture {
+    background: linear-gradient(180deg, #a226b8 0%, #8926c9 100%);
+  }
+
+  .droit.ecriture {
+    background: linear-gradient(180deg, #326fc0 0%, #4d3dc5 100%);
+  }
+
+  .droits-disponibles {
+    width: 11rem;
+    border-radius: 5px;
+    border: 1px solid #0c5c98;
+    background: white;
+    padding: 5px;
+    position: relative;
+  }
+
+  .droit-propose {
+    padding: 8px;
+    border-radius: 5px;
+  }
+
+  .droit-propose .nom {
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1.2rem;
+  }
+
+  .droit-propose.lecture .nom {
+    color: #7025da;
+  }
+  .droit-propose.ecriture .nom {
+    color: #0079d0;
+  }
+  .droit-propose .description {
+    color: #2f3a43;
+    font-weight: 400;
+  }
+  .droit-propose:hover .nom {
+    font-weight: 700;
+  }
+  .droit-propose:hover .description {
+    font-weight: 500;
+  }
+  .droit-propose.lecture:hover {
+    background: #e9ddff;
+  }
+  .droit-propose.ecriture:hover {
+    background: #dbeeff;
+  }
+</style>

--- a/svelte/lib/gestionContributeurs/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/TagNiveauDroit.svelte
@@ -13,7 +13,10 @@
   export let niveau: ResumeNiveauDroit;
   export let droitsModifiables: boolean;
 
-  const dispatch = createEventDispatcher<{ droitsChange: ResumeNiveauDroit }>();
+  const dispatch = createEventDispatcher<{
+    droitsChange: ResumeNiveauDroit;
+    choixPersonnalisation: null;
+  }>();
 </script>
 
 {#if !droitsModifiables}
@@ -42,6 +45,16 @@
       >
         <div class="nom">Édition</div>
         <div class="description">Modifier et ajouter des informations</div>
+      </div>
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <div
+        class="role-propose"
+        on:click={() => dispatch('choixPersonnalisation')}
+      >
+        <div class="nom">Personnalisé</div>
+        <div class="description">
+          Disposer de droits spécifiques à chaque rubrique
+        </div>
       </div>
     </div>
   </MenuFlottant>

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -17,8 +17,10 @@ export type Service = {
   nomService: string;
 };
 
+export type IdUtilisateur = string;
+
 export type Utilisateur = {
-  id: string;
+  id: IdUtilisateur;
   prenomNom: string;
   initiales: string;
   poste: string;
@@ -60,8 +62,10 @@ export const enDroitsSurRubrique = (
   }
 };
 
+export type IdAutorisation = string;
+
 export type Autorisation = {
-  idAutorisation: string;
-  idUtilisateur: string;
+  idAutorisation: IdAutorisation;
+  idUtilisateur: IdUtilisateur;
   resumeNiveauDroit: ResumeNiveauDroit;
 };

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -27,6 +27,11 @@ export type Utilisateur = {
   email: string;
 };
 
+type Invisible = 0;
+type Lecture = 1;
+type Ecriture = 2;
+type Permission = Invisible | Lecture | Ecriture;
+
 export type ResumeNiveauDroit =
   | 'PROPRIETAIRE'
   | 'ECRITURE'
@@ -42,20 +47,20 @@ export type Rubrique =
 
 export const enDroitsSurRubrique = (
   resume: ResumeNiveauDroit
-): Record<Rubrique, number> => {
-  const rubriquesAvecDroit = (droit: number) => ({
-    DECRIRE: droit,
-    SECURISER: droit,
-    HOMOLOGUER: droit,
-    RISQUES: droit,
-    CONTACTS: droit,
+): Record<Rubrique, Permission> => {
+  const rubriquesAvecPermission = (p: Permission) => ({
+    DECRIRE: p,
+    SECURISER: p,
+    HOMOLOGUER: p,
+    RISQUES: p,
+    CONTACTS: p,
   });
 
   switch (resume) {
     case 'LECTURE':
-      return rubriquesAvecDroit(1);
+      return rubriquesAvecPermission(1);
     case 'ECRITURE':
-      return rubriquesAvecDroit(2);
+      return rubriquesAvecPermission(2);
     case 'PROPRIETAIRE':
     case 'PERSONNALISE':
       throw new Error(`${resume} non convertible en permission`);
@@ -68,4 +73,5 @@ export type Autorisation = {
   idAutorisation: IdAutorisation;
   idUtilisateur: IdUtilisateur;
   resumeNiveauDroit: ResumeNiveauDroit;
+  droits: Record<Rubrique, Permission>;
 };

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.store.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 import type {
   Autorisation,
+  IdUtilisateur,
   Service,
   Utilisateur,
 } from './gestionContributeurs.d';
@@ -14,7 +15,7 @@ type EtatGestionContributeursStore = {
   etapeCourante: Etape;
   utilisateurEnCoursDeSuppression: Utilisateur | null;
   services: Service[];
-  autorisations: Record<string, Autorisation>;
+  autorisations: Record<IdUtilisateur, Autorisation>;
 };
 
 const valeurParDefaut: EtatGestionContributeursStore = {
@@ -59,7 +60,7 @@ export const store = {
   autorisations: {
     charge: (autorisations: Autorisation[]) => {
       const parIdUtilisateur = autorisations.reduce(
-        (acc: Record<string, Autorisation>, a: Autorisation) => ({
+        (acc: Record<IdUtilisateur, Autorisation>, a: Autorisation) => ({
           ...acc,
           [a.idUtilisateur]: a,
         }),

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.store.ts
@@ -9,11 +9,13 @@ import type {
 type Etape =
   | 'ListeContributeurs'
   | 'SuppressionContributeur'
-  | 'InvitationContributeurs';
+  | 'InvitationContributeurs'
+  | 'PersonnalisationContributeur';
 
 type EtatGestionContributeursStore = {
   etapeCourante: Etape;
   utilisateurEnCoursDeSuppression: Utilisateur | null;
+  utilisateurEnCoursDePersonnalisation: Utilisateur | null;
   services: Service[];
   autorisations: Record<IdUtilisateur, Autorisation>;
 };
@@ -21,6 +23,7 @@ type EtatGestionContributeursStore = {
 const valeurParDefaut: EtatGestionContributeursStore = {
   etapeCourante: 'ListeContributeurs',
   utilisateurEnCoursDeSuppression: null,
+  utilisateurEnCoursDePersonnalisation: null,
   services: [],
   autorisations: {},
 };
@@ -43,9 +46,16 @@ export const store = {
         ...etat,
         etapeCourante: 'ListeContributeurs',
         utilisateurEnCoursDeSuppression: null,
+        utilisateurEnCoursDePersonnalisation: null,
       })),
     afficheEtapeInvitation: () =>
       update((etat) => ({ ...etat, etapeCourante: 'InvitationContributeurs' })),
+    affichePersonnalisationContributeur: (cible: Utilisateur) =>
+      update((etat) => ({
+        ...etat,
+        etapeCourante: 'PersonnalisationContributeur',
+        utilisateurEnCoursDePersonnalisation: cible,
+      })),
   },
   contributeurs: {
     supprime: (contributeur: Utilisateur) =>

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1654,6 +1654,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idAutorisation: 'uuid-1',
         idUtilisateur: '888',
         resumeNiveauDroit: 'PERSONNALISE',
+        droits: droitsCible,
       });
     });
 
@@ -1730,11 +1731,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(donneesPassees).to.eql({ idService: '456' });
     });
 
-    it('retourne le résumé du niveau de droit pour chaque utilisateur du service', async () => {
+    it('retourne les autorisations de chaque utilisateur du service', async () => {
       testeur.depotDonnees().autorisationsDuService = async () => [
         uneAutorisation()
           .avecId('uuid-a')
           .deCreateurDeService('AAA', '456')
+          .avecDroits({ DECRIRE: 2 })
           .construis(),
       ];
 
@@ -1747,6 +1749,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           idAutorisation: 'uuid-a',
           idUtilisateur: 'AAA',
           resumeNiveauDroit: 'PROPRIETAIRE',
+          droits: { DECRIRE: 2 },
         },
       ]);
     });


### PR DESCRIPTION
Cette PR permet de choisir « Personnalisé » dans le menu des droits.

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/b669aca7-8aac-4bcf-ab54-6c59b47cd23a)

Ce choix ouvre une page où l'utilisateur choisit `LECTURE` ou `ECRITURE` pour chaque rubrique.

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/ed5ae72e-2cfd-4ee9-8881-9748b6022287)

La personnalisation fonctionne aussi bien depuis la liste des contributeurs qu'à l'invitation.