### PR TITLE
Ajout de la page `Indice cyber`

### DIFF
--- a/public/assets/images/fond_recommandation_anssi.svg
+++ b/public/assets/images/fond_recommandation_anssi.svg
@@ -1,0 +1,41 @@
+<svg width="568" height="149" viewBox="0 0 568 149" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.3">
+<path d="M417.905 144.532C417.905 269.89 388.033 290.835 263.338 290.835C138.642 290.835 -29.4062 183.957 -29.4062 58.7525C-29.4062 -66.6058 171.578 -92.3242 274.061 -92.3242C405.344 -92.3242 417.905 67.3766 417.905 144.532Z" fill="url(#paint0_linear_12244_17377)" fill-opacity="0.2"/>
+<path d="M439.688 277.283C385.332 423.892 222.874 498.504 76.9535 443.737C-68.9672 388.97 -143.076 225.9 -88.7193 79.2912C-34.3627 -67.3179 -87.035 107.444 58.8857 162.211C204.806 216.824 494.198 130.52 439.688 277.283Z" fill="url(#paint1_linear_12244_17377)" fill-opacity="0.2"/>
+<path d="M222.778 -38.1029C222.778 56.4986 221.858 133.103 127.589 133.103C33.4729 133.103 -43.0156 56.3448 -43.0156 -38.1029C-43.0156 -132.704 33.3196 -209.309 127.589 -209.309C221.858 -209.309 222.778 -132.704 222.778 -38.1029Z" fill="url(#paint2_linear_12244_17377)" fill-opacity="0.2"/>
+<path d="M551.863 270.431C512.326 356.211 337.321 521.622 251.811 481.96C166.301 442.298 167.833 128.079 207.37 42.2987C246.907 -43.4813 383.141 31.999 468.652 71.6607C554.162 111.322 591.4 184.651 551.863 270.431Z" fill="url(#paint3_linear_12244_17377)" fill-opacity="0.2"/>
+<path opacity="0.7" d="M166.14 195.39C151.887 275.635 40.3108 279.332 -17.7762 268.858C-76.0165 258.385 -94.8679 210.638 -80.6144 130.393C-66.3609 50.1478 -24.3666 -32.0997 33.8737 -21.7802C91.9607 -11.3068 180.394 115.145 166.14 195.39Z" fill="url(#paint4_linear_12244_17377)" fill-opacity="0.2"/>
+<path opacity="0.7" d="M411.789 -196.411C490.036 -218.086 541.587 -118.782 557.39 -61.751C573.346 -4.72029 538.518 32.9415 460.272 54.77C382.025 76.4447 289.97 73.9852 274.167 16.9545C258.364 -40.23 333.543 -174.736 411.789 -196.411Z" fill="url(#paint5_linear_12244_17377)" fill-opacity="0.2"/>
+<path d="M252.964 224.363C150.355 274.535 -140.012 295.311 -189.938 192.352C-239.864 89.3929 1.34267 -204.864 103.798 -255.035C206.407 -305.207 276.548 -129.607 326.474 -26.4938C376.4 76.4653 355.572 174.192 252.964 224.363Z" fill="url(#paint6_linear_12244_17377)" fill-opacity="0.2"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_12244_17377" x1="8.2293" y1="-138.549" x2="227.282" y2="407.438" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint1_linear_12244_17377" x1="-60.0206" y1="-31.0118" x2="177.87" y2="607.771" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint2_linear_12244_17377" x1="-20.6525" y1="-250.617" x2="229.919" y2="164.652" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint3_linear_12244_17377" x1="213.794" y1="-55.5412" x2="564.38" y2="540.721" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint4_linear_12244_17377" x1="-63.884" y1="-58.3393" x2="142.291" y2="317.966" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint5_linear_12244_17377" x1="296.374" y1="-231.644" x2="457.143" y2="140.29" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint6_linear_12244_17377" x1="-150.461" y1="-327.765" x2="178.374" y2="399.98" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+</defs>
+</svg>

