### PR TITLE
Corrige la fonction `ajouteDescriptionServiceAHomologation`

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -263,15 +263,21 @@ const creeDepot = (config = {}) => {
       return h;
     };
 
-    const envoieTrackingCompletude = (h) =>
-      serviceTracking
-        .completudeDesServicesPourUtilisateur({ homologations }, h.createur.id)
-        .then((tauxCompletude) =>
-          adaptateurTracking.envoieTrackingCompletudeService(
-            h.createur.email,
-            tauxCompletude
-          )
+    const envoieTrackingCompletude = async () => {
+      const tauxCompletude =
+        await serviceTracking.completudeDesServicesPourUtilisateur(
+          { homologations },
+          idUtilisateur
         );
+
+      const utilisateur =
+        await adaptateurPersistance.utilisateur(idUtilisateur);
+
+      await adaptateurTracking.envoieTrackingCompletudeService(
+        utilisateur.email,
+        tauxCompletude
+      );
+    };
 
     const metsAJourHomologation = (h) =>
       valideDescriptionService(idUtilisateur, infos, h.id)


### PR DESCRIPTION
Cette fonction utilisait sytématiquement l'`id` et l'`email` du créateur de service, et non pas de celui qui réalisait l'action de modification de description.
Cela nous permet aussi de supprimer la dépendance à `createur`.