### PR TITLE
Modifie la fonction `homologations` pour ne plus pouvoir être appellée sans paramètre

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -147,14 +147,8 @@ const nouvelAdaptateur = (env) => {
       .catch(() => undefined);
 
   const homologations = (idUtilisateur) => {
-    const seulementUnUtilisateur = typeof idUtilisateur !== 'undefined';
-
-    const filtre = seulementUnUtilisateur
-      ? ["(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur]
-      : ["(donnees->>'estProprietaire')::boolean = true"];
-
     const idsHomologations = knex('autorisations')
-      .whereRaw(...filtre)
+      .whereRaw("(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur)
       .select({ idHomologation: knex.raw("(donnees->>'idHomologation')") })
       .then((lignes) => lignes.map(({ idHomologation }) => idHomologation));
 


### PR DESCRIPTION
Afin de simplifier le code de la fonction.
L'appel n'était jamais fait sans paramètre dans le code.