### PR TITLE
Enrichissement du middleware `chargeAutorisationsService`

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -223,6 +223,8 @@ const middleware = (configuration = {}) => {
           peutHomologuer: autorisation.peutHomologuer(),
         };
 
+        requete.autorisationService = autorisation;
+
         suite();
       });
   };

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -49,7 +49,6 @@ const routesApiService = (
     routesApiServicePdf({
       adaptateurHorloge,
       adaptateurPdf,
-      depotDonnees,
       adaptateurZip,
       middleware,
       referentiel,

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -497,10 +497,11 @@ const routesApiService = (
   routes.patch(
     '/:id/autorisations/:idAutorisation',
     middleware.trouveService({}),
+    middleware.chargeAutorisationsService,
     middleware.aseptise('id', 'idAutorisation'),
     async (requete, reponse) => {
-      const { idUtilisateurCourant } = requete;
-      const { id: idService, idAutorisation } = requete.params;
+      const { autorisationService } = requete;
+      const { idAutorisation } = requete.params;
       const nouveauxDroits = requete.body.droits;
 
       if (!verifieCoherenceDesDroits(nouveauxDroits)) {
@@ -508,12 +509,7 @@ const routesApiService = (
         return;
       }
 
-      const autorisationUtilisateur = await depotDonnees.autorisationPour(
-        idUtilisateurCourant,
-        idService
-      );
-
-      if (!autorisationUtilisateur.peutGererContributeurs()) {
+      if (!autorisationService.peutGererContributeurs()) {
         reponse.status(403).json({ code: 'INTERDIT' });
         return;
       }

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -441,16 +441,13 @@ const routesApiService = (
 
   routes.copy(
     '/:id',
-    middleware.verificationAcceptationCGU,
+    middleware.trouveService({}),
+    middleware.chargeAutorisationsService,
     (requete, reponse, suite) => {
-      const verifiePermissionDuplicationService = (idUtilisateur, idService) =>
-        depotDonnees
-          .autorisationPour(idUtilisateur, idService)
-          .then((autorisation) =>
-            autorisation instanceof AutorisationCreateur
-              ? Promise.resolve()
-              : Promise.reject(new EchecAutorisation())
-          );
+      const verifiePermissionDuplicationService = () =>
+        requete.autorisationService instanceof AutorisationCreateur
+          ? Promise.resolve()
+          : Promise.reject(new EchecAutorisation());
 
       const { idUtilisateurCourant } = requete;
       const idService = requete.params.id;

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -129,14 +129,11 @@ const routesApiService = (
     '/:id',
     middleware.aseptise('id'),
     middleware.trouveService({}),
+    middleware.chargeAutorisationsService,
     async (requete, reponse) => {
-      const autorisation = await depotDonnees.autorisationPour(
-        requete.idUtilisateurCourant,
-        requete.homologation.id
-      );
       const donnees = objetGetService.donnees(
         requete.homologation,
-        autorisation,
+        requete.autorisationService,
         requete.idUtilisateurCourant,
         referentiel
       );

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -409,17 +409,14 @@ const routesApiService = (
 
   routes.delete(
     '/:id',
-    middleware.verificationAcceptationCGU,
+    middleware.trouveService({}),
     middleware.challengeMotDePasse,
+    middleware.chargeAutorisationsService,
     (requete, reponse, suite) => {
-      const verifiePermissionSuppressionService = (idUtilisateur, idService) =>
-        depotDonnees
-          .autorisationPour(idUtilisateur, idService)
-          .then((autorisation) =>
-            autorisation?.permissionSuppressionService
-              ? Promise.resolve()
-              : Promise.reject(new EchecAutorisation())
-          );
+      const verifiePermissionSuppressionService = () =>
+        requete.autorisationService.permissionSuppressionService
+          ? Promise.resolve()
+          : Promise.reject(new EchecAutorisation());
 
       const { idUtilisateurCourant } = requete;
       const idService = requete.params.id;

--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -7,7 +7,6 @@ const routesApiServicePdf = ({
   adaptateurHorloge,
   adaptateurPdf,
   adaptateurZip,
-  depotDonnees,
   middleware,
   referentiel,
 }) => {
@@ -96,13 +95,9 @@ const routesApiServicePdf = ({
   routes.get(
     '/:id/pdf/documentsHomologation.zip',
     middleware.trouveService({}),
+    middleware.chargeAutorisationsService,
     async (requete, reponse, suite) => {
-      const { homologation } = requete;
-
-      const autorisation = await depotDonnees.autorisationPour(
-        requete.idUtilisateurCourant,
-        homologation.id
-      );
+      const { homologation, autorisationService } = requete;
 
       const genereUnDocument = (idDocument) => {
         const references = {
@@ -131,7 +126,7 @@ const routesApiServicePdf = ({
 
       Promise.all(
         homologation
-          .documentsPdfDisponibles(autorisation)
+          .documentsPdfDisponibles(autorisationService)
           .map((d) => genereUnDocument(d))
       )
         .then((pdfs) => adaptateurZip.genereArchive(pdfs))

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -56,12 +56,10 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
     '/:id',
     middleware.aseptise('id'),
     middleware.trouveService({}),
+    middleware.chargeAutorisationsService,
     async (requete, reponse) => {
-      const autorisation = await depotDonnees.autorisationPour(
-        requete.idUtilisateurCourant,
-        requete.homologation.id
-      );
-      const routeRedirection = premiereRouteDisponible(autorisation);
+      const { autorisationService } = requete;
+      const routeRedirection = premiereRouteDisponible(autorisationService);
       if (!routeRedirection) {
         reponse.redirect('/tableauDeBord');
         return;

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -745,7 +745,28 @@ describe('Le middleware MSS', () => {
       });
     });
 
-    it("remanie l'objet d'autorisation pour qu'il soit utilisable par le `.pug`", (done) => {
+    it("ajoute l'autorisation à la *`requete`* pour qu'elle soit accessibles aux routes utilisant le middleware", (done) => {
+      const middleware = Middleware({ depotDonnees });
+      const autorisationChargee = uneAutorisation()
+        .avecDroits({
+          [DECRIRE]: ECRITURE,
+          [SECURISER]: LECTURE,
+          [HOMOLOGUER]: INVISIBLE,
+        })
+        .construis();
+      depotDonnees.autorisationPour = async () => autorisationChargee;
+
+      middleware.chargeAutorisationsService(requete, reponse, () => {
+        try {
+          expect(requete.autorisationService).to.be(autorisationChargee);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+
+    it("remanie l'objet d'autorisation à la *`reponse`* pour qu'il soit utilisable par le `.pug`", (done) => {
       const middleware = Middleware({ depotDonnees });
       depotDonnees.autorisationPour = async () =>
         uneAutorisation()

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -5,6 +5,9 @@ const Homologation = require('../../src/modeles/homologation');
 const {
   Rubriques: { DECRIRE, SECURISER, HOMOLOGUER, RISQUES, CONTACTS },
 } = require('../../src/modeles/autorisations/gestionDroits');
+const {
+  uneAutorisation,
+} = require('../constructeurs/constructeurAutorisation');
 
 const verifieRequeteChangeEtat = (donneesEtat, requete, done) => {
   const verifieEgalite = (valeurConstatee, valeurReference, ...diagnostics) => {
@@ -37,6 +40,7 @@ const verifieRequeteChangeEtat = (donneesEtat, requete, done) => {
     .catch((e) => done(e.response?.data || e));
 };
 
+let autorisationChargee;
 let autorisationsChargees = false;
 let cguAcceptees;
 let challengeMotDePasseEffectue = false;
@@ -63,6 +67,7 @@ const middlewareFantaisie = {
       id: '456',
       descriptionService: { nomService: 'un service' },
     }),
+    autorisationACharger = uneAutorisation().construis(),
   }) => {
     autorisationsChargees = false;
     cguAcceptees = acceptationCGU;
@@ -72,6 +77,7 @@ const middlewareFantaisie = {
     headersPositionnes = false;
     homologationTrouvee = homologationARenvoyer;
     idUtilisateurCourant = idUtilisateur;
+    autorisationChargee = autorisationACharger;
     listesAseptisees = [];
     listeAdressesIPsAutorisee = [];
     parametresAseptises = [];
@@ -102,7 +108,7 @@ const middlewareFantaisie = {
     suite();
   },
 
-  chargeAutorisationsService: (_requete, reponse, suite) => {
+  chargeAutorisationsService: (requete, reponse, suite) => {
     reponse.locals.autorisationsService = {
       [DECRIRE]: {},
       [SECURISER]: {},
@@ -112,6 +118,7 @@ const middlewareFantaisie = {
       peutHomologuer: true,
     };
     autorisationsChargees = true;
+    requete.autorisationService = autorisationChargee;
     suite();
   },
 

--- a/test/routes/privees/routesApiServicePdf.spec.js
+++ b/test/routes/privees/routesApiServicePdf.spec.js
@@ -14,10 +14,6 @@ const {
   Permissions,
   Rubriques,
 } = require('../../../src/modeles/autorisations/gestionDroits');
-const {
-  uneAutorisation,
-} = require('../../constructeurs/constructeurAutorisation');
-const AutorisationBase = require('../../../src/modeles/autorisations/autorisationBase');
 const { unService } = require('../../constructeurs/constructeurService');
 
 const { LECTURE } = Permissions;
@@ -247,23 +243,13 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       );
     });
 
-    it("interroge le dépôt de données pour charger l'autorisation de l'utilisateur", async () => {
-      let donneesPassees = {};
-      testeur.middleware().reinitialise({ idUtilisateur: '123' });
-      testeur.depotDonnees().autorisationPour = async (
-        idUtilisateur,
-        idService
-      ) => {
-        donneesPassees = { idUtilisateur, idService };
-        return uneAutorisation()
-          .avecDroits(AutorisationBase.DROITS_DOSSIER_DECISION_PDF)
-          .construis();
-      };
-
-      await axios.get(
-        'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip'
-      );
-      expect(donneesPassees).to.eql({ idUtilisateur: '123', idService: '456' });
+    it("utilise le middleware de chargement de l'autorisation", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
+          'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip',
+          done
+        );
     });
 
     it("ajoute dans l'archive zip seulement les documents indiqués par le service", async () => {


### PR DESCRIPTION
… pour qu'il mette l'autorisation dans la `requete`.

Ça simplifie le travail des routes, qui ont directement accès à l'object `Autorisation`.