### PR TITLE
[SECURISER] Ajout de mesure spécifique via le tiroir

### DIFF
--- a/public/assets/images/icone_enregistrement_en_cours.svg
+++ b/public/assets/images/icone_enregistrement_en_cours.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.9902 9.48998C15.8102 9.18998 15.5902 8.90998 15.3402 8.65998C13.5002 6.81998 10.5102 6.81998 8.66024 8.65998C7.91024 9.40998 7.48024 10.3601 7.34024 11.3301" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.6602 12.6697C16.5202 13.6497 16.0902 14.5897 15.3402 15.3397C13.5001 17.1797 10.5101 17.1797 8.66013 15.3397C8.40013 15.0797 8.19013 14.7997 8.01013 14.5097" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.1797 6.82023L16.1797 9.49023L13.5097 9.49023" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.82023 17.1797L7.82023 14.5097L10.4902 14.5097" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/images/icone_enregistrement_termine.svg
+++ b/public/assets/images/icone_enregistrement_termine.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.75 11.9999L10.58 14.8299L16.25 9.16992" stroke="#0E972B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/images/logo_mss_petit.svg
+++ b/public/assets/images/logo_mss_petit.svg
@@ -1,0 +1,48 @@
+<svg width="20" height="16" viewBox="0 0 20 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_13108_30876" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="16">
+<path d="M19.0665 9.89068C19.0665 15.1254 17.7932 16 12.4781 16C7.163 16 0 11.537 0 6.30868C0 1.07395 8.56687 0 12.9352 0C18.5311 0 19.0665 6.66881 19.0665 9.89068Z" fill="url(#paint0_linear_13108_30876)"/>
+</mask>
+<g mask="url(#mask0_13108_30876)">
+<path d="M19.0665 9.89068C19.0665 15.1254 17.7932 16 12.4781 16C7.163 16 0 11.537 0 6.30868C0 1.07395 8.56687 0 12.9352 0C18.5311 0 19.0665 6.66881 19.0665 9.89068Z" fill="url(#paint1_linear_13108_30876)"/>
+<path d="M19.9991 15.4514C17.681 21.58 10.7531 24.699 4.53038 22.4096C-1.69235 20.1202 -4.85269 13.3035 -2.53467 7.17486C-0.216655 1.04624 -2.46285 8.35171 3.75989 10.6411C9.98262 12.9241 22.3236 9.31634 19.9991 15.4514Z" fill="url(#paint2_linear_13108_30876)"/>
+<path d="M10.7189 2.26693C10.7189 6.22192 10.6797 9.42449 6.66396 9.42449C2.65477 9.42449 -0.603516 6.21549 -0.603516 2.26693C-0.603516 -1.68805 2.64824 -4.89062 6.66396 -4.89062C10.6797 -4.89062 10.7189 -1.68805 10.7189 2.26693Z" fill="url(#paint3_linear_13108_30876)" fill-opacity="0.2"/>
+<path d="M24.7588 15.1612C23.0742 18.7496 15.6173 25.6692 11.9738 24.0101C8.33029 22.3509 8.39558 9.2062 10.0802 5.61778C11.7649 2.02935 17.5697 5.18691 21.2132 6.84607C24.8568 8.50524 26.4435 11.5728 24.7588 15.1612Z" fill="url(#paint4_linear_13108_30876)"/>
+<path opacity="0.7" d="M8.32534 12.03C7.71808 15.3805 2.96451 15.5349 0.489787 15.0976C-1.99147 14.6603 -2.79461 12.6667 -2.18736 9.31622C-1.5801 5.96574 0.209013 2.53165 2.69027 2.96252C5.165 3.39982 8.93259 8.67956 8.32534 12.03Z" fill="url(#paint5_linear_13108_30876)"/>
+<path opacity="0.7" d="M18.7832 -4.35516C22.1134 -5.26192 24.3073 -1.10757 24.9799 1.27828C25.6589 3.66413 24.1767 5.23969 20.8466 6.15288C17.5165 7.05963 13.5987 6.95673 12.9262 4.57088C12.2536 2.1786 15.4531 -3.44841 18.7832 -4.35516Z" fill="url(#paint6_linear_13108_30876)"/>
+<path d="M12.0218 13.2251C7.64699 15.3216 -4.73318 16.1897 -6.86184 11.8875C-8.9905 7.58522 1.29366 -4.7106 5.66198 -6.80706C10.0368 -8.90352 13.0274 -1.5659 15.1561 2.74278C17.2847 7.04503 16.3967 11.1286 12.0218 13.2251Z" fill="url(#paint7_linear_13108_30876)" fill-opacity="0.1"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_13108_30876" x1="6.41652" y1="-0.657627" x2="13.5538" y2="16.9032" gradientUnits="userSpaceOnUse">
+<stop stop-color="#05DEC6"/>
+<stop offset="1" stop-color="#0245DA"/>
+</linearGradient>
+<linearGradient id="paint1_linear_13108_30876" x1="6.41652" y1="-0.657627" x2="13.5538" y2="16.9032" gradientUnits="userSpaceOnUse">
+<stop stop-color="#05DEC6"/>
+<stop offset="1" stop-color="#0245DA"/>
+</linearGradient>
+<linearGradient id="paint2_linear_13108_30876" x1="11.0975" y1="6.62747" x2="4.30736" y2="20.1441" gradientUnits="userSpaceOnUse">
+<stop stop-color="#05DFC6" stop-opacity="0.2"/>
+<stop offset="1" stop-color="#0145DC"/>
+</linearGradient>
+<linearGradient id="paint3_linear_13108_30876" x1="0.349117" y1="-6.6176" x2="10.7321" y2="10.9157" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint4_linear_13108_30876" x1="14.451" y1="-1.95349" x2="18.0314" y2="19.6152" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1992DC" stop-opacity="0"/>
+<stop offset="1" stop-color="#6C1CB9"/>
+</linearGradient>
+<linearGradient id="paint5_linear_13108_30876" x1="1.2042" y1="2.74788" x2="3.62462" y2="14.6266" gradientUnits="userSpaceOnUse">
+<stop stop-color="#8C1EE5" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#E01F8C" stop-opacity="0.9"/>
+</linearGradient>
+<linearGradient id="paint6_linear_13108_30876" x1="13.3658" y1="5.9803" x2="23.0393" y2="-1.50607" gradientUnits="userSpaceOnUse">
+<stop offset="0.5781" stop-color="#8C1EE5" stop-opacity="0.3"/>
+<stop offset="1" stop-color="#E01F8C" stop-opacity="0.9"/>
+</linearGradient>
+<linearGradient id="paint7_linear_13108_30876" x1="14.238" y1="0.848594" x2="6.29588" y2="4.43023" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -1,14 +1,14 @@
 $(() => {
-  const mesures = JSON.parse($('#donnees-mesures').text());
   const referentielMesuresGenerales = JSON.parse(
     $('#donnees-referentiel-mesures-generales').text()
   );
   const categories = JSON.parse($('#referentiel-categories-mesures').text());
   const statuts = JSON.parse($('#referentiel-statuts-mesures').text());
+  const idService = $('.page-service').data('id-service');
 
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-tableau-mesures', {
-      detail: { mesures, referentielMesuresGenerales, categories, statuts },
+      detail: { referentielMesuresGenerales, categories, statuts, idService },
     })
   );
 });

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -1,14 +1,11 @@
 $(() => {
-  const referentielMesuresGenerales = JSON.parse(
-    $('#donnees-referentiel-mesures-generales').text()
-  );
   const categories = JSON.parse($('#referentiel-categories-mesures').text());
   const statuts = JSON.parse($('#referentiel-statuts-mesures').text());
   const idService = $('.page-service').data('id-service');
 
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-tableau-mesures', {
-      detail: { referentielMesuresGenerales, categories, statuts, idService },
+      detail: { categories, statuts, idService },
     })
   );
 });

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -1,0 +1,14 @@
+$(() => {
+  const mesures = JSON.parse($('#donnees-mesures').text());
+  const referentielMesuresGenerales = JSON.parse(
+    $('#donnees-referentiel-mesures-generales').text()
+  );
+  const categories = JSON.parse($('#referentiel-categories-mesures').text());
+  const statuts = JSON.parse($('#referentiel-statuts-mesures').text());
+
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-recharge-tableau-mesures', {
+      detail: { mesures, referentielMesuresGenerales, categories, statuts },
+    })
+  );
+});

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -1,3 +1,6 @@
+import { gestionnaireTiroir } from '../modules/tableauDeBord/gestionnaireTiroir.mjs';
+import ActionMesure from '../modules/tableauDeBord/actions/ActionMesure.mjs';
+
 $(() => {
   const categories = JSON.parse($('#referentiel-categories-mesures').text());
   const statuts = JSON.parse($('#referentiel-statuts-mesures').text());
@@ -8,4 +11,18 @@ $(() => {
       detail: { categories, statuts, idService },
     })
   );
+
+  const actionMesure = new ActionMesure();
+  $(document.body).on('svelte-affiche-tiroir-ajout-mesure-specifique', (e) => {
+    const { mesuresExistantes } = e.detail;
+    gestionnaireTiroir.afficheContenuAction(
+      { action: actionMesure },
+      {
+        idService,
+        categories,
+        statuts,
+        mesuresExistantes,
+      }
+    );
+  });
 });

