### PR TITLE
Modification de l'affichage des tranches indice cyber

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -32,8 +32,7 @@ module.exports = {
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
       conseilHomologation: 'Homologation déconseillée',
-      description:
-        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un niveau de sécurisation très insuffisant face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
+      description: "Très insuffisant lorsqu'il est < 1",
     },
     {
       borneInferieure: 1,
@@ -41,32 +40,28 @@ module.exports = {
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
       conseilHomologation: 'Homologation déconseillée',
-      description:
-        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un niveau de sécurisation insuffisant face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
+      description: "Insuffisant lorsqu'il est < 2",
     },
     {
       borneInferieure: 2,
       borneSuperieure: 3,
       dureeHomologationConseillee: '1 an',
       conseilHomologation: 'Continuer à renforcer la sécurité du service',
-      description:
-        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un niveau de sécurisation modéré face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
+      description: "Modéré lorsqu'il est < 3",
     },
     {
       borneInferieure: 3,
       borneSuperieure: 4,
       dureeHomologationConseillee: '2 ans',
       conseilHomologation: 'Continuer à renforcer la sécurité du service',
-      description:
-        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un bon niveau de sécurisation face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
+      description: "Bon lorsqu'il est < 4",
     },
     {
       borneInferieure: 4,
       borneSuperieure: 5,
       borneSuperieureIncluse: true,
       dureeHomologationConseillee: '3 ans',
-      description:
-        "Un indice cyber de $INDICE_CYBER peut être considéré comme reflétant un très bon niveau de sécurisation face aux risques les plus courants. Cette évaluation est indicative et n'est pas une preuve du niveau de sécurité effectif du service.",
+      description: 'Très bon entre 4 et 5',
     },
   ],
 

--- a/public/assets/images/coche_blanche.svg
+++ b/public/assets/images/coche_blanche.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22Z" fill="white"/>
+<path d="M7.75 11.9999L10.58 14.8299L16.25 9.16992" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -137,6 +137,38 @@
   margin: 0;
 }
 
