### PR TITLE
Corrige la fonction `ajouteMesuresAHomologation`

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -287,6 +287,7 @@ const creeDepot = (config = {}) => {
 
   const ajouteMesuresAHomologation = async (
     idHomologation,
+    idUtilisateur,
     generales,
     specifiques
   ) => {
@@ -305,10 +306,11 @@ const creeDepot = (config = {}) => {
     const tauxCompletude =
       await serviceTracking.completudeDesServicesPourUtilisateur(
         { homologations },
-        h.createur.id
+        idUtilisateur
       );
+    const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
     await adaptateurTracking.envoieTrackingCompletudeService(
-      h.createur.email,
+      utilisateur.email,
       tauxCompletude
     );
   };

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -285,34 +285,33 @@ const creeDepot = (config = {}) => {
     return p.lis.une(idHomologation).then(metsAJourHomologation);
   };
 
-  const ajouteMesuresAHomologation = (idHomologation, generales, specifiques) =>
-    ajouteMesuresGeneralesAHomologation(idHomologation, generales)
-      .then(() =>
-        remplaceMesuresSpecifiquesPourHomologation(idHomologation, specifiques)
-      )
-      .then(() => p.lis.une(idHomologation))
-      .then((h) =>
-        adaptateurJournalMSS
-          .consigneEvenement(
-            new EvenementCompletudeServiceModifiee({
-              idService: h.id,
-              ...h.completudeMesures(),
-            }).toJSON()
-          )
-          .then(() =>
-            serviceTracking
-              .completudeDesServicesPourUtilisateur(
-                { homologations },
-                h.createur.id
-              )
-              .then((tauxCompletude) =>
-                adaptateurTracking.envoieTrackingCompletudeService(
-                  h.createur.email,
-                  tauxCompletude
-                )
-              )
-          )
+  const ajouteMesuresAHomologation = async (
+    idHomologation,
+    generales,
+    specifiques
+  ) => {
+    await ajouteMesuresGeneralesAHomologation(idHomologation, generales);
+    await remplaceMesuresSpecifiquesPourHomologation(
+      idHomologation,
+      specifiques
+    );
+    const h = await p.lis.une(idHomologation);
+    await adaptateurJournalMSS.consigneEvenement(
+      new EvenementCompletudeServiceModifiee({
+        idService: h.id,
+        ...h.completudeMesures(),
+      }).toJSON()
+    );
+    const tauxCompletude =
+      await serviceTracking.completudeDesServicesPourUtilisateur(
+        { homologations },
+        h.createur.id
       );
+    await adaptateurTracking.envoieTrackingCompletudeService(
+      h.createur.email,
+      tauxCompletude
+    );
+  };
 
   const toutesHomologations = () => p.lis.toutes();
 

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -153,6 +153,7 @@ const routesApiService = (
     (requete, reponse, suite) => {
       const { mesuresSpecifiques = [], mesuresGenerales = {} } = requete.body;
       const idService = requete.homologation.id;
+      const idUtilisateur = requete.idUtilisateurCourant;
 
       try {
         const generales = Object.keys(mesuresGenerales).map((idMesure) => {
@@ -172,7 +173,12 @@ const routesApiService = (
         );
 
         depotDonnees
-          .ajouteMesuresAHomologation(idService, generales, specifiques)
+          .ajouteMesuresAHomologation(
+            idService,
+            idUtilisateur,
+            generales,
+            specifiques
+          )
           .then(() => reponse.send({ idService }))
           .catch(suite);
       } catch {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -233,7 +233,12 @@ describe('Le dépôt de données des homologations', () => {
       );
 
       const specifiques = new MesuresSpecifiques();
-      await depot.ajouteMesuresAHomologation('123', [generale], specifiques);
+      await depot.ajouteMesuresAHomologation(
+        '123',
+        '789',
+        [generale],
+        specifiques
+      );
 
       const {
         mesures: { mesuresGenerales },
@@ -253,7 +258,12 @@ describe('Le dépôt de données des homologations', () => {
       );
 
       const specifiques = new MesuresSpecifiques();
-      await depot.ajouteMesuresAHomologation('123', [generale], specifiques);
+      await depot.ajouteMesuresAHomologation(
+        '123',
+        '789',
+        [generale],
+        specifiques
+      );
 
       const {
         mesures: { mesuresGenerales },
@@ -270,7 +280,12 @@ describe('Le dépôt de données des homologations', () => {
       );
 
       const specifiques = new MesuresSpecifiques();
-      await depot.ajouteMesuresAHomologation('123', [generale], specifiques);
+      await depot.ajouteMesuresAHomologation(
+        '123',
+        '789',
+        [generale],
+        specifiques
+      );
 
       const {
         mesures: { mesuresGenerales },
@@ -287,7 +302,12 @@ describe('Le dépôt de données des homologations', () => {
         mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
       });
 
-      await depot.ajouteMesuresAHomologation('123', generales, specifiques);
+      await depot.ajouteMesuresAHomologation(
+        '123',
+        '789',
+        generales,
+        specifiques
+      );
 
       const {
         mesures: { mesuresSpecifiques },
@@ -309,7 +329,7 @@ describe('Le dépôt de données des homologations', () => {
         mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
       });
 
-      await depot.ajouteMesuresAHomologation('123', generales, mesures);
+      await depot.ajouteMesuresAHomologation('123', '789', generales, mesures);
 
       const {
         mesures: { mesuresSpecifiques },
@@ -332,7 +352,12 @@ describe('Le dépôt de données des homologations', () => {
         mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
       });
 
-      await depot.ajouteMesuresAHomologation('123', generales, specifiques);
+      await depot.ajouteMesuresAHomologation(
+        '123',
+        '789',
+        generales,
+        specifiques
+      );
 
       expect(evenementRecu.type).to.equal('COMPLETUDE_SERVICE_MODIFIEE');
     });
@@ -357,7 +382,7 @@ describe('Le dépôt de données des homologations', () => {
         mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
       });
 
-      await depot.ajouteMesuresAHomologation('123', [], mesures);
+      await depot.ajouteMesuresAHomologation('123', '789', [], mesures);
 
       expect(donneesPassees).to.eql({
         destinataire: 'jean.dujardin@beta.gouv.com',

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -299,6 +299,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         mesures: { identifiantMesure: {} },
         statutsMesures: { fait: 'Fait' },
       });
+      testeur.middleware().reinitialise({
+        idUtilisateur: '999',
+      });
     });
 
     it('recherche le service correspondant', (done) => {
@@ -335,10 +338,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
       testeur.depotDonnees().ajouteMesuresAHomologation = (
         idService,
+        idUtilisateur,
         [generale],
         specifiques
       ) => {
         expect(idService).to.equal('456');
+        expect(idUtilisateur).to.equal('999');
         expect(generale.id).to.equal('identifiantMesure');
         expect(generale.statut).to.equal('fait');
         expect(generale.modalites).to.equal("Des modalités d'application");
@@ -381,6 +386,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       let mesuresRemplacees = false;
       testeur.depotDonnees().ajouteMesuresAHomologation = (
         _id,
+        _idUtilisateur,
         _generales,
         specifiques
       ) => {
@@ -409,6 +415,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       let mesuresRemplacees = false;
       testeur.depotDonnees().ajouteMesuresAHomologation = (
         _id,
+        _idUtilisateur,
         _generales,
         specifiques
       ) => {


### PR DESCRIPTION
Cette fonction utilisait sytématiquement l'`id` et l'`email` du créateur de service, et non pas de celui qui réalisait l'action d'ajout de mesures.
Cela nous permet aussi de supprimer la dépendance à `createur`.