### PR TITLE
Envoie jusqu'à Metabase le nombre d'organisations utilisatrices d'un service

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -257,6 +257,8 @@ const creeDepot = (config = {}) => {
         new EvenementCompletudeServiceModifiee({
           idService: idHomologation,
           ...h.completudeMesures(),
+          nombreOrganisationsUtilisatrices:
+            h.descriptionService.nombreOrganisationsUtilisatrices,
         }).toJSON()
       );
       return h;
@@ -306,6 +308,8 @@ const creeDepot = (config = {}) => {
       new EvenementCompletudeServiceModifiee({
         idService: h.id,
         ...h.completudeMesures(),
+        nombreOrganisationsUtilisatrices:
+          h.descriptionService.nombreOrganisationsUtilisatrices,
       }).toJSON()
     );
     const tauxCompletude =
@@ -379,6 +383,8 @@ const creeDepot = (config = {}) => {
         new EvenementCompletudeServiceModifiee({
           idService: s.id,
           ...s.completudeMesures(),
+          nombreOrganisationsUtilisatrices:
+            s.descriptionService.nombreOrganisationsUtilisatrices,
         }).toJSON()
       ),
       homologations(idUtilisateur).then((hs) => {

--- a/src/modeles/journalMSS/erreurs.js
+++ b/src/modeles/journalMSS/erreurs.js
@@ -5,6 +5,7 @@ class ErreurDureeHomologationManquante extends ErreurJournal {}
 class ErreurIdentifiantServiceManquant extends ErreurJournal {}
 class ErreurIdentifiantUtilisateurManquant extends ErreurJournal {}
 class ErreurIndiceCyberManquant extends ErreurJournal {}
+class ErreurNombreOrganisationsUtilisatricesManquant extends ErreurJournal {}
 class ErreurNombreMesuresCompletesManquant extends ErreurJournal {}
 class ErreurNombreTotalMesuresManquant extends ErreurJournal {}
 
@@ -15,6 +16,7 @@ module.exports = {
   ErreurIdentifiantServiceManquant,
   ErreurIdentifiantUtilisateurManquant,
   ErreurIndiceCyberManquant,
+  ErreurNombreOrganisationsUtilisatricesManquant,
   ErreurNombreMesuresCompletesManquant,
   ErreurNombreTotalMesuresManquant,
 };

--- a/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
+++ b/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
@@ -3,6 +3,7 @@ const {
   ErreurDetailMesuresManquant,
   ErreurIdentifiantServiceManquant,
   ErreurNombreMesuresCompletesManquant,
+  ErreurNombreOrganisationsUtilisatricesManquant,
   ErreurNombreTotalMesuresManquant,
   ErreurIndiceCyberManquant,
 } = require('./erreurs');
@@ -23,6 +24,8 @@ class EvenementCompletudeServiceModifiee extends Evenement {
       if (manque(donnees.detailMesures))
         throw new ErreurDetailMesuresManquant();
       if (manque(donnees.indiceCyber)) throw new ErreurIndiceCyberManquant();
+      if (manque(donnees.nombreOrganisationsUtilisatrices))
+        throw new ErreurNombreOrganisationsUtilisatricesManquant();
     };
 
     const enTableau = (donneesIndiceCyber) =>
@@ -41,6 +44,12 @@ class EvenementCompletudeServiceModifiee extends Evenement {
         idService: adaptateurChiffrement.hacheSha256(idService),
         detailIndiceCyber: enTableau(indiceCyber),
         ...donneesBrutes,
+        nombreOrganisationsUtilisatrices: {
+          borneBasse:
+            Number(donnees.nombreOrganisationsUtilisatrices.borneBasse) || 1,
+          borneHaute:
+            Number(donnees.nombreOrganisationsUtilisatrices.borneHaute) || 1,
+        },
       },
       date
     );

--- a/test/modeles/journalMSS/constructeurEvenementCompletudeServiceModifiee.js
+++ b/test/modeles/journalMSS/constructeurEvenementCompletudeServiceModifiee.js
@@ -8,6 +8,7 @@ class ConstructeurEvenementCompletudeServiceModifiee {
       nombreMesuresCompletes: 38,
       detailMesures: [{ idMesure: 'analyseRisques', statut: 'fait' }],
       indiceCyber: { total: 4.1 },
+      nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
     };
     this.date = '14/02/2023';
     this.adaptateurChiffrement = { hacheSha256: (valeur) => valeur };
@@ -30,6 +31,12 @@ class ConstructeurEvenementCompletudeServiceModifiee {
 
   sans(propriete) {
     delete this.donnees[propriete];
+    return this;
+  }
+
+  avecNombreOrganisationsUtilisatricesInconnu() {
+    this.donnees.nombreOrganisationsUtilisatrices.borneBasse = '0';
+    this.donnees.nombreOrganisationsUtilisatrices.borneHaute = '0';
     return this;
   }
 

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -7,6 +7,7 @@ const {
   ErreurNombreTotalMesuresManquant,
   ErreurNombreMesuresCompletesManquant,
   ErreurIndiceCyberManquant,
+  ErreurNombreOrganisationsUtilisatricesManquant,
 } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de complétude modifiée', () => {
@@ -33,6 +34,10 @@ describe('Un événement de complétude modifiée', () => {
         nombreMesuresCompletes: 38,
         detailMesures: [{ idMesure: 'analyseRisques', statut: 'fait' }],
         indiceCyber: { total: 4.1 },
+        nombreOrganisationsUtilisatrices: {
+          borneBasse: 1,
+          borneHaute: 5,
+        },
       },
       { date: '17/11/2022', adaptateurChiffrement: hacheEnMajuscules }
     );
@@ -45,6 +50,10 @@ describe('Un événement de complétude modifiée', () => {
         nombreMesuresCompletes: 38,
         detailMesures: [{ idMesure: 'analyseRisques', statut: 'fait' }],
         detailIndiceCyber: [{ categorie: 'total', indice: 4.1 }],
+        nombreOrganisationsUtilisatrices: {
+          borneBasse: 1,
+          borneHaute: 5,
+        },
       },
       date: '17/11/2022',
     });
@@ -60,6 +69,18 @@ describe('Un événement de complétude modifiée', () => {
       { categorie: 'total', indice: 4.1 },
       { categorie: 'gouvernance', indice: 3.8 },
     ]);
+  });
+
+  it("utilise des bornes à « 1 » pour les services dont le nombre d'organisations utilisatrices est à « 0 »", () => {
+    const evenement = unEvenement()
+      .avecNombreOrganisationsUtilisatricesInconnu()
+      .construis()
+      .toJSON();
+
+    expect(evenement.donnees.nombreOrganisationsUtilisatrices).to.eql({
+      borneBasse: 1,
+      borneHaute: 1,
+    });
   });
 
   it("exige que l'identifiant du service soit renseigné", (done) => {
@@ -123,6 +144,19 @@ describe('Un événement de complétude modifiée', () => {
       );
     } catch (e) {
       expect(e).to.be.an(ErreurIndiceCyberManquant);
+      done();
+    }
+  });
+
+  it("exige que le nombre d'organisations utilisatrices soit renseigné", (done) => {
+    try {
+      unEvenement().sans('nombreOrganisationsUtilisatrices').construis();
+
+      done(
+        Error("L'instanciation de l'événement aurait dû lever une exception")
+      );
+    } catch (e) {
+      expect(e).to.be.an(ErreurNombreOrganisationsUtilisatricesManquant);
       done();
     }
   });


### PR DESCRIPTION
… dans l'événement existant `COMPLETUDE_SERVICE_MODIFIEE`.

L'événement ressemble désormais à :

```js
{
  "type": "COMPLETUDE_SERVICE_MODIFIEE",
  "donnees": {
    "idService": "…",
    "detailIndiceCyber": [   ],
    "nombreTotalMesures": 33,
    "nombreMesuresCompletes": 0,
    "detailMesures": [],
    "nombreOrganisationsUtilisatrices": {  // <-- Nouveau champ
      "borneBasse": 1,
      "borneHaute": 1
    }
  },
  "date": 1701705532045
}
```