### PR TITLE
[SECURISER] Édition de mesure via le tiroir

### DIFF
--- a/public/assets/images/chevron_noir.svg
+++ b/public/assets/images/chevron_noir.svg
@@ -1,0 +1,10 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_13241_39391)">
+<path d="M14.1727 11.9993L9.22266 7.04928L10.6367 5.63528L17.0007 11.9993L10.6367 18.3633L9.22266 16.9493L14.1727 11.9993Z" fill="#2F3A43"/>
+</g>
+<defs>
+<clipPath id="clip0_13241_39391">
+<rect width="24" height="24" fill="white" transform="matrix(0 -1 1 0 0 24)"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/modules/tableauDeBord/actions/ActionMesure.mjs
+++ b/public/modules/tableauDeBord/actions/ActionMesure.mjs
@@ -6,11 +6,23 @@ class ActionMesure extends ActionAbstraite {
     this.appliqueContenu({ titre: '', texteSimple: '', texteMultiple: '' });
   }
 
-  initialise({ idService, categories, statuts, mesuresExistantes }) {
+  initialise({
+    idService,
+    categories,
+    statuts,
+    mesuresExistantes,
+    mesureAEditer,
+  }) {
     super.initialise();
     document.body.dispatchEvent(
       new CustomEvent('svelte-recharge-mesure', {
-        detail: { idService, categories, statuts, mesuresExistantes },
+        detail: {
+          idService,
+          categories,
+          statuts,
+          mesuresExistantes,
+          mesureAEditer,
+        },
       })
     );
   }

--- a/public/modules/tableauDeBord/actions/ActionMesure.mjs
+++ b/public/modules/tableauDeBord/actions/ActionMesure.mjs
@@ -1,9 +1,9 @@
 import ActionAbstraite from './Action.mjs';
 
 class ActionMesure extends ActionAbstraite {
-  constructor() {
+  constructor(titre = '') {
     super('#contenu-mesure');
-    this.appliqueContenu({ titre: '', texteSimple: '', texteMultiple: '' });
+    this.appliqueContenu({ titre, texteSimple: '', texteMultiple: '' });
   }
 
   initialise({

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -12,7 +12,7 @@ $(() => {
     })
   );
 
-  const actionMesure = new ActionMesure();
+  let actionMesure;
   $(document.body).on('svelte-affiche-tiroir-ajout-mesure-specifique', (e) => {
     const propsDuBundle = {
       idService,
@@ -21,6 +21,7 @@ $(() => {
       mesuresExistantes: e.detail.mesuresExistantes,
       mesureAEditer: e.detail.mesureAEditer,
     };
+    actionMesure = new ActionMesure(e.detail.titreTiroir);
 
     gestionnaireTiroir.afficheContenuAction(
       { action: actionMesure },

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -19,6 +19,7 @@ $(() => {
       categories,
       statuts,
       mesuresExistantes: e.detail.mesuresExistantes,
+      mesureAEditer: e.detail.mesureAEditer,
     };
 
     gestionnaireTiroir.afficheContenuAction(

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import type { MesuresExistantes, MesureSpecifique } from './mesure.d';
+  import type {
+    MesureAEditer,
+    MesuresExistantes,
+    MesureSpecifique,
+  } from './mesure.d';
   import Formulaire from '../ui/Formulaire.svelte';
   import { validationChamp } from '../directives/validationChamp';
 
@@ -7,8 +11,18 @@
   export let categories: Record<string, string>;
   export let statuts: Record<string, string>;
   export let mesuresExistantes: MesuresExistantes;
+  export let mesureAEditer: MesureAEditer | null = null;
 
   let intitule: string, details: string, categorie: string, statut: string;
+  if (mesureAEditer) {
+    intitule = mesureAEditer.description;
+    details = mesureAEditer.modalites ?? '';
+    categorie = mesureAEditer.categorie;
+    statut = mesureAEditer.statut;
+  }
+  $: doitAfficherIntitule =
+    !mesureAEditer ||
+    (mesureAEditer && mesureAEditer.typeMesure === 'SPECIFIQUE');
 
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
@@ -29,18 +43,20 @@
 <span>Ajoutée</span>
 
 <Formulaire on:formulaireValide={enregistreMesure}>
-  <label for="intitule" class="requis">
-    Intitulé
-    <textarea
-      rows="2"
-      bind:value={intitule}
-      id="intitule"
-      placeholder="Description de la mesure"
-      class="intouche"
-      required
-      use:validationChamp={"L'intitulé est obligatoire. Veuillez le renseigner."}
-    />
-  </label>
+  {#if doitAfficherIntitule}
+    <label for="intitule" class="requis">
+      Intitulé
+      <textarea
+        rows="2"
+        bind:value={intitule}
+        id="intitule"
+        placeholder="Description de la mesure"
+        class="intouche"
+        required
+        use:validationChamp={"L'intitulé est obligatoire. Veuillez le renseigner."}
+      />
+    </label>
+  {/if}
 
   <label for="details">
     Détails sur la mise en œuvre

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-  import type {
-    MesureEditee,
-    MesuresExistantes,
-    MesureSpecifique,
-  } from './mesure.d';
+  import type { MesuresExistantes } from './mesure.d';
   import Formulaire from '../ui/Formulaire.svelte';
   import { validationChamp } from '../directives/validationChamp';
   import { configurationAffichage, store } from './mesure.store';
+  import { enregistreMesures } from './mesure.api';
 
   export let idService: string;
   export let categories: Record<string, string>;
@@ -16,20 +13,7 @@
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
     enCoursEnvoi = true;
-    if ($store.etape === 'Creation') {
-      mesuresExistantes.mesuresSpecifiques.push($store.mesureEditee.mesure);
-    } else {
-      if ($store.etape === 'EditionGenerale') {
-        mesuresExistantes.mesuresGenerales[
-          $store.mesureEditee.metadonnees.idMesure
-        ] = $store.mesureEditee.mesure;
-      } else {
-        mesuresExistantes.mesuresSpecifiques[
-          $store.mesureEditee.metadonnees.idMesure as number
-        ] = $store.mesureEditee.mesure;
-      }
-    }
-    await axios.post(`/api/service/${idService}/mesures`, mesuresExistantes);
+    await enregistreMesures(idService, mesuresExistantes, $store);
     enCoursEnvoi = false;
     window.location.reload();
   };

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -141,18 +141,6 @@
 </Formulaire>
 
 <style>
-  span {
-    position: absolute;
-    top: 24px;
-    left: 32px;
-    font-size: 0.95em;
-    font-weight: 500;
-    color: #08416a;
-    border-radius: 40px;
-    background: #ffffff;
-    padding: 4px 10px;
-  }
-
   label {
     font-weight: bold;
     margin-bottom: 16px;

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -23,6 +23,8 @@
   $: doitAfficherIntitule =
     !mesureAEditer ||
     (mesureAEditer && mesureAEditer.typeMesure === 'SPECIFIQUE');
+  $: doitAfficherDescriptionLongue =
+    mesureAEditer && mesureAEditer.typeMesure === 'GENERALE';
 
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
@@ -56,6 +58,12 @@
         use:validationChamp={"L'intitulé est obligatoire. Veuillez le renseigner."}
       />
     </label>
+  {/if}
+  {#if doitAfficherDescriptionLongue}
+    <details>
+      <summary />
+      <p>{@html mesureAEditer.descriptionLongue}</p>
+    </details>
   {/if}
 
   <label for="details">
@@ -176,5 +184,39 @@
 
   :global(textarea.invalide, select.invalide) {
     border-color: var(--rose-anssi);
+  }
+
+  summary {
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  summary:before {
+    content: 'Description';
+  }
+
+  summary:after {
+    content: '';
+    width: 24px;
+    height: 24px;
+    background: url('/statique/assets/images/chevron_noir.svg');
+    transform: translateY(1px) rotate(90deg);
+    transition: transform 0.1s ease-in-out;
+  }
+
+  details[open] > summary:after {
+    transform: translateY(1px) rotate(270deg);
+  }
+
+  details p {
+    margin: 8px 0 0;
+    font-weight: 500;
+  }
+
+  details {
+    margin-bottom: 16px;
   }
 </style>

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -62,8 +62,6 @@
   };
 </script>
 
-<span>Ajoutée</span>
-
 <Formulaire on:formulaireValide={enregistreMesure}>
   {#if doitAfficherIntitule}
     <label for="intitule" class="requis">

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -23,6 +23,7 @@
   $: doitAfficherIntitule =
     !mesureAEditer ||
     (mesureAEditer && mesureAEditer.typeMesure === 'SPECIFIQUE');
+  $: doitAfficherChoixCategorie = doitAfficherIntitule;
   $: doitAfficherDescriptionLongue =
     mesureAEditer && mesureAEditer.typeMesure === 'GENERALE';
 
@@ -96,21 +97,23 @@
     />
   </label>
 
-  <label for="categorie" class="requis">
-    Catégorie
-    <select
-      bind:value={categorie}
-      id="categorie"
-      class="intouche"
-      required
-      use:validationChamp={'Ce champ est obligatoire. Veuillez sélectionner une option.'}
-    >
-      <option value="" disabled selected>Non renseigné</option>
-      {#each Object.entries(categories) as [valeur, label]}
-        <option value={valeur}>{label}</option>
-      {/each}
-    </select>
-  </label>
+  {#if doitAfficherChoixCategorie}
+    <label for="categorie" class="requis">
+      Catégorie
+      <select
+        bind:value={categorie}
+        id="categorie"
+        class="intouche"
+        required
+        use:validationChamp={'Ce champ est obligatoire. Veuillez sélectionner une option.'}
+      >
+        <option value="" disabled selected>Non renseigné</option>
+        {#each Object.entries(categories) as [valeur, label]}
+          <option value={valeur}>{label}</option>
+        {/each}
+      </select>
+    </label>
+  {/if}
 
   <label for="statut" class="requis">
     Statut de mise en œuvre

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -29,13 +29,32 @@
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
     enCoursEnvoi = true;
-    const mesureSpecifique: MesureSpecifique = {
-      categorie,
-      description: intitule,
-      modalites: details,
-      statut,
-    };
-    mesuresExistantes.mesuresSpecifiques.push(mesureSpecifique);
+    if (!mesureAEditer) {
+      const mesureSpecifique: MesureSpecifique = {
+        categorie,
+        description: intitule,
+        modalites: details,
+        statut,
+      };
+      mesuresExistantes.mesuresSpecifiques.push(mesureSpecifique);
+    } else {
+      let mesure = {
+        modalites: details,
+        statut,
+      };
+      if (mesureAEditer.typeMesure === 'SPECIFIQUE') {
+        mesure = {
+          ...mesure,
+          categorie: categorie,
+          description: intitule,
+        };
+      }
+      if (mesureAEditer.typeMesure === 'GENERALE') {
+        mesuresExistantes.mesuresGenerales[mesureAEditer.idMesure] = mesure;
+      } else {
+        mesuresExistantes.mesuresSpecifiques[mesureAEditer.idMesure] = mesure;
+      }
+    }
     await axios.post(`/api/service/${idService}/mesures`, mesuresExistantes);
     enCoursEnvoi = false;
     window.location.reload();

--- a/svelte/lib/mesure/entete/EnteteTiroir.svelte
+++ b/svelte/lib/mesure/entete/EnteteTiroir.svelte
@@ -1,18 +1,8 @@
 <script lang="ts">
-  import type { MesureAEditer } from '../mesure.d';
+  import { configurationAffichage } from '../mesure.store';
 
-  export let mesureAEditer: MesureAEditer | null = null;
-
-  let contenuTexte: string;
-  if (!mesureAEditer) {
-    contenuTexte = 'Ajoutée';
-  } else {
-    if (mesureAEditer.typeMesure === 'SPECIFIQUE') contenuTexte = 'Nouvelle';
-    else {
-      if (mesureAEditer.indispensable) contenuTexte = 'Indispensable';
-      else contenuTexte = 'Recommandée';
-    }
-  }
+  const contenuTexte =
+    $configurationAffichage.contenuTexteCartoucheDuReferentiel;
 </script>
 
 <p

--- a/svelte/lib/mesure/entete/EnteteTiroir.svelte
+++ b/svelte/lib/mesure/entete/EnteteTiroir.svelte
@@ -15,7 +15,13 @@
   }
 </script>
 
-<p class="referentiel">{contenuTexte}</p>
+<p
+  class="referentiel"
+  class:indispensable={contenuTexte === 'Indispensable'}
+  class:recommandee={contenuTexte === 'Recommandée'}
+>
+  {contenuTexte}
+</p>
 
 <style>
   p {
@@ -27,5 +33,27 @@
     background: #ffffff;
     width: fit-content;
     margin-top: 0;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  p:is(.indispensable, .recommandee):before {
+    content: '';
+    display: flex;
+    background-image: url('/statique/assets/images/logo_mss_petit.svg');
+    background-repeat: no-repeat;
+    background-size: contain;
+    width: 19px;
+    height: 16px;
+    margin-right: 6px;
+  }
+
+  .indispensable {
+    color: #7025da;
+  }
+
+  .recommandee {
+    color: #0079d0;
   }
 </style>

--- a/svelte/lib/mesure/entete/EnteteTiroir.svelte
+++ b/svelte/lib/mesure/entete/EnteteTiroir.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { MesureAEditer } from '../mesure.d';
+
+  export let mesureAEditer: MesureAEditer | null = null;
+
+  let contenuTexte: string;
+  if (!mesureAEditer) {
+    contenuTexte = 'Ajoutée';
+  } else {
+    if (mesureAEditer.typeMesure === 'SPECIFIQUE') contenuTexte = 'Nouvelle';
+    else {
+      if (mesureAEditer.indispensable) contenuTexte = 'Indispensable';
+      else contenuTexte = 'Recommandée';
+    }
+  }
+</script>
+
+<p class="referentiel">{contenuTexte}</p>
+
+<style>
+  p {
+    font-size: 0.6em;
+    font-weight: 500;
+    color: #08416a;
+    border-radius: 40px;
+    background: #ffffff;
+    width: fit-content;
+    margin-top: 0;
+  }
+</style>

--- a/svelte/lib/mesure/entete/EnteteTiroir.svelte
+++ b/svelte/lib/mesure/entete/EnteteTiroir.svelte
@@ -19,6 +19,7 @@
 
 <style>
   p {
+    padding: 4px 10px;
     font-size: 0.6em;
     font-weight: 500;
     color: #08416a;

--- a/svelte/lib/mesure/mesure.api.ts
+++ b/svelte/lib/mesure/mesure.api.ts
@@ -1,0 +1,24 @@
+import type { MesuresExistantes } from './mesure.d';
+import type { MesureStore } from './mesure.store';
+
+export const enregistreMesures = async (
+  idService: string,
+  mesuresExistantes: MesuresExistantes,
+  $store: MesureStore
+) => {
+  if ($store.etape === 'Creation') {
+    mesuresExistantes.mesuresSpecifiques.push($store.mesureEditee.mesure);
+  } else {
+    if ($store.etape === 'EditionGenerale') {
+      const { modalites, statut } = $store.mesureEditee.mesure;
+      mesuresExistantes.mesuresGenerales[
+        $store.mesureEditee.metadonnees.idMesure
+      ] = { modalites, statut };
+    } else {
+      mesuresExistantes.mesuresSpecifiques[
+        $store.mesureEditee.metadonnees.idMesure as number
+      ] = $store.mesureEditee.mesure;
+    }
+  }
+  await axios.post(`/api/service/${idService}/mesures`, mesuresExistantes);
+};

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -29,6 +29,7 @@ export type MesureSpecifique = MesureGenerale & {
 
 export type MesureAEditer = (MesureSpecifique | MesureGenerale) & {
   description: string;
+  descriptionLongue: string;
   categorie: string;
   typeMesure: 'GENERALE' | 'SPECIFIQUE';
   idMesure: string | number;

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -31,6 +31,7 @@ export type MesureAEditer = (MesureSpecifique | MesureGenerale) & {
   description: string;
   descriptionLongue: string;
   categorie: string;
+  indispensable?: boolean;
   typeMesure: 'GENERALE' | 'SPECIFIQUE';
   idMesure: string | number;
 };

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -9,7 +9,7 @@ export type MesureProps = {
   categories: Record<string, string>;
   statuts: Record<string, string>;
   mesuresExistantes: MesuresExistantes;
-  mesureAEditer?: MesureGenerale | MesureSpecifique;
+  mesureAEditer?: MesureEditee;
 };
 
 export type MesuresExistantes = {
@@ -22,16 +22,22 @@ export type MesureGenerale = {
   modalites?: string;
 };
 
+export type MesureGeneraleEnrichie = MesureGenerale & {
+  description: string;
+  descriptionLongue: string;
+  categorie: string;
+  indispensable?: boolean;
+};
+
 export type MesureSpecifique = MesureGenerale & {
   categorie: string;
   description: string;
 };
 
-export type MesureAEditer = (MesureSpecifique | MesureGenerale) & {
-  description: string;
-  descriptionLongue: string;
-  categorie: string;
-  indispensable?: boolean;
-  typeMesure: 'GENERALE' | 'SPECIFIQUE';
-  idMesure: string | number;
+export type MesureEditee = {
+  mesure: MesureSpecifique | MesureGeneraleEnrichie;
+  metadonnees: {
+    typeMesure: 'GENERALE' | 'SPECIFIQUE';
+    idMesure: string | number;
+  };
 };

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -9,6 +9,7 @@ export type MesureProps = {
   categories: Record<string, string>;
   statuts: Record<string, string>;
   mesuresExistantes: MesuresExistantes;
+  mesureAEditer?: MesureGenerale | MesureSpecifique;
 };
 
 export type MesuresExistantes = {
@@ -24,4 +25,11 @@ export type MesureGenerale = {
 export type MesureSpecifique = MesureGenerale & {
   categorie: string;
   description: string;
+};
+
+export type MesureAEditer = (MesureSpecifique | MesureGenerale) & {
+  description: string;
+  categorie: string;
+  typeMesure: 'GENERALE' | 'SPECIFIQUE';
+  idMesure: string | number;
 };

--- a/svelte/lib/mesure/mesure.store.ts
+++ b/svelte/lib/mesure/mesure.store.ts
@@ -1,0 +1,57 @@
+import { derived, writable } from 'svelte/store';
+import type { MesureEditee, MesureGeneraleEnrichie } from './mesure.d';
+
+type Etape = 'Creation' | 'EditionGenerale' | 'EditionSpecifique';
+type MesureStore = {
+  etape: Etape;
+  mesureEditee: MesureEditee;
+};
+
+const { subscribe, set } = writable<MesureStore>();
+
+const mesureEditeeParDefaut: MesureEditee = {
+  mesure: {
+    categorie: '',
+    description: '',
+    statut: '',
+    modalites: '',
+  },
+  metadonnees: {
+    typeMesure: 'SPECIFIQUE',
+    idMesure: 0,
+  },
+};
+export const store = {
+  set,
+  subscribe,
+  reinitialise: (mesureEditee?: MesureEditee) => {
+    const etape: Etape = !mesureEditee
+      ? 'Creation'
+      : mesureEditee.metadonnees.typeMesure === 'GENERALE'
+      ? 'EditionGenerale'
+      : 'EditionSpecifique';
+    set({
+      etape,
+      mesureEditee: mesureEditee ?? mesureEditeeParDefaut,
+    });
+  },
+};
+
+export const configurationAffichage = derived(store, ($store) => {
+  const contenuTexteCartoucheDuReferentiel: string =
+    $store.etape === 'Creation'
+      ? 'Ajoutée'
+      : $store.etape === 'EditionSpecifique'
+      ? 'Nouvelle'
+      : ($store.mesureEditee.mesure as MesureGeneraleEnrichie).indispensable
+      ? 'Indispensable'
+      : 'Recommandée';
+  return {
+    contenuTexteCartoucheDuReferentiel,
+    doitAfficherIntitule:
+      $store.etape === 'Creation' || $store.etape === 'EditionSpecifique',
+    doitAfficherChoixCategorie:
+      $store.etape === 'Creation' || $store.etape === 'EditionSpecifique',
+    doitAfficherDescriptionLongue: $store.etape === 'EditionGenerale',
+  };
+});

--- a/svelte/lib/mesure/mesure.store.ts
+++ b/svelte/lib/mesure/mesure.store.ts
@@ -2,7 +2,7 @@ import { derived, writable } from 'svelte/store';
 import type { MesureEditee, MesureGeneraleEnrichie } from './mesure.d';
 
 type Etape = 'Creation' | 'EditionGenerale' | 'EditionSpecifique';
-type MesureStore = {
+export type MesureStore = {
   etape: Etape;
   mesureEditee: MesureEditee;
 };

--- a/svelte/lib/mesure/mesure.ts
+++ b/svelte/lib/mesure/mesure.ts
@@ -1,19 +1,34 @@
 import Mesure from './Mesure.svelte';
-import type { MesureProps } from './mesure.d';
+import EnteteTiroir from './entete/EnteteTiroir.svelte';
+import type { MesureGenerale, MesureProps, MesureSpecifique } from './mesure.d';
 
 document.body.addEventListener(
   'svelte-recharge-mesure',
   (e: CustomEvent<MesureProps>) => rechargeApp({ ...e.detail })
 );
 
-let app: Mesure;
+let enteteTiroir: EnteteTiroir;
+const changeCartoucheDuReferentiel = (
+  mesureAEditer?: MesureGenerale | MesureSpecifique
+) => {
+  enteteTiroir?.$destroy();
+  const cible = document.querySelector('.titre-tiroir');
+  const insererAvant = cible?.lastChild;
+  enteteTiroir = new EnteteTiroir({
+    target: cible,
+    anchor: insererAvant,
+    props: { mesureAEditer },
+  });
+};
 
+let app: Mesure;
 const rechargeApp = (props: MesureProps) => {
   app?.$destroy();
   app = new Mesure({
     target: document.getElementById('conteneur-mesure')!,
     props,
   });
+  changeCartoucheDuReferentiel(props.mesureAEditer);
 };
 
 export default app;

--- a/svelte/lib/mesure/mesure.ts
+++ b/svelte/lib/mesure/mesure.ts
@@ -1,6 +1,7 @@
 import Mesure from './Mesure.svelte';
 import EnteteTiroir from './entete/EnteteTiroir.svelte';
-import type { MesureGenerale, MesureProps, MesureSpecifique } from './mesure.d';
+import type { MesureEditee, MesureProps } from './mesure.d';
+import { store } from './mesure.store';
 
 document.body.addEventListener(
   'svelte-recharge-mesure',
@@ -8,27 +9,29 @@ document.body.addEventListener(
 );
 
 let enteteTiroir: EnteteTiroir;
-const changeCartoucheDuReferentiel = (
-  mesureAEditer?: MesureGenerale | MesureSpecifique
-) => {
+const changeCartoucheDuReferentiel = () => {
   enteteTiroir?.$destroy();
   const cible = document.querySelector('.titre-tiroir');
   const insererAvant = cible?.lastChild;
   enteteTiroir = new EnteteTiroir({
     target: cible,
     anchor: insererAvant,
-    props: { mesureAEditer },
   });
 };
 
+const reinitialiseStore = (mesureAEditer?: MesureEditee) => {
+  store.reinitialise(mesureAEditer);
+};
+
 let app: Mesure;
-const rechargeApp = (props: MesureProps) => {
+const rechargeApp = ({ mesureAEditer, ...autreProps }: MesureProps) => {
   app?.$destroy();
+  reinitialiseStore(mesureAEditer);
+  changeCartoucheDuReferentiel();
   app = new Mesure({
     target: document.getElementById('conteneur-mesure')!,
-    props,
+    props: autreProps,
   });
-  changeCartoucheDuReferentiel(props.mesureAEditer);
 };
 
 export default app;

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -48,6 +48,10 @@
       new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
         detail: {
           mesuresExistantes: metEnFormeMesures(mesures),
+          titreTiroir:
+            mesureAEditer && mesureAEditer.typeMesure === 'GENERALE'
+              ? mesureAEditer.description
+              : '',
           ...(mesureAEditer && { mesureAEditer }),
         },
       })

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -39,9 +39,12 @@
     etatEnregistrement = Fait;
   };
 
-  type MesureAEditer = (MesureSpecifique | MesureGenerale) & {
-    typeMesure: 'GENERALE' | 'SPECIFIQUE';
-    idMesure: string | number;
+  type MesureAEditer = {
+    mesure: MesureSpecifique | MesureGenerale;
+    metadonnees: {
+      typeMesure: 'GENERALE' | 'SPECIFIQUE';
+      idMesure: string | number;
+    };
   };
   const afficheTiroirDeMesure = (mesureAEditer?: MesureAEditer) => {
     document.body.dispatchEvent(
@@ -49,8 +52,8 @@
         detail: {
           mesuresExistantes: metEnFormeMesures(mesures),
           titreTiroir:
-            mesureAEditer && mesureAEditer.typeMesure === 'GENERALE'
-              ? mesureAEditer.description
+            mesureAEditer && mesureAEditer.metadonnees.typeMesure === 'GENERALE'
+              ? mesureAEditer.mesure.description
               : '',
           ...(mesureAEditer && { mesureAEditer }),
         },
@@ -90,9 +93,11 @@
         on:modificationStatut={metAJourMesures}
         on:click={() =>
           afficheTiroirDeMesure({
-            ...mesure,
-            typeMesure: 'GENERALE',
-            idMesure: id,
+            mesure,
+            metadonnees: {
+              typeMesure: 'GENERALE',
+              idMesure: id,
+            },
           })}
       />
     {/each}
@@ -107,9 +112,11 @@
         on:modificationStatut={metAJourMesures}
         on:click={() =>
           afficheTiroirDeMesure({
-            ...mesure,
-            typeMesure: 'SPECIFIQUE',
-            idMesure: index,
+            mesure,
+            metadonnees: {
+              typeMesure: 'SPECIFIQUE',
+              idMesure: index,
+            },
           })}
       />
     {/each}

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -3,7 +3,9 @@
     IdCategorie,
     IdService,
     IdStatut,
+    MesureGenerale,
     Mesures,
+    MesureSpecifique,
   } from './tableauDesMesures.d';
   import LigneMesure from './ligne/LigneMesure.svelte';
   import {
@@ -18,6 +20,7 @@
     EnCours,
     Fait,
   }
+
   const { Jamais, EnCours, Fait } = EtatEnregistrement;
 
   export let idService: IdService;
@@ -36,19 +39,26 @@
     etatEnregistrement = Fait;
   };
 
-  const afficheTiroirAjoutDeMesureSpecifique = () => {
+  type MesureAEditer = (MesureSpecifique | MesureGenerale) & {
+    typeMesure: 'GENERALE' | 'SPECIFIQUE';
+    idMesure: string | number;
+  };
+  const afficheTiroirDeMesure = (mesureAEditer?: MesureAEditer) => {
     document.body.dispatchEvent(
       new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
-        detail: { mesuresExistantes: metEnFormeMesures(mesures) },
+        detail: {
+          mesuresExistantes: metEnFormeMesures(mesures),
+          ...(mesureAEditer && { mesureAEditer }),
+        },
       })
     );
   };
 </script>
 
 <div class="barre-actions">
-  <button class="bouton" on:click={afficheTiroirAjoutDeMesureSpecifique}
-    >Ajouter</button
-  >
+  <button class="bouton" on:click={() => afficheTiroirDeMesure()}
+    >Ajouter
+  </button>
   {#if etatEnregistrement === EnCours}
     <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
   {/if}
@@ -74,6 +84,12 @@
         referentielStatuts={statuts}
         bind:mesure
         on:modificationStatut={metAJourMesures}
+        on:click={() =>
+          afficheTiroirDeMesure({
+            ...mesure,
+            typeMesure: 'GENERALE',
+            idMesure: id,
+          })}
       />
     {/each}
     {#each mesures.mesuresSpecifiques as mesure, index (index)}
@@ -85,6 +101,12 @@
         referentielStatuts={statuts}
         bind:mesure
         on:modificationStatut={metAJourMesures}
+        on:click={() =>
+          afficheTiroirDeMesure({
+            ...mesure,
+            typeMesure: 'SPECIFIQUE',
+            idMesure: index,
+          })}
       />
     {/each}
   {/if}

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -30,8 +30,10 @@
     class:indispensable={referentiel.indispensable}>{referentiel.label}</span
   >
   <div class="titre-mesure">
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
     <p class="titre" on:click={() => dispatch('click')}>
       {nom}
+      <!-- svelte-ignore a11y-missing-attribute -->
       <img src="/statique/assets/images/chevron_noir.svg" />
     </p>
     <span class="categorie">{categorie}</span>

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -18,7 +18,10 @@
   export let categorie: string;
   export let referentielStatuts: Record<string, string>;
 
-  const dispatch = createEventDispatcher<{ modificationStatut: null }>();
+  const dispatch = createEventDispatcher<{
+    modificationStatut: null;
+    click: null;
+  }>();
 </script>
 
 <div class="ligne-de-mesure">
@@ -27,7 +30,7 @@
     class:indispensable={referentiel.indispensable}>{referentiel.label}</span
   >
   <div class="titre-mesure">
-    <p class="titre">
+    <p class="titre" on:click={() => dispatch('click')}>
       {nom}
       <img src="/statique/assets/images/chevron_noir.svg" />
     </p>
@@ -111,6 +114,7 @@
   .titre {
     font-weight: 500;
     text-align: left;
+    cursor: pointer;
   }
 
   .titre img {

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -27,7 +27,10 @@
     class:indispensable={referentiel.indispensable}>{referentiel.label}</span
   >
   <div class="titre-mesure">
-    <p class="titre">{nom}</p>
+    <p class="titre">
+      {nom}
+      <img src="/statique/assets/images/chevron_noir.svg" />
+    </p>
     <span class="categorie">{categorie}</span>
   </div>
   <label for={`statut-${id}`}>
@@ -108,6 +111,12 @@
   .titre {
     font-weight: 500;
     text-align: left;
+  }
+
+  .titre img {
+    width: 24px;
+    height: 24px;
+    position: absolute;
   }
 
   .categorie {


### PR DESCRIPTION
On ajoute la modification des mesures par le tiroir 'Mesure' existant.

Toute la payload de mesures est passée au bundle Svelte lors de l'instanciation.
Le bundle "écrase" la valeur de la mesure à éditer avant de la renvoyer vers l'API.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/eab7d8a8-f430-4b4d-998c-af0a2cf46cd7)
