### PR TITLE
Cesse de polluer Sentry avec les erreurs remontées par les bibliothèques distantes

### DIFF
--- a/src/routes/publiques/routesBibliotheques.js
+++ b/src/routes/publiques/routesBibliotheques.js
@@ -20,7 +20,7 @@ const routesBibliotheques = () => {
   const routes = express.Router();
 
   const ajouteRoutes = (methode) =>
-    routes[methode]('/:nomBibliotheque', async (requete, reponse, suite) => {
+    routes[methode]('/:nomBibliotheque', async (requete, reponse) => {
       const { nomBibliotheque } = requete.params;
       const chemin = CHEMINS_BIBLIOTHEQUES[methode][nomBibliotheque];
 
@@ -35,12 +35,18 @@ const routesBibliotheques = () => {
           {},
           { params: requete.query }
         );
+
         reponse
           .status(reponseServeur.status)
           .type('text/javascript')
           .send(reponseServeur.data);
       } catch (e) {
-        suite();
+        const details = JSON.stringify(e.toJSON());
+        // eslint-disable-next-line no-console
+        console.error(
+          `[ERREUR] Bibliothèque [${methode}] ${chemin}\n${details}`
+        );
+        reponse.sendStatus(400);
       }
     });
 

--- a/src/routes/publiques/routesBibliotheques.js
+++ b/src/routes/publiques/routesBibliotheques.js
@@ -24,18 +24,19 @@ const routesBibliotheques = () => {
       const { nomBibliotheque } = requete.params;
       const chemin = CHEMINS_BIBLIOTHEQUES[methode][nomBibliotheque];
 
-      if (chemin) {
-        axios[methode](chemin, {}, { params: requete.query })
-          .then((reponseServeur) =>
-            reponse
-              .status(reponseServeur.status)
-              .type('text/javascript')
-              .send(reponseServeur.data)
-          )
-          .catch(suite);
-      } else {
+      if (!chemin) {
         reponse.status(404).send(`Bibliothèque inconnue : ${nomBibliotheque}`);
+        return;
       }
+
+      axios[methode](chemin, {}, { params: requete.query })
+        .then((reponseServeur) =>
+          reponse
+            .status(reponseServeur.status)
+            .type('text/javascript')
+            .send(reponseServeur.data)
+        )
+        .catch(suite);
     });
 
   Object.keys(CHEMINS_BIBLIOTHEQUES).forEach(ajouteRoutes);

--- a/src/routes/publiques/routesBibliotheques.js
+++ b/src/routes/publiques/routesBibliotheques.js
@@ -20,7 +20,7 @@ const routesBibliotheques = () => {
   const routes = express.Router();
 
   const ajouteRoutes = (methode) =>
-    routes[methode]('/:nomBibliotheque', (requete, reponse, suite) => {
+    routes[methode]('/:nomBibliotheque', async (requete, reponse, suite) => {
       const { nomBibliotheque } = requete.params;
       const chemin = CHEMINS_BIBLIOTHEQUES[methode][nomBibliotheque];
 
@@ -29,14 +29,19 @@ const routesBibliotheques = () => {
         return;
       }
 
-      axios[methode](chemin, {}, { params: requete.query })
-        .then((reponseServeur) =>
-          reponse
-            .status(reponseServeur.status)
-            .type('text/javascript')
-            .send(reponseServeur.data)
-        )
-        .catch(suite);
+      try {
+        const reponseServeur = await axios[methode](
+          chemin,
+          {},
+          { params: requete.query }
+        );
+        reponse
+          .status(reponseServeur.status)
+          .type('text/javascript')
+          .send(reponseServeur.data);
+      } catch (e) {
+        suite();
+      }
     });
 
   Object.keys(CHEMINS_BIBLIOTHEQUES).forEach(ajouteRoutes);


### PR DESCRIPTION
Afin d'éviter de polluer notre Sentry avec les erreurs `400` de Matomo lorsque celui-ci dysfonctionne cette PR cesse d'appeler le `error handler` global (branché à Sentry) sur ce type d'erreur.

🧹 On en profite pour passer quelques soins : `async/await` et `guard clause`.