### PR TITLE
Titres et sous-titres des pages du service

### DIFF
--- a/public/assets/styles/headerLarge.css
+++ b/public/assets/styles/headerLarge.css
@@ -7,7 +7,7 @@ header {
 }
 
 .header-gauche .conteneur-logo {
-  width: var(--menu-largeur);
+  margin-right: 52px;
 }
 
 .header-gauche .logo-mss {

--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -20,3 +20,9 @@
 #nom-service.invalide {
   border-color: var(--rose-anssi);
 }
+
+.informations-complementaires {
+  margin: 0;
+  font-weight: normal;
+  font-size: 1rem;
+}

--- a/public/assets/styles/homologation/formulaire.css
+++ b/public/assets/styles/homologation/formulaire.css
@@ -19,15 +19,6 @@ form.homologation h1 {
   text-transform: uppercase;
 }
 
-form.homologation h1.action {
-  padding-top: 0;
-
-  font-weight: normal;
-  font-size: 1.7em;
-  text-transform: none;
-  color: var(--texte-clair);
-}
-
 .action + section {
   margin-top: 2em;
 }

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -169,3 +169,36 @@ main {
   font-weight: normal;
   font-size: 1rem;
 }
+
+.formulaire {
+  position: relative;
+}
+
+.conteneur-indice-cyber {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  gap: 0;
+  align-items: center;
+  cursor: pointer;
+}
+
+.conteneur-indice-cyber svg {
+  width: 4.2em;
+  height: 4.2em;
+}
+
+.conteneur-indice-cyber svg .indice-cyber {
+  font-size: 2.9em;
+}
+
+.conteneur-indice-cyber .cartouche-indice-cyber {
+  border-radius: 8px;
+  background: #f1f5f9;
+  padding: 8px 12px;
+  color: #08416a;
+  font-weight: bold;
+  transform: translateX(12px);
+}

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -163,3 +163,9 @@ footer {
 main {
   border-bottom: 0;
 }
+
+.informations-complementaires {
+  margin: 0;
+  font-weight: normal;
+  font-size: 1rem;
+}

--- a/public/assets/styles/homologation/risques.css
+++ b/public/assets/styles/homologation/risques.css
@@ -121,6 +121,7 @@ ul.niveaux-gravite {
 }
 
 #risques .description-risques {
+  font-size: 1rem;
   margin-bottom: 1em;
   padding-bottom: 2em;
   border-bottom: 1px solid #cbd5e1;

--- a/public/assets/styles/homologation/rolesResponsabilites.css
+++ b/public/assets/styles/homologation/rolesResponsabilites.css
@@ -35,3 +35,9 @@
 
   font-weight: bold;
 }
+
+.informations-complementaires {
+  margin: 0;
+  font-weight: normal;
+  font-size: 1rem;
+}

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -14,7 +14,7 @@
   position: sticky;
   top: 0;
   left: 0;
