### PR TITLE
[SOIN] Renomme `AutorisationBase` en `Autorisation`

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -13,7 +13,7 @@ const EvenementNouveauServiceCree = require('../modeles/journalMSS/evenementNouv
 const EvenementNouvelleHomologationCreee = require('../modeles/journalMSS/evenementNouvelleHomologationCreee');
 const EvenementServiceSupprime = require('../modeles/journalMSS/evenementServiceSupprime');
 const { fabriqueServiceTracking } = require('../tracking/serviceTracking');
-const AutorisationBase = require('../modeles/autorisations/autorisationBase');
+const Autorisation = require('../modeles/autorisations/autorisation');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -355,7 +355,7 @@ const creeDepot = (config = {}) => {
 
     await p.sauvegarde(idService, donneesService);
 
-    const proprietaire = AutorisationBase.NouvelleAutorisationProprietaire({
+    const proprietaire = Autorisation.NouvelleAutorisationProprietaire({
       idUtilisateur,
       idService,
     });

--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -1,6 +1,6 @@
 const { EchecAutorisation, EchecEnvoiMessage } = require('../../erreurs');
 const { fabriqueServiceTracking } = require('../../tracking/serviceTracking');
-const AutorisationBase = require('./autorisationBase');
+const Autorisation = require('./autorisation');
 
 const ajoutContributeurSurServices = ({
   depotDonnees,
@@ -89,11 +89,11 @@ const ajoutContributeurSurServices = ({
     const ajouteAuService = async (s) => {
       await depotDonnees.ajouteContributeurAuService(
         droits.estProprietaire
-          ? AutorisationBase.NouvelleAutorisationProprietaire({
+          ? Autorisation.NouvelleAutorisationProprietaire({
               idUtilisateur: contributeur.id,
               idService: s.id,
             })
-          : AutorisationBase.NouvelleAutorisationContributeur({
+          : Autorisation.NouvelleAutorisationContributeur({
               idUtilisateur: contributeur.id,
               idService: s.id,
               droits,

--- a/src/modeles/autorisations/autorisation.js
+++ b/src/modeles/autorisations/autorisation.js
@@ -7,7 +7,7 @@ const {
   tousDroitsEnEcriture,
 } = require('./gestionDroits');
 
-class AutorisationBase extends Base {
+class Autorisation extends Base {
   constructor(donnees = {}) {
     super({
       proprietesAtomiquesRequises: [
@@ -24,10 +24,10 @@ class AutorisationBase extends Base {
   }
 
   static NouvelleAutorisationContributeur = (donnees = {}) =>
-    new AutorisationBase({ ...donnees, estProprietaire: false });
+    new Autorisation({ ...donnees, estProprietaire: false });
 
   static NouvelleAutorisationProprietaire = (donnees = {}) =>
-    new AutorisationBase({
+    new Autorisation({
       ...donnees,
       droits: tousDroitsEnEcriture(),
       estProprietaire: true,
@@ -60,7 +60,7 @@ class AutorisationBase extends Base {
   }
 
   resumeNiveauDroit() {
-    const { RESUME_NIVEAU_DROIT } = AutorisationBase;
+    const { RESUME_NIVEAU_DROIT } = Autorisation;
 
     if (this.estProprietaire) return RESUME_NIVEAU_DROIT.PROPRIETAIRE;
 
@@ -141,4 +141,4 @@ class AutorisationBase extends Base {
   }
 }
 
-module.exports = AutorisationBase;
+module.exports = Autorisation;

--- a/src/modeles/autorisations/fabriqueAutorisation.js
+++ b/src/modeles/autorisations/fabriqueAutorisation.js
@@ -1,8 +1,8 @@
-const AutorisationBase = require('./autorisationBase');
+const Autorisation = require('./autorisation');
 
 const fabrique = (donnees) =>
   donnees.estProprietaire
-    ? AutorisationBase.NouvelleAutorisationProprietaire(donnees)
-    : AutorisationBase.NouvelleAutorisationContributeur(donnees);
+    ? Autorisation.NouvelleAutorisationProprietaire(donnees)
+    : Autorisation.NouvelleAutorisationContributeur(donnees);
 
 module.exports = { fabrique };

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -12,7 +12,7 @@ const Utilisateur = require('./utilisateur');
 const ObjetPDFAnnexeDescription = require('./objetsPDF/objetPDFAnnexeDescription');
 const ObjetPDFAnnexeMesures = require('./objetsPDF/objetPDFAnnexeMesures');
 const ObjetPDFAnnexeRisques = require('./objetsPDF/objetPDFAnnexeRisques');
-const AutorisationBase = require('./autorisations/autorisationBase');
+const Autorisation = require('./autorisations/autorisation');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -111,13 +111,13 @@ class Homologation {
 
   documentsPdfDisponibles(autorisation) {
     const droitAuxAnnexes = autorisation.aLesPermissions(
-      AutorisationBase.DROITS_ANNEXES_PDF
+      Autorisation.DROITS_ANNEXES_PDF
     );
     const droitALaSyntheseSecurite = autorisation.aLesPermissions(
-      AutorisationBase.DROIT_SYNTHESE_SECURITE_PDF
+      Autorisation.DROIT_SYNTHESE_SECURITE_PDF
     );
     const droitAuDossierDecision = autorisation.aLesPermissions(
-      AutorisationBase.DROITS_DOSSIER_DECISION_PDF
+      Autorisation.DROITS_DOSSIER_DECISION_PDF
     );
     const dossierCourant = this.dossierCourant();
 

--- a/src/modeles/objetsApi/objetGetIndicesCyber.js
+++ b/src/modeles/objetsApi/objetGetIndicesCyber.js
@@ -1,6 +1,6 @@
-const AutorisationBase = require('../autorisations/autorisationBase');
+const Autorisation = require('../autorisations/autorisation');
 
-const { DROITS_VOIR_INDICE_CYBER } = AutorisationBase;
+const { DROITS_VOIR_INDICE_CYBER } = Autorisation;
 
 const donnees = (services, autorisations) => {
   const servicesIndiceCyberCalcules = services.map((s) => ({

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -1,7 +1,7 @@
 const Dossiers = require('../dossiers');
-const AutorisationBase = require('../autorisations/autorisationBase');
+const Autorisation = require('../autorisations/autorisation');
 
-const { DROITS_VOIR_STATUT_HOMOLOGATION } = AutorisationBase;
+const { DROITS_VOIR_STATUT_HOMOLOGATION } = Autorisation;
 
 const donnees = (service, autorisation, referentiel) => ({
   id: service.id,

--- a/src/modeles/objetsApi/objetGetServices.js
+++ b/src/modeles/objetsApi/objetGetServices.js
@@ -1,8 +1,8 @@
 const Dossiers = require('../dossiers');
 const objetGetService = require('./objetGetService');
-const AutorisationBase = require('../autorisations/autorisationBase');
+const Autorisation = require('../autorisations/autorisation');
 
-const { DROITS_VOIR_STATUT_HOMOLOGATION } = AutorisationBase;
+const { DROITS_VOIR_STATUT_HOMOLOGATION } = Autorisation;
 
 const donnees = (services, autorisations, referentiel) => ({
   services: services.map((s) =>

--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const AutorisationBase = require('../../modeles/autorisations/autorisationBase');
+const Autorisation = require('../../modeles/autorisations/autorisation');
 const { genereGradientConique } = require('../../pdf/graphiques/camembert');
 const { dateYYYYMMDD } = require('../../utilitaires/date');
 
@@ -57,7 +57,7 @@ const routesApiServicePdf = ({
   };
   routes.get(
     '/:id/pdf/annexes.pdf',
-    middleware.trouveService(AutorisationBase.DROITS_ANNEXES_PDF),
+    middleware.trouveService(Autorisation.DROITS_ANNEXES_PDF),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 
@@ -69,7 +69,7 @@ const routesApiServicePdf = ({
 
   routes.get(
     '/:id/pdf/dossierDecision.pdf',
-    middleware.trouveService(AutorisationBase.DROITS_DOSSIER_DECISION_PDF),
+    middleware.trouveService(Autorisation.DROITS_DOSSIER_DECISION_PDF),
     middleware.trouveDossierCourant,
     (requete, reponse, suite) => {
       const { homologation, dossierCourant } = requete;
@@ -82,7 +82,7 @@ const routesApiServicePdf = ({
 
   routes.get(
     '/:id/pdf/syntheseSecurite.pdf',
-    middleware.trouveService(AutorisationBase.DROIT_SYNTHESE_SECURITE_PDF),
+    middleware.trouveService(Autorisation.DROIT_SYNTHESE_SECURITE_PDF),
     (requete, reponse, suite) => {
       const { homologation } = requete;
 

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -11,12 +11,12 @@ const {
   Rubriques,
   premiereRouteDisponible,
 } = require('../../modeles/autorisations/gestionDroits');
-const AutorisationBase = require('../../modeles/autorisations/autorisationBase');
+const Autorisation = require('../../modeles/autorisations/autorisation');
 
 const { LECTURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
 const { DROITS_VOIR_INDICE_CYBER, DROITS_VOIR_STATUT_HOMOLOGATION } =
-  AutorisationBase;
+  Autorisation;
 
 const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   const routes = express.Router();

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -1,7 +1,7 @@
 const {
   tousDroitsEnEcriture,
 } = require('../../src/modeles/autorisations/gestionDroits');
-const AutorisationBase = require('../../src/modeles/autorisations/autorisationBase');
+const Autorisation = require('../../src/modeles/autorisations/autorisation');
 
 class ConstructeurAutorisation {
   constructor() {
@@ -48,8 +48,8 @@ class ConstructeurAutorisation {
 
   construis() {
     return this.donnees.estProprietaire
-      ? AutorisationBase.NouvelleAutorisationProprietaire(this.donnees)
-      : AutorisationBase.NouvelleAutorisationContributeur(this.donnees);
+      ? Autorisation.NouvelleAutorisationProprietaire(this.donnees)
+      : Autorisation.NouvelleAutorisationContributeur(this.donnees);
   }
 }
 

--- a/test/modeles/autorisations/autorisation.spec.js
+++ b/test/modeles/autorisations/autorisation.spec.js
@@ -1,6 +1,6 @@
 const expect = require('expect.js');
 
-const AutorisationBase = require('../../../src/modeles/autorisations/autorisationBase');
+const Autorisation = require('../../../src/modeles/autorisations/autorisation');
 const {
   Permissions,
   Rubriques,
@@ -13,30 +13,30 @@ const { DECRIRE, SECURISER, HOMOLOGUER, RISQUES, CONTACTS } = Rubriques;
 describe('Une autorisation', () => {
   describe('sur demande de permission de suppression de service', () => {
     it('interdit la suppression pour un contributeur', () => {
-      const autorisation = AutorisationBase.NouvelleAutorisationContributeur();
+      const autorisation = Autorisation.NouvelleAutorisationContributeur();
       expect(autorisation.peutSupprimerService()).to.be(false);
     });
 
     it('autorise la suppression pour un propriétaire', () => {
-      const autorisation = AutorisationBase.NouvelleAutorisationProprietaire();
+      const autorisation = Autorisation.NouvelleAutorisationProprietaire();
       expect(autorisation.peutSupprimerService()).to.be(true);
     });
   });
 
   describe('sur demande de permission de duplication de service', () => {
     it('interdit la duplication pour un contributeur', () => {
-      const autorisation = AutorisationBase.NouvelleAutorisationContributeur();
+      const autorisation = Autorisation.NouvelleAutorisationContributeur();
       expect(autorisation.peutDupliquer()).to.be(false);
     });
 
     it('autorise la duplication pour un propriétaire', () => {
-      const autorisation = AutorisationBase.NouvelleAutorisationProprietaire();
+      const autorisation = Autorisation.NouvelleAutorisationProprietaire();
       expect(autorisation.peutDupliquer()).to.be(true);
     });
   });
 
   it("permet de savoir s'il y a une permission en lecture sur une rubrique", () => {
-    const autorisation = new AutorisationBase({
+    const autorisation = new Autorisation({
       droits: { [DECRIRE]: LECTURE },
     });
 
@@ -44,7 +44,7 @@ describe('Une autorisation', () => {
   });
 
   it("permet de savoir s'il y a une permission en écriture sur une rubrique", () => {
-    const autorisation = new AutorisationBase({
+    const autorisation = new Autorisation({
       droits: { [DECRIRE]: ECRITURE },
     });
 
@@ -52,7 +52,7 @@ describe('Une autorisation', () => {
   });
 
   it("autorise la lecture sur une rubrique avec droits d'écriture", () => {
-    const autorisationEcriture = new AutorisationBase({
+    const autorisationEcriture = new Autorisation({
       droits: { [DECRIRE]: ECRITURE },
     });
 
@@ -62,7 +62,7 @@ describe('Une autorisation', () => {
   });
 
   it("n'autorise pas l'accès à une rubrique non référencée", () => {
-    const autorisationSecuriser = new AutorisationBase({
+    const autorisationSecuriser = new Autorisation({
       droits: { [SECURISER]: ECRITURE },
     });
 
@@ -75,7 +75,7 @@ describe('Une autorisation', () => {
   });
 
   it("n'autorise aucun accès pour un niveau invisible", () => {
-    const niveauInvisible = new AutorisationBase({
+    const niveauInvisible = new Autorisation({
       droits: { [DECRIRE]: INVISIBLE },
     });
 
@@ -87,7 +87,7 @@ describe('Une autorisation', () => {
   });
 
   it('sait appliquer de nouveaux droits', () => {
-    const autorisation = new AutorisationBase({
+    const autorisation = new Autorisation({
       droits: tousDroitsEnEcriture(),
     });
     expect(autorisation.aLaPermission(ECRITURE, HOMOLOGUER)).to.be(true);
@@ -100,7 +100,7 @@ describe('Une autorisation', () => {
   });
 
   it('passe tous les droits en écriture si on devient propriétaire', () => {
-    const autorisation = new AutorisationBase({
+    const autorisation = new Autorisation({
       droits: { [DECRIRE]: LECTURE },
     });
 
@@ -117,7 +117,7 @@ describe('Une autorisation', () => {
   });
 
   it("supprime le droit de propriétaire lors de l'application d'un droit d'écriture", () => {
-    const autorisation = AutorisationBase.NouvelleAutorisationProprietaire();
+    const autorisation = Autorisation.NouvelleAutorisationProprietaire();
 
     autorisation.appliqueDroits({ HOMOLOGUER: ECRITURE });
 
@@ -125,7 +125,7 @@ describe('Une autorisation', () => {
   });
 
   it("supprime le droit de propriétaire lors de l'application d'un droit de lecture", () => {
-    const autorisation = AutorisationBase.NouvelleAutorisationProprietaire();
+    const autorisation = Autorisation.NouvelleAutorisationProprietaire();
 
     autorisation.appliqueDroits({ HOMOLOGUER: LECTURE });
 
@@ -135,15 +135,15 @@ describe('Une autorisation', () => {
   describe('sur demande de résumé de niveau de droit', () => {
     it("retourne 'PROPRIETAIRE' si l'utilisateur est propriétaire du service", async () => {
       const autorisationProprietaire =
-        AutorisationBase.NouvelleAutorisationProprietaire();
+        Autorisation.NouvelleAutorisationProprietaire();
 
       expect(autorisationProprietaire.resumeNiveauDroit()).to.be(
-        AutorisationBase.RESUME_NIVEAU_DROIT.PROPRIETAIRE
+        Autorisation.RESUME_NIVEAU_DROIT.PROPRIETAIRE
       );
     });
 
     it("retourne 'ECRITURE' si tous les droits sont en ECRITURE", () => {
-      const autorisationLecture = new AutorisationBase({
+      const autorisationLecture = new Autorisation({
         droits: {
           [DECRIRE]: ECRITURE,
           [SECURISER]: ECRITURE,
@@ -154,12 +154,12 @@ describe('Une autorisation', () => {
       });
 
       expect(autorisationLecture.resumeNiveauDroit()).to.equal(
-        AutorisationBase.RESUME_NIVEAU_DROIT.ECRITURE
+        Autorisation.RESUME_NIVEAU_DROIT.ECRITURE
       );
     });
 
     it("retourne 'LECTURE' si tous les droits sont en LECTURE", () => {
-      const autorisationLecture = new AutorisationBase({
+      const autorisationLecture = new Autorisation({
         droits: {
           [DECRIRE]: LECTURE,
           [SECURISER]: LECTURE,
@@ -170,12 +170,12 @@ describe('Une autorisation', () => {
       });
 
       expect(autorisationLecture.resumeNiveauDroit()).to.equal(
-        AutorisationBase.RESUME_NIVEAU_DROIT.LECTURE
+        Autorisation.RESUME_NIVEAU_DROIT.LECTURE
       );
     });
 
     it("retourne 'PERSONNALISE' si les droits sont mixtes", () => {
-      const autorisationLecture = new AutorisationBase({
+      const autorisationLecture = new Autorisation({
         droits: {
           [DECRIRE]: LECTURE,
           [SECURISER]: ECRITURE,
@@ -186,7 +186,7 @@ describe('Une autorisation', () => {
       });
 
       expect(autorisationLecture.resumeNiveauDroit()).to.equal(
-        AutorisationBase.RESUME_NIVEAU_DROIT.PERSONNALISE
+        Autorisation.RESUME_NIVEAU_DROIT.PERSONNALISE
       );
     });
   });
@@ -194,14 +194,14 @@ describe('Une autorisation', () => {
   describe('sur demande de permission de gestion des contributeurs', () => {
     it('interdit la gestion pour un contributeur', () => {
       const autorisationContributeur =
-        AutorisationBase.NouvelleAutorisationContributeur();
+        Autorisation.NouvelleAutorisationContributeur();
 
       expect(autorisationContributeur.peutGererContributeurs()).to.be(false);
     });
 
     it('autorise la gestion pour un propriétaire', () => {
       const autorisationCreateur =
-        AutorisationBase.NouvelleAutorisationProprietaire();
+        Autorisation.NouvelleAutorisationProprietaire();
 
       expect(autorisationCreateur.peutGererContributeurs()).to.be(true);
     });
@@ -209,13 +209,13 @@ describe('Une autorisation', () => {
 
   describe("sur demande de permission d'homologuer un service", () => {
     it("autorise l'homologation pour un propriétaire", () => {
-      const proprietaire = AutorisationBase.NouvelleAutorisationProprietaire();
+      const proprietaire = Autorisation.NouvelleAutorisationProprietaire();
 
       expect(proprietaire.peutHomologuer()).to.be(true);
     });
 
     it("interdit l'homologation pour un contributeur", () => {
-      const contributeur = AutorisationBase.NouvelleAutorisationContributeur({
+      const contributeur = Autorisation.NouvelleAutorisationContributeur({
         droits: tousDroitsEnEcriture(),
       });
 
@@ -226,7 +226,7 @@ describe('Une autorisation', () => {
   describe('sur demande des données à persister', () => {
     it('connaît ses données pour une autorisation de contributeur', () => {
       const autorisationContributeur =
-        AutorisationBase.NouvelleAutorisationContributeur({
+        Autorisation.NouvelleAutorisationContributeur({
           id: 'uuid',
           idService: '123',
           idUtilisateur: '999',
@@ -251,7 +251,7 @@ describe('Une autorisation', () => {
 
     it('connaît ses données pour une autorisation de propriétaire', () => {
       const autorisationProprietaire =
-        AutorisationBase.NouvelleAutorisationProprietaire({
+        Autorisation.NouvelleAutorisationProprietaire({
           id: 'uuid',
           idService: '123',
           idUtilisateur: '999',

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -19,7 +19,7 @@ const {
 const {
   uneAutorisation,
 } = require('../../constructeurs/constructeurAutorisation');
-const AutorisationBase = require('../../../src/modeles/autorisations/autorisationBase');
+const Autorisation = require('../../../src/modeles/autorisations/autorisation');
 const {
   unUtilisateur,
 } = require('../../constructeurs/constructeurUtilisateur');
@@ -1219,8 +1219,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
   describe('quand requête DELETE sur `/api/service/:id`', () => {
     beforeEach(() => {
       testeur.middleware().reinitialise({
-        autorisationACharger:
-          AutorisationBase.NouvelleAutorisationProprietaire(),
+        autorisationACharger: Autorisation.NouvelleAutorisationProprietaire(),
       });
       testeur.depotDonnees().supprimeHomologation = () => Promise.resolve();
     });
@@ -1322,8 +1321,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     beforeEach(() => {
       testeur.depotDonnees().dupliqueHomologation = () => Promise.resolve();
       testeur.middleware().reinitialise({
-        autorisationACharger:
-          AutorisationBase.NouvelleAutorisationProprietaire(),
+        autorisationACharger: Autorisation.NouvelleAutorisationProprietaire(),
       });
     });
 
@@ -1419,8 +1417,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
       testeur.middleware().reinitialise({
         idUtilisateur: '999',
-        autorisationACharger:
-          AutorisationBase.NouvelleAutorisationProprietaire(),
+        autorisationACharger: Autorisation.NouvelleAutorisationProprietaire(),
       });
 
       testeur.depotDonnees().dupliqueHomologation = (


### PR DESCRIPTION
Il n'y a plus de classes filles, donc inutile de suffixer avec `Base`.