### PR TITLE
Augmente la taille de la jauge de progression

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -205,7 +205,7 @@ main {
 .conteneur-jauge-progression .cartouche-progression-mesures {
   border-radius: 8px;
   background: #f1f5f9;
-  padding: 8px 12px 8px 60px;
+  padding: 8px 12px 8px 68px;
   color: #08416a;
   font-weight: 500;
   white-space: nowrap;
@@ -213,6 +213,7 @@ main {
 
 .conteneur-jauge-progression .jauge-progression-mesures {
   position: absolute;
+  left: 5px;
 }
 
 .conteneur-indice-cyber {

--- a/src/vues/fragments/jaugeProgressionMesures.pug
+++ b/src/vues/fragments/jaugeProgressionMesures.pug
@@ -1,9 +1,9 @@
 mixin jaugeProgressionMesures(progression)
   - const taille = 100;
   svg.jauge-progression-mesures(viewbox=`0 0 ${taille} ${taille}`)
-    - const tailleCercle = taille * 0.7
+    - const tailleCercle = taille * 0.85
     - const perimetreCercle = (2 * Math.PI * (tailleCercle / 2))
     circle(cx=taille/2 cy=taille/2 r=tailleCercle/2 fill='white' stroke='#DBEEFF' stroke-width=4)
     circle(cx=taille/2 cy=taille/2 r=tailleCercle/2 fill='none' stroke='#0079D0' stroke-width=6 stroke-linecap='round' transform=`rotate(90 ${taille/2} ${taille/2})` stroke-dasharray=`${progression * perimetreCercle / 100} ${perimetreCercle}`)
 
-    text(x=taille/2 y=taille/2+6 text-anchor='middle' fill='#0C5C98' font-weight='bold' font-size='1.3em')= `${progression} %`
+    text(x=taille/2 y=taille/2+8 text-anchor='middle' fill='#0C5C98' font-weight='bold' font-size=`${taille*0.22}px`)= `${progression} %`


### PR DESCRIPTION
Pour que le texte du pourcentage soit de la même taille que le corps de texte à côté

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/cc3bd70c-c6df-45be-88dc-0bdadbd9deed)
