### PR TITLE
Passe l'identifiant de l'utilisateur propriétaire au moment de la duplication

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -34,10 +34,6 @@ class ConsoleAdministration {
     };
   }
 
-  dupliqueHomologation(idHomologation) {
-    return this.depotDonnees.dupliqueHomologation(idHomologation);
-  }
-
   transfereAutorisations(idUtilisateurSource, idUtilisateurCible) {
     return this.depotDonnees.transfereAutorisations(
       idUtilisateurSource,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -419,7 +419,7 @@ const creeDepot = (config = {}) => {
       supprimeHomologation
     );
 
-  const trouveIndexDisponible = (idCreateur, nomHomologationDupliquee) => {
+  const trouveIndexDisponible = (idProprietaire, nomHomologationDupliquee) => {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
     const nomCompatibleRegExp = nomHomologationDupliquee.replace(
       /[.*+?^${}()|[\]\\]/g,
@@ -439,7 +439,7 @@ const creeDepot = (config = {}) => {
       return Math.max(0, resultat) + 1;
     };
 
-    return p.lis.cellesDeUtilisateur(idCreateur).then(indexMax);
+    return p.lis.cellesDeUtilisateur(idProprietaire).then(indexMax);
   };
 
   const dupliqueHomologation = (idHomologation, idProprietaire) => {

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -442,16 +442,15 @@ const creeDepot = (config = {}) => {
     return p.lis.cellesDeUtilisateur(idCreateur).then(indexMax);
   };
 
-  const dupliqueHomologation = (idHomologation) => {
+  const dupliqueHomologation = (idHomologation, idProprietaire) => {
     const duplique = (h) => {
       const nomHomologationADupliquer = `${h.nomService()} - Copie`;
-      const idCreateur = h.createur.id;
       const donneesADupliquer = (index) =>
         h.donneesADupliquer(`${nomHomologationADupliquer} ${index}`);
 
-      return trouveIndexDisponible(idCreateur, nomHomologationADupliquer)
+      return trouveIndexDisponible(idProprietaire, nomHomologationADupliquer)
         .then(donneesADupliquer)
-        .then((donnees) => nouveauService(idCreateur, donnees));
+        .then((donnees) => nouveauService(idProprietaire, donnees));
     };
 
     return p.lis

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -449,7 +449,9 @@ const routesApiService = (
       const idService = requete.params.id;
 
       verifiePermissionDuplicationService(idUtilisateurCourant, idService)
-        .then(() => depotDonnees.dupliqueHomologation(idService))
+        .then(() =>
+          depotDonnees.dupliqueHomologation(idService, idUtilisateurCourant)
+        )
         .then(() => reponse.send('Service dupliqué'))
         .catch((e) => {
           if (e instanceof EchecAutorisation) {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -1637,7 +1637,7 @@ describe('Le dépôt de données des homologations', () => {
 
     it("reste robuste quand l'homologation n'est pas trouvée", (done) => {
       depot
-        .dupliqueHomologation('id-invalide')
+        .dupliqueHomologation('id-invalide', '123')
         .then(() =>
           done('La tentative de duplication aurait dû lever une exception')
         )
@@ -1651,7 +1651,7 @@ describe('Le dépôt de données des homologations', () => {
 
     it('peut dupliquer une homologation à partir de son identifiant', (done) => {
       depot
-        .dupliqueHomologation('123-1')
+        .dupliqueHomologation('123-1', '123')
         .then(() => depot.homologations('123'))
         .then((homologations) => {
           expect(homologations.length).to.equal(2);
@@ -1662,8 +1662,8 @@ describe('Le dépôt de données des homologations', () => {
 
     it("utilise un nom disponible pour l'homologation dupliquée", (done) => {
       depot
-        .dupliqueHomologation('123-1')
-        .then(() => depot.dupliqueHomologation('123-1'))
+        .dupliqueHomologation('123-1', '123')
+        .then(() => depot.dupliqueHomologation('123-1', '123'))
         .then(() => depot.homologations('123'))
         .then(([_, h2, h3]) => {
           expect(h2.nomService()).to.equal('Service à dupliquer - Copie 1');

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1394,9 +1394,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           AutorisationBase.NouvelleAutorisationProprietaire(),
       });
 
-      testeur.depotDonnees().dupliqueHomologation = (idService) => {
+      testeur.depotDonnees().dupliqueHomologation = (
+        idService,
+        idUtilisateur
+      ) => {
         try {
           expect(idService).to.equal('123');
+          expect(idUtilisateur).to.equal('999');
           serviceDuplique = true;
 
           return Promise.resolve();


### PR DESCRIPTION
On fait cette modification pour deux raisons:
- On ne veut plus se reposer sur `homologation.createur` car ce champ va disparaître
- La duplication est donc maintenant disponible pour TOUT les propriétaires