### PR TITLE
Renomme `Createur` en `Proprietaire` dans le constructeur d'autorisation de test

### DIFF
--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -21,7 +21,7 @@ class ConstructeurAutorisation {
     return this;
   }
 
-  deCreateurDeService(idUtilisateur, idService) {
+  deProprietaireDeService(idUtilisateur, idService) {
     this.donnees.estProprietaire = true;
     this.donnees.type = 'createur';
     this.donnees.idUtilisateur = idUtilisateur;

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -50,7 +50,7 @@ class ConstructeurAutorisation {
   }
 
   construis() {
-    return this.donnees.type === 'createur'
+    return this.donnees.estProprietaire
       ? AutorisationBase.NouvelleAutorisationProprietaire(this.donnees)
       : AutorisationBase.NouvelleAutorisationContributeur(this.donnees);
   }

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -51,7 +51,7 @@ describe('Le dépôt de données des autorisations', () => {
       const avecDroitEcriture = unePersistanceMemoire()
         .ajouteUneAutorisation(
           uneAutorisation()
-            .deCreateurDeService('456', '123')
+            .deProprietaireDeService('456', '123')
             .avecDroits({ [DECRIRE]: ECRITURE }).donnees
         )
         .construis();
@@ -139,7 +139,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().deCreateurDeService('999', '123').donnees
+          uneAutorisation().deProprietaireDeService('999', '123').donnees
         )
         .construis();
 
@@ -194,7 +194,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees
         )
         .ajouteUneAutorisation(
@@ -225,7 +225,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees
         )
         .construis();
@@ -258,7 +258,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees
         )
         .construis();
@@ -303,7 +303,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees
         )
         .construis();
@@ -369,7 +369,7 @@ describe('Le dépôt de données des autorisations', () => {
         descriptionService: { nomService: 'Un service' },
       })
       .ajouteUneAutorisation(
-        uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+        uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
           .donnees
       )
       .construis();
@@ -390,7 +390,7 @@ describe('Le dépôt de données des autorisations', () => {
         descriptionService: { nomService: 'Un service' },
       })
       .ajouteUneAutorisation(
-        uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+        uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
           .donnees
       )
       .construis();
@@ -417,7 +417,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees
         )
         .construis();
@@ -443,7 +443,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees
         )
         .construis();
@@ -470,7 +470,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees
         )
         .ajouteUneAutorisation(
@@ -500,7 +500,7 @@ describe('Le dépôt de données des autorisations', () => {
         descriptionService: { nomService: 'Un service' },
       })
       .ajouteUneAutorisation(
-        uneAutorisation().deCreateurDeService('888', '123').donnees
+        uneAutorisation().deProprietaireDeService('888', '123').donnees
       )
       .ajouteUneAutorisation(
         uneAutorisation().deContributeurDeService('999', '123').donnees

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -73,8 +73,8 @@ describe('Le dépôt de données des homologations', () => {
           },
         ],
         autorisations: [
-          uneAutorisation().deCreateurDeService('456', '123').donnees,
-          uneAutorisation().deCreateurDeService('999', '789').donnees,
+          uneAutorisation().deProprietaireDeService('456', '123').donnees,
+          uneAutorisation().deProprietaireDeService('999', '789').donnees,
         ],
       }
     );
@@ -132,9 +132,9 @@ describe('Le dépôt de données des homologations', () => {
           },
         ],
         autorisations: [
-          uneAutorisation().deCreateurDeService('999', '123').donnees,
-          uneAutorisation().deCreateurDeService('999', '456').donnees,
-          uneAutorisation().deCreateurDeService('999', '789').donnees,
+          uneAutorisation().deProprietaireDeService('999', '123').donnees,
+          uneAutorisation().deProprietaireDeService('999', '456').donnees,
+          uneAutorisation().deProprietaireDeService('999', '789').donnees,
         ],
       }
     );
@@ -178,7 +178,7 @@ describe('Le dépôt de données des homologations', () => {
           { id: '789', descriptionService: { nomService: 'nom' } },
         ],
         autorisations: [
-          uneAutorisation().deCreateurDeService('111', '789').donnees,
+          uneAutorisation().deProprietaireDeService('111', '789').donnees,
           uneAutorisation().deContributeurDeService('999', '789').donnees,
         ],
       }
