### PR TITLE
Ajoute la capacité de supprimer un propriétaire

### DIFF
--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -4,8 +4,8 @@ const {
   ErreurAutorisationExisteDeja,
   ErreurAutorisationInexistante,
   ErreurServiceInexistant,
-  ErreurTentativeSuppressionCreateur,
   ErreurUtilisateurInexistant,
+  ErreurSuppressionImpossible,
 } = require('../erreurs');
 const FabriqueAutorisation = require('../modeles/autorisations/fabriqueAutorisation');
 
@@ -93,7 +93,11 @@ const creeDepot = (config = {}) => {
     );
   };
 
-  const supprimeContributeur = async (idContributeur, idService) => {
+  const supprimeContributeur = async (
+    idContributeur,
+    idService,
+    idUtilisateurCourant
+  ) => {
     const verifieAutorisationExiste = async () => {
       const existe = await autorisationExiste(idContributeur, idService);
       if (!existe) {
@@ -104,12 +108,11 @@ const creeDepot = (config = {}) => {
     };
 
     const verifieSuppressionPermise = async () => {
-      const a = await autorisationPour(idContributeur, idService);
-      if (a.estProprietaire) {
-        throw new ErreurTentativeSuppressionCreateur(
-          `Suppression impossible : l'utilisateur "${idContributeur}" est le propriétaire du service "${idService}"`
+      const impossible = idContributeur === idUtilisateurCourant;
+      if (impossible)
+        throw new ErreurSuppressionImpossible(
+          `L'utilisateur "${idUtilisateurCourant}" ne peut pas supprimer sa propre autorisation`
         );
-      }
     };
 
     await verifieAutorisationExiste();

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -43,7 +43,6 @@ class ErreurRisqueInconnu extends ErreurModele {}
 class ErreurStatutDeploiementInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
 class ErreurSuppressionImpossible extends Error {}
-class ErreurTentativeSuppressionCreateur extends ErreurModele {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
 
@@ -90,7 +89,6 @@ module.exports = {
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,
   ErreurSuppressionImpossible,
-  ErreurTentativeSuppressionCreateur,
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,
   ErreurUtilisateurInexistant,

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -296,17 +296,21 @@ const routesApiPrivee = ({
     middleware.verificationAcceptationCGU,
     middleware.aseptise('idHomologation', 'idContributeur'),
     async (requete, reponse, suite) => {
-      const verifiePermissionSuppression = async (...params) => {
-        const a = await depotDonnees.autorisationPour(...params);
+      const idUtilisateur = requete.idUtilisateurCourant;
+      const { idHomologation: idService, idContributeur } = requete.query;
+
+      const verifiePermissionSuppression = async () => {
+        const a = await depotDonnees.autorisationPour(idUtilisateur, idService);
         if (!a.peutGererContributeurs()) throw new EchecAutorisation();
       };
 
-      const idUtilisateur = requete.idUtilisateurCourant;
-      const { idHomologation, idContributeur } = requete.query;
-
       try {
-        await verifiePermissionSuppression(idUtilisateur, idHomologation);
-        await depotDonnees.supprimeContributeur(idContributeur, idHomologation);
+        await verifiePermissionSuppression();
+        await depotDonnees.supprimeContributeur(
+          idContributeur,
+          idService,
+          idUtilisateur
+        );
         reponse.sendStatus(200);
       } catch (e) {
         if (e instanceof EchecAutorisation)

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -275,20 +275,9 @@ describe('Le dépôt de données des autorisations', () => {
 
   describe("sur demande de suppression d'un contributeur", () => {
     it("vérifie que l'autorisation de contribution existe", async () => {
-      const adaptateurPersistance = unePersistanceMemoire()
-        .ajouteUnUtilisateur({ id: '999', email: 'jean.dupont@mail.fr' })
-        .ajouteUnUtilisateur({ id: '000', email: 'annie.dubois@mail.fr' })
-        .ajouteUnService({
-          id: '123',
-          descriptionService: { nomService: 'Un service' },
-        })
-        .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-            .donnees
-        )
-        .construis();
+      const sansAutorisations = unePersistanceMemoire().construis();
 
-      const depot = creeDepot(adaptateurPersistance);
+      const depot = creeDepot(sansAutorisations);
 
       try {
         await depot.supprimeContributeur('000', '123');

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -310,31 +310,20 @@ describe('Le dépôt de données des autorisations', () => {
     });
 
     it('supprime le contributeur', async () => {
-      const adaptateurPersistance = unePersistanceMemoire()
-        .ajouteUnUtilisateur({ id: '999', email: 'jean.dupont@mail.fr' })
-        .ajouteUnUtilisateur({ id: '000', email: 'contributeur@mail.fr' })
-        .ajouteUnService({
-          id: '123',
-          descriptionService: { nomService: 'Un service' },
-        })
+      const avecUneAutorisation = unePersistanceMemoire()
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-            .donnees
-        )
-        .ajouteUneAutorisation(
-          uneAutorisation().avecId('789').deContributeurDeService('000', '123')
-            .donnees
+          uneAutorisation().deContributeurDeService('000', 'ABC').donnees
         )
         .construis();
 
-      const depot = creeDepot(adaptateurPersistance);
+      const depot = creeDepot(avecUneAutorisation);
 
-      const a = await depot.autorisationPour('000', '123');
-      expect(a.estProprietaire).to.be(false);
+      const avant = await depot.autorisationPour('000', 'ABC');
+      expect(avant).not.to.be(undefined);
 
-      await depot.supprimeContributeur('000', '123');
+      await depot.supprimeContributeur('000', 'ABC', '123');
 
-      const apres = await depot.autorisationPour('000', '123');
+      const apres = await depot.autorisationPour('000', 'ABC');
       expect(apres).to.be(undefined);
     });
   });

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -969,14 +969,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
   });
 
   describe('quand requête DELETE sur `/api/autorisation`', () => {
-    const autorisation = uneAutorisation()
-      .deProprietaireDeService()
-      .construis();
-
     beforeEach(() => {
       testeur.middleware().reinitialise({ idUtilisateur: '456' });
-      autorisation.permissionSuppressionContributeur = true;
-      testeur.depotDonnees().autorisationPour = async () => autorisation;
+      testeur.depotDonnees().autorisationPour = async () =>
+        uneAutorisation().deProprietaireDeService().construis();
       testeur.depotDonnees().supprimeContributeur = async () => {};
     });
 

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -1034,24 +1034,30 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("utilise le dépôt de données pour supprimer l'autorisation du contributeur", async () => {
-      let contributeurSupprime = {};
+      let suppressionDemandee = {};
       testeur.depotDonnees().supprimeContributeur = async (
         idContributeur,
-        idHomologation
+        idHomologation,
+        idUtilisateurCourant
       ) => {
-        contributeurSupprime = { idContributeur, idHomologation };
+        suppressionDemandee = {
+          idContributeur,
+          idHomologation,
+          idUtilisateurCourant,
+        };
         return {};
       };
 
       await axios.delete('http://localhost:1234/api/autorisation', {
         params: {
-          idHomologation: '123',
+          idHomologation: 'ABC',
           idContributeur: '999',
         },
       });
 
-      expect(contributeurSupprime.idContributeur).to.be('999');
-      expect(contributeurSupprime.idHomologation).to.be('123');
+      expect(suppressionDemandee.idContributeur).to.be('999');
+      expect(suppressionDemandee.idHomologation).to.be('ABC');
+      expect(suppressionDemandee.idUtilisateurCourant).to.be('456');
     });
 
     it("retourne une erreur HTTP 424 si le dépôt ne peut pas supprimer l'autorisation", async () => {


### PR DESCRIPTION
Avec cette PR le dépôt de données accepte de supprimer n'importe quelle autorisation à condition qu'elle ne concerne pas l'utilisateur courant.

Donc la suppression de propriétaire devient possible…sans toutefois pouvoir se supprimer soi-même.

L'API passe donc désormais l'ID de l'utilisateur courant au dépôt.