### PR TITLE
Ajoute un `rate-limit` sur les endpoints sensibles

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,3 +40,7 @@ AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire
 AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que le « Journal MSS » en mémoire logue les événements reçus dans la console
 AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
 AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logués dans la console
+
+# configuration du `rate-limit`
+NB_REQUETES_MAX_PAR_MINUTE= # Nombre maximal de requêtes autorisées par IP et par minute, supprimer la variable permet de désactiver la protection
+NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes autorisées par IP et par minute pour les endpoints sensibles (connexion, inscription, modification de mot de passe, creation de service), supprimer la variable permet de désactiver la protection

--- a/server.js
+++ b/server.js
@@ -44,6 +44,7 @@ const middleware = Middleware({
   adaptateurChiffrement,
   adaptateurEnvironnement,
   adaptateurJWT,
+  adaptateurProtection,
   depotDonnees,
 });
 const procedures = fabriqueProcedures({

--- a/src/adaptateurs/adaptateurProtection.js
+++ b/src/adaptateurs/adaptateurProtection.js
@@ -4,31 +4,49 @@ const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
 
+const uneMinute = 60 * 1000;
+const parametresCommuns = (typeRequete, doitFermerConnexion = false) => ({
+  windowMs: uneMinute,
+  handler: (requete, reponse) => {
+    const attaque = requete.headers['x-real-ip']?.replaceAll('.', '*');
+    fabriqueAdaptateurGestionErreur().logueErreur(
+      new Error('Limite de trafic atteinte par une IP.'),
+      {
+        typeRequete,
+        'IP de la requete': attaque,
+      }
+    );
+    if (doitFermerConnexion) reponse.end();
+    else reponse.render('erreurTropDeTrafic');
+  },
+  keyGenerator: (requete) =>
+    // Utilise l'IP de l'utilisateur : https://doc.scalingo.com/platform/internals/routing
+    requete.headers['x-real-ip'],
+});
+
 const adaptateurProtection = {
   protectionCsrf: (pointsEntreesSansProtection) =>
     csrf({ blocklist: pointsEntreesSansProtection }),
 
   protectionLimiteTrafic: () => {
-    const uneMinute = 60 * 1000;
-    const maxParFenetreParIp = 600;
+    const maxParFenetreParIp = process.env.NB_REQUETES_MAX_PAR_MINUTE ?? 0;
     const routesNonLimitees = ['/statique/', '/bibliotheques/', '/favicon.ico'];
 
     return rateLimit({
-      windowMs: uneMinute,
+      ...parametresCommuns('Navigation'),
       max: maxParFenetreParIp,
-      handler: (requete, reponse) => {
-        const attaque = requete.headers['x-real-ip']?.replaceAll('.', '*');
-        fabriqueAdaptateurGestionErreur().logueErreur(
-          new Error('Limite de trafic atteinte par une IP.'),
-          { 'IP de la requete': attaque }
-        );
-        reponse.render('erreurTropDeTrafic');
-      },
       skip: (requete) =>
         routesNonLimitees.some((r) => requete.path.startsWith(r)),
-      keyGenerator: (requete) =>
-        // Utilise l'IP de l'utilisateur : https://doc.scalingo.com/platform/internals/routing
-        requete.headers['x-real-ip'],
+    });
+  },
+
+  protectionLimiteTraficEndpointSensible: () => {
+    const maxParFenetreParIp =
+      process.env.NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE ?? 0;
+
+    return rateLimit({
+      ...parametresCommuns('API', true),
+      max: maxParFenetreParIp,
     });
   },
 };

--- a/src/adaptateurs/adaptateurProtection.js
+++ b/src/adaptateurs/adaptateurProtection.js
@@ -11,10 +11,7 @@ const parametresCommuns = (typeRequete, doitFermerConnexion = false) => ({
     const attaque = requete.headers['x-real-ip']?.replaceAll('.', '*');
     fabriqueAdaptateurGestionErreur().logueErreur(
       new Error('Limite de trafic atteinte par une IP.'),
-      {
-        typeRequete,
-        'IP de la requete': attaque,
-      }
+      { typeRequete, 'IP de la requete': attaque }
     );
     if (doitFermerConnexion) reponse.end();
     else reponse.render('erreurTropDeTrafic');

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -19,6 +19,7 @@ const middleware = (configuration = {}) => {
     adaptateurChiffrement,
     adaptateurEnvironnement = adaptateurEnvironnementParDefaut,
     adaptateurJWT,
+    adaptateurProtection,
   } = configuration;
 
   const positionneHeaders = (requete, reponse, suite) => {
@@ -259,6 +260,9 @@ const middleware = (configuration = {}) => {
       .catch(() => reponse.status(401).send('Mot de passe incorrect'));
   };
 
+  const protegeTrafic = () =>
+    adaptateurProtection.protectionLimiteTraficEndpointSensible();
+
   return {
     aseptise,
     aseptiseListe,
@@ -267,6 +271,7 @@ const middleware = (configuration = {}) => {
     chargePreferencesUtilisateur,
     positionneHeaders,
     positionneHeadersAvecNonce,
+    protegeTrafic,
     repousseExpirationCookie,
     suppressionCookie,
     trouveService,

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -130,14 +130,14 @@ const routesApiPrivee = ({
 
   routes.use(
     '/service',
-    routesApiService(
+    routesApiService({
       middleware,
       depotDonnees,
       referentiel,
       adaptateurHorloge,
       adaptateurPdf,
-      adaptateurZip
-    )
+      adaptateurZip,
+    })
   );
 
   routes.put(

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -444,6 +444,7 @@ const routesApiService = ({
 
   routes.copy(
     '/:id',
+    middleware.protegeTrafic(),
     middleware.trouveService({}),
     middleware.chargeAutorisationsService,
     (requete, reponse, suite) => {

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -34,14 +34,14 @@ const {
 const { ECRITURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
 
-const routesApiService = (
+const routesApiService = ({
   middleware,
   depotDonnees,
   referentiel,
   adaptateurHorloge,
   adaptateurPdf,
-  adaptateurZip
-) => {
+  adaptateurZip,
+}) => {
   const routes = express.Router();
 
   routes.use(
@@ -56,6 +56,7 @@ const routesApiService = (
 
   routes.post(
     '/',
+    middleware.protegeTrafic(),
     middleware.verificationAcceptationCGU,
     middleware.aseptise('nomService', 'organisationsResponsables.*'),
     middleware.aseptiseListes([

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -23,6 +23,7 @@ const routesApiPublique = ({
 
   routes.post(
     '/utilisateur',
+    middleware.protegeTrafic(),
     middleware.aseptise(...Utilisateur.nomsProprietesBase()),
     (requete, reponse, suite) => {
       const verifieSuccesEnvoiMessage = (promesseEnvoiMessage, utilisateur) =>

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -118,41 +118,45 @@ const routesApiPublique = ({
       .catch(suite);
   });
 
-  routes.post('/token', (requete, reponse, suite) => {
-    const login = requete.body.login?.toLowerCase();
-    const { motDePasse } = requete.body;
-    depotDonnees
-      .utilisateurAuthentifie(login, motDePasse)
-      .then((utilisateur) => {
-        if (utilisateur) {
-          const token = utilisateur.genereToken();
-          requete.session.token = token;
-          depotDonnees.homologations(utilisateur.id).then((services) =>
-            adaptateurTracking.envoieTrackingConnexion(utilisateur.email, {
-              nombreServices: services.length,
-            })
-          );
-          depotDonnees
-            .lisParcoursUtilisateur(utilisateur.id)
-            .then((parcoursUtilisateur) => {
-              const nouvelleFonctionnalite =
-                parcoursUtilisateur.recupereNouvelleFonctionnalite();
-              parcoursUtilisateur.enregistreDerniereConnexionMaintenant();
-              depotDonnees
-                .sauvegardeParcoursUtilisateur(parcoursUtilisateur)
-                .then(() =>
-                  reponse.json({
-                    utilisateur: utilisateur.toJSON(),
-                    nouvelleFonctionnalite,
-                  })
-                );
-            });
-        } else {
-          reponse.status(401).send("L'authentification a échoué");
-        }
-      })
-      .catch(suite);
-  });
+  routes.post(
+    '/token',
+    middleware.protegeTrafic(),
+    (requete, reponse, suite) => {
+      const login = requete.body.login?.toLowerCase();
+      const { motDePasse } = requete.body;
+      depotDonnees
+        .utilisateurAuthentifie(login, motDePasse)
+        .then((utilisateur) => {
+          if (utilisateur) {
+            const token = utilisateur.genereToken();
+            requete.session.token = token;
+            depotDonnees.homologations(utilisateur.id).then((services) =>
+              adaptateurTracking.envoieTrackingConnexion(utilisateur.email, {
+                nombreServices: services.length,
+              })
+            );
+            depotDonnees
+              .lisParcoursUtilisateur(utilisateur.id)
+              .then((parcoursUtilisateur) => {
+                const nouvelleFonctionnalite =
+                  parcoursUtilisateur.recupereNouvelleFonctionnalite();
+                parcoursUtilisateur.enregistreDerniereConnexionMaintenant();
+                depotDonnees
+                  .sauvegardeParcoursUtilisateur(parcoursUtilisateur)
+                  .then(() =>
+                    reponse.json({
+                      utilisateur: utilisateur.toJSON(),
+                      nouvelleFonctionnalite,
+                    })
+                  );
+              });
+          } else {
+            reponse.status(401).send("L'authentification a échoué");
+          }
+        })
+        .catch(suite);
+    }
+  );
 
   routes.get(
     '/annuaire/organisations',

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -101,22 +101,26 @@ const routesApiPublique = ({
     }
   );
 
-  routes.post('/reinitialisationMotDePasse', (requete, reponse, suite) => {
-    const email = requete.body.email?.toLowerCase();
+  routes.post(
+    '/reinitialisationMotDePasse',
+    middleware.protegeTrafic(),
+    (requete, reponse, suite) => {
+      const email = requete.body.email?.toLowerCase();
 
-    depotDonnees
-      .reinitialiseMotDePasse(email)
-      .then((utilisateur) => {
-        if (utilisateur) {
-          adaptateurMail.envoieMessageReinitialisationMotDePasse(
-            utilisateur.email,
-            utilisateur.idResetMotDePasse
-          );
-        }
-      })
-      .then(() => reponse.send(''))
-      .catch(suite);
-  });
+      depotDonnees
+        .reinitialiseMotDePasse(email)
+        .then((utilisateur) => {
+          if (utilisateur) {
+            adaptateurMail.envoieMessageReinitialisationMotDePasse(
+              utilisateur.email,
+              utilisateur.idResetMotDePasse
+            );
+          }
+        })
+        .then(() => reponse.send(''))
+        .catch(suite);
+    }
+  );
 
   routes.post(
     '/token',

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -56,6 +56,7 @@ let parametresAseptises = [];
 let preferencesChargees = false;
 let rechercheDossierCourantEffectuee = false;
 let suppressionCookieEffectuee = false;
+let traficProtege = false;
 let verificationJWTMenee = false;
 let verificationCGUMenee = false;
 
@@ -84,6 +85,7 @@ const middlewareFantaisie = {
     preferencesChargees = false;
     rechercheDossierCourantEffectuee = false;
     suppressionCookieEffectuee = false;
+    traficProtege = false;
     verificationJWTMenee = false;
     verificationCGUMenee = false;
     challengeMotDePasseEffectue = false;
@@ -137,6 +139,11 @@ const middlewareFantaisie = {
 
   positionneHeadersAvecNonce: (_requete, _reponse, suite) => {
     headersAvecNoncePositionnes = true;
+    suite();
+  },
+
+  protegeTrafic: () => (_requete, _reponse, suite) => {
+    traficProtege = true;
     suite();
   },
 
@@ -229,6 +236,10 @@ const middlewareFantaisie = {
       { lectureEtat: () => preferencesChargees },
       ...params
     );
+  },
+
+  verifieProtectionTrafic: (...params) => {
+    verifieRequeteChangeEtat({ lectureEtat: () => traficProtege }, ...params);
   },
 
   verifieRechercheService: (droitsAttendus, ...params) => {

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -36,6 +36,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().nouveauService = () => Promise.resolve();
     });
 
+    it('applique une protection de trafic', (done) => {
+      testeur.middleware().verifieProtectionTrafic(
+        {
+          method: 'post',
+          url: 'http://localhost:1234/api/service',
+        },
+        done
+      );
+    });
+
     it("vérifie que l'utilisateur est authentifié", (done) => {
       testeur
         .middleware()

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1324,6 +1324,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
+    it('applique une protection de trafic', (done) => {
+      testeur
+        .middleware()
+        .verifieProtectionTrafic(
+          { method: 'copy', url: 'http://localhost:1234/api/service/123' },
+          done
+        );
+    });
+
     it('utilise le middleware de chargement du service', (done) => {
       testeur
         .middleware()

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -376,6 +376,16 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
   });
 
   describe('quand requête POST sur `/api/token`', () => {
+    it('applique une protection de trafic', (done) => {
+      testeur.middleware().verifieProtectionTrafic(
+        {
+          method: 'post',
+          url: 'http://localhost:1234/api/token',
+        },
+        done
+      );
+    });
+
     it("authentifie l'utilisateur avec le login en minuscules", (done) => {
       testeur.depotDonnees().lisParcoursUtilisateur = async () => {
         const p = new ParcoursUtilisateur();

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -307,6 +307,16 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         Promise.resolve(utilisateur);
     });
 
+    it('applique une protection de trafic', (done) => {
+      testeur.middleware().verifieProtectionTrafic(
+        {
+          method: 'post',
+          url: 'http://localhost:1234/api/reinitialisationMotDePasse',
+        },
+        done
+      );
+    });
+
     it("convertit l'email en minuscules", (done) => {
       testeur.depotDonnees().reinitialiseMotDePasse = (email) => {
         expect(email).to.equal('jean.dupont@mail.fr');

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -43,6 +43,16 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         Promise.resolve(utilisateur);
     });
 
+    it('applique une protection de trafic', (done) => {
+      testeur.middleware().verifieProtectionTrafic(
+        {
+          method: 'post',
+          url: 'http://localhost:1234/api/utilisateur',
+        },
+        done
+      );
+    });
+
     it('aseptise les paramètres de la requête', (done) => {
       testeur.middleware().verifieAseptisationParametres(
         [

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -70,6 +70,9 @@ const testeurMss = () => {
     adaptateurProtection = {
       protectionCsrf: () => (_requete, _reponse, suite) => suite(),
       protectionLimiteTrafic: () => (_requete, _reponse, suite) => suite(),
+      protectionLimiteTraficEndpointSensible:
+        () => (_requete, _reponse, suite) =>
+          suite(),
     };
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();


### PR DESCRIPTION
On souhaite ajouter du `rate-limit` plus fin sur certaines routes afin de sécuriser les points sensibles.
Les routes :
- `POST /token`
- `POST /reinitialisationMotDePasse`
- `POST /utilisateur`
- `POST /api/service`
- `COPY /api/service/:id`

### :warning: Il faut rajouter au déploiement les variables `NB_REQUETES_MAX_PAR_MINUTE` et `NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE`