### PR TITLE
Suppression du champ `type` de `Autorisation`

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -193,11 +193,10 @@ const nouvelAdaptateur = (
   const supprimeAutorisations = () =>
     Promise.resolve((donnees.autorisations = []));
 
-  const supprimeAutorisationsContribution = (idUtilisateur) => {
+  const supprimeAutorisationsContribution = async (idUtilisateur) => {
     donnees.autorisations = donnees.autorisations.filter(
-      (a) => a.idUtilisateur !== idUtilisateur || a.type !== 'contributeur'
+      (a) => a.idUtilisateur !== idUtilisateur || a.estProprietaire
     );
-    return Promise.resolve();
   };
 
   const supprimeAutorisationsHomologation = (idHomologation) => {

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -244,7 +244,7 @@ const nouvelAdaptateur = (env) => {
   const supprimeAutorisationsContribution = (idUtilisateur) =>
     knex('autorisations')
       .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
-      .whereRaw("donnees->>'type'='contributeur'")
+      .whereRaw("(donnees->>'estProprietaire')::boolean=false")
       .del();
 
   const supprimeAutorisationsHomologation = (idHomologation) =>

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -132,31 +132,27 @@ const creeDepot = (config = {}) => {
       })
       .then(() => utilisateur(utilisateurAModifier.id));
 
-  const supprimeUtilisateur = (...params) => {
-    const verifieUtilisateurExistant = (id) =>
-      adaptateurPersistance.utilisateur(id).then((u) => {
-        if (typeof u === 'undefined') {
-          throw new ErreurUtilisateurInexistant(
-            `L'utilisateur "${id}" n'existe pas`
-          );
-        }
-      });
+  const supprimeUtilisateur = async (id) => {
+    const verifieUtilisateurExistant = async () => {
+      const u = await adaptateurPersistance.utilisateur(id);
+      if (typeof u === 'undefined')
+        throw new ErreurUtilisateurInexistant(
+          `L'utilisateur "${id}" n'existe pas`
+        );
+    };
 
-    const verifieUtilisateurPasProprietaire = (id) =>
-      adaptateurPersistance.nbAutorisationsProprietaire(id).then((nb) => {
-        if (nb > 0) {
-          throw new ErreurSuppressionImpossible(
-            `Suppression impossible : l'utilisateur "${id}" a créé des services`
-          );
-        }
-      });
+    const verifieUtilisateurPasProprietaire = async () => {
+      const nb = await adaptateurPersistance.nbAutorisationsProprietaire(id);
+      if (nb > 0)
+        throw new ErreurSuppressionImpossible(
+          `Suppression impossible : l'utilisateur "${id}" a créé des services`
+        );
+    };
 
-    return verifieUtilisateurExistant(...params)
-      .then(() => verifieUtilisateurPasProprietaire(...params))
-      .then(() =>
-        adaptateurPersistance.supprimeAutorisationsContribution(...params)
-      )
-      .then(() => adaptateurPersistance.supprimeUtilisateur(...params));
+    await verifieUtilisateurExistant();
+    await verifieUtilisateurPasProprietaire();
+    await adaptateurPersistance.supprimeAutorisationsContribution(id);
+    await adaptateurPersistance.supprimeUtilisateur(id);
   };
 
   const tousUtilisateurs = () =>

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -24,18 +24,13 @@ class AutorisationBase extends Base {
   }
 
   static NouvelleAutorisationContributeur = (donnees = {}) =>
-    new AutorisationBase({
-      ...donnees,
-      estProprietaire: false,
-      type: 'contributeur',
-    });
+    new AutorisationBase({ ...donnees, estProprietaire: false });
 
   static NouvelleAutorisationProprietaire = (donnees = {}) =>
     new AutorisationBase({
       ...donnees,
       droits: tousDroitsEnEcriture(),
       estProprietaire: true,
-      type: 'createur',
     });
 
   aLaPermission(niveau, rubrique) {
@@ -101,7 +96,6 @@ class AutorisationBase extends Base {
       idHomologation: this.idService,
       idUtilisateur: this.idUtilisateur,
       droits: this.droits,
-      type: this.type,
     };
   }
 

--- a/src/modeles/autorisations/fabriqueAutorisation.js
+++ b/src/modeles/autorisations/fabriqueAutorisation.js
@@ -1,11 +1,8 @@
 const AutorisationBase = require('./autorisationBase');
 
-const CONSTRUCTEURS_AUTORISATIONS = {
-  contributeur: AutorisationBase.NouvelleAutorisationContributeur,
-  createur: AutorisationBase.NouvelleAutorisationProprietaire,
-};
-
-const fabrique = ({ type, ...autresDonnees }) =>
-  CONSTRUCTEURS_AUTORISATIONS[type](autresDonnees);
+const fabrique = (donnees) =>
+  donnees.estProprietaire
+    ? AutorisationBase.NouvelleAutorisationProprietaire(donnees)
+    : AutorisationBase.NouvelleAutorisationContributeur(donnees);
 
 module.exports = { fabrique };

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -11,7 +11,6 @@ class ConstructeurAutorisation {
       idUtilisateur: '',
       idHomologation: '',
       idService: '',
-      type: 'contributeur',
       droits: {},
     };
   }
@@ -23,7 +22,6 @@ class ConstructeurAutorisation {
 
   deProprietaireDeService(idUtilisateur, idService) {
     this.donnees.estProprietaire = true;
-    this.donnees.type = 'createur';
     this.donnees.idUtilisateur = idUtilisateur;
     this.donnees.idService = idService;
     this.donnees.idHomologation = idService;
@@ -32,7 +30,6 @@ class ConstructeurAutorisation {
 
   deContributeurDeService(idUtilisateur, idService) {
     this.donnees.estProprietaire = false;
-    this.donnees.type = 'contributeur';
     this.donnees.idUtilisateur = idUtilisateur;
     this.donnees.idService = idService;
     this.donnees.idHomologation = idService;

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -190,7 +190,6 @@ describe('Une autorisation', () => {
         idService: '123',
         idHomologation: '123',
         idUtilisateur: '999',
-        type: 'contributeur',
         droits: {
           CONTACTS: 2,
           DECRIRE: 2,
@@ -215,7 +214,6 @@ describe('Une autorisation', () => {
         idService: '123',
         idHomologation: '123',
         idUtilisateur: '999',
-        type: 'createur',
         droits: {
           CONTACTS: 2,
           DECRIRE: 2,


### PR DESCRIPTION
Ce champ est osbolète. C'est désormais `estProprietaire` qui est utilisé.


#### Les dépendances touchées par cette PR 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/1d66e951-a30a-4fc1-9d6d-8cd012f95d10)

#### Les modifications 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/c2118aec-019d-4a75-ab05-93e4a90ea6ec)
