### PR TITLE
[SECURISER] Ajout de la jauge de progression de complétude des mesures

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -174,10 +174,14 @@ main {
   position: relative;
 }
 
+.titre {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .conteneur-indice-cyber {
-  position: absolute;
-  top: 0;
-  right: 0;
   display: flex;
   flex-direction: row;
   gap: 0;

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -174,7 +174,7 @@ main {
   position: relative;
 }
 
-.titre {
+.titre-page {
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -178,7 +178,39 @@ main {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: flex-start;
+}
+
+.conteneur-indicateurs {
+  display: flex;
+  flex-direction: row;
+  gap: 1em;
+}
+
+.jauge-progression-mesures {
+  width: 4.2em;
+  height: 4.2em;
+}
+
+.conteneur-jauge-progression {
+  display: flex;
+  flex-direction: row;
+  gap: 0;
   align-items: center;
+  user-select: none;
+}
+
+.conteneur-jauge-progression .cartouche-progression-mesures {
+  border-radius: 8px;
+  background: #f1f5f9;
+  padding: 8px 12px 8px 60px;
+  color: #08416a;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.conteneur-jauge-progression .jauge-progression-mesures {
+  position: absolute;
 }
 
 .conteneur-indice-cyber {
@@ -205,6 +237,7 @@ main {
   color: #08416a;
   font-weight: bold;
   transform: translateX(12px);
+  white-space: nowrap;
 }
 
 .conteneur-indice-cyber:hover .cartouche-indice-cyber {

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -185,6 +185,8 @@ main {
   display: flex;
   flex-direction: row;
   gap: 1em;
+  position: absolute;
+  right: 0;
 }
 
 .jauge-progression-mesures {

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -84,11 +84,17 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
       const { homologation } = requete;
 
       const mesures = moteurRegles.mesures(homologation.descriptionService);
+      const completude = homologation.completudeMesures();
+      const pourcentageProgression = Math.round(
+        (completude.nombreMesuresCompletes / completude.nombreTotalMesures) *
+          100
+      );
       reponse.render('service/mesures', {
         InformationsHomologation,
         referentiel,
         service: homologation,
         etapeActive: 'mesures',
+        pourcentageProgression,
         mesures,
       });
     }

--- a/src/vues/fragments/jaugeProgressionMesures.pug
+++ b/src/vues/fragments/jaugeProgressionMesures.pug
@@ -1,0 +1,9 @@
+mixin jaugeProgressionMesures(progression)
+  - const taille = 100;
+  svg.jauge-progression-mesures(viewbox=`0 0 ${taille} ${taille}`)
+    - const tailleCercle = taille * 0.7
+    - const perimetreCercle = (2 * Math.PI * (tailleCercle / 2))
+    circle(cx=taille/2 cy=taille/2 r=tailleCercle/2 fill='white' stroke='#DBEEFF' stroke-width=4)
+    circle(cx=taille/2 cy=taille/2 r=tailleCercle/2 fill='none' stroke='#0079D0' stroke-width=6 stroke-linecap='round' transform=`rotate(90 ${taille/2} ${taille/2})` stroke-dasharray=`${progression * perimetreCercle / 100} ${perimetreCercle}`)
+
+    text(x=taille/2 y=taille/2+6 text-anchor='middle' fill='#0C5C98' font-weight='bold' font-size='1.3em')= `${progression} %`

--- a/src/vues/parcoursService.pug
+++ b/src/vues/parcoursService.pug
@@ -32,7 +32,7 @@ block main
       .zone-principale
         block zone-principale
           .formulaire
-            .titre
+            .titre.titre-page
               block titre
             .sous-titre
               block sous-titre

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -3,6 +3,7 @@ include ../fragments/inputChoix
 include ../fragments/cartesInformations
 include ../fragments/texteTronque
 include ../fragments/indiceCyber/scoreIndiceCyber
+include ../fragments/jaugeProgressionMesures
 
 mixin inputMesure({ nom, titre, indispensable, lectureSeule = false })
   +inputChoix({
@@ -24,9 +25,13 @@ block header-titre-page
 
 block titre
   h1 Sécuriser
-  a.conteneur-indice-cyber(href="indiceCyber")
-    .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
-    +scoreIndiceCyber(service.indiceCyber().total, referentiel.indiceCyberNoteMax())
+  .conteneur-indicateurs
+    .conteneur-jauge-progression
+      .cartouche-progression-mesures des mesures renseignées
+      +jaugeProgressionMesures(pourcentageProgression)
+    a.conteneur-indice-cyber(href="indiceCyber")
+      .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
+      +scoreIndiceCyber(service.indiceCyber().total, referentiel.indiceCyberNoteMax())
 
 block sous-titre
   h2 Mettre en oeuvre des mesures de sécurité adaptées


### PR DESCRIPTION
On l'affiche à coté de l'indice cyber en attendant la refonte de la page.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/64293c92-36ed-4387-af29-ce6788df8753)


Cette jauge ne peut pour l'instant pas être animée à cause d'un blocage de l'animation par les CSP.
Ce bug est uniquement présent sur Firefox.

