### PR TITLE
Ajout de la possibilité de nommer un « Propriétaire »

### DIFF
--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -88,11 +88,16 @@ const ajoutContributeurSurServices = ({
   const ajouteContributeur = async (contributeur, services, droits) => {
     const ajouteAuService = async (s) => {
       await depotDonnees.ajouteContributeurAuService(
-        AutorisationBase.NouvelleAutorisationContributeur({
-          idUtilisateur: contributeur.id,
-          idService: s.id,
-          droits,
-        })
+        droits.estProprietaire
+          ? AutorisationBase.NouvelleAutorisationProprietaire({
+              idUtilisateur: contributeur.id,
+              idService: s.id,
+            })
+          : AutorisationBase.NouvelleAutorisationContributeur({
+              idUtilisateur: contributeur.id,
+              idService: s.id,
+              droits,
+            })
       );
     };
 

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -138,6 +138,12 @@ class AutorisationBase extends Base {
   };
 
   appliqueDroits(nouveauxDroits) {
+    if (nouveauxDroits.estProprietaire) {
+      this.estProprietaire = true;
+      this.droits = tousDroitsEnEcriture();
+      return;
+    }
+
     this.droits = { ...this.droits, ...nouveauxDroits };
   }
 }

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -144,6 +144,7 @@ class AutorisationBase extends Base {
       return;
     }
 
+    this.estProprietaire = false;
     this.droits = { ...this.droits, ...nouveauxDroits };
   }
 }

--- a/src/modeles/autorisations/gestionDroits.js
+++ b/src/modeles/autorisations/gestionDroits.js
@@ -33,12 +33,15 @@ const tousDroitsEnEcriture = () =>
     {}
   );
 
