### PR TITLE
Outillage du dev en local 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ dans le fichier `.env`).
 
 Il est alors possible de créer un compte utilisateur à l'url `http://localhost:[PORT_MSS]/inscription`.
 
+Il est également possible d'attacher un debugger `nodejs` car MSS est démarré avec `--inspect=0.0.0.0`.
+
 ## Exécution de la suite de tests automatisés
 
 Les tests peuvent être lancés depuis un conteneur Docker en exécutant le script

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ dans le fichier `.env`).
 
 Il est alors possible de créer un compte utilisateur à l'url `http://localhost:[PORT_MSS]/inscription`.
 
-Il est également possible d'attacher un debugger `nodejs` car MSS est démarré avec `--inspect=0.0.0.0`.
+### Outils en local
+
+- Il est possible d'attacher un debugger `nodejs` car MSS est démarré avec `--inspect=0.0.0.0`.
+- `Postgres` est relayé sur le port `5432` de l'hôte. Donc le requêtage via un outil graphique est possible.
 
 ## Exécution de la suite de tests automatisés
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
       - mss-network
+    ports:
+      - '5432:5432'
     volumes:
       - /var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   web:
     <<: *configuration-base
-    command: bash -c "export PUPPETEER_EXECUTABLE_PATH=$$(which chromium) && npx knex migrate:latest && npx concurrently \"npx nodemon server.js\" \"npx vite build --watch --minify false --config svelte/vite.config.mts\""
+    command: bash -c "export PUPPETEER_EXECUTABLE_PATH=$$(which chromium) && npx knex migrate:latest && npx concurrently \"npx nodemon --inspect=0.0.0.0 server.js\" \"npx vite build --watch --minify false --config svelte/vite.config.mts\""
     environment:
       - NODE_ENV=development
       # Sur Mac M1 le téléchargement de Chromium échoue, car aucune version compatible `arm64`.
@@ -38,6 +38,7 @@ services:
       - mss-network
     ports:
       - '${PORT_MSS}:3000'
+      - '9229:9229'
     depends_on:
       - mss-db
       - mss-crypto


### PR DESCRIPTION
Pour faciliter le travail en local, cette PR :
 - ouvre le port `5432` de Postgres
 - exécute MSS en `--inspect` pour y brancher un debugger.


Exemple de branchement du debugger dans IntelliJ 👇 
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/9cac9be0-6f78-4967-a360-5ad575514974)
