### PR TITLE
[SECURISER] Ajout de mesure spécifique via le tiroir

### DIFF
--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -22,6 +22,7 @@
   background: #dbecf1;
   text-align: left;
   padding: 0 2em;
+  overflow: hidden;
 }
 
 .entete-tiroir .image-entete {

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -1,3 +1,6 @@
+import { gestionnaireTiroir } from '../modules/tableauDeBord/gestionnaireTiroir.mjs';
+import ActionMesure from '../modules/tableauDeBord/actions/ActionMesure.mjs';
+
 $(() => {
   const categories = JSON.parse($('#referentiel-categories-mesures').text());
   const statuts = JSON.parse($('#referentiel-statuts-mesures').text());
@@ -8,4 +11,19 @@ $(() => {
       detail: { categories, statuts, idService },
     })
   );
+
+  const actionMesure = new ActionMesure();
+  $(document.body).on('svelte-affiche-tiroir-ajout-mesure-specifique', (e) => {
+    const propsDuBundle = {
+      idService,
+      categories,
+      statuts,
+      mesuresExistantes: e.detail.mesuresExistantes,
+    };
+
+    gestionnaireTiroir.afficheContenuAction(
+      { action: actionMesure },
+      propsDuBundle
+    );
+  });
 });

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -6,7 +6,11 @@
     Mesures,
   } from './tableauDesMesures.d';
   import LigneMesure from './ligne/LigneMesure.svelte';
-  import { enregistreMesures, recupereMesures } from './tableauDesMesures.api';
+  import {
+    recupereMesures,
+    enregistreMesures,
+    metEnFormeMesures,
+  } from './tableauDesMesures.api';
   import { onMount } from 'svelte';
 
   enum EtatEnregistrement {
@@ -31,9 +35,20 @@
     await enregistreMesures(idService, mesures);
     etatEnregistrement = Fait;
   };
+
+  const afficheTiroirAjoutDeMesureSpecifique = () => {
+    document.body.dispatchEvent(
+      new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
+        detail: { mesuresExistantes: metEnFormeMesures(mesures) },
+      })
+    );
+  };
 </script>
 
 <div class="barre-actions">
+  <button class="bouton" on:click={afficheTiroirAjoutDeMesureSpecifique}
+    >Ajouter</button
+  >
   {#if etatEnregistrement === EnCours}
     <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
   {/if}
@@ -78,7 +93,8 @@
 <style>
   .barre-actions {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
+    gap: 1em;
     padding: 1em 0;
   }
 
@@ -126,5 +142,10 @@
 
   .enregistrement-termine:before {
     background-image: url('/statique/assets/images/icone_enregistrement_termine.svg');
+  }
+
+  .bouton {
+    margin: 0;
+    padding: 0.5em 2em;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -27,7 +27,7 @@
     class:indispensable={referentiel.indispensable}>{referentiel.label}</span
   >
   <div class="titre-mesure">
-    <p class="titre">{@html nom}</p>
+    <p class="titre">{nom}</p>
     <span class="categorie">{categorie}</span>
   </div>
   <label for={`statut-${id}`}>

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
@@ -1,11 +1,32 @@
+import { decode } from 'html-entities';
 import type {
   IdMesureGenerale,
   IdService,
   Mesures,
+  MesureSpecifique,
 } from './tableauDesMesures.d';
+
+const decodeEntitesHtml = (mesures: Mesures) => {
+  mesures.mesuresSpecifiques = mesures.mesuresSpecifiques.map(
+    (m: MesureSpecifique) => ({
+      ...m,
+      description: decode(m.description),
+      modalites: decode(m.modalites),
+    })
+  );
+
+  for (const idMesure in mesures.mesuresGenerales) {
+    const laMesure = mesures.mesuresGenerales[idMesure];
+
+    if (!laMesure.modalites) continue;
+
+    laMesure.modalites = decode(laMesure.modalites);
+  }
+};
 
 export const recupereMesures = async (idService: IdService) => {
   const reponse = await axios.get(`/api/service/${idService}/mesures`);
+  decodeEntitesHtml(reponse.data);
   return reponse.data as Mesures;
 };
 

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
@@ -9,10 +9,7 @@ export const recupereMesures = async (idService: IdService) => {
   return reponse.data as Mesures;
 };
 
-export const enregistreMesures = async (
-  idService: IdService,
-  mesures: Mesures
-) => {
+export const metEnFormeMesures = (mesures: Mesures) => {
   type MesureGeneraleApi = {
     statut: string;
     modalites?: string;
@@ -32,8 +29,18 @@ export const enregistreMesures = async (
         {}
       );
 
-  await axios.post(`/api/service/${idService}/mesures`, {
+  return {
     mesuresGenerales,
     mesuresSpecifiques: mesures.mesuresSpecifiques,
-  });
+  };
+};
+
+export const enregistreMesures = async (
+  idService: IdService,
+  mesures: Mesures
+) => {
+  await axios.post(
+    `/api/service/${idService}/mesures`,
+    metEnFormeMesures(mesures)
+  );
 };


### PR DESCRIPTION
On peut désormais ajouter une mesure spécifique via un bouton "Ajouter" présent au dessus du tableau des mesures.
Ce bouton déclenche l'affichage du tiroir de mesure :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/9b1cb1c2-f317-43dd-b9ae-de2444706ec1)

Pour l'instant, on est obligé de `window.location.reload()` la page pour ne pas casser le fonctionnement existant sur l'ancienne page des mesures.
À l'avenir, on pourra imaginer fermer le tiroir et rafraichir le tableau en utilisant des `events` sur le `document.body`