### PR TITLE
Supprime le lien "Découvrez nos nouveautés" sur la page d'erreur de droit d'accès

### DIFF
--- a/src/vues/erreurAccesRefuse.pug
+++ b/src/vues/erreurAccesRefuse.pug
@@ -14,5 +14,3 @@ block main
     p Mais vous pouvez continuer à sécuriser sur les autres pages de notre site.
 
     a.bouton(href = '/tableauDeBord') Aller au tableau de bord
-    br
-    a.lien(href = '/historiqueProduit') Découvrez nos nouveautés


### PR DESCRIPTION
Car inutile sur cette page. (Retour démo)