### PR TITLE
Empêche de modifier une autorisation n'appartenant pas au service ciblé

### DIFF
--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -529,6 +529,13 @@ const routesApiService = ({
         return;
       }
 
+      const { homologation } = requete;
+      const cibleUnServiceDifferent = ciblee.idService !== homologation.id;
+      if (cibleUnServiceDifferent) {
+        reponse.status(422).json({ code: 'LIEN_INCOHERENT' });
+        return;
+      }
+
       ciblee.appliqueDroits(nouveauxDroits);
       await depotDonnees.sauvegardeAutorisation(ciblee);
 


### PR DESCRIPTION
… pour éviter une attaque comme :
 - j'ai les droits sur A, pas sur B
 - je fais un `PATCH /service/A/autorisations/une-autorisation-de-B`
 - MSS me laisse modifier l'autorisation de B, car il a seulement vérifié mes droits sur A

Avec cette PR, cette traversée de A vers B devient bloquée.