### PR TITLE
[MIGRATION] Ajoute le champ `estProprietaire`

### DIFF
--- a/migrations/20231020062200_ajouteChampEstProprietaire.js
+++ b/migrations/20231020062200_ajouteChampEstProprietaire.js
@@ -1,0 +1,20 @@
+exports.up = async (knex) => {
+  const autorisations = await knex('autorisations');
+  const misesAJour = autorisations.map(({ id, donnees }) => {
+    const estProprietaire = donnees.type === 'createur';
+    return knex('autorisations')
+      .where({ id })
+      .update({ donnees: { ...donnees, estProprietaire } });
+  });
+  await Promise.all(misesAJour);
+};
+
+exports.down = async (knex) => {
+  const autorisations = await knex('autorisations');
+  const misesAJour = autorisations.map(
+    ({ id, donnees: { estProprietaire, ...autresDonnees } }) =>
+      knex('autorisations').where({ id }).update({ donnees: autresDonnees })
+  );
+
+  await Promise.all(misesAJour);
+};


### PR DESCRIPTION
On ajoute le champ `estProprietaire` pour démarrer le développement des fonctionnalités de service à propriétaires multiple.
Le champ `type` est pour l'instant conservé : il sera supprimé à la fin du dev. de cette feature.