### PR TITLE
Utilise `estProprietaire` dans la méthode `homologations`

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -151,7 +151,7 @@ const nouvelAdaptateur = (env) => {
 
     const filtre = seulementUnUtilisateur
       ? ["(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur]
-      : ["(donnees->>'type') = 'createur'"];
+      : ["(donnees->>'estProprietaire')::boolean = true"];
 
     const idsHomologations = knex('autorisations')
       .whereRaw(...filtre)


### PR DESCRIPTION
...afin de ne plus utiliser le `type = createur`