--- a/src/modeles/objetsApi/objetGetMesures.js
+++ b/src/modeles/objetsApi/objetGetMesures.js
@@ -1,0 +1,24 @@
+const donnees = (service, moteurRegles) => {
+  const { mesuresGenerales, mesuresSpecifiques } = service.mesures.toJSON();
+
+  const mesuresPersonnalisees = Object.entries(
+    moteurRegles.mesures(service.descriptionService)
+  ).reduce((acc, [idMesure, donneesMesure]) => {
+    const mesure = mesuresGenerales.find((m) => m.id === idMesure);
+    if (mesure) delete mesure.id;
+    return {
+      ...acc,
+      [idMesure]: {
+        ...donneesMesure,
+        ...(mesure && { ...mesure }),
+      },
+    };
+  }, {});
+
+  return {
+    mesuresGenerales: mesuresPersonnalisees,
+    mesuresSpecifiques,
+  };
+};
+
+module.exports = { donnees };

--- a/src/mss.js
+++ b/src/mss.js
@@ -217,6 +217,7 @@ const creeServeur = (
       adaptateurZip,
       procedures,
       serviceAnnuaire,
+      moteurRegles,
     })
   );
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -37,6 +37,7 @@ const routesApiPrivee = ({
   adaptateurZip,
   procedures,
   serviceAnnuaire,
+  moteurRegles,
 }) => {
   const routes = express.Router();
 
@@ -135,6 +136,7 @@ const routesApiPrivee = ({
       adaptateurHorloge,
       adaptateurPdf,
       adaptateurZip,
+      moteurRegles,
     })
   );
 

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -30,6 +30,7 @@ const {
   Rubriques,
   verifieCoherenceDesDroits,
 } = require('../../modeles/autorisations/gestionDroits');