-  width: var(--menu-largeur);
+  width: 280px;
   height: 100%;
   max-height: 100vh;
   display: flex;

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -1,7 +1,3 @@
-:root {
-  --menu-largeur: 280px;
-}
-
 html {
   height: 100%;
 }

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -65,7 +65,7 @@ section:last-of-type {
 
 .zone-principale,
 .etroit {
-  padding: 4em 7em 2em;
+  padding: 1.65em 7em 2em;
   border-radius: 5px;
   background: #fff;
 }

--- a/public/assets/styles/parcoursService.css
+++ b/public/assets/styles/parcoursService.css
@@ -6,5 +6,19 @@ main {
   display: grid;
   grid-template-columns: 4fr 1fr;
   grid-gap: 2em;
-  margin-top: 3em;
+}
+
+.titre h1 {
+  font-size: 1.625rem;
+  font-weight: bold;
+  text-align: left;
+  margin: 0;
+}
+
+.sous-titre h2 {
+  font-size: 0.875rem;
+  font-weight: normal;
+  text-align: left;
+  margin: 0 0 32px 0;
+  color: #667892;
 }

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -8,9 +8,7 @@ mixin formulaireDescriptionService(idHomologation)
   - const estEnCreation = !idHomologation
   - const estLectureSeule  = estEnCreation ? false : autorisationsService.DECRIRE.estLectureSeule
   form.homologation#homologation
-    h1.action Décrire
-    p.
-      Précisez les caractéristiques de votre service pour obtenir des recommandations personnalisées de l'ANSSI.
+    p.informations-complementaires Présentez les caractéristiques de votre service numérique pour obtenir des recommandations personnalisées de l'ANSSI.
     section
       .mention champ obligatoire
       .requis

--- a/src/vues/parcoursService.pug
+++ b/src/vues/parcoursService.pug
@@ -32,6 +32,10 @@ block main
       .zone-principale
         block zone-principale
           .formulaire
+            .titre
+              block titre
+            .sous-titre
+              block sous-titre
             block formulaire
 
   +tiroir

--- a/src/vues/service/descriptionService.pug
+++ b/src/vues/service/descriptionService.pug
@@ -6,5 +6,11 @@ block header-titre-page
   h3
     +texteTronque({texte: service.nomService() || ''})
 
+block titre
+  h1 Décrire
+
+block sous-titre
+  h2 Fournir les informations permettant d'évaluer les besoins de sécurité du service et de proposer des mesures de sécurité adaptées
+
 block formulaire
   +formulaireDescriptionService(service.id)

--- a/src/vues/service/formulaireEtapier.pug
+++ b/src/vues/service/formulaireEtapier.pug
@@ -30,13 +30,16 @@ block header-titre-page
     +texteTronque({texte: service.nomService() || ''})
 
 block zone-principale
-  form.homologation
-    h1.action Homologuer
+  .titre
+    h1 Homologuer
 
+
+  form.homologation
     if idEtape
       +barre-progression({ numeroEtapeCourante: referentiel.numeroEtape(idEtape) })
     else
-      h2 Réalisez et suivez les homologations de sécurité pour votre service
+      .sous-titre
+        h2 Gérer un dossier et un projet de décision d'homologation pour se mettre en conformité avec la réglementation
 
     hr
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -21,15 +21,20 @@ block header-titre-page
   h3
     +texteTronque({texte: service.nomService() || ''})
 
+block titre
+  h1 Sécuriser
+
+block sous-titre
+  h2 Mettre en oeuvre des mesures de sécurité adaptées
+
 block formulaire
   - const estLectureSeule  = autorisationsService.SECURISER.estLectureSeule
   form.homologation#mesures
-    h1.action Sécuriser
-    p.
+    p.informations-complementaires.
       Sélectionnez le statut de mise en œuvre de chaque mesure de sécurité
-      et apportez des précisions, si nécessaire.<br>
+      et apportez des précisions, si nécessaire.
       Ces informations permettent de suivre la mise en œuvre des mesures de
-      sécurité adaptées au service et d'évaluer son niveau de sécurité.
+      sécurité adaptées au service et d'évaluer son niveau de sécurité (Indice cyber).
 
     section
       nav

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -2,6 +2,7 @@ extends ../parcoursService
 include ../fragments/inputChoix
 include ../fragments/cartesInformations
 include ../fragments/texteTronque
+include ../fragments/indiceCyber/scoreIndiceCyber
 
 mixin inputMesure({ nom, titre, indispensable, lectureSeule = false })
   +inputChoix({
@@ -23,6 +24,9 @@ block header-titre-page
 
 block titre
   h1 Sécuriser
+  a.conteneur-indice-cyber(href="indiceCyber")
+    .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
+    +scoreIndiceCyber(service.indiceCyber().total, referentiel.indiceCyberNoteMax())
 
 block sous-titre
   h2 Mettre en oeuvre des mesures de sécurité adaptées
@@ -35,6 +39,7 @@ block formulaire
       et apportez des précisions, si nécessaire.
       Ces informations permettent de suivre la mise en œuvre des mesures de
       sécurité adaptées au service et d'évaluer son niveau de sécurité (Indice cyber).
+
 
     section
       nav

--- a/src/vues/service/risques.pug
+++ b/src/vues/service/risques.pug
@@ -16,10 +16,14 @@ block header-titre-page
   h3
     +texteTronque({texte: service.nomService() || ''})
 
+block titre
+  h1 Risques de sécurité
+block sous-titre
+  h2 Évaluer le niveau de gravité des risques cyber les plus courants pour le service
+
 block formulaire
   - const estLectureSeule  = autorisationsService.RISQUES.estLectureSeule
   form.homologation#risques
-    h1.action Risques de sécurité
     p.description-risques
       | Cliquez sur le curseur pour évaluer l'impact potentiel des risques
       | de sécurité les plus courants sur votre service. Apportez des précisions

--- a/src/vues/service/rolesResponsabilites.pug
+++ b/src/vues/service/rolesResponsabilites.pug
@@ -12,11 +12,15 @@ block header-titre-page
   h3
     +texteTronque({texte: service.nomService() || ''})
 
+block titre
+  h1 Contacts utiles
+block sous-titre
+  h2 Enregistrer les coordonnées des personnes importantes pour le service
+
 block formulaire
   - const estLectureSeule  = autorisationsService.CONTACTS.estLectureSeule
   form.homologation#roles-responsabilites
-    h1.action Rôles et responsabilités
-    p.
+    p.informations-complementaires.
       Listez toutes les personnes assurant le bon fonctionnement du service pour les contacter rapidement en cas de besoin.
 
     section

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -174,6 +174,9 @@ describe('Le serveur MSS des routes /service/*', () => {
 
   describe('quand requête GET sur `/service/:id/mesures`', () => {
     beforeEach(() => {
+      const service = unService().avecNomService('un service').construis();
+      service.indiceCyber = () => ({ total: 2 });
+      testeur.middleware().reinitialise({ homologationARenvoyer: service });
       testeur.referentiel().recharge({
         autorisationACharger: uneAutorisation().construis(),
       });


### PR DESCRIPTION
On met à jour l'affichage des titres et sous-titres de toute les pages 'Service'

On en profite pour réaligner le nom du service dans le header.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/d3da1787-a58d-4cbb-a4f6-00779b8e6bef)
