### PR TITLE
Renomme les fonctions utilisant `createur`

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -205,7 +205,7 @@ const nouvelAdaptateur = (
     return Promise.resolve();
   };
 
-  const nbAutorisationsCreateur = (idUtilisateur) =>
+  const nbAutorisationsProprietaire = (idUtilisateur) =>
     Promise.resolve(
       donnees.autorisations.filter(
         (a) => a.idUtilisateur === idUtilisateur && a.estProprietaire
@@ -337,7 +337,7 @@ const nouvelAdaptateur = (
     idsHomologationsCreeesParUtilisateur,
     lisParcoursUtilisateur,
     metsAJourUtilisateur,
-    nbAutorisationsCreateur,
+    nbAutorisationsProprietaire,
     rechercheContributeurs,
     sauvegardeAutorisation,
     sauvegardeParcoursUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -231,11 +231,11 @@ const nouvelAdaptateur = (env) => {
   const ajouteAutorisation = (...params) =>
     ajouteLigneDansTable('autorisations', ...params);
 
-  const nbAutorisationsCreateur = (idUtilisateur) =>
+  const nbAutorisationsProprietaire = (idUtilisateur) =>
     knex('autorisations')
       .count('id')
       .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
-      .whereRaw("donnees->>'type'='createur'")
+      .whereRaw("(donnees->>'estProprietaire')::boolean=true")
       .then(([{ count }]) => parseInt(count, 10));
 
   const sauvegardeHomologation = (id, donneesHomologations) => {
@@ -420,7 +420,7 @@ const nouvelAdaptateur = (env) => {
     idsHomologationsCreeesParUtilisateur,
     lisParcoursUtilisateur,
     metsAJourUtilisateur,
-    nbAutorisationsCreateur,
+    nbAutorisationsProprietaire,
     rechercheContributeurs,
     sauvegardeHomologation,
     sauvegardeService,

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -143,7 +143,7 @@ const creeDepot = (config = {}) => {
       });
 
     const verifieUtilisateurPasCreateur = (id) =>
-      adaptateurPersistance.nbAutorisationsCreateur(id).then((nb) => {
+      adaptateurPersistance.nbAutorisationsProprietaire(id).then((nb) => {
         if (nb > 0) {
           throw new ErreurSuppressionImpossible(
             `Suppression impossible : l'utilisateur "${id}" a créé des services`

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -142,7 +142,7 @@ const creeDepot = (config = {}) => {
         }
       });
 
-    const verifieUtilisateurPasCreateur = (id) =>
+    const verifieUtilisateurPasProprietaire = (id) =>
       adaptateurPersistance.nbAutorisationsProprietaire(id).then((nb) => {
         if (nb > 0) {
           throw new ErreurSuppressionImpossible(
@@ -152,7 +152,7 @@ const creeDepot = (config = {}) => {
       });
 
     return verifieUtilisateurExistant(...params)
-      .then(() => verifieUtilisateurPasCreateur(...params))
+      .then(() => verifieUtilisateurPasProprietaire(...params))
       .then(() =>
         adaptateurPersistance.supprimeAutorisationsContribution(...params)
       )


### PR DESCRIPTION
... en `proprietaire` afin de coller avec la nouvelle implémentation.