### PR TITLE
Ajoute un placeholder sur le champ d'invitation de contributeur

### DIFF
--- a/svelte/lib/gestionContributeurs/kit/ChampAvecSuggestions.svelte
+++ b/svelte/lib/gestionContributeurs/kit/ChampAvecSuggestions.svelte
@@ -42,6 +42,7 @@
     on:input={() => avecTemporisation(rechercheSuggestions)}
     bind:value={saisie}
     autocomplete="off"
+    placeholder="ex : Émilie Leroy, e.leroy@domaine.fr"
   />
   <div class="liste-suggestions" class:visible={suggestionsVisibles}>
     {#if proposeAjout}


### PR DESCRIPTION
Afin de rendre plus claire les possibilités du champs, suite à une demande d'@henricasa 