### PR TITLE
Ajout du champ `nombreOrganisationsUtilisatrices` à `DescriptionService`

### DIFF
--- a/public/modules/parametresDescriptionService.mjs
+++ b/public/modules/parametresDescriptionService.mjs
@@ -19,6 +19,11 @@ const extraisParametresDescriptionService = (selecteurFormulaire) => {
     params.organisationsResponsables = [params.organisationsResponsables];
   }
 
+  params.nombreOrganisationsUtilisatrices = {
+    borneBasse: 0,
+    borneHaute: 0,
+  };
+
   return params;
 };
 

--- a/src/modeles/descriptionService.js
+++ b/src/modeles/descriptionService.js
@@ -18,6 +18,7 @@ class DescriptionService extends InformationsHomologation {
         'provenanceService',
         'risqueJuridiqueFinancierReputationnel',
         'statutDeploiement',
+        'nombreOrganisationsUtilisatrices',
       ],
       proprietesAtomiquesFacultatives: ['presentation'],
       proprietesListes: [
@@ -73,6 +74,7 @@ class DescriptionService extends InformationsHomologation {
       'risqueJuridiqueFinancierReputationnel',
       'statutDeploiement',
       'typeService',
+      'nombreOrganisationsUtilisatrices',
     ];
   }
 

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -72,11 +72,17 @@ const routesApiService = ({
     ]),
     async (requete, reponse, suite) => {
       try {
+        requete.body.nombreOrganisationsUtilisatrices ??= {
+          borneBasse: 0,
+          borneHaute: 0,
+        };
         const description = new DescriptionService(requete.body, referentiel);
+
         const idService = await depotDonnees.nouveauService(
           requete.idUtilisateurCourant,
           { descriptionService: description.toJSON() }
         );
+
         reponse.json({ idService });
       } catch (e) {
         if (e instanceof ErreurNomServiceDejaExistant)

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -70,26 +70,25 @@ const routesApiService = ({
         proprietes: DonneesSensiblesSpecifiques.proprietesItem(),
       },
     ]),
-    (requete, reponse, suite) => {
-      Promise.resolve()
-        .then(() => new DescriptionService(requete.body, referentiel))
-        .then((description) =>
-          depotDonnees.nouveauService(requete.idUtilisateurCourant, {
-            descriptionService: description.toJSON(),
-          })
-        )
-        .then((idService) => reponse.json({ idService }))
-        .catch((e) => {
-          if (e instanceof ErreurNomServiceDejaExistant)
-            reponse
-              .status(422)
-              .json({ erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } });
-          else if (e instanceof ErreurModele)
-            reponse.status(422).send(e.message);
-          else suite(e);
-        });
+    async (requete, reponse, suite) => {
+      try {
+        const description = new DescriptionService(requete.body, referentiel);
+        const idService = await depotDonnees.nouveauService(
+          requete.idUtilisateurCourant,
+          { descriptionService: description.toJSON() }
+        );
+        reponse.json({ idService });
+      } catch (e) {
+        if (e instanceof ErreurNomServiceDejaExistant)
+          reponse
+            .status(422)
+            .json({ erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } });
+        else if (e instanceof ErreurModele) reponse.status(422).send(e.message);
+        else suite(e);
+      }
     }
   );