@@ -207,7 +207,7 @@ describe('Le dépôt de données des homologations', () => {
 
     beforeEach(() => {
       const utilisateur = unUtilisateur().avecId('789').donnees;
-      const autorisation = uneAutorisation().deCreateurDeService(
+      const autorisation = uneAutorisation().deProprietaireDeService(
         '789',
         '123'
       ).donnees;
@@ -411,7 +411,7 @@ describe('Le dépôt de données des homologations', () => {
       const utilisateur = unUtilisateur()
         .avecId('999')
         .avecEmail('jean.dupont@mail.fr').donnees;
-      const autorisation = uneAutorisation().deCreateurDeService(
+      const autorisation = uneAutorisation().deProprietaireDeService(
         '999',
         '123'
       ).donnees;
@@ -926,10 +926,11 @@ describe('Le dépôt de données des homologations', () => {
         .toJSON();
       const utilisateur = unUtilisateur().avecId('456').donnees;
       const unServiceExistant = unService(referentiel).avecId('123').donnees;
-      const uneAutorisationExistante = uneAutorisation().deCreateurDeService(
-        utilisateur.id,
-        unServiceExistant.id
-      ).donnees;
+      const uneAutorisationExistante =
+        uneAutorisation().deProprietaireDeService(
+          utilisateur.id,
+          unServiceExistant.id
+        ).donnees;
       adaptateurPersistance = unePersistanceMemoire()
         .ajouteUneAutorisation(uneAutorisationExistante)
         .ajouteUnService(unServiceExistant)
@@ -1045,7 +1046,7 @@ describe('Le dépôt de données des homologations', () => {
             },
           ],
           autorisations: [
-            uneAutorisation().deCreateurDeService('123', '789').donnees,
+            uneAutorisation().deProprietaireDeService('123', '789').donnees,
           ],
         });
       const depot = DepotDonneesHomologations.creeDepot({
@@ -1102,8 +1103,8 @@ describe('Le dépôt de données des homologations', () => {
             },
           ],
           autorisations: [
-            uneAutorisation().deCreateurDeService('123', '888').donnees,
-            uneAutorisation().deCreateurDeService('123', '999').donnees,
+            uneAutorisation().deProprietaireDeService('123', '888').donnees,
+            uneAutorisation().deProprietaireDeService('123', '999').donnees,
           ],
         });
       const depot = DepotDonneesHomologations.creeDepot({
@@ -1136,7 +1137,7 @@ describe('Le dépôt de données des homologations', () => {
         homologations: [copie(donneesHomologation)],
         services: [copie(donneesHomologation)],
         autorisations: [
-          uneAutorisation().avecId('456').deCreateurDeService('999', '123')
+          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
             .donnees,
         ],
       });
@@ -1191,7 +1192,7 @@ describe('Le dépôt de données des homologations', () => {
           { id: '222', descriptionService: { nomService: 'Un autre service' } },
         ],
         autorisations: [
-          uneAutorisation().avecId('123').deCreateurDeService('999', '111')
+          uneAutorisation().avecId('123').deProprietaireDeService('999', '111')
             .donnees,
           uneAutorisation().avecId('456').deContributeurDeService('000', '111')
             .donnees,
@@ -1552,8 +1553,9 @@ describe('Le dépôt de données des homologations', () => {
             { id: '123', descriptionService: { nomService: 'Un service' } },
           ],
           autorisations: [
-            uneAutorisation().avecId('456').deCreateurDeService('ABC', '123')
-              .donnees,
+            uneAutorisation()
+              .avecId('456')
+              .deProprietaireDeService('ABC', '123').donnees,
           ],
         });
       const adaptateurJournalMSS =
@@ -1584,7 +1586,7 @@ describe('Le dépôt de données des homologations', () => {
             { id: '123', descriptionService: { nomService: 'Un service' } },
           ],
           autorisations: [
-            uneAutorisation().avecId('a').deCreateurDeService('ABC', '123')
+            uneAutorisation().avecId('a').deProprietaireDeService('ABC', '123')
               .donnees,
             uneAutorisation().avecId('b').deContributeurDeService('DEF', '123')
               .donnees,
@@ -1622,7 +1624,7 @@ describe('Le dépôt de données des homologations', () => {
           homologations: [{ id: '123-1', descriptionService }],
           services: [{ id: '123-1', descriptionService }],
           autorisations: [
-            uneAutorisation().deCreateurDeService('123', '123-1').donnees,
+            uneAutorisation().deProprietaireDeService('123', '123-1').donnees,
           ],
         });
 
@@ -1686,7 +1688,7 @@ describe('Le dépôt de données des homologations', () => {
           utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
           homologations: [{ id: '123', descriptionService }],
           autorisations: [
-            uneAutorisation().deCreateurDeService('999', '123').donnees,
+            uneAutorisation().deProprietaireDeService('999', '123').donnees,
           ],
         });
 
@@ -1713,7 +1715,7 @@ describe('Le dépôt de données des homologations', () => {
           utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
           homologations: [{ id: '123', descriptionService: copie1 }],
           autorisations: [
-            uneAutorisation().deCreateurDeService('999', '123').donnees,
+            uneAutorisation().deProprietaireDeService('999', '123').donnees,
           ],
         });
 
@@ -1747,8 +1749,8 @@ describe('Le dépôt de données des homologations', () => {
             { id: '456', descriptionService: duplication },
           ],
           autorisations: [
-            uneAutorisation().deCreateurDeService('999', '123').donnees,
-            uneAutorisation().deCreateurDeService('999', '456').donnees,
+            uneAutorisation().deProprietaireDeService('999', '123').donnees,
+            uneAutorisation().deProprietaireDeService('999', '456').donnees,
           ],
         });
 
@@ -1775,7 +1777,7 @@ describe('Le dépôt de données des homologations', () => {
           utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
           homologations: [{ id: '123', descriptionService: original }],
           autorisations: [
-            uneAutorisation().deCreateurDeService('999', '123').donnees,
+            uneAutorisation().deProprietaireDeService('999', '123').donnees,
           ],
         });
 

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -553,7 +553,7 @@ describe('Le dépôt de données des utilisateurs', () => {
             { id: '123', descriptionService: { nomService: 'Un service' } },
           ],
           autorisations: [
-            uneAutorisation().deCreateurDeService('999', '123').donnees,
+            uneAutorisation().deProprietaireDeService('999', '123').donnees,
           ],
         });
       const depot = DepotDonneesUtilisateurs.creeDepot({

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -28,7 +28,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
     unService().avecId(id).avecNomService('Nom Service').construis();
 
   const peutGererContributeurs = uneAutorisation()
-    .deCreateurDeService()
+    .deProprietaireDeService()
     .construis();
   const utilisateur = {
     id: '999',

--- a/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
+++ b/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
@@ -18,11 +18,11 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
   let unAutreService;
   const autorisations = [
     uneAutorisation()
-      .deCreateurDeService('999', '123')
+      .deProprietaireDeService('999', '123')
       .avecDroits({ [SECURISER]: LECTURE })
       .construis(),
     uneAutorisation()
-      .deCreateurDeService('999', '456')
+      .deProprietaireDeService('999', '456')
       .avecDroits({ [SECURISER]: LECTURE })
       .construis(),
   ];
@@ -82,7 +82,9 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
 
     const services = [unService, unAutreService];
     const autorisationsSansPermission = [
-      uneAutorisation().deCreateurDeService('999', unService.id).construis(),
+      uneAutorisation()
+        .deProprietaireDeService('999', unService.id)
+        .construis(),
       uneAutorisation()
         .deContributeurDeService('999', unAutreService.id)
         .construis(),

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -107,7 +107,7 @@ describe("L'objet d'API de `GET /service`", () => {
       expect(
         objetGetService.donnees(
           unServiceDontAestCreateur,
-          uneAutorisation().deCreateurDeService('A', '123').construis(),
+          uneAutorisation().deProprietaireDeService('A', '123').construis(),
           'A',
           referentiel
         ).permissions

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -53,7 +53,7 @@ describe("L'objet d'API de `GET /services`", () => {
   it('fournit les données nécessaires', () => {
     const services = [service];
     const autorisationComplete = uneAutorisation()
-      .deCreateurDeService('456', '123')
+      .deProprietaireDeService('456', '123')
       .construis();
     expect(
       objetGetServices.donnees(
@@ -102,14 +102,14 @@ describe("L'objet d'API de `GET /services`", () => {
     unAutreService.dossiers.statutHomologation = () => Dossiers.ACTIVEE;
 
     const autorisationPourUnService = uneAutorisation()
-      .deCreateurDeService('999', service.id)
+      .deProprietaireDeService('999', service.id)
       .avecDroits({
         [HOMOLOGUER]: LECTURE,
       })
       .construis();
 
     const autorisationPourUnAutreService = uneAutorisation()
-      .deCreateurDeService('999', unAutreService.id)
+      .deProprietaireDeService('999', unAutreService.id)
       .avecDroits({
         [HOMOLOGUER]: LECTURE,
       })

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -74,7 +74,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deCreateurDeService('123', '456')
+          .deProprietaireDeService('123', '456')
           .avecDroits({})
           .construis(),
       ];
@@ -104,7 +104,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesPassees = { idUtilisateur };
         return [
           uneAutorisation()
-            .deCreateurDeService('123', '456')
+            .deProprietaireDeService('123', '456')
             .avecDroits({})
             .construis(),
         ];
@@ -133,7 +133,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesPassees = { idUtilisateur };
         return [
           uneAutorisation()
-            .deCreateurDeService('123', '456')
+            .deProprietaireDeService('123', '456')
             .avecDroits({})
             .construis(),
         ];
@@ -149,7 +149,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deCreateurDeService('123', '456')
+          .deProprietaireDeService('123', '456')
           .avecDroits({})
           .construis(),
       ];
@@ -184,7 +184,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deCreateurDeService('123', '456')
+          .deProprietaireDeService('123', '456')
           .avecDroits({ [SECURISER]: LECTURE })
           .construis(),
       ];
@@ -218,7 +218,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesPassees = { idUtilisateur };
         return [
           uneAutorisation()
-            .deCreateurDeService('123', '456')
+            .deProprietaireDeService('123', '456')
             .avecDroits({})
             .construis(),
         ];
@@ -277,7 +277,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deCreateurDeService('123', '456')
+          .deProprietaireDeService('123', '456')
           .avecDroits({})
           .construis(),
       ];
@@ -969,7 +969,9 @@ describe('Le serveur MSS des routes privées /api/*', () => {
   });
 
   describe('quand requête DELETE sur `/api/autorisation`', () => {
-    const autorisation = uneAutorisation().deCreateurDeService().construis();
+    const autorisation = uneAutorisation()
+      .deProprietaireDeService()
+      .construis();
 
     beforeEach(() => {
       testeur.middleware().reinitialise({ idUtilisateur: '456' });
@@ -1005,7 +1007,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         idHomologation
       ) => {
         autorisationCherchee = { idUtilisateur, idHomologation };
-        return uneAutorisation().deCreateurDeService().construis();
+        return uneAutorisation().deProprietaireDeService().construis();
       };
 
       await axios.delete('http://localhost:1234/api/autorisation', {

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1508,7 +1508,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     beforeEach(() => {
       testeur.middleware().reinitialise({
         autorisationACharger: uneAutorisation()
-          .deCreateurDeService('AAA', '456')
+          .deProprietaireDeService('AAA', '456')
           .construis(),
       });
 
@@ -1652,7 +1652,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: 'AAA',
       });
       testeur.depotDonnees().autorisationsDuService = async (idService) => [
-        uneAutorisation().deCreateurDeService('AAA', idService).construis(),
+        uneAutorisation().deProprietaireDeService('AAA', idService).construis(),
       ];
     });
 
@@ -1683,7 +1683,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().autorisationsDuService = async (idService) => {
         donneesPassees = { idService };
         return [
-          uneAutorisation().deCreateurDeService('AAA', idService).construis(),
+          uneAutorisation()
+            .deProprietaireDeService('AAA', idService)
+            .construis(),
         ];
       };
 
@@ -1705,7 +1707,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().autorisationsDuService = async () => [
         uneAutorisation()
           .avecId('uuid-a')
-          .deCreateurDeService('AAA', '456')
+          .deProprietaireDeService('AAA', '456')
           .construis(),
       ];
 
@@ -1733,7 +1735,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: 'AAA',
       });
       testeur.depotDonnees().autorisationsDuService = async () => [
-        uneAutorisation().deCreateurDeService('AAA', '456').construis(),
+        uneAutorisation().deProprietaireDeService('AAA', '456').construis(),
         uneAutorisation().deContributeurDeService('ABC', '456').construis(),
         uneAutorisation().deContributeurDeService('DEF', '456').construis(),
         uneAutorisation().deContributeurDeService('GHI', '456').construis(),
@@ -1756,7 +1758,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: 'DEF',
       });
       testeur.depotDonnees().autorisationsDuService = async () => [
-        uneAutorisation().deCreateurDeService('AAA', '456').construis(),
+        uneAutorisation().deProprietaireDeService('AAA', '456').construis(),
         uneAutorisation().deContributeurDeService('ABC', '456').construis(),
         uneAutorisation().deContributeurDeService('DEF', '456').construis(),
         uneAutorisation().deContributeurDeService('GHI', '456').construis(),


### PR DESCRIPTION
Afin de supprimer tous les références à `createur` dans le projet