-const verifieCoherenceDesDroits = (droits) =>
-  Object.entries(droits).every(([rubrique, niveau]) => {
+const verifieCoherenceDesDroits = (droits) => {
+  if (droits.estProprietaire) return true;
+
+  return Object.entries(droits).every(([rubrique, niveau]) => {
     const rubriqueExiste = Object.values(Rubriques).includes(rubrique);
     const niveauExiste = Object.values(Permissions).includes(niveau);
     return rubriqueExiste && niveauExiste;
   });
+};
 
 module.exports = {
   Permissions,

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -62,6 +62,7 @@ export const enDroitsSurRubrique = (
     case 'ECRITURE':
       return rubriquesAvecPermission(2);
     case 'PROPRIETAIRE':
+      return { estProprietaire: true };
     case 'PERSONNALISE':
       throw new Error(`${resume} non convertible en permission`);
   }

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -47,7 +47,7 @@ export type Rubrique =
 
 export const enDroitsSurRubrique = (
   resume: ResumeNiveauDroit
-): Record<Rubrique, Permission> => {
+): Record<Rubrique, Permission> & { estProprietaire: boolean } => {
   const rubriquesAvecPermission = (p: Permission) => ({
     DECRIRE: p,
     SECURISER: p,
@@ -70,7 +70,7 @@ export const enDroitsSurRubrique = (
 
 export type Invitation = {
   utilisateur: Utilisateur;
-  droits: Record<Rubrique, Permission>;
+  droits: Record<Rubrique, Permission> & { estProprietaire: boolean };
 };
 
 export type IdAutorisation = string;

--- a/svelte/lib/gestionContributeurs/invitation/ListeInvitations.svelte
+++ b/svelte/lib/gestionContributeurs/invitation/ListeInvitations.svelte
@@ -19,8 +19,9 @@
   }>();
 
   const resumeLesDroits = (
-    droits: Record<Rubrique, Permission>
+    droits: Record<Rubrique, Permission> & { estProprietaire: boolean }
   ): ResumeNiveauDroit => {
+    if (droits.estProprietaire) return 'PROPRIETAIRE';
     if (Object.values(droits).every((p) => p === 1)) return 'LECTURE';
     if (Object.values(droits).every((p) => p === 2)) return 'ECRITURE';
     return 'PERSONNALISE';

--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -124,6 +124,16 @@
     font-weight: 400;
   }
 
+  .role-propose.personnalise {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  .role-propose.proprietaire {
+    border-top: 1px solid #cbd5e1;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
   .role-propose:hover {
     background: #eff6ff;
   }

--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -56,6 +56,14 @@
           Avoir un droit d'accès adapté par rubrique
         </div>
       </div>
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <div
+        class="role-propose proprietaire"
+        on:click={() => dispatch('droitsChange', 'PROPRIETAIRE')}
+      >
+        <div class="nom">Propriétaire</div>
+        <div class="description">Gérer le service et les contributeurs</div>
+      </div>
     </div>
   </MenuFlottant>
 {/if}

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -382,6 +382,30 @@ describe("L'ajout d'un contributeur sur des services", () => {
     expect(a2.idService).to.be('888');
   });
 
+  it('sait ajouter un contributeur en tant que « Propriétaire »', async () => {
+    const autorisations = [];
+    depotDonnees.ajouteContributeurAuService = async (nouvelleAutorisation) => {
+      autorisations.push(nouvelleAutorisation);
+    };
+
+    await ajoutContributeurSurServices({
+      depotDonnees,
+      adaptateurMail,
+      adaptateurTracking,
+    }).executer(
+      'jean.dupont@mail.fr',
+      [leService('123')],
+      { estProprietaire: true },
+      unEmetteur()
+    );
+
+    expect(autorisations.length).to.be(1);
+    const [a1] = autorisations;
+    expect(a1.estProprietaire).to.be(true);
+    expect(a1.idUtilisateur).to.be('999');
+    expect(a1.idService).to.be('123');
+  });
+
   it("envoie un événement d'invitation contributeur via l'adaptateur de tracking", async () => {
     let idEmetteur;
     let donneesTracking;

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -99,6 +99,23 @@ describe('Une autorisation', () => {
     expect(autorisation.aLaPermission(LECTURE, HOMOLOGUER)).to.be(true);
   });
 
+  it('passe tous les droits en écriture si on devient propriétaire', () => {
+    const autorisation = new AutorisationBase({
+      droits: { [DECRIRE]: LECTURE },
+    });
+
+    autorisation.appliqueDroits({ estProprietaire: true });
+
+    expect(autorisation.estProprietaire).to.be(true);
+    expect(autorisation.droits).to.eql({
+      [DECRIRE]: ECRITURE,
+      [SECURISER]: ECRITURE,
+      [HOMOLOGUER]: ECRITURE,
+      [RISQUES]: ECRITURE,
+      [CONTACTS]: ECRITURE,
+    });
+  });
+
   describe('sur demande de résumé de niveau de droit', () => {
     it("retourne 'PROPRIETAIRE' si l'utilisateur est propriétaire du service", async () => {
       const autorisationProprietaire =

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -116,6 +116,22 @@ describe('Une autorisation', () => {
     });
   });
 
+  it("supprime le droit de propriétaire lors de l'application d'un droit d'écriture", () => {
+    const autorisation = AutorisationBase.NouvelleAutorisationProprietaire();
+
+    autorisation.appliqueDroits({ HOMOLOGUER: ECRITURE });
+
+    expect(autorisation.estProprietaire).to.be(false);
+  });
+
+  it("supprime le droit de propriétaire lors de l'application d'un droit de lecture", () => {
+    const autorisation = AutorisationBase.NouvelleAutorisationProprietaire();
+
+    autorisation.appliqueDroits({ HOMOLOGUER: LECTURE });
+
+    expect(autorisation.estProprietaire).to.be(false);
+  });
+
   describe('sur demande de résumé de niveau de droit', () => {
     it("retourne 'PROPRIETAIRE' si l'utilisateur est propriétaire du service", async () => {
       const autorisationProprietaire =

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1739,6 +1739,23 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         done
       );
     });
+
+    it('permet de nommer un nouveau propriétaire', async () => {
+      testeur.depotDonnees().autorisation = async () =>
+        uneAutorisation().deContributeurDeService('BBB', '456').construis();
+
+      let autorisationPersistee;
+      testeur.depotDonnees().sauvegardeAutorisation = async (autorisation) => {
+        autorisationPersistee = autorisation;
+      };
+
+      await axios.patch(
+        'http://localhost:1234/api/service/456/autorisations/uuid-1',
+        { droits: { estProprietaire: true } }
+      );
+
+      expect(autorisationPersistee.estProprietaire).to.be(true);
+    });
   });
 
   describe('quand requête GET sur `/api/service/:id/autorisations', () => {


### PR DESCRIPTION
Cette PR permet à un utilisateur de nommer un autre propriétaire 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/ddda8aa0-f5cb-4e2b-8e06-0a0071799843)

qui donne comme résultat 👇 
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/bf660526-daf2-4d86-a1e8-483206341bb7)