--- a/public/assets/images/icone_explication_tranche.svg
+++ b/public/assets/images/icone_explication_tranche.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="40" height="40" rx="20" fill="white"/>
+<path d="M25 26.4298H21L16.55 29.3897C15.89 29.8297 15 29.3598 15 28.5598V26.4298C12 26.4298 10 24.4298 10 21.4298V15.4297C10 12.4297 12 10.4297 15 10.4297H25C28 10.4297 30 12.4297 30 15.4297V21.4298C30 24.4298 28 26.4298 25 26.4298Z" stroke="#0C5C98" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.9998 19.3604V19.1504C19.9998 18.4704 20.4198 18.1104 20.8398 17.8204C21.2498 17.5404 21.6597 17.1804 21.6597 16.5204C21.6597 15.6004 20.9198 14.8604 19.9998 14.8604C19.0798 14.8604 18.3398 15.6004 18.3398 16.5204" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.9961 21.75H20.0051" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/images/icone_recommandation_anssi.svg
+++ b/public/assets/images/icone_recommandation_anssi.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="40" height="40" rx="20" fill="white"/>
+<path d="M20 22.5C23.7279 22.5 26.75 19.5899 26.75 16C26.75 12.4102 23.7279 9.5 20 9.5C16.2721 9.5 13.25 12.4102 13.25 16C13.25 19.5899 16.2721 22.5 20 22.5Z" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.5217 21.0198L15.5117 28.3998C15.5117 29.2998 16.1417 29.7398 16.9217 29.3698L19.6017 28.0998C19.8217 27.9898 20.1917 27.9898 20.4117 28.0998L23.1017 29.3698C23.8717 29.7298 24.5117 29.2998 24.5117 28.3998V20.8398" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -1,0 +1,225 @@
+.corps {
+  margin-top: 1.7em;
+}
+
+.zone-principale {
+  padding: 0 4em;
+  width: 100%;
+  margin-bottom: 8em;
+}
+
+.cartes-informations {
+  display: none;
+}
+
+.conteneur-indice-cyber {
+  text-align: left;
+}
+
+.conteneur-indice-cyber .conteneur-titre {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 0.6em;
+}
+
+.conteneur-indice-cyber h1 {
+  margin: 0;
+  font-weight: bold;
+  font-size: 1.7em;
+}
+
+.conteneur-indice-cyber h2 {
+  margin: 0;
+  font-weight: 500;
+  font-size: 1.4em;
+}
+
+.conteneur-indice-cyber .conteneur-descriptif {
+  background: #eff6ff;
+  border-radius: 8px 8px 0px 0px;
+  padding: 24px;
+  margin-top: 120px;
+  color: #0c5c98;
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  position: relative;
+}
+
+.conteneur-descriptif p {
+  margin: 0;
+}
+
+.conteneur-descriptif .disque-indice {
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  width: 8em;
+  height: 8em;
+  font-size: 1.3em;
+  position: absolute;
+  top: -5em;
+}
+
+.disque-indice .note {
+  font-size: 1.73em;
+}
+
+.disque-indice .note-max {
+  font-size: 1.06em;
+}
+
+.conteneur-descriptif .contenu-descriptif {
+  padding-left: 12em;
+}
+
+.conteneur-indice-cyber .conteneur-plus-details {
+  border-radius: 0px 0px 8px 8px;
+  border: 1.5px solid #dbecf1;
+  padding: 8px 24px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.conteneur-plus-details details {
+  width: 100%;
+}
+
+.conteneur-indice-cyber .conteneur-plus-details summary {
+  margin: 0;
+  font-weight: 500;
+  color: #0079d0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  cursor: pointer;
+}
+
+.conteneur-indice-cyber .conteneur-plus-details summary:before {
+  content: 'Plus de détails';
+}
+
+.conteneur-indice-cyber .conteneur-plus-details details[open] > summary:before {
+  content: 'Moins de détails';
+}
+
+.conteneur-indice-cyber .conteneur-plus-details summary:after {
+  content: '';
+  width: 20px;
+  height: 20px;
+  background: url('/statique/assets/images/forme_chevron_bleu.svg');
+  transform: translateY(1px) rotate(90deg);
+  transition: transform 0.1s ease-in-out;
+}
+
+.conteneur-indice-cyber .conteneur-plus-details details[open] > summary:after {
+  transform: translateY(1px) rotate(270deg);
+}
+
+.contenu-plus-details {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 17px 0 8px 0;
+  gap: 2em;
+}
+
+.contenu-plus-details h4 {
+  font-size: 1.15em;
+  margin: 0;
+}
+
+.conteneur-graphique svg {
+  margin-top: 1em;
+}
+
+.contenu-plus-details :is(.conteneur-graphique, .conteneur-explication-valeur) {
+  flex: 1;
+}
+
+.contenu-plus-details .conteneur-explication-valeur {
+  color: #0c5c98;
+}
+
+.contenu-plus-details .conteneur-explication-valeur p {
+  font-weight: 500;
+  margin: 0;
+}
+
+.contenu-plus-details .conteneur-explication-valeur {
+  border-radius: 8px;
+  background: #eff6ff;
+  padding: 16px 24px 24px 24px;
+}
+
+.contenu-plus-details .conteneur-explication-valeur .titre {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.conteneur-recommandation-anssi {
+  border-radius: 8px;
+  margin-top: 32px;
+  padding: 16px 32px 25px 32px;
+  background: #eff6ff;
+  position: relative;
+  color: #0c5c98;
+  overflow: hidden;
+}
+
+.conteneur-recommandation-anssi img.fond {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+}
+
+.conteneur-recommandation-anssi .titre {
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.conteneur-recommandation-anssi h3,
+.conteneur-recommandation-anssi p {
+  margin: 0;
+}
+
+.conteneur-duree-recommandee {
+  margin-top: 24px;
+  margin-left: 40px;
+  display: flex;
+  flex-direction: row;
+  background: #ffffff;
+  position: relative;
+  z-index: 1;
+  padding: 8px 16px;
+  gap: 18px;
+  font-weight: bold;
+  border-radius: 8px;
+  align-items: center;
+  width: fit-content;
+}
+
+.conteneur-duree-recommandee .separateur {
+  width: 0;
+  height: 22px;
+  border: 1px solid #0c5c98;
+}
+
+#duree-recommandee {
+  border-radius: 8px;
+  background: #0c5c98;
+  padding: 8px 16px;
+  color: #ffffff;
+  margin-left: -10px;
+  font-weight: 500;
+}

--- a/public/assets/styles/radarIndiceCyber.css
+++ b/public/assets/styles/radarIndiceCyber.css
@@ -1,0 +1,14 @@
+svg {
+  width: 100%;
+  height: 260px;
+}
+
+svg text {
+  fill: #667892;
+  font-size: 0.5em;
+}
+
+svg text.echelle {
+  font-size: 0.4em;
+  fill: black;
+}

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -119,6 +119,23 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
   );
 
   routes.get(
+    '/:id/indiceCyber',
+    middleware.trouveService(Autorisation.DROITS_VOIR_INDICE_CYBER),
+    middleware.chargeAutorisationsService,
+    middleware.chargePreferencesUtilisateur,
+    async (requete, reponse) => {
+      const { homologation: service } = requete;
+      reponse.render('service/indiceCyber', {
+        InformationsHomologation,
+        service,
+        actionsSaisie: new ActionsSaisie(referentiel, service).toJSON(),
+        etapeActive: 'mesures',
+        referentiel,
+      });
+    }
+  );
+
+  routes.get(
     '/:id/rolesResponsabilites',
     middleware.trouveService({ [CONTACTS]: LECTURE }),
     middleware.chargeAutorisationsService,

--- a/src/vues/fragments/radarIndiceCyber.pug
+++ b/src/vues/fragments/radarIndiceCyber.pug
@@ -1,0 +1,55 @@
+block append styles
+  link(href = '/statique/assets/styles/radarIndiceCyber.css', rel = 'stylesheet')
+
+mixin radarIndiceCyber(indicesCyber, indiceMax)
+  - const labels = ['Gouvernance', 'Résilience', 'Défense', 'Protection']
+
+  -
+    const taille = 100
+    const centre = [taille / 2, taille / 2]
+    const rayonMax = 0.95 * taille / 2
+    const zoomX = -40
+    const zoomY = -10
+    const decallageTexte = 5
+    const nbPoints = indicesCyber.length;
+    const nbEchelle = parseInt(noteMax)
+    const angleOrigine = -Math.PI / 2
+    const incrementEchelle = rayonMax / nbEchelle;
+
+  svg(
+    width=taille,
+    height=taille,
+    viewBox=`${zoomX} ${zoomY} ${taille + Math.abs(zoomX * 2)} ${taille + Math.abs(zoomY * 2)}`,
+    fill="none",
+    xmlns="http://www.w3.org/2000/svg"
+  )
+    - const polaireVersCartesien = (r, theta, i) => [r * Math.cos(i * theta + angleOrigine) + centre[0], r * Math.sin(i * theta + angleOrigine) + centre[1]];
+    - const generePoints = (centre, radius, nbPoints) => {const theta = (2 * Math.PI) / nbPoints;return new Array(nbPoints).fill(0).map((_, i) => polaireVersCartesien(radius, theta, i))}
+    - const generePointsValeur = (indices, indiceMax, centre) => {const nbPoints = indices.length;const theta = (2 * Math.PI) / nbPoints; return indices.map((indice, idx) => polaireVersCartesien(indice / indiceMax * rayonMax , theta, idx))}
+    - const tableauVersPointsPolygone = (array) => { return array.map((c) => c.join(' ')).join(' ')}
+    - const angleVersPointAncrage = (angle) => {if (angle > 320 || angle < 40 || (angle > 140 && angle < 220)) return "middle"; if (angle > 140) return "end"; return "start";}
+    each point in generePoints(centre, rayonMax, nbPoints)
+      line(x1=centre[0] y1=centre[1] x2=point[0] y2=point[1] stroke="#D9D9D9" stroke-width="0.5")
+    each point, index in generePoints(centre, rayonMax + decallageTexte, nbPoints)
+      -
+        const angle = index * (360 / nbPoints)
+        const pointAncrage = angleVersPointAncrage(angle)
+        const decallageY = (angle > 90 && angle < 270) ? 6 : 0;
+      text(x=point[0] y=point[1] dy=decallageY text-anchor=pointAncrage)= labels[index]
+    each radius, index in new Array(nbEchelle + 1).fill().map((_, i) => i * incrementEchelle)
+      polygon(
+        stroke="#D9D9D9",
+        points=tableauVersPointsPolygone(generePoints(centre, radius, nbPoints)),
+        stroke-width="0.5"
+      )
+      if(index != 0)
+        text.echelle(x=centre[0] y=(centre[1] - radius) dx=2 dy=2)= index
+    polygon(
+      stroke="url(#gradient-lineaire-anssi)"
+      stroke-width="1.5"
+      stroke-linejoin="round"
+      points=tableauVersPointsPolygone(generePointsValeur(indicesCyber, indiceMax, centre))
+    )
+    linearGradient(id="gradient-lineaire-anssi" x1=taille/2 y1="0" x2=taille/2 y2=taille gradientUnits="userSpaceOnUse")
+      stop(stop-color="#54B8F6")
+      stop(offset="1" stop-color="#3479C9")

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -1,0 +1,55 @@
+extends ./formulaire
+include ../fragments/texteTronque
+include ../fragments/radarIndiceCyber
+include ../fragments/scoreIndiceCyber
+
+block append styles
+  link(href = '/statique/assets/styles/homologation/indiceCyber.css', rel = 'stylesheet')
+
+block header-titre-page
+  h3
+    +texteTronque({ texte: service.nomService() || '' })
+
+block zone-principale
+  - const indiceCyber = service.indiceCyber()
+  - const noteMax = referentiel.indiceCyberNoteMax()
+  - const trancheIndiceCyber = referentiel.trancheIndiceCyber(indiceCyber.total)
+  - const formatIndiceCyber = Intl.NumberFormat('fr', { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format
+  .conteneur-indice-cyber
+    .conteneur-titre
+      h1 Sécuriser
+      h2 •
+      h2 L'indice cyber
+    .conteneur-descriptif
+      .disque-indice
+        +scoreIndiceCyber(formatIndiceCyber, indiceCyber.total, noteMax)
+      .contenu-descriptif
+        p L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures faites et partielles proposées par l'ANSSI dans MonServiceSécurisé.
+    .conteneur-plus-details
+      details
+        summary(role='button')
+        .contenu-plus-details
+          .conteneur-graphique
+            h4 Répartition par catégorie
+            +radarIndiceCyber([
+              indiceCyber.gouvernance,
+              indiceCyber.resilience,
+              indiceCyber.defense,
+              indiceCyber.protection,
+            ], noteMax)
+          .conteneur-explication-valeur
+            .titre
+              img.icone(src="/statique/assets/images/icone_explication_tranche.svg")
+              h4 Quelle est la valeur de l'indice cyber ?
+            p= referentiel.descriptionTrancheIndiceCyber(indiceCyber.total)
+    .conteneur-recommandation-anssi
+      img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
+      .titre
+        img.icone(src="/statique/assets/images/icone_recommandation_anssi.svg")
+        h3 Recommandation indicative de l'ANSSI en cas de décision d'homologation
+      .conteneur-duree-recommandee
+        if(trancheIndiceCyber.conseilHomologation)
+          p= trancheIndiceCyber.conseilHomologation
+          .separateur
+        p Durée recommandée de l'homologation
+        p#duree-recommandee= trancheIndiceCyber.dureeHomologationConseillee

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -225,6 +225,36 @@ describe('Le serveur MSS des routes /service/*', () => {
     });
   });
 
+  describe('quand requête GET sur `/service/:id/indiceCyber`', () => {
+    it('recherche le service correspondant', (done) => {
+      testeur
+        .middleware()
+        .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: SECURISER }],
+          'http://localhost:1234/service/456/indiceCyber',
+          done
+        );
+    });
+
+    it("charge les autorisations du service pour l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesAutorisations(
+          'http://localhost:1234/service/456/indiceCyber',
+          done
+        );
+    });
+
+    it("charge les préférences de l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesPreferences(
+          'http://localhost:1234/service/456/indiceCyber',
+          done
+        );
+    });
+  });
+
   describe('quand requete GET sur `/service/:id/rolesResponsabilites`', () => {
     it('recherche le service correspondant', (done) => {
       testeur


### PR DESCRIPTION
On ajoute la nouvelle page `Indice cyber` :point_down: 
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/56104e84-94ab-476f-a446-030a73f95efa)


Elle n'est pour l'instant accessible que par l'url. 
Le graphique est un SVG.