### PR TITLE
Ajoute un point au survol du graphique radar

### DIFF
--- a/public/assets/styles/radarIndiceCyber.css
+++ b/public/assets/styles/radarIndiceCyber.css
@@ -15,8 +15,17 @@
 
 .zone-hover-point-radar {
   opacity: 0;
+  cursor: pointer;
 }
 
 .zone-hover-point-radar:hover {
   opacity: 1;
+}
+
+.zone-hover-point-radar text {
+  font-size: 0.45em;
+}
+
+.zone-hover-point-radar .fond-zone-hover {
+  filter: drop-shadow(0 0 2px rgba(26, 68, 139, 0.2));
 }

--- a/public/assets/styles/radarIndiceCyber.css
+++ b/public/assets/styles/radarIndiceCyber.css
@@ -12,3 +12,11 @@
   font-size: 0.4em;
   fill: black;
 }
+
+.zone-hover-point-radar {
+  opacity: 0;
+}
+
+.zone-hover-point-radar:hover {
+  opacity: 1;
+}

--- a/src/vues/fragments/indiceCyber/radarIndiceCyber.pug
+++ b/src/vues/fragments/indiceCyber/radarIndiceCyber.pug
@@ -44,12 +44,21 @@ mixin radarIndiceCyber(indicesCyber, indiceMax)
       )
       if(index != 0)
         text.echelle(x=centre[0] y=(centre[1] - radius) dx=2 dy=2)= index
+    - const pointsIndiceCyber = generePointsValeur(indicesCyber, indiceMax, centre)
     polygon(
       stroke="url(#gradient-lineaire-anssi)"
       stroke-width="1.5"
       stroke-linejoin="round"
-      points=tableauVersPointsPolygone(generePointsValeur(indicesCyber, indiceMax, centre))
+      points=tableauVersPointsPolygone(pointsIndiceCyber)
     )
+    each point in pointsIndiceCyber
+      g.zone-hover-point-radar
+        circle(cx=point[0] cy=point[1] r=4 fill='transparent')
+        circle(cx=point[0] cy=point[1] r=2 fill='url(#gradient-lineaire-point)')
+
     linearGradient(id="gradient-lineaire-anssi" x1=taille/2 y1="0" x2=taille/2 y2=taille gradientUnits="userSpaceOnUse")
       stop(stop-color="#54B8F6")
       stop(offset="1" stop-color="#3479C9")
+    linearGradient(id="gradient-lineaire-point" gradientTransform="rotate(90)")
+      stop(offset="0%" stop-color="#54B8F6")
+      stop(offset="100%" stop-color="#3479C9")

--- a/src/vues/fragments/indiceCyber/radarIndiceCyber.pug
+++ b/src/vues/fragments/indiceCyber/radarIndiceCyber.pug
@@ -42,7 +42,7 @@ mixin radarIndiceCyber(indicesCyber, indiceMax)
         points=tableauVersPointsPolygone(generePoints(centre, radius, nbPoints)),
         stroke-width="0.5"
       )
-      if(index != 0)
+      if(index !== 0)
         text.echelle(x=centre[0] y=(centre[1] - radius) dx=2 dy=2)= index
     - const pointsIndiceCyber = generePointsValeur(indicesCyber, indiceMax, centre)
     polygon(
@@ -51,10 +51,16 @@ mixin radarIndiceCyber(indicesCyber, indiceMax)
       stroke-linejoin="round"
       points=tableauVersPointsPolygone(pointsIndiceCyber)
     )
-    each point in pointsIndiceCyber
+    - const format = Intl.NumberFormat('fr', { minimumFractionDigits: 1, maximumFractionDigits: 1 }).format
+    each point, index in pointsIndiceCyber
+      - const valeur = format(indicesCyber[index])
+      - const [x, y] = point
       g.zone-hover-point-radar
-        circle(cx=point[0] cy=point[1] r=4 fill='transparent')
-        circle(cx=point[0] cy=point[1] r=2 fill='url(#gradient-lineaire-point)')
+        g.fond-zone-hover
+          rect(x=x-5 y=y-6 fill='white' width=22 height=12 rx=6 ry=10)
+          text(x=x+4 y=y+2 fill='#2F3A43' font-weight='bold')= valeur
+        circle(cx=x cy=y r=4 fill='transparent')
+        circle(cx=x cy=y r=2 fill='url(#gradient-lineaire-point)')
 
     linearGradient(id="gradient-lineaire-anssi" x1=taille/2 y1="0" x2=taille/2 y2=taille gradientUnits="userSpaceOnUse")
       stop(stop-color="#54B8F6")


### PR DESCRIPTION
On rajoute un comportement `hover` sur le diagramme radar.

Les données sont affichées lors du click sur le point.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/a25b7a65-d258-4488-bbee-8b554e8babe3)
