### PR TITLE
Homologuer réservé aux propriétaires

### DIFF
--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -52,7 +52,7 @@ class AutorisationBase extends Base {
   }
 
   peutHomologuer() {
-    return this.aLesPermissions(AutorisationBase.DROITS_HOMOLOGUER);
+    return this.estProprietaire;
   }
 
   peutSupprimerService() {

--- a/src/modeles/autorisations/autorisationBase.js
+++ b/src/modeles/autorisations/autorisationBase.js
@@ -1,6 +1,6 @@
 const Base = require('../base');
 const {
-  Rubriques: { DECRIRE, SECURISER, RISQUES, HOMOLOGUER, CONTACTS },
+  Rubriques: { DECRIRE, SECURISER, RISQUES, HOMOLOGUER },
   Permissions: { LECTURE, ECRITURE },
   Rubriques,
   Permissions,
@@ -104,14 +104,6 @@ class AutorisationBase extends Base {
     ECRITURE: 'ECRITURE',
     LECTURE: 'LECTURE',
     PERSONNALISE: 'PERSONNALISE',
-  };
-
-  static DROITS_HOMOLOGUER = {
-    [DECRIRE]: ECRITURE,
-    [SECURISER]: ECRITURE,
-    [HOMOLOGUER]: ECRITURE,
-    [RISQUES]: ECRITURE,
-    [CONTACTS]: ECRITURE,
   };
 
   static DROITS_VOIR_INDICE_CYBER = {

--- a/test/modeles/autorisations/autorisationBase.spec.js
+++ b/test/modeles/autorisations/autorisationBase.spec.js
@@ -207,6 +207,22 @@ describe('Une autorisation', () => {
     });
   });
 
+  describe("sur demande de permission d'homologuer un service", () => {
+    it("autorise l'homologation pour un propriétaire", () => {
+      const proprietaire = AutorisationBase.NouvelleAutorisationProprietaire();
+
+      expect(proprietaire.peutHomologuer()).to.be(true);
+    });
+
+    it("interdit l'homologation pour un contributeur", () => {
+      const contributeur = AutorisationBase.NouvelleAutorisationContributeur({
+        droits: tousDroitsEnEcriture(),
+      });
+
+      expect(contributeur.peutHomologuer()).to.be(false);
+    });
+  });
+
   describe('sur demande des données à persister', () => {
     it('connaît ses données pour une autorisation de contributeur', () => {
       const autorisationContributeur =


### PR DESCRIPTION
Maintenant que MSS autorisation la nomination d'autres propriétaires, on peut sereinement utiliser `estProprietaire` dans `peutHomologuer()`.