### PR TITLE
[SECURISER] Ajoute un comportement `hover` et `active` sur le cartouche de l'indice cyber

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -202,3 +202,12 @@ main {
   font-weight: bold;
   transform: translateX(12px);
 }
+
+.conteneur-indice-cyber:hover .cartouche-indice-cyber {
+  background: #dbecf1;
+}
+
+.conteneur-indice-cyber:active .cartouche-indice-cyber {
+  background: #08416a;
+  color: white;
+}


### PR DESCRIPTION
Afin de coller avec le figma :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/38a77ffe-6a28-485d-8e7f-e98643c6f9b1)
