### PR TITLE
Empêche l'utilisateur courant de modifier ses propres autorisations

### DIFF
--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -509,7 +509,7 @@ const routesApiService = ({
     middleware.chargeAutorisationsService,
     middleware.aseptise('id', 'idAutorisation'),
     async (requete, reponse) => {
-      const { autorisationService } = requete;
+      const { autorisationService, idUtilisateurCourant } = requete;
       const { idAutorisation } = requete.params;
       const nouveauxDroits = requete.body.droits;
 
@@ -524,6 +524,11 @@ const routesApiService = ({
       }
 
       const ciblee = await depotDonnees.autorisation(idAutorisation);
+      if (ciblee.idUtilisateur === idUtilisateurCourant) {
+        reponse.status(422).json({ code: 'AUTO-MODIFICATION_INTERDITE' });
+        return;
+      }
+
       ciblee.appliqueDroits(nouveauxDroits);
       await depotDonnees.sauvegardeAutorisation(ciblee);
 


### PR DESCRIPTION
… pour éviter des problèmes de suppression de l'unique propriétaire restant.