### PR TITLE
[HOTFIX] Corrige la soumissions des formulaires

### DIFF
--- a/public/service/risques.js
+++ b/public/service/risques.js
@@ -99,7 +99,8 @@ $(() => {
   const $bouton = $('.bouton[idHomologation]');
   const identifiantService = $bouton.attr('idHomologation');
 
-  $bouton.on('click', async () => {
+  $bouton.on('click', async (e) => {
+    e.preventDefault();
     basculeEnCoursChargement($bouton, true);
     const params = parametresAvecItemsExtraits(
       'form#risques',

--- a/public/service/rolesResponsabilites.js
+++ b/public/service/rolesResponsabilites.js
@@ -34,7 +34,8 @@ $(() => {
   const $bouton = $('.bouton[idHomologation]');
   const identifiantService = $bouton.attr('idHomologation');
 
-  $bouton.on('click', async () => {
+  $bouton.on('click', async (e) => {
+    e.preventDefault();
     basculeEnCoursChargement($bouton, true);
     const params = tousLesParametres('form#roles-responsabilites');
 


### PR DESCRIPTION
... sur les rubriques "Risques" et "Contacts".

On ne faisait pas le `preventDefault`, donc le seul bouton du formulaire agissait comme un submit, ce qui entrainait un rechargement de la page et donc une concurence entre notre `POST` réel et le rechargement.

On avait donc dans certains cas des données qui n'était pas sauvegardée.