### PR TITLE
Utilise le constructeur de Service dans les tests d'`objetGetService`

### DIFF
--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -43,6 +43,13 @@ class ConstructeurService {
     return this;
   }
 
+  avecOrganisationResponsable(organisationResponsable) {
+    this.donnees.descriptionService.organisationsResponsables = [
+      organisationResponsable,
+    ];
+    return this;
+  }
+
   avecNContributeurs(combien, ids = []) {
     for (let i = 0; i < combien; i += 1) {
       let { donnees } = unUtilisateur();

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -29,6 +29,11 @@ class ConstructeurUtilisateur {
     return this;
   }
 
+  avecPostes(postes) {
+    this.donnees.postes = postes;
+    return this;
+  }
+
   quiSAppelle(prenomNom) {
     const [prenom, nom] = prenomNom.split(' ');
     this.donnees.prenom = prenom;


### PR DESCRIPTION
Afin de faciliter la transition `createur` -> `proprietaires`