### PR TITLE
Extrais la variable de `cache-control` en variable d'environnement

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,6 +41,9 @@ AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que le « Journal MSS » en 
 AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
 AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logués dans la console
 
+# Politique de cache
+CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local
+
 # configuration du `rate-limit`
 NB_REQUETES_MAX_PAR_MINUTE= # Nombre maximal de requêtes autorisées par IP et par minute, supprimer la variable permet de désactiver la protection
 NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes autorisées par IP et par minute pour les endpoints sensibles (connexion, inscription, modification de mot de passe, creation de service), supprimer la variable permet de désactiver la protection

--- a/src/http/configurationServeur.js
+++ b/src/http/configurationServeur.js
@@ -13,4 +13,10 @@ const ENDPOINTS_SANS_CSRF = [
   { path: '/bibliotheques/evenementMatomo', type: 'exact' },
 ];
 
-module.exports = { DUREE_SESSION, ENDPOINTS_SANS_CSRF };
+const { CACHE_CONTROL_FICHIERS_STATIQUES } = process.env;
+
+module.exports = {
+  CACHE_CONTROL_FICHIERS_STATIQUES,
+  DUREE_SESSION,
+  ENDPOINTS_SANS_CSRF,
+};

--- a/src/mss.js
+++ b/src/mss.js
@@ -2,6 +2,7 @@ const cookieSession = require('cookie-session');
 const cookieParser = require('cookie-parser');
 const express = require('express');
 const {
+  CACHE_CONTROL_FICHIERS_STATIQUES,
   DUREE_SESSION,
   ENDPOINTS_SANS_CSRF,
 } = require('./http/configurationServeur');
@@ -243,7 +244,7 @@ const creeServeur = (
     '/statique',
     express.static('public', {
       setHeaders: (reponse) =>
-        reponse.setHeader('cache-control', 'max-age=3600, must-revalidate'),
+        reponse.setHeader('cache-control', CACHE_CONTROL_FICHIERS_STATIQUES),
     })
   );
 


### PR DESCRIPTION
... Afin de ne pas utiliser de cache lors du dev local.

### :warning: Il faut mettre CACHE_CONTROL_FICHIERS_STATIQUES="max-age=3600, must-revalidate" au moment du déploiement