+const objetGetMesures = require('../../modeles/objetsApi/objetGetMesures');
 
 const { ECRITURE, LECTURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
@@ -156,24 +157,8 @@ const routesApiService = ({
     middleware.trouveService({ [SECURISER]: LECTURE }),
     (requete, reponse) => {
       const { homologation: service } = requete;
-      const { mesuresGenerales, mesuresSpecifiques } = service.mesures.toJSON();
 
-      const mesuresPersonnalisees = Object.entries(
-        moteurRegles.mesures(service.descriptionService)
-      ).reduce((acc, [idMesure, donneesMesure]) => {
-        const mesure = mesuresGenerales.find((m) => m.id === idMesure);
-        return {
-          ...acc,
-          [idMesure]: {
-            ...donneesMesure,
-            ...(mesure && { ...mesure, id: undefined }),
-          },
-        };
-      }, {});
-      reponse.json({
-        mesuresGenerales: mesuresPersonnalisees,
-        mesuresSpecifiques,
-      });
+      reponse.json(objetGetMesures.donnees(service, moteurRegles));
     }
   );
 

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -83,12 +83,26 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
     async (requete, reponse) => {
       const { homologation } = requete;
 
+      const { v } = requete.query;
+
       const mesures = moteurRegles.mesures(homologation.descriptionService);
       const completude = homologation.completudeMesures();
       const pourcentageProgression = Math.round(
         (completude.nombreMesuresCompletes / completude.nombreTotalMesures) *
           100
       );
+      if (v === '2') {
+        reponse.render('service/mesures-v2', {
+          InformationsHomologation,
+          referentiel,
+          service: homologation,
+          etapeActive: 'mesures',
+          pourcentageProgression,
+          mesures,
+        });
+        return;
+      }
+
       reponse.render('service/mesures', {
         InformationsHomologation,
         referentiel,

--- a/src/vues/service/mesures-v2.pug
+++ b/src/vues/service/mesures-v2.pug
@@ -12,8 +12,6 @@ block append scripts
   script(type = 'module', src = '/statique/composants-svelte/mesure.js')
   script(type = 'module', src = '/statique/composants-svelte/tableauDesMesures.js')
   script(type = 'module', src = '/statique/service/mesures-v2.js')
-  script(id = 'donnees-referentiel-mesures-generales', type = 'application/json').
-    !{JSON.stringify(mesures || {})}
   script(id = 'referentiel-categories-mesures', type = 'application/json').
     !{JSON.stringify(referentiel.categoriesMesures())}
   script(id = 'referentiel-statuts-mesures', type = 'application/json').

--- a/src/vues/service/mesures-v2.pug
+++ b/src/vues/service/mesures-v2.pug
@@ -12,8 +12,6 @@ block append scripts
   script(type = 'module', src = '/statique/composants-svelte/mesure.js')
   script(type = 'module', src = '/statique/composants-svelte/tableauDesMesures.js')
   script(type = 'module', src = '/statique/service/mesures-v2.js')
-  script(id = 'donnees-mesures', type = 'application/json').
-    !{JSON.stringify(service.mesures.toJSON() || {})}
   script(id = 'donnees-referentiel-mesures-generales', type = 'application/json').
     !{JSON.stringify(mesures || {})}
   script(id = 'referentiel-categories-mesures', type = 'application/json').

--- a/src/vues/service/mesures-v2.pug
+++ b/src/vues/service/mesures-v2.pug
@@ -1,0 +1,43 @@
+extends ../parcoursService
+include ../fragments/texteTronque
+include ../fragments/indiceCyber/scoreIndiceCyber
+include ../fragments/jaugeProgressionMesures
+
+block append styles
+  link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
+  link(href = '/statique/composants-svelte/mesure.css', rel = 'stylesheet')
+  link(href = '/statique/composants-svelte/tableauDesMesures.css', rel = 'stylesheet')
+
+block append scripts
+  script(type = 'module', src = '/statique/composants-svelte/mesure.js')
+  script(type = 'module', src = '/statique/composants-svelte/tableauDesMesures.js')
+  script(type = 'module', src = '/statique/service/mesures-v2.js')
+  script(id = 'donnees-mesures', type = 'application/json').
+    !{JSON.stringify(service.mesures.toJSON() || {})}
+  script(id = 'donnees-referentiel-mesures-generales', type = 'application/json').
+    !{JSON.stringify(mesures || {})}
+  script(id = 'referentiel-categories-mesures', type = 'application/json').
+    !{JSON.stringify(referentiel.categoriesMesures())}
+  script(id = 'referentiel-statuts-mesures', type = 'application/json').
+    !{JSON.stringify(referentiel.statutsMesures())}
+
+block header-titre-page
+  h3
+    +texteTronque({texte: service.nomService() || ''})
+
+block titre
+  h1 Sécuriser
+  .conteneur-indicateurs
+    .conteneur-jauge-progression
+      .cartouche-progression-mesures des mesures renseignées
+      +jaugeProgressionMesures(pourcentageProgression)
+    a.conteneur-indice-cyber(href="indiceCyber")
+      .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
+      +scoreIndiceCyber(service.indiceCyber().total, referentiel.indiceCyberNoteMax())
+
+block sous-titre
+  h2 Mettre en oeuvre des mesures de sécurité adaptées
+
+block formulaire
+  - const estLectureSeule  = autorisationsService.SECURISER.estLectureSeule
+  #tableau-des-mesures

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { Mesures } from './tableauDesMesures.d';
   import LigneMesure from './ligne/LigneMesure.svelte';
-  import { recupereMesures, enregistreMesures } from './tableauDesMesures.api';
+  import {
+    recupereMesures,
+    enregistreMesures,
+    metEnFormeMesures,
+  } from './tableauDesMesures.api';
   import { onMount } from 'svelte';
 
   export let idService: string;
@@ -24,9 +28,18 @@
     if (!etatEnregistrement.premierEnregistrementFait)
       etatEnregistrement.premierEnregistrementFait = true;
   };
+
+  const ajouteMesureSpecifique = () => {
+    document.body.dispatchEvent(
+      new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
+        detail: { mesuresExistantes: metEnFormeMesures(mesures) },
+      })
+    );
+  };
 </script>
 
 <div class="barre-actions">
+  <button class="bouton" on:click={ajouteMesureSpecifique}>Ajouter</button>
   {#if etatEnregistrement.enCours}
     <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
   {/if}
@@ -65,7 +78,8 @@
 <style>
   .barre-actions {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
+    gap: 1em;
     padding: 1em 0;
   }
 
@@ -113,5 +127,10 @@
 
   .enregistrement-termine:before {
     background-image: url('/statique/assets/images/icone_enregistrement_termine.svg');
+  }
+
+  .bouton {
+    margin: 0;
+    padding: 0.5em 2em;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -4,34 +4,43 @@
     ReferentielMesuresGenerales,
   } from './tableauDesMesures.d';
   import LigneMesure from './ligne/LigneMesure.svelte';
+  import { recupereMesures } from './tableauDesMesures.api';
+  import { onMount } from 'svelte';
 
-  export let mesures: Mesures;
   export let referentielMesuresGenerales: ReferentielMesuresGenerales;
+  export let idService: string;
   export let categories: Record<string, string>;
   export let statuts: Record<string, string>;
+
+  let mesures: Mesures;
+  onMount(async () => {
+    mesures = await recupereMesures(idService);
+  });
 </script>
 
 <div class="tableau-des-mesures">
-  {#each mesures.mesuresGenerales as mesure (mesure.id)}
-    {@const donneesMesure = referentielMesuresGenerales[mesure.id]}
-    {@const labelReferentiel = donneesMesure.indispensable
-      ? 'Indispensable'
-      : 'Recommandé'}
-    <LigneMesure
-      referentiel={{ label: labelReferentiel, classe: 'mss' }}
-      nom={donneesMesure.description}
-      categorie={categories[donneesMesure.categorie]}
-      idStatut={mesure.statut}
-      referentielStatuts={statuts}
-    />
-  {/each}
-  {#each mesures.mesuresSpecifiques as mesure, index (index)}
-    <LigneMesure
-      referentiel={{ label: 'Nouvelle' }}
-      nom={mesure.description}
-      categorie={categories[mesure.categorie]}
-      idStatut={mesure.statut}
-      referentielStatuts={statuts}
-    />
-  {/each}
+  {#if mesures}
+    {#each Object.entries(mesures.mesuresGenerales) as [id, mesure] (id)}
+      {@const donneesMesure = referentielMesuresGenerales[id]}
+      {@const labelReferentiel = donneesMesure.indispensable
+        ? 'Indispensable'
+        : 'Recommandé'}
+      <LigneMesure
+        referentiel={{ label: labelReferentiel, classe: 'mss' }}
+        nom={donneesMesure.description}
+        categorie={categories[donneesMesure.categorie]}
+        idStatut={mesure.statut}
+        referentielStatuts={statuts}
+      />
+    {/each}
+    {#each mesures.mesuresSpecifiques as mesure, index (index)}
+      <LigneMesure
+        referentiel={{ label: 'Nouvelle' }}
+        nom={mesure.description}
+        categorie={categories[mesure.categorie]}
+        idStatut={mesure.statut}
+        referentielStatuts={statuts}
+      />
+    {/each}
+  {/if}
 </div>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-  import type {
-    Mesures,
-    ReferentielMesuresGenerales,
-  } from './tableauDesMesures.d';
+  import type { Mesures, MesuresDTO } from './tableauDesMesures.d';
   import LigneMesure from './ligne/LigneMesure.svelte';
-  import { recupereMesures } from './tableauDesMesures.api';
+  import { recupereMesures, enregistreMesures } from './tableauDesMesures.api';
   import { onMount } from 'svelte';
 
-  export let referentielMesuresGenerales: ReferentielMesuresGenerales;
   export let idService: string;
   export let categories: Record<string, string>;
   export let statuts: Record<string, string>;
@@ -16,21 +12,25 @@
   onMount(async () => {
     mesures = await recupereMesures(idService);
   });
+
+  const metAJourMesures = async () => {
+    await enregistreMesures(idService, mesures);
+  };
 </script>
 
 <div class="tableau-des-mesures">
   {#if mesures}
     {#each Object.entries(mesures.mesuresGenerales) as [id, mesure] (id)}
-      {@const donneesMesure = referentielMesuresGenerales[id]}
-      {@const labelReferentiel = donneesMesure.indispensable
+      {@const labelReferentiel = mesure.indispensable
         ? 'Indispensable'
         : 'Recommandé'}
       <LigneMesure
         referentiel={{ label: labelReferentiel, classe: 'mss' }}
-        nom={donneesMesure.description}
-        categorie={categories[donneesMesure.categorie]}
-        idStatut={mesure.statut}
+        nom={mesure.description}
+        categorie={categories[mesure.categorie]}
         referentielStatuts={statuts}
+        bind:mesure
+        on:modificationStatut={metAJourMesures}
       />
     {/each}
     {#each mesures.mesuresSpecifiques as mesure, index (index)}
@@ -38,8 +38,9 @@
         referentiel={{ label: 'Nouvelle' }}
         nom={mesure.description}
         categorie={categories[mesure.categorie]}
-        idStatut={mesure.statut}
         referentielStatuts={statuts}
+        bind:mesure
+        on:modificationStatut={metAJourMesures}
       />
     {/each}
   {/if}

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Mesures, MesuresDTO } from './tableauDesMesures.d';
+  import type { Mesures } from './tableauDesMesures.d';
   import LigneMesure from './ligne/LigneMesure.svelte';
   import { recupereMesures, enregistreMesures } from './tableauDesMesures.api';
   import { onMount } from 'svelte';
@@ -13,11 +13,27 @@
     mesures = await recupereMesures(idService);
   });
 
+  let etatEnregistrement = {
+    enCours: false,
+    premierEnregistrementFait: false,
+  };
   const metAJourMesures = async () => {
+    etatEnregistrement.enCours = true;
     await enregistreMesures(idService, mesures);
+    etatEnregistrement.enCours = false;
+    if (!etatEnregistrement.premierEnregistrementFait)
+      etatEnregistrement.premierEnregistrementFait = true;
   };
 </script>
 
+<div class="barre-actions">
+  {#if etatEnregistrement.enCours}
+    <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
+  {/if}
+  {#if !etatEnregistrement.enCours && etatEnregistrement.premierEnregistrementFait}
+    <p class="enregistrement-termine">Enregistré</p>
+  {/if}
+</div>
 <div class="tableau-des-mesures">
   {#if mesures}
     {#each Object.entries(mesures.mesuresGenerales) as [id, mesure] (id)}
@@ -45,3 +61,57 @@
     {/each}
   {/if}
 </div>
+
+<style>
+  .barre-actions {
+    display: flex;
+    align-items: flex-start;
+    padding: 1em 0;
+  }
+
+  .barre-actions p {
+    margin: 0;
+  }
+
+  .enregistrement-en-cours,
+  .enregistrement-termine {
+    font-size: 1.1em;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .enregistrement-en-cours:before,
+  .enregistrement-termine:before {
+    content: '';
+    display: flex;
+    width: 24px;
+    height: 24px;
+    background-size: contain;
+    background-repeat: no-repeat;
+  }
+
+  .enregistrement-en-cours {
+    color: #0c5c98;
+  }
+
+  .enregistrement-termine {
+    color: #0e972b;
+  }
+
+  .enregistrement-en-cours:before {
+    background-image: url('/statique/assets/images/icone_enregistrement_en_cours.svg');
+    animation: rotation 1s linear infinite;
+  }
+
+  @keyframes rotation {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  .enregistrement-termine:before {
+    background-image: url('/statique/assets/images/icone_enregistrement_termine.svg');
+  }
+</style>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type {
+    Mesures,
+    ReferentielMesuresGenerales,
+  } from './tableauDesMesures.d';
+  import LigneMesure from './ligne/LigneMesure.svelte';
+
+  export let mesures: Mesures;
+  export let referentielMesuresGenerales: ReferentielMesuresGenerales;
+  export let categories: Record<string, string>;
+  export let statuts: Record<string, string>;
+</script>
+
+<div class="tableau-des-mesures">
+  {#each mesures.mesuresGenerales as mesure (mesure.id)}
+    {@const donneesMesure = referentielMesuresGenerales[mesure.id]}
+    {@const labelReferentiel = donneesMesure.indispensable
+      ? 'Indispensable'
+      : 'Recommandé'}
+    <LigneMesure
+      referentiel={{ label: labelReferentiel, classe: 'mss' }}
+      nom={donneesMesure.description}
+      categorie={categories[donneesMesure.categorie]}
+      idStatut={mesure.statut}
+      referentielStatuts={statuts}
+    />
+  {/each}
+  {#each mesures.mesuresSpecifiques as mesure, index (index)}
+    <LigneMesure
+      referentiel={{ label: 'Nouvelle' }}
+      nom={mesure.description}
+      categorie={categories[mesure.categorie]}
+      idStatut={mesure.statut}
+      referentielStatuts={statuts}
+    />
+  {/each}
+</div>

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  export let referentiel: { label: string; classe?: string };
+  export let nom: string;
+  export let categorie: string;
+  export let idStatut: string;
+  export let referentielStatuts: Record<string, string>;
+</script>
+
+<div class="ligne-de-mesure">
+  <span class={referentiel.classe}>{referentiel.label}</span>
+  <div class="titre-mesure">
+    <p class="titre">{nom}</p>
+    <span class="categorie">{categorie}</span>
+  </div>
+  <label for="statut">
+    <select bind:value={idStatut} id="statut" class="intouche" required>
+      <option value="" disabled selected>--</option>
+      {#each Object.entries(referentielStatuts) as [valeur, label]}
+        <option value={valeur}>{label}</option>
+      {/each}
+    </select>
+  </label>
+</div>
+
+<style>
+  .ligne-de-mesure {
+    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    padding: 20px 16px;
+    gap: 56px;
+    margin-bottom: 8px;
+    display: grid;
+    grid-template-columns: 2fr 6fr 3fr;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  span {
+    color: #08416a;
+    background: #f1f5f9;
+    border-radius: 40px;
+    padding: 4px 10px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: fit-content;
+  }
+
+  span.mss:before {
+    content: '';
+    display: flex;
+    background-image: url('/statique/assets/images/logo_mss_petit.svg');
+    background-repeat: no-repeat;
+    background-size: contain;
+    width: 19px;
+    height: 16px;
+    margin-right: 6px;
+  }
+
+  .titre-mesure {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .titre-mesure p {
+    margin: 0;
+  }
+
+  .titre {
+    font-weight: 500;
+    text-align: left;
+  }
+
+  .categorie {
+    color: #667892;
+    font-size: 0.9em;
+    font-weight: 500;
+  }
+
+  select {
+    appearance: auto;
+  }
+</style>

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import type {
+    MesureGenerale,
+    MesureSpecifique,
+  } from '../tableauDesMesures.d';
+
   export let referentiel: { label: string; classe?: string };
+  export let mesure: MesureSpecifique | MesureGenerale;
   export let nom: string;
   export let categorie: string;
-  export let idStatut: string;
   export let referentielStatuts: Record<string, string>;
+
+  const dispatch = createEventDispatcher<{ modificationStatut: null }>();
 </script>
 
 <div class="ligne-de-mesure">
@@ -13,7 +21,13 @@
     <span class="categorie">{categorie}</span>
   </div>
   <label for="statut">
-    <select bind:value={idStatut} id="statut" class="intouche" required>
+    <select
+      bind:value={mesure.statut}
+      id="statut"
+      class="intouche"
+      required
+      on:change={() => dispatch('modificationStatut')}
+    >
       <option value="" disabled selected>--</option>
       {#each Object.entries(referentielStatuts) as [valeur, label]}
         <option value={valeur}>{label}</option>

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
@@ -1,6 +1,31 @@
-import type { Mesures } from './tableauDesMesures.d';
+import type { MesureGeneraleDTO, Mesures } from './tableauDesMesures.d';
 
 export const recupereMesures = async (idService: string) => {
   const reponse = await axios.get(`/api/service/${idService}/mesures`);
   return reponse.data as Mesures;
+};
+
+export const enregistreMesures = async (
+  idService: string,
+  mesures: Mesures
+) => {
+  const mesuresGenerales: Record<string, MesureGeneraleDTO> = Object.entries(
+    mesures.mesuresGenerales
+  )
+    .filter(([id, mesure]) => mesure.statut)
+    .reduce(
+      (acc, [id, m]) => ({
+        ...acc,
+        [id]: {
+          statut: m.statut,
+          ...(m.modalites && { modalites: m.modalites }),
+        },
+      }),
+      {}
+    );
+
+  await axios.post(`/api/service/${idService}/mesures`, {
+    mesuresGenerales,
+    mesuresSpecifiques: mesures.mesuresSpecifiques,
+  });
 };

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
@@ -1,0 +1,6 @@
+import type { Mesures } from './tableauDesMesures.d';
+
+export const recupereMesures = async (idService: string) => {
+  const reponse = await axios.get(`/api/service/${idService}/mesures`);
+  return reponse.data as Mesures;
+};

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
@@ -5,10 +5,7 @@ export const recupereMesures = async (idService: string) => {
   return reponse.data as Mesures;
 };
 
-export const enregistreMesures = async (
-  idService: string,
-  mesures: Mesures
-) => {
+export const metEnFormeMesures = (mesures: Mesures) => {
   const mesuresGenerales: Record<string, MesureGeneraleDTO> = Object.entries(
     mesures.mesuresGenerales
   )
@@ -23,9 +20,18 @@ export const enregistreMesures = async (
       }),
       {}
     );
-
-  await axios.post(`/api/service/${idService}/mesures`, {
+  return {
     mesuresGenerales,
     mesuresSpecifiques: mesures.mesuresSpecifiques,
-  });
+  };
+};
+
+export const enregistreMesures = async (
+  idService: string,
+  mesures: Mesures
+) => {
+  await axios.post(
+    `/api/service/${idService}/mesures`,
+    metEnFormeMesures(mesures)
+  );
 };

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -5,8 +5,10 @@ declare global {
 }
 
 export type TableauDesMesuresProps = {
-  mesures: Mesures;
   referentielMesuresGenerales: ReferentielMesuresGenerales;
+  idService: string;
+  categories: Record<string, string>;
+  statuts: Record<string, string>;
 };
 
 export type ReferentielMesuresGenerales = Record<
@@ -20,17 +22,16 @@ export type ReferentielMesuresGenerales = Record<
 >;
 
 export type MesureGenerale = {
-  id: string;
   statut: string;
   modalites?: string;
 };
 
-export type MesureSpecifique = Omit<MesureGenerale, 'id'> & {
+export type MesureSpecifique = MesureGenerale & {
   categorie: string;
   description: string;
 };
 
 export type Mesures = {
-  mesuresGenerales: MesureGenerale[];
+  mesuresGenerales: Record<string, MesureGenerale>;
   mesuresSpecifiques: MesureSpecifique[];
 };

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -5,33 +5,33 @@ declare global {
 }
 
 export type TableauDesMesuresProps = {
-  referentielMesuresGenerales: ReferentielMesuresGenerales;
   idService: string;
   categories: Record<string, string>;
   statuts: Record<string, string>;
 };
 
-export type ReferentielMesuresGenerales = Record<
-  string,
-  {
-    description: string;
-    categorie: string;
-    indispensable: boolean;
-    descriptionLongue: string;
-  }
->;
-
 export type MesureGenerale = {
-  statut: string;
+  description: string;
+  categorie: string;
+  indispensable: boolean;
+  descriptionLongue: string;
+  statut?: string;
   modalites?: string;
 };
 
-export type MesureSpecifique = MesureGenerale & {
+export type MesureSpecifique = {
   categorie: string;
   description: string;
+  statut: string;
+  modalites: string;
 };
 
 export type Mesures = {
   mesuresGenerales: Record<string, MesureGenerale>;
   mesuresSpecifiques: MesureSpecifique[];
+};
+
+export type MesureGeneraleDTO = {
+  statut: string;
+  modalites?: string;
 };

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -1,0 +1,36 @@
+declare global {
+  interface HTMLElementEventMap {
+    'svelte-recharge-tableau-mesures': CustomEvent;
+  }
+}
+
+export type TableauDesMesuresProps = {
+  mesures: Mesures;
+  referentielMesuresGenerales: ReferentielMesuresGenerales;
+};
+
+export type ReferentielMesuresGenerales = Record<
+  string,
+  {
+    description: string;
+    categorie: string;
+    indispensable: boolean;
+    descriptionLongue: string;
+  }
+>;
+
+export type MesureGenerale = {
+  id: string;
+  statut: string;
+  modalites?: string;
+};
+
+export type MesureSpecifique = Omit<MesureGenerale, 'id'> & {
+  categorie: string;
+  description: string;
+};
+
+export type Mesures = {
+  mesuresGenerales: MesureGenerale[];
+  mesuresSpecifiques: MesureSpecifique[];
+};

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.ts
@@ -1,0 +1,19 @@
+import TableauDesMesures from './TableauDesMesures.svelte';
+import type { TableauDesMesuresProps } from './tableauDesMesures.d';
+
+document.body.addEventListener(
+  'svelte-recharge-tableau-mesures',
+  (e: CustomEvent<TableauDesMesuresProps>) => rechargeApp({ ...e.detail })
+);
+
+let app: TableauDesMesures;
+
+const rechargeApp = (props: TableauDesMesuresProps) => {
+  app?.$destroy();
+  app = new TableauDesMesures({
+    target: document.getElementById('tableau-des-mesures')!,
+    props,
+  });
+};
+
+export default app!;

--- a/test/modeles/objetsApi/objetGetMesures.spec.js
+++ b/test/modeles/objetsApi/objetGetMesures.spec.js
@@ -1,0 +1,99 @@
+const expect = require('expect.js');
+const objetGetMesures = require('../../../src/modeles/objetsApi/objetGetMesures');
+const { unService } = require('../../constructeurs/constructeurService');
+const Mesures = require('../../../src/modeles/mesures');
+const referentiel = require('../../../src/referentiel');
+
+describe("L'objet d'API de `GET /mesures`", () => {
+  it('interroge le moteur de règles pour obtenir les mesures personnalisées', async () => {
+    let descriptionRecue;
+
+    const moteurRegles = {
+      mesures: (descriptionService) => {
+        descriptionRecue = descriptionService;
+        return {};
+      },
+    };
+
+    objetGetMesures.donnees(
+      unService().avecNomService('un service').construis(),
+      moteurRegles
+    );
+
+    expect(descriptionRecue.nomService).to.equal('un service');
+  });
+
+  it('associe les statuts et commentaires des mesures générales du service aux mesures personnalisées', async () => {
+    const service = unService()
+      .avecMesures(
+        new Mesures(
+          {
+            mesuresGenerales: [
+              {
+                id: 'mesureA',
+                statut: 'fait',
+                modalites: 'un commentaire',
+              },
+            ],
+          },
+          referentiel.creeReferentiel({ mesures: { mesureA: {} } })
+        )
+      )
+      .construis();
+
+    const moteurRegles = {
+      mesures: () => ({
+        mesureA: { description: 'Mesure A' },
+      }),
+    };
+
+    const resultat = objetGetMesures.donnees(service, moteurRegles);
+
+    expect(resultat.mesuresGenerales.mesureA).to.eql({
+      description: 'Mesure A',
+      statut: 'fait',
+      modalites: 'un commentaire',
+    });
+  });
+
+  it('ne pollue pas les mesures personnalisée avec des mesures inexistantes sur le service (undefined)', async () => {
+    const service = unService()
+      .avecMesures(
+        new Mesures({
+          mesuresGenerales: [],
+        })
+      )
+      .construis();
+
+    const moteurRegles = {
+      mesures: () => ({
+        mesureA: { description: 'Mesure A' },
+      }),
+    };
+
+    const resultat = objetGetMesures.donnees(service, moteurRegles);
+
+    expect(resultat.mesuresGenerales.mesureA).to.eql({
+      description: 'Mesure A',
+    });
+  });
+
+  it('fait passe plat sur les mesures spécifiques du service', async () => {
+    const service = unService()
+      .avecMesures(
+        new Mesures({
+          mesuresGenerales: [],
+          mesuresSpecifiques: [{ description: 'une mesure' }],
+        })
+      )
+      .construis();
+
+    const moteurRegles = {
+      mesures: () => ({}),
+    };
+
+    const resultat = objetGetMesures.donnees(service, moteurRegles);
+
+    expect(resultat.mesuresSpecifiques).to.eql([{ description: 'une mesure' }]);
+  });
+});

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -306,20 +306,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it('interroge le moteur de règles pour obtenir les mesures personnalisées', async () => {
-      let descriptionRecue;
-
-      testeur.moteurRegles().mesures = (descriptionService) => {
-        descriptionRecue = descriptionService;
-        return {};
-      };
-
-      await axios('http://localhost:1234/api/service/456/mesures');
-
-      expect(descriptionRecue.nomService).to.equal('un service');
-    });
-
-    it('associe les statuts et commentaires des mesures générales du service aux mesures personnalisées', async () => {
+    it('retourne la représenation des mesures en utilisant `objetGetMesures`', async () => {
       testeur.middleware().reinitialise({
         homologationARenvoyer: unService()
           .avecMesures(
@@ -347,56 +334,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'http://localhost:1234/api/service/456/mesures'
       );
 
-      expect(reponse.data.mesuresGenerales.mesureA).to.eql({
-        description: 'Mesure A',
-        statut: 'fait',
-        modalites: 'un commentaire',
+      expect(reponse.data).to.eql({
+        mesuresGenerales: {
+          mesureA: {
+            description: 'Mesure A',
+            statut: 'fait',
+            modalites: 'un commentaire',
+          },
+        },
+        mesuresSpecifiques: [],
       });
-    });
-
-    it('ne pollue pas les mesures personnalisée avec des mesures inexistantes sur le service (undefined)', async () => {
-      testeur.middleware().reinitialise({
-        homologationARenvoyer: unService()
-          .avecMesures(
-            new Mesures({
-              mesuresGenerales: [],
-            })
-          )
-          .construis(),
-      });
-
-      testeur.moteurRegles().mesures = () => ({
-        mesureA: { description: 'Mesure A' },
-      });
-
-      const reponse = await axios(
-        'http://localhost:1234/api/service/456/mesures'
-      );
-
-      expect(reponse.data.mesuresGenerales.mesureA).to.eql({
-        description: 'Mesure A',
-      });
-    });
-
-    it('fait passe plat sur les mesures spécifiques du service', async () => {
-      testeur.middleware().reinitialise({
-        homologationARenvoyer: unService()
-          .avecMesures(
-            new Mesures({
-              mesuresGenerales: [],
-              mesuresSpecifiques: [{ description: 'une mesure' }],
-            })
-          )
-          .construis(),
-      });
-
-      const reponse = await axios(
-        'http://localhost:1234/api/service/456/mesures'
-      );
-
-      expect(reponse.data.mesuresSpecifiques).to.eql([
-        { description: 'une mesure' },
-      ]);
     });
   });
 

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -23,6 +23,8 @@ const Autorisation = require('../../../src/modeles/autorisations/autorisation');
 const {
   unUtilisateur,
 } = require('../../constructeurs/constructeurUtilisateur');
+const Mesures = require('../../../src/modeles/mesures');
+const referentiel = require('../../../src/referentiel');
 
 const { ECRITURE, LECTURE } = Permissions;
 const { RISQUES, DECRIRE, SECURISER, CONTACTS, HOMOLOGUER } = Rubriques;
@@ -289,6 +291,112 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         },
         done
       );
+    });
+  });
+
+  describe('quand requête GET sur `/api/service/:id/mesures', () => {
+    it('recherche le service correspondant', (done) => {
+      testeur.middleware().verifieRechercheService(
+        [{ niveau: LECTURE, rubrique: SECURISER }],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/service/456/mesures',
+        },
+        done
+      );
+    });
+
+    it('interroge le moteur de règles pour obtenir les mesures personnalisées', async () => {
+      let descriptionRecue;
+
+      testeur.moteurRegles().mesures = (descriptionService) => {
+        descriptionRecue = descriptionService;
+        return {};
+      };
+
+      await axios('http://localhost:1234/api/service/456/mesures');
+
+      expect(descriptionRecue.nomService).to.equal('un service');
+    });
+
+    it('associe les statuts et commentaires des mesures générales du service aux mesures personnalisées', async () => {
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: unService()
+          .avecMesures(
+            new Mesures(
+              {
+                mesuresGenerales: [
+                  {
+                    id: 'mesureA',
+                    statut: 'fait',
+                    modalites: 'un commentaire',
+                  },
+                ],
+              },
+              referentiel.creeReferentiel({ mesures: { mesureA: {} } })
+            )
+          )
+          .construis(),
+      });
+
+      testeur.moteurRegles().mesures = () => ({
+        mesureA: { description: 'Mesure A' },
+      });
+
+      const reponse = await axios(
+        'http://localhost:1234/api/service/456/mesures'
+      );
+
+      expect(reponse.data.mesuresGenerales.mesureA).to.eql({
+        description: 'Mesure A',
+        statut: 'fait',
+        modalites: 'un commentaire',
+      });
+    });
+
+    it('ne pollue pas les mesures personnalisée avec des mesures inexistantes sur le service (undefined)', async () => {
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: unService()
+          .avecMesures(
+            new Mesures({
+              mesuresGenerales: [],
+            })
+          )
+          .construis(),
+      });
+
+      testeur.moteurRegles().mesures = () => ({
+        mesureA: { description: 'Mesure A' },
+      });
+
+      const reponse = await axios(
+        'http://localhost:1234/api/service/456/mesures'
+      );
+
+      expect(reponse.data.mesuresGenerales.mesureA).to.eql({
+        description: 'Mesure A',
+      });
+    });
+
+    it('fait passe plat sur les mesures spécifiques du service', async () => {
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: unService()
+          .avecMesures(
+            new Mesures({
+              mesuresGenerales: [],
+              mesuresSpecifiques: [{ description: 'une mesure' }],
+            })
+          )
+          .construis(),
+      });
+
+      const reponse = await axios(
+        'http://localhost:1234/api/service/456/mesures'
+      );
+
+      expect(reponse.data.mesuresSpecifiques).to.eql([
+        { description: 'une mesure' },
+      ]);
     });
   });
 


### PR DESCRIPTION
### Cette PR dépend de #1214 

On peut désormais ajouter une mesure spécifique via un bouton "Ajouter" présent au dessus du tableau des mesures.
Ce bouton déclenche l'affichage du tiroir de mesure :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/9b1cb1c2-f317-43dd-b9ae-de2444706ec1)

Pour l'instant, on est obligé de "window.location.reload()" la page pour ne pas casser le fonctionnement existant sur l'ancienne page des mesures.
À l'avenir, on pourra imaginer fermer le tiroir et rafraichir le tableau en utilisant des `events` sur le `document.body`