### PR TITLE
[CORRECTION] Ajoute `nombreOrganisationsUtilisatrices` à la création du service de l'utilisateur de démo

### DIFF
--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -16,6 +16,7 @@ const descriptionService = new DescriptionService(
     statutDeploiement: 'enLigne',
     typeService: ['siteInternet'],
     organisationsResponsables: ['Agglomération de Mansart'],
+    nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
   },
   referentiel
 );


### PR DESCRIPTION
Sinon la `descriptionService` est incomplète, ce qui empêche de créer des reviews app chez Scalingo :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/90caddcd-3c8b-49f7-a5a5-c4941e9ffba7)
