### PR TITLE
Force tous les droits en écriture pour un proprietaire

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -14,9 +14,6 @@ const EvenementNouvelleHomologationCreee = require('../modeles/journalMSS/evenem
 const EvenementServiceSupprime = require('../modeles/journalMSS/evenementServiceSupprime');
 const { avecPMapPourChaqueElement } = require('../utilitaires/pMap');
 const { fabriqueServiceTracking } = require('../tracking/serviceTracking');
-const {
-  tousDroitsEnEcriture,
-} = require('../modeles/autorisations/gestionDroits');
 const AutorisationBase = require('../modeles/autorisations/autorisationBase');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
@@ -355,7 +352,6 @@ const creeDepot = (config = {}) => {
     const createur = AutorisationBase.NouvelleAutorisationProprietaire({
       idUtilisateur,
       idService,
-      droits: tousDroitsEnEcriture(),
     });
     await adaptateurPersistance.ajouteAutorisation(
       idAutorisation,

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -4,6 +4,7 @@ const {
   Permissions: { LECTURE, ECRITURE },
   Rubriques,
   Permissions,
+  tousDroitsEnEcriture,
 } = require('./gestionDroits');
 
 class AutorisationBase extends Base {
@@ -32,6 +33,7 @@ class AutorisationBase extends Base {
   static NouvelleAutorisationProprietaire = (donnees = {}) =>
     new AutorisationBase({
       ...donnees,
+      droits: tousDroitsEnEcriture(),
       estProprietaire: true,
       type: 'createur',
     });

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -69,7 +69,7 @@ describe('Le dépôt de données des autorisations', () => {
       const avecDroitLecture = unePersistanceMemoire()
         .ajouteUneAutorisation(
           uneAutorisation()
-            .deCreateurDeService('456', '123')
+            .deContributeurDeService('456', '123')
             .avecDroits({ [DECRIRE]: LECTURE }).donnees
         )
         .construis();

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -207,7 +207,6 @@ describe('Une autorisation', () => {
           id: 'uuid',
           idService: '123',
           idUtilisateur: '999',
-          droits: tousDroitsEnEcriture(),
         });
 
       expect(autorisationProprietaire.donneesAPersister()).to.eql({

--- a/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
+++ b/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
@@ -43,8 +43,7 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
 
   it("ne fournit pas l'indice cyber si les permissions ne sont pas suffisantes", () => {
     const autorisationSansSecuriser = uneAutorisation()
-      .deCreateurDeService('999', '123')
-      .avecDroits({})
+      .deContributeurDeService('999', '123')
       .construis();
 
     const { services } = objetGetIndicesCyber.donnees(
@@ -83,13 +82,9 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
 
     const services = [unService, unAutreService];
     const autorisationsSansPermission = [
+      uneAutorisation().deCreateurDeService('999', unService.id).construis(),
       uneAutorisation()
-        .deCreateurDeService('999', unService.id)
-        .avecDroits({ [SECURISER]: LECTURE })
-        .construis(),
-      uneAutorisation()
-        .deCreateurDeService('999', unAutreService.id)
-        .avecDroits({})
+        .deContributeurDeService('999', unAutreService.id)
         .construis(),
     ];
     expect(

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -60,9 +60,6 @@ describe("L'objet d'API de `GET /services`", () => {
     const services = [unService];
     const autorisationComplete = uneAutorisation()
       .deCreateurDeService('456', '123')
-      .avecDroits({
-        [HOMOLOGUER]: LECTURE,
-      })
       .construis();
     expect(
       objetGetServices.donnees(
@@ -100,7 +97,7 @@ describe("L'objet d'API de `GET /services`", () => {
         },
         nombreContributeurs: 1 + 1,
         estProprietaire: true,
-        documentsPdfDisponibles: [],
+        documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
         permissions: { gestionContributeurs: true },
       },
     ]);
@@ -143,14 +140,14 @@ describe("L'objet d'API de `GET /services`", () => {
     unAutreService.dossiers.statutHomologation = () => Dossiers.ACTIVEE;
 
     const autorisationPourUnService = uneAutorisation()
-      .deCreateurDeService('999', '123')
+      .deContributeurDeService('999', '123')
       .avecDroits({
         [HOMOLOGUER]: LECTURE,
       })
       .construis();
 
     const autorisationSansHomologuerPourUnAutreService = uneAutorisation()
-      .deCreateurDeService('999', '456')
+      .deContributeurDeService('999', '456')
       .avecDroits({})
       .construis();
 

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1702,7 +1702,6 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         uneAutorisation()
           .avecId('uuid-a')
           .deCreateurDeService('AAA', '456')
-          .avecDroits({ DECRIRE: 2 })
           .construis(),
       ];
 
@@ -1715,7 +1714,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           idAutorisation: 'uuid-a',
           idUtilisateur: 'AAA',
           resumeNiveauDroit: 'PROPRIETAIRE',
-          droits: { DECRIRE: 2 },
+          droits: tousDroitsEnEcriture(),
         },
       ]);
     });


### PR DESCRIPTION
Afin de pouvoir instancier directement les autorisations de propriétaire sans se soucier des droits, qui seront par définition métier toujours en `ECRITURE` sur toutes les rubriques