### PR TITLE
[CORRECTION] Réparation d'une disparition de données dans le PDF dossier d'homologation

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -1,5 +1,8 @@
 const { departements } = require('./donneesReferentielDepartements');
 
+const recommandationPoursuiteRenforcement =
+  "L'ANSSI recommande la poursuite du renforcement de la sécurité du service numérique.";
+
 const expiration = (duree) =>
   `${duree.charAt(0).toUpperCase()}${duree.slice(
     1
@@ -29,6 +32,10 @@ module.exports = {
     {
       borneInferieure: 0,
       borneSuperieure: 1,
+      recommandationANSSI:
+        "L'homologation du service est déconseillée ou devrait être limitée à <b>6 mois</b>.",
+      recommandationANSSIComplement:
+        "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
       conseilHomologation: 'Homologation déconseillée',
@@ -37,6 +44,10 @@ module.exports = {
     {
       borneInferieure: 1,
       borneSuperieure: 2,
+      recommandationANSSI:
+        "L'homologation du service est déconseillée ou devrait être limitée à <b>6 mois</b>.",
+      recommandationANSSIComplement:
+        "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
       deconseillee: true,
       dureeHomologationConseillee: '6 mois',
       conseilHomologation: 'Homologation déconseillée',
@@ -45,6 +56,9 @@ module.exports = {
     {
       borneInferieure: 2,
       borneSuperieure: 3,
+      recommandationANSSI:
+        "La durée d'homologation du service devrait être limitée à <b>1 an</b>.",
+      recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '1 an',
       conseilHomologation: 'Continuer à renforcer la sécurité du service',
       description: "Modéré lorsqu'il est < 3",
@@ -52,6 +66,9 @@ module.exports = {
     {
       borneInferieure: 3,
       borneSuperieure: 4,
+      recommandationANSSI:
+        "La durée d'homologation du service peut aller jusqu'à <b>2 ans</b>.",
+      recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '2 ans',
       conseilHomologation: 'Continuer à renforcer la sécurité du service',
       description: "Bon lorsqu'il est < 4",
@@ -60,6 +77,9 @@ module.exports = {
       borneInferieure: 4,
       borneSuperieure: 5,
       borneSuperieureIncluse: true,
+      recommandationANSSI:
+        "La durée d'homologation du service peut aller jusqu'à <b>3 ans</b>.",
+      recommandationANSSIComplement: recommandationPoursuiteRenforcement,
       dureeHomologationConseillee: '3 ans',
       description: 'Très bon entre 4 et 5',
     },

--- a/src/pdf/modeles/annexeAvis.pug
+++ b/src/pdf/modeles/annexeAvis.pug
@@ -7,7 +7,7 @@ block page
     const noteObtenue = formatIndiceCyber(donnees.indiceCyberTotal)
     const noteMaximale = donnees.referentiel.indiceCyberNoteMax()
   +boite-grise('Recommandation ANSSI', 'recommandation-anssi')
-    p.note= `L'indice cyber est du service numérique est de ${noteObtenue}/${noteMaximale}`
+    p.note= `L'indice cyber du service numérique est de ${noteObtenue}/${noteMaximale}`
     p.recommandation!= donnees.referentiel.trancheIndiceCyber(donnees.indiceCyberTotal).recommandationANSSI
     p.complement= donnees.referentiel.trancheIndiceCyber(donnees.indiceCyberTotal).recommandationANSSIComplement
   if donnees.avis.length === 0


### PR DESCRIPTION
Ce screenshot montre ce qui a disparu 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/7a93120e-b2e9-4386-9f50-bf13580bb799)


Cette PR remet en place les données utilisées pour la génération du PDF.

Et au passage corrige une coquille.