### PR TITLE
Supprime la dépendance à `service.createur` dans la fonction `nouveauService`

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -349,16 +349,18 @@ const creeDepot = (config = {}) => {
 
     await p.sauvegarde(idService, donneesService);
 
-    const createur = AutorisationBase.NouvelleAutorisationProprietaire({
+    const proprietaire = AutorisationBase.NouvelleAutorisationProprietaire({
       idUtilisateur,
       idService,
     });
     await adaptateurPersistance.ajouteAutorisation(
       idAutorisation,
-      createur.donneesAPersister()
+      proprietaire.donneesAPersister()
     );
 
     const s = await p.lis.une(idService);
+
+    const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
 
     await Promise.all([
       adaptateurJournalMSS.consigneEvenement(
@@ -374,7 +376,7 @@ const creeDepot = (config = {}) => {
         }).toJSON()
       ),
       homologations(idUtilisateur).then((hs) => {
-        adaptateurTracking.envoieTrackingNouveauServiceCree(s.createur.email, {
+        adaptateurTracking.envoieTrackingNouveauServiceCree(utilisateur.email, {
           nombreServices: hs.length,
         });
       }),
@@ -382,7 +384,7 @@ const creeDepot = (config = {}) => {
         .completudeDesServicesPourUtilisateur({ homologations }, idUtilisateur)
         .then((tauxCompletude) =>
           adaptateurTracking.envoieTrackingCompletudeService(
-            s.createur.email,
+            utilisateur.email,
             tauxCompletude
           )
         ),


### PR DESCRIPTION
Cette fonction utilisait sytématiquement l'`email` du créateur de service.
On préfère lire l'utilisateur en base ici pour supprimer la dépendance avec `service.createur`.