+.conteneur-explication-valeur .liste-tranches {
+  padding-left: 24px;
+  margin-top: 8px;
+  margin-bottom: 0;
+}
+
+.conteneur-explication-valeur .liste-tranches li {
+  margin-bottom: 6px;
+  width: fit-content;
+  font-weight: 500;
+}
+
+.conteneur-explication-valeur .liste-tranches .tranche-courante {
+  border-radius: 4px;
+  background: #0079d0;
+  font-weight: bold;
+  color: white;
+  padding: 4px 10px 4px 6px;
+  list-style-type: none;
+  margin-left: -16px;
+  display: flex;
+  gap: 6px;
+  flex-direction: row;
+}
+
+.conteneur-explication-valeur .liste-tranches .tranche-courante:before {
+  content: '';
+  width: 24px;
+  height: 24px;
+  background-image: url('/statique/assets/images/coche_blanche.svg');
+}
+
 .contenu-plus-details .conteneur-explication-valeur {
   border-radius: 8px;
   background: #eff6ff;

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -118,27 +118,24 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
 
   const indiceCyberNoteMax = () => donnees.indiceCyber?.noteMax || 10;
 
+  const verifieIndiceEstDansTranche = (indiceCyber, tranche) =>
+    indiceCyber >= tranche.borneInferieure &&
+    (tranche.borneSuperieureIncluse
+      ? indiceCyber <= tranche.borneSuperieure
+      : indiceCyber < tranche.borneSuperieure);
+
   const trancheIndiceCyber = (indiceCyber) =>
-    donnees.tranchesIndicesCybers.find(
-      (tranche) =>
-        indiceCyber >= tranche.borneInferieure &&
-        (tranche.borneSuperieureIncluse
-          ? indiceCyber <= tranche.borneSuperieure
-          : indiceCyber < tranche.borneSuperieure)
+    donnees.tranchesIndicesCybers.find((tranche) =>
+      verifieIndiceEstDansTranche(indiceCyber, tranche)
     ) || {};
 
-  const descriptionTrancheIndiceCyber = (indiceCyber) => {
-    const formatIndiceCyber = Intl.NumberFormat('fr', {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
-    }).format;
-    return (
-      trancheIndiceCyber(indiceCyber)?.description?.replaceAll(
-        '$INDICE_CYBER',
-        formatIndiceCyber(indiceCyber)
-      ) ?? ''
-    );
-  };
+  const descriptionsTranchesIndiceCyber = (indiceCyber) =>
+    donnees.tranchesIndicesCybers
+      .sort((a, b) => a.borneInferieure - b.borneInferieure)
+      .map((tranche) => ({
+        description: tranche.description,
+        trancheCourante: verifieIndiceEstDansTranche(indiceCyber, tranche),
+      }));
 
   const infosNiveauxGravite = (ordreInverse = false) => {
     const niveaux = Object.keys(niveauxGravite()).map((clef) => ({
@@ -263,7 +260,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     descriptionFonctionnalite,
     descriptionRisque,
     descriptionStatutMesure,
-    descriptionTrancheIndiceCyber,
+    descriptionsTranchesIndiceCyber,
     descriptionsDonneesCaracterePersonnel,
     descriptionsFonctionnalites,
     donneesCaracterePersonnel,

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -40,7 +40,10 @@ block zone-principale
             .titre
               img.icone(src="/statique/assets/images/icone_explication_tranche.svg")
               h4 Quelle est la valeur de l'indice cyber ?
-            p= referentiel.descriptionTrancheIndiceCyber(indiceCyber.total)
+            p Face aux risques les plus courants, un indice cyber peut être considéré comme
+            ul.liste-tranches
+              each tranche in referentiel.descriptionsTranchesIndiceCyber(indiceCyber.total)
+                li(class=`${tranche.trancheCourante ? 'tranche-courante' : ''}`)= tranche.description
     .conteneur-recommandation-anssi
       img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
       .titre

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -687,29 +687,41 @@ describe('Le référentiel', () => {
     });
   });
 
-  describe("sur une demande de description de tranche de l'indice cyber", () => {
-    it("renvoie la description de la tranche, mise en forme avec la valeur de l'indice cyber", () => {
-      const tranche = {
-        borneInferieure: 0,
-        borneSuperieure: 2,
-        description: 'La valeur est $INDICE_CYBER',
-      };
-      const referentiel = Referentiel.creeReferentiel({
-        tranchesIndicesCybers: [tranche],
-      });
+  describe("sur une demande des descriptions des tranches de l'indice cyber", () => {
+    let referentiel;
 
-      expect(referentiel.descriptionTrancheIndiceCyber(1.51)).to.eql(
-        'La valeur est 1,5'
-      );
+    beforeEach(() => {
+      const tranche1 = {
+        borneInferieure: 0,
+        borneSuperieure: 1,
+        description: 'Indice cyber 0-1',
+      };
+      const tranche2 = {
+        borneInferieure: 1,
+        borneSuperieure: 2,
+        description: 'Indice cyber 1-2',
+      };
+      referentiel = Referentiel.creeReferentiel({
+        tranchesIndicesCybers: [tranche2, tranche1],
+      });
     });
 
-    it("reste robuste quand l'indice n'est pas dans une tranche", () => {
-      const tranche = { borneInferieure: 0, borneSuperieure: 2 };
-      const referentiel = Referentiel.creeReferentiel({
-        tranchesIndicesCybers: [tranche],
-      });
+    it("renvoie les descriptions dans l'ordre croissant", () => {
+      const resultat = referentiel.descriptionsTranchesIndiceCyber(1);
+      expect(resultat[0].description).to.eql('Indice cyber 0-1');
+      expect(resultat[1].description).to.eql('Indice cyber 1-2');
+    });
 
-      expect(referentiel.descriptionTrancheIndiceCyber(6)).to.eql('');
+    it("indique dans quel tranche se situe l'indice cyber passé en paramètre", () => {
+      const resultat = referentiel.descriptionsTranchesIndiceCyber(0.5);
+      expect(resultat[0]).to.eql({
+        description: 'Indice cyber 0-1',
+        trancheCourante: true,
+      });
+      expect(resultat[1]).to.eql({
+        description: 'Indice cyber 1-2',
+        trancheCourante: false,
+      });
     });
   });
 


### PR DESCRIPTION
On affiche maintenant les tranches sous forme de liste :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/a7820042-c92d-487d-bc43-2b34233d3725)
