### PR TITLE
Masque l'indice cyber aux utilisateurs n'ayant pas le droit de le voir

### DIFF
--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -94,6 +94,10 @@ class AutorisationBase extends Base {
     [CONTACTS]: ECRITURE,
   };
 
+  static DROITS_VOIR_INDICE_CYBER = {
+    [SECURISER]: LECTURE,
+  };
+
   static DROITS_ANNEXES_PDF = {
     [DECRIRE]: LECTURE,
     [SECURISER]: LECTURE,

--- a/src/modeles/objetsApi/objetGetIndicesCyber.js
+++ b/src/modeles/objetsApi/objetGetIndicesCyber.js
@@ -1,14 +1,13 @@
-const { Permissions, Rubriques } = require('../autorisations/gestionDroits');
+const AutorisationBase = require('../autorisations/autorisationBase');
 
-const { LECTURE } = Permissions;
-const { SECURISER } = Rubriques;
+const { DROITS_VOIR_INDICE_CYBER } = AutorisationBase;
 
 const donnees = (services, autorisations) => {
   const servicesIndiceCyberCalcules = services.map((s) => ({
     id: s.id,
     ...(autorisations
       .find((a) => a.idService === s.id)
-      .aLaPermission(LECTURE, SECURISER) && {
+      .aLesPermissions(DROITS_VOIR_INDICE_CYBER) && {
       indiceCyber: s.indiceCyber().total,
     }),
   }));

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -197,6 +197,11 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
           return;
         }
 
+        const autorisation = await depotDonnees.autorisationPour(
+          requete.idUtilisateurCourant,
+          homologation.id
+        );
+
         reponse.render(`service/etapeDossier/${idEtape}`, {
           InformationsHomologation,
           referentiel,
@@ -204,6 +209,9 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
           actionsSaisie: new ActionsSaisie(referentiel, h).toJSON(),
           etapeActive: 'dossiers',
           idEtape,
+          peutVoirIndiceCyber: autorisation.aLesPermissions(
+            DROITS_VOIR_INDICE_CYBER
+          ),
         });
       } catch (e) {
         suite();

--- a/src/vues/service/formulaireEtapierRecommandation.pug
+++ b/src/vues/service/formulaireEtapierRecommandation.pug
@@ -4,7 +4,7 @@ include ../cartes/recommandationsANSSI
 include ../fragments/cartesInformations
 
 block cartes-informations
-  - const indiceCyber = service.indiceCyber()
-  +indiceCyber({ referentiel, indiceCyber })
-
-  +recommandationsANSSI({ referentiel, noteObtenue: indiceCyber.total })
+  if peutVoirIndiceCyber
+    - const indiceCyber = service.indiceCyber()
+    +indiceCyber({ referentiel, indiceCyber })
+    +recommandationsANSSI({ referentiel, noteObtenue: indiceCyber.total })

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -85,7 +85,7 @@ block formulaire
 block cartes-informations
   +statutHomologation({ donneesStatutHomologation })
 
-  - const indiceCyber = service.indiceCyber()
-  +indiceCyber({referentiel, indiceCyber})
-
-  +recommandationsANSSI({referentiel, noteObtenue: indiceCyber.total})
+  if peutVoirIndiceCyber
+    - const indiceCyber = service.indiceCyber()
+    +indiceCyber({referentiel, indiceCyber})
+    +recommandationsANSSI({referentiel, noteObtenue: indiceCyber.total})

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -176,6 +176,8 @@ describe('Le serveur MSS des routes /service/*', () => {
         statutsHomologation: {},
         etapesParcoursHomologation: [{ numero: 1 }],
       });
+      testeur.depotDonnees().autorisationPour = async () =>
+        uneAutorisation().construis();
     });
 
     it('recherche le service correspondant', (done) => {

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -342,6 +342,8 @@ describe('Le serveur MSS des routes /service/*', () => {
       });
       testeur.depotDonnees().ajouteDossierCourantSiNecessaire = async () => {};
       testeur.depotDonnees().homologation = async () => homologationARenvoyer;
+      testeur.depotDonnees().autorisationPour = async () =>
+        uneAutorisation().construis();
     });
 
     it('recherche le service correspondant', (done) => {


### PR DESCRIPTION
Pour voir l'indice cyber, il faut `LECTURE` sur `SECURISER`.

Cette PR masque la carte `Indice Cyber` pour les utilisateurs qui n'ont pas ce droit.

AVANT 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/02d83fa3-4ea4-4d58-aa73-f47ad83e4ce9)

APRÈS 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/4de1189a-c90a-4dc3-993d-2867ede67336)
