### PR TITLE
Contributeurs Svelte : ajustements graphiques

### DIFF
--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -59,5 +59,6 @@
     border-radius: 8px;
     padding: 1em;
     margin-bottom: 0.5em;
+    column-gap: 16px;
   }
 </style>

--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -32,7 +32,7 @@
     <div class="roles-disponibles">
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <div
-        class="role-propose"
+        class="role-propose lecture"
         on:click={() => dispatch('droitsChange', 'LECTURE')}
       >
         <div class="nom">Lecture</div>
@@ -40,7 +40,7 @@
       </div>
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <div
-        class="role-propose"
+        class="role-propose ecriture"
         on:click={() => dispatch('droitsChange', 'ECRITURE')}
       >
         <div class="nom">Édition</div>
@@ -48,7 +48,7 @@
       </div>
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <div
-        class="role-propose"
+        class="role-propose personnalise"
         on:click={() => dispatch('choixPersonnalisation')}
       >
         <div class="nom">Personnalisé</div>
@@ -102,8 +102,16 @@
     border-radius: 5px;
   }
 
-  .role-propose .nom {
+  .role-propose.lecture .nom {
+    color: #7025da;
+  }
+  .role-propose.ecriture .nom {
     color: #0079d0;
+  }
+  .role-propose.personnalise .nom {
+    color: #0079d0;
+  }
+  .role-propose .nom {
     font-style: normal;
     font-weight: 500;
     line-height: 1.2rem;
@@ -114,7 +122,13 @@
     font-weight: 400;
   }
 
-  .role-propose:hover {
+  .role-propose.lecture:hover {
+    background: #e9ddff;
+  }
+  .role-propose.ecriture:hover {
+    background: #dbeeff;
+  }
+  .role-propose.personnalise:hover {
     background: #eff6ff;
   }
 


### PR DESCRIPTION
Cette PR ajuste 2 choses vues en démo.

**Ajout d'une marge sur chaque ligne de contributeur**

| AVANT | APRÈS |
|--------|--------|
| ![image](https://github.com/betagouv/mon-service-securise/assets/24898521/1d919b2d-2ba7-4012-a2ec-acb19770caa3) | ![image](https://github.com/betagouv/mon-service-securise/assets/24898521/7eab1ba7-ca13-4d0c-a803-f43ba6c4557c) | 

**Change les couleurs de survol de choix des droits**
Pour réutiliser les même couleurs que sur la personnalisation fine de droits.

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/ab3d6e87-8c0f-42e6-82f2-fd9302b55fdb)


![image](https://github.com/betagouv/mon-service-securise/assets/24898521/3d0a655d-ffdc-41c0-b7d9-f0ab44460a28)
