### PR TITLE
[MIGRATION] Supprime le champ `type` de `autorisations`

### DIFF
--- a/migrations/20231124110131_supprimeTypeAutorisation.js
+++ b/migrations/20231124110131_supprimeTypeAutorisation.js
@@ -1,0 +1,18 @@
+// Le champ `type` des `Autorisation` n'est plus nécessaire, car il est remplacé par
+// `estProprietaire`.
+
+exports.up = async (knex) => {
+  const autorisations = await knex('autorisations');
+  const misesAJour = autorisations.map(({ id, donnees }) => {
+    const { type, ...autresDonnees } = donnees;
+    return knex('autorisations')
+      .where({ id })
+      .update({ donnees: autresDonnees });
+  });
+  await Promise.all(misesAJour);
+};
+
+// Impossible de remettre le champ, car la notion de `type = 'createur'` n'est pas faite
+// pour supporter plusieurs créateurs. Alors que `estProprietaire: true` peut être
+// présent sur plusieurs autorisations d'un même service.
+exports.down = async () => {};


### PR DESCRIPTION
Ce champ est devenu inutile maintenant que MSS utilise systématiquement `estProprietaire`.