### PR TITLE
Navigation vers « Sécuriser » ou « Décrire »

### DIFF
--- a/public/modules/soumetsHomologation.mjs
+++ b/public/modules/soumetsHomologation.mjs
@@ -23,13 +23,14 @@ const initialiseComportementFormulaire = (
     evenement.preventDefault();
     requete.data = fonctionExtractionParametres(selecteurFormulaire);
 
-    const redirigeVersSynthese = ({ data: { idService } }) =>
-      (window.location = `/service/${idService}/descriptionService`);
+    const redirige = ({ data: { idService } }) => {
+      const estCreationDeService = !identifiantService;
+      window.location = estCreationDeService
+        ? `/service/${idService}/mesures`
+        : `/service/${idService}/descriptionService`;
+    };
 
-    adaptateurAjax
-      .execute(requete)
-      .then(redirigeVersSynthese)
-      .catch(callbackErreur);
+    adaptateurAjax.execute(requete).then(redirige).catch(callbackErreur);
   });
 
   $bouton.on('click', () => {

--- a/test_public/modules/soumetsHomologation.spec.mjs
+++ b/test_public/modules/soumetsHomologation.spec.mjs
@@ -36,7 +36,7 @@ describe("L'initialisation du comportement du formulaire", () => {
       };
     });
 
-    it('envoie au serveur les données du service à créer', (done) => {
+    it('envoie au serveur les données du service à créer', async () => {
       const evenementsDifferes = $.Deferred();
       initialiseComportementFormulaire(
         '.formulaire',
@@ -46,18 +46,13 @@ describe("L'initialisation du comportement du formulaire", () => {
         adaptateurAjax
       );
 
-      evenementsDifferes
-        .resolveWith($('.bouton').trigger('click'))
-        .then(() => {
-          expect(ajaxRequete.method).to.equal('post');
-          expect(ajaxRequete.url).to.equal('/api/service');
-          expect(ajaxRequete.data['champ-1']).to.equal('valeur 1');
-        })
-        .then(() => done())
-        .catch(done);
+      await evenementsDifferes.resolveWith($('.bouton').trigger('click'));
+      expect(ajaxRequete.method).to.equal('post');
+      expect(ajaxRequete.url).to.equal('/api/service');
+      expect(ajaxRequete.data['champ-1']).to.equal('valeur 1');
     });
 
-    it('envoie au serveur les données du service à modifier', (done) => {
+    it('envoie au serveur les données du service à modifier', async () => {
       const evenementsDifferes = $.Deferred();
       $('.bouton').attr('idHomologation', '12345');
 
@@ -69,18 +64,13 @@ describe("L'initialisation du comportement du formulaire", () => {
         adaptateurAjax
       );
 
-      evenementsDifferes
-        .resolveWith($('.bouton').trigger('click'))
-        .then(() => {
-          expect(ajaxRequete.method).to.equal('put');
-          expect(ajaxRequete.url).to.equal('/api/service/12345');
-          expect(ajaxRequete.data['champ-1']).to.equal('valeur 1');
-        })
-        .then(() => done())
-        .catch(done);
+      await evenementsDifferes.resolveWith($('.bouton').trigger('click'));
+      expect(ajaxRequete.method).to.equal('put');
+      expect(ajaxRequete.url).to.equal('/api/service/12345');
+      expect(ajaxRequete.data['champ-1']).to.equal('valeur 1');
     });
 
-    it('renvoie vers la description du service', (done) => {
+    it('renvoie vers la description du service', async () => {
       const evenementsDifferes = $.Deferred();
       initialiseComportementFormulaire(
         '.formulaire',
@@ -90,16 +80,11 @@ describe("L'initialisation du comportement du formulaire", () => {
         adaptateurAjax
       );
 
-      evenementsDifferes
-        .resolveWith($('.bouton').trigger('click'))
-        .then(() =>
-          expect(window.location).to.equal('/service/123/descriptionService')
-        )
-        .then(() => done())
-        .catch(done);
+      await evenementsDifferes.resolveWith($('.bouton').trigger('click'));
+      expect(window.location).to.equal('/service/123/descriptionService');
     });
 
-    it("exécute la callback d'erreur en cas d'erreur", (done) => {
+    it("exécute la callback d'erreur en cas d'erreur", async () => {
       const evenementsDifferes = $.Deferred();
       const adaptateurAjaxErreur = {
         execute: () => Promise.reject(),
@@ -116,11 +101,8 @@ describe("L'initialisation du comportement du formulaire", () => {
         adaptateurAjaxErreur
       );
 
-      evenementsDifferes
-        .resolveWith($('.bouton').trigger('click'))
-        .then(() => expect(callbackErreurAppele).to.be(true))
-        .then(() => done())
-        .catch(done);
+      await evenementsDifferes.resolveWith($('.bouton').trigger('click'));
+      expect(callbackErreurAppele).to.be(true);
     });
   });
 });

--- a/test_public/modules/soumetsHomologation.spec.mjs
+++ b/test_public/modules/soumetsHomologation.spec.mjs
@@ -70,7 +70,7 @@ describe("L'initialisation du comportement du formulaire", () => {
       expect(ajaxRequete.data['champ-1']).to.equal('valeur 1');
     });
 
-    it('renvoie vers la description du service', async () => {
+    it('renvoie vers « Sécuriser » après une création de service', async () => {
       const evenementsDifferes = $.Deferred();
       initialiseComportementFormulaire(
         '.formulaire',
@@ -81,6 +81,24 @@ describe("L'initialisation du comportement du formulaire", () => {
       );
 
       await evenementsDifferes.resolveWith($('.bouton').trigger('click'));
+
+      expect(window.location).to.equal('/service/123/mesures');
+    });
+
+    it('renvoie vers « Décrire » après une édition de service existant', async () => {
+      const evenementsDifferes = $.Deferred();
+      $('.bouton').attr('idHomologation', '12345');
+
+      initialiseComportementFormulaire(
+        '.formulaire',
+        '.bouton',
+        fonctionExtractionParametres,
+        callbackErreurParDefaut,
+        adaptateurAjax
+      );
+
+      await evenementsDifferes.resolveWith($('.bouton').trigger('click'));
+
       expect(window.location).to.equal('/service/123/descriptionService');
     });
 


### PR DESCRIPTION
… depuis la page « Décrire ».

Cette PR ajoute de la logique d'aiguillage : 
* à l'édition d'un service, on reste sur « Décrire » (ce que faisait systématiquement l'existant)
* à la création, on passe à « Sécuriser »