### PR TITLE
Filtre les propriétaires via `estProprietaire` dans l'affichage des autorisations d'un service

### DIFF
--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -474,7 +474,7 @@ const routesApiService = (
     middleware.trouveService({}),
     middleware.aseptise('id'),
     async (requete, reponse) => {
-      const { id: idService, createur } = requete.homologation;
+      const { id: idService } = requete.homologation;
       let autorisations = await depotDonnees.autorisationsDuService(idService);
 
       const autorisationUtilisateurCourant = autorisations.find(
@@ -484,7 +484,7 @@ const routesApiService = (
       if (!autorisationUtilisateurCourant.peutGererContributeurs()) {
         autorisations = autorisations.filter(
           (a) =>
-            a.idUtilisateur === createur.id ||
+            a.estProprietaire ||
             a.idUtilisateur === requete.idUtilisateurCourant
         );
       }


### PR DESCRIPTION
... au lieu d'utiliser `type = createur`.
On peut maintenant, en tant que contributeur, voir le **OU LES** propriétaires d'un service.