### PR TITLE
Ajoute un `max-age` sur les fichiers statiques afin de pouvoir les ajouter au `cache`

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -239,7 +239,13 @@ const creeServeur = (
     }
   );
 
-  app.use('/statique', express.static('public'));
+  app.use(
+    '/statique',
+    express.static('public', {
+      setHeaders: (reponse) =>
+        reponse.setHeader('cache-control', 'max-age=3600, must-revalidate'),
+    })
+  );
 
   app.use(adaptateurGestionErreur.controleurErreurs());
 


### PR DESCRIPTION
Afin de garantir un cache pendant une heure et rendre la navigation plus fluide.
