### PR TITLE
Supprime la coche blanche sur la valeur de l'indice cyber

### DIFF
--- a/public/assets/images/coche_blanche.svg
+++ b/public/assets/images/coche_blanche.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 22C17.5 22 22 17.5 22 12C22 6.5 17.5 2 12 2C6.5 2 2 6.5 2 12C2 17.5 6.5 22 12 22Z" fill="white"/>
-<path d="M7.75 11.9999L10.58 14.8299L16.25 9.16992" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -154,19 +154,16 @@
   background: #0079d0;
   font-weight: bold;
   color: white;
-  padding: 4px 10px 4px 6px;
+  padding: 4px 10px 4px 8px;
   list-style-type: none;
-  margin-left: -16px;
+  margin-left: -20px;
   display: flex;
   gap: 6px;
   flex-direction: row;
 }
 
 .conteneur-explication-valeur .liste-tranches .tranche-courante:before {
-  content: '';
-  width: 24px;
-  height: 24px;
-  background-image: url('/statique/assets/images/coche_blanche.svg');
+  content: '•';
 }
 
 .contenu-plus-details .conteneur-explication-valeur {


### PR DESCRIPTION
On remplace par un `bullet` blanc

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/25ad2048-39e8-40f5-a039-f5b1446d4bbd)
