### PR TITLE
Uniformise les couleurs des `:hover` et `.nom` du menu de droit

### DIFF
--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -102,13 +102,7 @@
     border-radius: 5px;
   }
 
-  .role-propose.lecture .nom {
-    color: #7025da;
-  }
-  .role-propose.ecriture .nom {
-    color: #0079d0;
-  }
-  .role-propose.personnalise .nom {
+  .role-propose .nom {
     color: #0079d0;
   }
   .role-propose .nom {
@@ -122,13 +116,7 @@
     font-weight: 400;
   }
 
-  .role-propose.lecture:hover {
-    background: #e9ddff;
-  }
-  .role-propose.ecriture:hover {
-    background: #dbeeff;
-  }
-  .role-propose.personnalise:hover {
+  .role-propose:hover {
     background: #eff6ff;
   }
 

--- a/svelte/lib/gestionContributeurs/personnalisation/TagLectureEcriture.svelte
+++ b/svelte/lib/gestionContributeurs/personnalisation/TagLectureEcriture.svelte
@@ -104,28 +104,20 @@
     font-style: normal;
     font-weight: 500;
     line-height: 1.2rem;
-  }
-
-  .droit-propose.lecture .nom {
-    color: #7025da;
-  }
-  .droit-propose.ecriture .nom {
     color: #0079d0;
   }
+
   .droit-propose .description {
     color: #2f3a43;
     font-weight: 400;
+  }
+  .droit-propose:hover {
+    background: #eff6ff;
   }
   .droit-propose:hover .nom {
     font-weight: 700;
   }
   .droit-propose:hover .description {
     font-weight: 500;
-  }
-  .droit-propose.lecture:hover {
-    background: #e9ddff;
-  }
-  .droit-propose.ecriture:hover {
-    background: #dbeeff;
   }
 </style>


### PR DESCRIPTION
Afin de les mettres tous de la même couleur, en suivant le figma :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/4b678f90-eb73-463b-94d7-406f9a4eb886)
