### PR TITLE
[CORRECTION] Corrige le nombre de contributeurs affichés dans le menu de navigation

### DIFF
--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -9,7 +9,7 @@ const tiroirContributeur = (idService) => {
     const reponse = await axios.get(`/api/service/${idService}`);
     donneesService = reponse.data;
     $('.nombre-contributeurs', '#gerer-contributeurs').text(
-      donneesService.contributeurs.length + 1
+      donneesService.contributeurs.length
     );
   };
 


### PR DESCRIPTION
Le nombre de contributeurs était encore incrémenté de 1, mais l'`objetGetService` fait maintenant le travail de grouper le(s) propriétaires avec les contributeurs