### PR TITLE
Ajoute le type de requête dans l'erreur « Trop de trafic »

### DIFF
--- a/src/adaptateurs/adaptateurProtection.js
+++ b/src/adaptateurs/adaptateurProtection.js
@@ -10,7 +10,7 @@ const parametresCommuns = (typeRequete, doitFermerConnexion = false) => ({
   handler: (requete, reponse) => {
     const attaque = requete.headers['x-real-ip']?.replaceAll('.', '*');
     fabriqueAdaptateurGestionErreur().logueErreur(
-      new Error('Limite de trafic atteinte par une IP.'),
+      new Error(`[${typeRequete}] Limite de trafic atteinte par une IP.`),
       { typeRequete, 'IP de la requete': attaque }
     );
     if (doitFermerConnexion) reponse.end();


### PR DESCRIPTION
Ça permettra d'avoir directement l'info quand on regarde les erreurs dans Sentry.