### PR TITLE
Supprime complètement l'abstraction `homologation.createur`

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -69,23 +69,6 @@ const nouvelAdaptateur = (env) => {
       .select({ id: 'id', donnees: 'donnees' })
       .first();
 
-    const requeteCreateur = knex('autorisations as a')
-      .join(
-        'utilisateurs as u',
-        knex.raw("(a.donnees->>'idUtilisateur')::uuid"),
-        'u.id'
-      )
-      .whereRaw(
-        "(a.donnees->>'idHomologation')::uuid = ? AND a.donnees->>'type' = 'createur'",
-        id
-      )
-      .select({
-        id: 'u.id',
-        dateCreation: 'u.date_creation',
-        donnees: 'u.donnees',
-      })
-      .first();
-
     const requeteContributeurs = knex('autorisations as a')
       .join(
         'utilisateurs as u',
@@ -99,20 +82,14 @@ const nouvelAdaptateur = (env) => {
         donnees: 'u.donnees',
       });
 
-    const [h, createur, contributeurs] = await Promise.all([
+    const [h, contributeurs] = await Promise.all([
       requeteHomologation,
-      requeteCreateur,
       requeteContributeurs,
     ]);
 
     return {
       id: h.id,
       ...h.donnees,
-      createur: {
-        id: createur.id,
-        dateCreation: createur.dateCreation,
-        ...createur.donnees,
-      },
       contributeurs: contributeurs.map((c) => ({
         id: c.id,
         dateCreation: c.dateCreation,

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -30,7 +30,6 @@ class Homologation {
     const {
       id = '',
       contributeurs = [],
-      createur = {},
       descriptionService = {},
       dossiers = [],
       mesuresSpecifiques = [],
@@ -40,7 +39,6 @@ class Homologation {
     } = donnees;
 
     this.id = id;
-    if (createur.email) this.createur = new Utilisateur(createur);
     this.contributeurs = contributeurs.map((c) => new Utilisateur(c));
     this.descriptionService = new DescriptionService(
       descriptionService,

--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -9,7 +9,6 @@ class ConstructeurService {
       id: '',
       descriptionService: uneDescriptionValide(referentiel).donnees,
       contributeurs: [],
-      createur: { id: 'AAA', email: 'jean.dujardin@beta.gouv.com' },
     };
     this.mesures = undefined;
     this.referentiel = referentiel;
@@ -63,11 +62,6 @@ class ConstructeurService {
 
   ajouteUnContributeur(contributeur) {
     this.donnees.contributeurs.push(contributeur);
-    return this;
-  }
-
-  ajouteUnProprietaire(proprietaire) {
-    this.donnees.createur = proprietaire;
     return this;
   }
 }

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -51,22 +51,6 @@ describe('Une homologation', () => {
     expect(contributeur.id).to.equal('456');
   });
 
-  it('connaît son créateur', () => {
-    const homologation = unService()
-      .avecId('123')
-      .ajouteUnProprietaire(
-        unUtilisateur()
-          .avecId('456')
-          .quiSAppelle('Jean Dupont')
-          .avecEmail('jean.dupont@mail.fr').donnees
-      )
-      .construis();
-
-    const { createur } = homologation;
-    expect(createur).to.be.an(Utilisateur);
-    expect(createur.id).to.equal('456');
-  });
-
   it('sait décrire le type service', () => {
     const referentiel = Referentiel.creeReferentiel({
       typesService: {


### PR DESCRIPTION
C'est la fin de ce cycle de commits démarré en 5cf41984750b2f8da05035c70f4339884c05377a qui vise à ne plus avoir de `createur` dans `homologation`. 

On va désormais dépendre des `contributeurs`. Et quand il faut raisonner sur les droits & permissions, on utilise la grappe des `Autorisations` du modèle.

Cette PR termine le travail commencé par #1172.