### PR TITLE
[CORRECTION] Réparation de l'envoi de complétude à Metabase

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -51,7 +51,7 @@ const creeDepot = (config = {}) => {
   });
 
   const {
-    ajouteDescriptionServiceAHomologation,
+    ajouteDescriptionService,
     ajouteDossierCourantSiNecessaire,
     ajouteMesuresAHomologation,
     ajouteRisqueGeneralAHomologation,
@@ -103,7 +103,7 @@ const creeDepot = (config = {}) => {
   return {
     accesAutorise,
     ajouteContributeurAuService,
-    ajouteDescriptionServiceAHomologation,
+    ajouteDescriptionService,
     ajouteDossierCourantSiNecessaire,
     ajouteMesuresAHomologation,
     ajouteRisqueGeneralAHomologation,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -280,20 +280,13 @@ const creeDepot = (config = {}) => {
       );
     };
 
-    const metsAJourHomologation = async (h) => {
-      await valideDescriptionService(idUtilisateur, infos, h.id);
-      await metsAJourDescriptionServiceHomologation(
-        donneesAPersister(h),
-        infos
-      );
-
-      const homologationFraiche = await p.lis.une(idHomologation);
-      await consigneEvenement(homologationFraiche);
-      await envoieTrackingCompletude();
-    };
-
     const h = await p.lis.une(idHomologation);
-    await metsAJourHomologation(h);
+    await valideDescriptionService(idUtilisateur, infos, h.id);
+    await metsAJourDescriptionServiceHomologation(donneesAPersister(h), infos);
+
+    const homologationFraiche = await p.lis.une(idHomologation);
+    await consigneEvenement(homologationFraiche);
+    await envoieTrackingCompletude();
   };
 
   const ajouteMesuresAHomologation = async (

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -245,7 +245,7 @@ const creeDepot = (config = {}) => {
   const homologations = (idUtilisateur) =>
     p.lis.cellesDeUtilisateur(idUtilisateur);
 
-  const ajouteDescriptionServiceAHomologation = (
+  const ajouteDescriptionServiceAHomologation = async (
     idUtilisateur,
     idHomologation,
     infos
@@ -280,16 +280,20 @@ const creeDepot = (config = {}) => {
       );
     };
 
-    const metsAJourHomologation = (h) =>
-      valideDescriptionService(idUtilisateur, infos, h.id)
-        .then(() =>
-          metsAJourDescriptionServiceHomologation(donneesAPersister(h), infos)
-        )
-        .then(() => p.lis.une(idHomologation))
-        .then(consigneEvenement)
-        .then(envoieTrackingCompletude);
+    const metsAJourHomologation = async (h) => {
+      await valideDescriptionService(idUtilisateur, infos, h.id);
+      await metsAJourDescriptionServiceHomologation(
+        donneesAPersister(h),
+        infos
+      );
 
-    return p.lis.une(idHomologation).then(metsAJourHomologation);
+      const homologationFraiche = await p.lis.une(idHomologation);
+      await consigneEvenement(homologationFraiche);
+      await envoieTrackingCompletude();
+    };
+
+    const h = await p.lis.une(idHomologation);
+    await metsAJourHomologation(h);
   };
 
   const ajouteMesuresAHomologation = async (

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -250,8 +250,6 @@ const creeDepot = (config = {}) => {
     idHomologation,
     infos
   ) => {
-    const donneesAPersister = (h) => h.donneesAPersister().toutes();
-
     const consigneEvenement = (h) => {
       adaptateurJournalMSS.consigneEvenement(
         new EvenementCompletudeServiceModifiee({
@@ -282,7 +280,10 @@ const creeDepot = (config = {}) => {
 
     const h = await p.lis.une(idHomologation);
     await valideDescriptionService(idUtilisateur, infos, h.id);
-    await metsAJourDescriptionServiceHomologation(donneesAPersister(h), infos);
+    await metsAJourDescriptionServiceHomologation(
+      h.donneesAPersister().toutes(),
+      infos
+    );
 
     const homologationFraiche = await p.lis.une(idHomologation);
     await consigneEvenement(homologationFraiche);

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -250,7 +250,7 @@ const creeDepot = (config = {}) => {
     idHomologation,
     infos
   ) => {
-    const consigneEvenement = (h) => {
+    const consigneEvenement = async (h) =>
       adaptateurJournalMSS.consigneEvenement(
         new EvenementCompletudeServiceModifiee({
           idService: idHomologation,
@@ -259,8 +259,6 @@ const creeDepot = (config = {}) => {
             h.descriptionService.nombreOrganisationsUtilisatrices,
         }).toJSON()
       );
-      return h;
-    };
 
     const envoieTrackingCompletude = async () => {
       const tauxCompletude =

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -121,7 +121,7 @@ const routesApiService = ({
           referentiel
         );
 
-        await depotDonnees.ajouteDescriptionServiceAHomologation(
+        await depotDonnees.ajouteDescriptionService(
           requete.idUtilisateurCourant,
           requete.params.id,
           descriptionService

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -458,11 +458,7 @@ describe('Le dépôt de données des homologations', () => {
         .avecNomService('Nouveau Nom')
         .construis();
 
-      await depot.ajouteDescriptionServiceAHomologation(
-        '999',
-        '123',
-        description
-      );
+      await depot.ajouteDescriptionService('999', '123', description);
 
       const { descriptionService } = await depot.homologation('123');
       expect(descriptionService.nomService).to.equal('Nouveau Nom');
@@ -477,11 +473,7 @@ describe('Le dépôt de données des homologations', () => {
         .avecNomService('Nouveau Nom')
         .construis();
 
-      await depot.ajouteDescriptionServiceAHomologation(
-        '999',
-        '123',
-        description
-      );
+      await depot.ajouteDescriptionService('999', '123', description);
 
       const { descriptionService } = await depotServices.service('123');
       expect(descriptionService.nomService).to.equal('Nouveau Nom');
@@ -493,11 +485,7 @@ describe('Le dépôt de données des homologations', () => {
         .construis();
 
       depot
-        .ajouteDescriptionServiceAHomologation(
-          '999',
-          '123',
-          descriptionIncomplete
-        )
+        .ajouteDescriptionService('999', '123', descriptionIncomplete)
         .then(() =>
           done(
             'La mise à jour de la description du service aurait dû lever une exception'
@@ -518,11 +506,7 @@ describe('Le dépôt de données des homologations', () => {
         .avecPresentation('Une autre présentation')
         .construis();
 
-      await depot.ajouteDescriptionServiceAHomologation(
-        '999',
-        '123',
-        description
-      );
+      await depot.ajouteDescriptionService('999', '123', description);
 
       const { descriptionService } = await depot.homologation('123');
       expect(descriptionService.presentation).to.equal(
@@ -538,11 +522,7 @@ describe('Le dépôt de données des homologations', () => {
       };
       const description = uneDescriptionValide(referentiel).construis();
 
-      await depot.ajouteDescriptionServiceAHomologation(
-        '999',
-        '123',
-        description
-      );
+      await depot.ajouteDescriptionService('999', '123', description);
 
       expect(evenementRecu.type).to.equal('COMPLETUDE_SERVICE_MODIFIEE');
     });
@@ -566,11 +546,7 @@ describe('Le dépôt de données des homologations', () => {
         )
         .construis();
 
-      await depot.ajouteDescriptionServiceAHomologation(
-        '999',
-        '123',
-        description
-      );
+      await depot.ajouteDescriptionService('999', '123', description);
 
       expect(donneesPassees).to.eql({
         destinataire: 'jean.dupont@mail.fr',

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -186,8 +186,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête PUT sur `/api/service/:id`', () => {
     beforeEach(() => {
-      testeur.depotDonnees().ajouteDescriptionServiceAHomologation =
-        async () => {};
+      testeur.depotDonnees().ajouteDescriptionService = async () => {};
     });
 
     it('recherche le service correspondant', (done) => {
@@ -245,7 +244,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('demande au dépôt de données de mettre à jour le service', async () => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
-      testeur.depotDonnees().ajouteDescriptionServiceAHomologation = async (
+      testeur.depotDonnees().ajouteDescriptionService = async (
         idUtilisateur,
         idService,
         infosGenerales
@@ -277,7 +276,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('retourne une erreur HTTP 422 si la validation des propriétés obligatoires échoue', (done) => {
-      testeur.depotDonnees().ajouteDescriptionServiceAHomologation = () =>
+      testeur.depotDonnees().ajouteDescriptionService = () =>
         Promise.reject(new ErreurNomServiceDejaExistant('oups'));
 
       testeur.verifieRequeteGenereErreurHTTP(


### PR DESCRIPTION
… lors de la modification de la description du service.

Depuis 870e24b99c04485d6c8787bdb37cc7b7cd8495bd la promesse de `adaptateurJournalMSS.consigneEvenement` était ignorée, donc le code non exécuté.

Cette PR :
 - répare ce bug 
 - passe du code en `async/await` 
 - change du vocabulaire `homologation` en `service`