### PR TITLE
[SECURISER] Modifie les labels des statuts

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -366,9 +366,9 @@ module.exports = {
   },
 
   statutsMesures: {
-    fait: 'Fait',
-    enCours: 'En cours',
-    nonFait: 'Non fait',
+    fait: 'Faite',
+    enCours: 'Partielle',
+    nonFait: 'Non prise en compte',
   },
 
   mesures: {

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -116,7 +116,7 @@ $(() => {
     const statuts = choixParBoutonsRadios(
       referentielStatutsMesures,
       'statut',
-      'Niveau de mise en œuvre',
+      'Statut de mise en œuvre',
       statut
     );
 

--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -696,8 +696,8 @@ p {
   font-size: 10px;
 }
 
-.synthese-securite .total :is(.contenu, .legende) {
-  flex: 1;
+.synthese-securite .total.conteneur {
+  justify-content: space-between;
 }
 
 .synthese-securite .total .contenu {

--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -42,8 +42,8 @@ mixin totalMesures(totalMesuresGenerales, totalMesuresSpecifiques)
         span .
     .legende
       .legende-faites Faites
-      .legende-en-cours En cours
-      .legende-non-faites Non faites
+      .legende-en-cours Partielles
+      .legende-non-faites Non prises en compte
       .legende-a-remplir À remplir
 
 block page


### PR DESCRIPTION
Afin de correspondre au nouveau statut :point_down: 
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/962f68a1-9e74-43d3-bd9f-fb812aab50d0)

Les valeurs en base restent les mêmes, il s'agit seulement d'une modification cosmétique.