### PR TITLE
Mise à jour du référentiel de l'indice cyber

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -38,6 +38,7 @@ module.exports = {
         "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
+      conseilHomologation: 'Homologation déconseillée',
     },
     {
       borneInferieure: 1,
@@ -48,6 +49,7 @@ module.exports = {
         "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
+      conseilHomologation: 'Homologation déconseillée',
     },
     {
       borneInferieure: 2,
@@ -56,6 +58,7 @@ module.exports = {
         "La durée d'homologation du service devrait être limitée à <b>1 an</b>.",
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '1 an',
+      conseilHomologation: 'Continuer à renforcer la sécurité du service',
     },
     {
       borneInferieure: 3,
@@ -64,6 +67,7 @@ module.exports = {
         "La durée d'homologation du service peut aller jusqu'à <b>2 ans</b>.",
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '2 ans',
+      conseilHomologation: 'Continuer à renforcer la sécurité du service',
     },
     {
       borneInferieure: 4,

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -37,6 +37,7 @@ module.exports = {
       recommandationANSSIComplement:
         "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
       deconseillee: true,
+      dureeHomologationConseillee: '6 mois',
     },
     {
       borneInferieure: 1,
@@ -46,6 +47,7 @@ module.exports = {
       recommandationANSSIComplement:
         "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
       deconseillee: true,
+      dureeHomologationConseillee: '6 mois',
     },
     {
       borneInferieure: 2,
@@ -53,6 +55,7 @@ module.exports = {
       recommandationANSSI:
         "La durée d'homologation du service devrait être limitée à <b>1 an</b>.",
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
+      dureeHomologationConseillee: '1 an',
     },
     {
       borneInferieure: 3,
@@ -60,6 +63,7 @@ module.exports = {
       recommandationANSSI:
         "La durée d'homologation du service peut aller jusqu'à <b>2 ans</b>.",
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
+      dureeHomologationConseillee: '2 ans',
     },
     {
       borneInferieure: 4,
@@ -68,6 +72,7 @@ module.exports = {
       recommandationANSSI:
         "La durée d'homologation du service peut aller jusqu'à <b>3 ans</b>.",
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
+      dureeHomologationConseillee: '3 ans',
     },
   ],
 

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -31,6 +31,15 @@ module.exports = {
   tranchesIndicesCybers: [
     {
       borneInferieure: 0,
+      borneSuperieure: 1,
+      recommandationANSSI:
+        "L'homologation du service est déconseillée ou devrait être limitée à <b>6 mois</b>.",
+      recommandationANSSIComplement:
+        "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
+      deconseillee: true,
+    },
+    {
+      borneInferieure: 1,
       borneSuperieure: 2,
       recommandationANSSI:
         "L'homologation du service est déconseillée ou devrait être limitée à <b>6 mois</b>.",

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -39,6 +39,8 @@ module.exports = {
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
       conseilHomologation: 'Homologation déconseillée',
+      description:
+        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un niveau de sécurisation très insuffisant face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
     },
     {
       borneInferieure: 1,
@@ -50,6 +52,8 @@ module.exports = {
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
       conseilHomologation: 'Homologation déconseillée',
+      description:
+        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un niveau de sécurisation insuffisant face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
     },
     {
       borneInferieure: 2,
@@ -59,6 +63,8 @@ module.exports = {
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '1 an',
       conseilHomologation: 'Continuer à renforcer la sécurité du service',
+      description:
+        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un niveau de sécurisation modéré face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
     },
     {
       borneInferieure: 3,
@@ -68,6 +74,8 @@ module.exports = {
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '2 ans',
       conseilHomologation: 'Continuer à renforcer la sécurité du service',
+      description:
+        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un bon niveau de sécurisation face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
     },
     {
       borneInferieure: 4,
@@ -77,6 +85,8 @@ module.exports = {
         "La durée d'homologation du service peut aller jusqu'à <b>3 ans</b>.",
       recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '3 ans',
+      description:
+        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un très bon niveau de sécurisation face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
     },
   ],
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -139,6 +139,19 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
           : indiceCyber < tranche.borneSuperieure)
     ) || {};
 
+  const descriptionTrancheIndiceCyber = (indiceCyber) => {
+    const formatIndiceCyber = Intl.NumberFormat('fr', {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    }).format;
+    return (
+      trancheIndiceCyber(indiceCyber)?.description?.replaceAll(
+        '$INDICE_CYBER',
+        formatIndiceCyber(indiceCyber)
+      ) ?? ''
+    );
+  };
+
   const infosNiveauxGravite = (ordreInverse = false) => {
     const niveaux = Object.keys(niveauxGravite()).map((clef) => ({
       identifiant: clef,
@@ -264,6 +277,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     descriptionFonctionnalite,
     descriptionRisque,
     descriptionStatutMesure,
+    descriptionTrancheIndiceCyber,
     descriptionsDonneesCaracterePersonnel,
     descriptionsFonctionnalites,
     donneesCaracterePersonnel,

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -702,6 +702,32 @@ describe('Le référentiel', () => {
     });
   });
 
+  describe("sur une demande de description de tranche de l'indice cyber", () => {
+    it("renvoie la description de la tranche, mise en forme avec la valeur de l'indice cyber", () => {
+      const tranche = {
+        borneInferieure: 0,
+        borneSuperieure: 2,
+        description: 'La valeur est $INDICE_CYBER',
+      };
+      const referentiel = Referentiel.creeReferentiel({
+        tranchesIndicesCybers: [tranche],
+      });
+
+      expect(referentiel.descriptionTrancheIndiceCyber(1.51)).to.eql(
+        'La valeur est 1,5'
+      );
+    });
+
+    it("reste robuste quand l'indice n'est pas dans une tranche", () => {
+      const tranche = { borneInferieure: 0, borneSuperieure: 2 };
+      const referentiel = Referentiel.creeReferentiel({
+        tranchesIndicesCybers: [tranche],
+      });
+
+      expect(referentiel.descriptionTrancheIndiceCyber(6)).to.eql('');
+    });
+  });
+
   describe('sur demande de derniére nouvelle fonctionnalité en date', () => {
     it('sait renvoyer la dernière nouvelle fonctionnalité', () => {
       const referentiel = Referentiel.creeReferentiel({


### PR DESCRIPTION
Afin de préparer la nouvelle page indice cyber, nous mettons à jours le référentiel pour y incorporer :
- une durée d'homologation recommandée
- un conseil avant homologation
- une explication de la tranche de l'indice cyber