+
   routes.put(
     '/:id',
     middleware.trouveService({ [DECRIRE]: ECRITURE }),

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -72,10 +72,6 @@ const routesApiService = ({
     ]),
     async (requete, reponse, suite) => {
       try {
-        requete.body.nombreOrganisationsUtilisatrices ??= {
-          borneBasse: 0,
-          borneHaute: 0,
-        };
         const description = new DescriptionService(requete.body, referentiel);
 
         const idService = await depotDonnees.nouveauService(

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -58,7 +58,11 @@ const routesApiService = ({
     '/',
     middleware.protegeTrafic(),
     middleware.verificationAcceptationCGU,
-    middleware.aseptise('nomService', 'organisationsResponsables.*'),
+    middleware.aseptise(
+      'nomService',
+      'organisationsResponsables.*',
+      'nombreOrganisationsUtilisatrices.*'
+    ),
     middleware.aseptiseListes([
       { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
       {
@@ -94,7 +98,11 @@ const routesApiService = ({
   routes.put(
     '/:id',
     middleware.trouveService({ [DECRIRE]: ECRITURE }),
-    middleware.aseptise('nomService', 'organisationsResponsables.*'),
+    middleware.aseptise(
+      'nomService',
+      'organisationsResponsables.*',
+      'nombreOrganisationsUtilisatrices.*'
+    ),
     middleware.aseptiseListes([
       { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
       {

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -110,22 +110,24 @@ const routesApiService = ({
         proprietes: DonneesSensiblesSpecifiques.proprietesItem(),
       },
     ]),
-    (requete, reponse, suite) => {
-      Promise.resolve()
-        .then(() => new DescriptionService(requete.body, referentiel))
-        .then((descriptionService) =>
-          depotDonnees.ajouteDescriptionServiceAHomologation(
-            requete.idUtilisateurCourant,
-            requete.params.id,
-            descriptionService
-          )
-        )
-        .then(() => reponse.send({ idService: requete.homologation.id }))
-        .catch((e) => {
-          if (e instanceof ErreurModele) {
-            reponse.status(422).send(e.message);
-          } else suite(e);
-        });
+    async (requete, reponse, suite) => {
+      try {
+        const descriptionService = new DescriptionService(
+          requete.body,
+          referentiel
+        );
+
+        await depotDonnees.ajouteDescriptionServiceAHomologation(
+          requete.idUtilisateurCourant,
+          requete.params.id,
+          descriptionService
+        );
+
+        reponse.send({ idService: requete.homologation.id });
+      } catch (e) {
+        if (e instanceof ErreurModele) reponse.status(422).send(e.message);
+        else suite(e);
+      }
     }
   );
 

--- a/test/constructeurs/constructeurDescriptionService.js
+++ b/test/constructeurs/constructeurDescriptionService.js
@@ -18,6 +18,7 @@ class ConstructeurDescriptionService {
       risqueJuridiqueFinancierReputationnel: false,
       statutDeploiement: 'unStatutDeploiement',
       typeService: 'unType',
+      nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
     };
   }
 

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -34,6 +34,7 @@ describe('La description du service', () => {
         provenanceService: 'uneProvenance',
         risqueJuridiqueFinancierReputationnel: true,
         statutDeploiement: 'unStatut',
+        nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
       },
       referentielAvecStatutValide('unStatut')
     );
@@ -55,6 +56,10 @@ describe('La description du service', () => {
       true
     );
     expect(descriptionService.statutDeploiement).to.equal('unStatut');
+    expect(descriptionService.nombreOrganisationsUtilisatrices).to.eql({
+      borneBasse: 1,
+      borneHaute: 5,
+    });
 
     expect(descriptionService.nombreDonneesSensiblesSpecifiques()).to.equal(1);
     expect(descriptionService.nombreFonctionnalitesSpecifiques()).to.equal(1);
@@ -70,6 +75,7 @@ describe('La description du service', () => {
       'risqueJuridiqueFinancierReputationnel',
       'statutDeploiement',
       'typeService',
+      'nombreOrganisationsUtilisatrices',
     ]);
   });
 
@@ -208,6 +214,7 @@ describe('La description du service', () => {
         provenanceService: 'uneProvenance',
         risqueJuridiqueFinancierReputationnel: true,
         statutDeploiement: 'accessible',
+        nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
       },
       referentielAvecStatutValide('accessible')
     );

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -614,6 +614,7 @@ describe('Une homologation', () => {
           fonctionnalitesSpecifiques: [],
           pointsAcces: [],
           organisationsResponsables: ['ANSSI'],
+          nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
         },
         dossiers: [
           {

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -182,8 +182,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête PUT sur `/api/service/:id`', () => {
     beforeEach(() => {
-      testeur.depotDonnees().ajouteDescriptionServiceAHomologation = () =>
-        Promise.resolve();
+      testeur.depotDonnees().ajouteDescriptionServiceAHomologation =
+        async () => {};
     });
 
     it('recherche le service correspondant', (done) => {
@@ -206,50 +206,38 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         );
     });
 
-    it("aseptise la liste des points d'accès ainsi que son contenu", (done) => {
-      axios
-        .put('http://localhost:1234/api/service/456', {})
-        .then(() => {
-          testeur
-            .middleware()
-            .verifieAseptisationListe('pointsAcces', ['description']);
-          done();
-        })
-        .catch(done);
+    it("aseptise la liste des points d'accès ainsi que son contenu", async () => {
+      await axios.put('http://localhost:1234/api/service/456', {});
+
+      testeur
+        .middleware()
+        .verifieAseptisationListe('pointsAcces', ['description']);
     });
 
-    it('aseptise la liste des fonctionnalités spécifiques ainsi que son contenu', (done) => {
-      axios
-        .put('http://localhost:1234/api/service/456', {})
-        .then(() => {
-          testeur
-            .middleware()
-            .verifieAseptisationListe('fonctionnalitesSpecifiques', [
-              'description',
-            ]);
-          done();
-        })
-        .catch(done);
+    it('aseptise la liste des fonctionnalités spécifiques ainsi que son contenu', async () => {
+      await axios.put('http://localhost:1234/api/service/456', {});
+
+      testeur
+        .middleware()
+        .verifieAseptisationListe('fonctionnalitesSpecifiques', [
+          'description',
+        ]);
     });
 
-    it('aseptise la liste des données sensibles spécifiques ainsi que son contenu', (done) => {
-      axios
-        .put('http://localhost:1234/api/service/456', {})
-        .then(() => {
-          testeur
-            .middleware()
-            .verifieAseptisationListe('donneesSensiblesSpecifiques', [
-              'description',
-            ]);
-          done();
-        })
-        .catch(done);
+    it('aseptise la liste des données sensibles spécifiques ainsi que son contenu', async () => {
+      await axios.put('http://localhost:1234/api/service/456', {});
+
+      testeur
+        .middleware()
+        .verifieAseptisationListe('donneesSensiblesSpecifiques', [
+          'description',
+        ]);
     });
 
-    it('demande au dépôt de données de mettre à jour le service', (done) => {
+    it('demande au dépôt de données de mettre à jour le service', async () => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
-      testeur.depotDonnees().ajouteDescriptionServiceAHomologation = (
+      testeur.depotDonnees().ajouteDescriptionServiceAHomologation = async (
         idUtilisateur,
         idService,
         infosGenerales
@@ -257,19 +245,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         expect(idUtilisateur).to.equal('123');
         expect(idService).to.equal('456');
         expect(infosGenerales.nomService).to.equal('Nouveau Nom');
-        return Promise.resolve();
       };
 
-      axios
-        .put('http://localhost:1234/api/service/456', {
-          nomService: 'Nouveau Nom',
-        })
-        .then((reponse) => {
-          expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.eql({ idService: '456' });
-          done();
-        })
-        .catch(done);
+      const reponse = await axios.put('http://localhost:1234/api/service/456', {
+        nomService: 'Nouveau Nom',
+      });
+
+      expect(reponse.status).to.equal(200);
+      expect(reponse.data).to.eql({ idService: '456' });
     });
 
     it('retourne une erreur HTTP 422 si le validateur du modèle échoue', (done) => {

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -153,31 +153,30 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it("demande au dépôt de données d'enregistrer les nouveaux service", (done) => {
+    it("demande au dépôt de données d'enregistrer les nouveaux service", async () => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
+
       const donneesDescriptionService = uneDescriptionValide(
         testeur.referentiel()
       )
         .construis()
         .toJSON();
 
-      testeur.depotDonnees().nouveauService = (
+      testeur.depotDonnees().nouveauService = async (
         idUtilisateur,
         { descriptionService }
       ) => {
         expect(idUtilisateur).to.equal('123');
         expect(descriptionService).to.eql(donneesDescriptionService);
-        return Promise.resolve('456');
+        return '456';
       };
 
-      axios
-        .post('http://localhost:1234/api/service', donneesDescriptionService)
-        .then((reponse) => {
-          expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.eql({ idService: '456' });
-          done();
-        })
-        .catch((e) => done(e.response?.data || e));
+      const reponse = await axios.post(
+        'http://localhost:1234/api/service',
+        donneesDescriptionService
+      );
+      expect(reponse.status).to.equal(200);
+      expect(reponse.data).to.eql({ idService: '456' });
     });
   });
 

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -62,7 +62,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur
         .middleware()
         .verifieAseptisationParametres(
-          ['nomService', 'organisationsResponsables.*'],
+          [
+            'nomService',
+            'organisationsResponsables.*',
+            'nombreOrganisationsUtilisatrices.*',
+          ],
           { method: 'post', url: 'http://localhost:1234/api/service' },
           done
         );
@@ -200,7 +204,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur
         .middleware()
         .verifieAseptisationParametres(
-          ['nomService', 'organisationsResponsables.*'],
+          [
+            'nomService',
+            'organisationsResponsables.*',
+            'nombreOrganisationsUtilisatrices.*',
+          ],
           { method: 'put', url: 'http://localhost:1234/api/service/456' },
           done
         );


### PR DESCRIPTION
Cette PR ajoute le champ `nombreOrganisationsUtilisatrices` sur les **CRÉATIONS** de service.
La valeur du champ est codée en dur. 

En BDD, chaque service créé ou édité reçoit donc 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/0bb1cd96-e10f-4eb8-a042-2e38bd375cf7)



C'est le premier pas sur le chemin de la feature complète autour du champ.



### 🗒️ Feuille de route
 - [ ] Champ valorisé en dur à la création / édition  **⬅️ Cette PR**
 - [ ] Migration pour ajouter la valeur par défaut à tous les services
 - [ ] Propagation de la valeur du champ dans événement Metabase
 - [ ] Affichage du champ dans le formulaire de création/édition
 - [ ] Ajout d'un message incitatif autour du champ, pour les utilisateurs qui n'ont pas encore renseigné le champ