### PR TITLE
Activation de l'auto-save sur la page « Sécuriser » v1

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -117,8 +117,8 @@ form#mesures .specifiques input[type='radio'] {
   background-color: #fff;
   bottom: 0;
   display: flex;
-  justify-content: flex-end;
-  column-gap: 1.7em;
+  justify-content: space-between;
+  align-items: center;
   width: calc(100% + 7em);
   margin-left: -7em;
   padding: 1.4em 7em 1.4em 0;
@@ -133,6 +133,51 @@ form#mesures .specifiques input[type='radio'] {
       #a826b333
     )
     1;
+}
+
+.enregistrement #statut-enregistrement {
+  margin-left: 7em;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.enregistrement #statut-enregistrement.enregistrement-en-cours {
+  color: #0c5c98;
+}
+
+.enregistrement #statut-enregistrement.enregistrement-termine {
+  color: #0e972b;
+}
+
+.enregistrement #statut-enregistrement:before {
+  content: '';
+  display: flex;
+  width: 24px;
+  height: 24px;
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+
+.enregistrement #statut-enregistrement.enregistrement-en-cours:before {
+  background-image: url('/statique/assets/images/icone_enregistrement_en_cours.svg');
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.enregistrement #statut-enregistrement.enregistrement-termine:before {
+  background-image: url('/statique/assets/images/icone_enregistrement_termine.svg');
+}
+
+.enregistrement .boutons {
+  display: flex;
+  gap: 25px;
 }
 
 .enregistrement .bouton {

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -207,6 +207,9 @@ ${statuts}
       sauvegardeLesMesures()
     );
     $('textarea', formulaire).on('blur', async () => sauvegardeLesMesures());
+    $('.icone-suppression', formulaire).on('click', async () =>
+      sauvegardeLesMesures()
+    );
   };
 
   brancheAutoSave();

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -195,11 +195,11 @@ ${statuts}
   brancheValidation('form#mesures');
 
   const brancheAutoSave = () => {
-    const mesure = 'form#mesures .mesure';
-    $('input[type="radio"]', mesure).on('change', async () =>
+    const formulaire = 'form#mesures';
+    $('input[type="radio"]', formulaire).on('change', async () =>
       sauvegardeLesMesures()
     );
-    $('textarea', mesure).on('blur', async () => sauvegardeLesMesures());
+    $('textarea', formulaire).on('blur', async () => sauvegardeLesMesures());
   };
 
   brancheAutoSave();

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -194,10 +194,13 @@ ${statuts}
 
   brancheValidation('form#mesures');
 
-  const brancheAutoSave = () =>
-    $('input[type="radio"]', 'form#mesures .mesure').on('change', async () =>
+  const brancheAutoSave = () => {
+    const mesure = 'form#mesures .mesure';
+    $('input[type="radio"]', mesure).on('change', async () =>
       sauvegardeLesMesures()
     );
+    $('textarea', mesure).on('blur', async () => sauvegardeLesMesures());
+  };
 
   brancheAutoSave();
 

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -180,15 +180,23 @@ ${statuts}
 
   $('form#mesures').on('submit', async (evenement) => {
     evenement.preventDefault();
-    basculeEnCoursChargement($bouton, true);
+
+    const indiqueSauvegardeEnCours = (estEnCours) => {
+      basculeEnCoursChargement($bouton, estEnCours);
+      const $statut = $('#statut-enregistrement');
+      $statut.toggleClass('enregistrement-en-cours', estEnCours);
+      $statut.toggleClass('enregistrement-termine', !estEnCours);
+      $statut.text(estEnCours ? 'Enregistrement en cours…' : 'Terminé');
+    };
+
+    indiqueSauvegardeEnCours(true);
     const params = parametres('form#mesures');
     arrangeParametresMesures(params);
-
     const reponse = await axios.post(
       `/api/service/${identifiantService}/mesures`,
       params
     );
-    basculeEnCoursChargement($bouton, false);
+    indiqueSauvegardeEnCours(false);
     window.location = `/service/${reponse.data.idService}/mesures`;
   });
 

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -71,12 +71,8 @@ $(() => {
     indiqueSauvegardeEnCours(true);
     const params = parametres('form#mesures');
     arrangeParametresMesures(params);
-    const reponse = await axios.post(
-      `/api/service/${identifiantService}/mesures`,
-      params
-    );
+    await axios.post(`/api/service/${identifiantService}/mesures`, params);
     indiqueSauvegardeEnCours(false);
-    window.location = `/service/${reponse.data.idService}/mesures`;
   };
 
   const peupleFormulaire = () => {

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -65,6 +65,9 @@ $(() => {
       $statut.text(estEnCours ? 'Enregistrement en cours…' : 'Terminé');
     };
 
+    const formulaireEstValide = $('form')[0].reportValidity();
+    if (!formulaireEstValide) return;
+
     indiqueSauvegardeEnCours(true);
     const params = parametres('form#mesures');
     arrangeParametresMesures(params);
@@ -145,6 +148,7 @@ $(() => {
   <label for="description-mesure-specifique-${index}" class="nom-champ">
     Intitulé
     <input id="description-mesure-specifique-${index}"
+          type="text"
           name="description-mesure-specifique-${index}"
           placeholder="Description de la mesure"
           value="${description}"
@@ -197,6 +201,9 @@ ${statuts}
   const brancheAutoSave = () => {
     const formulaire = 'form#mesures';
     $('input[type="radio"]', formulaire).on('change', async () =>
+      sauvegardeLesMesures()
+    );
+    $('input[type="text"]', formulaire).on('blur', async () =>
       sauvegardeLesMesures()
     );
     $('textarea', formulaire).on('blur', async () => sauvegardeLesMesures());

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -174,13 +174,7 @@ ${statuts}
   const $bouton = $('.bouton[idHomologation]');
   const identifiantService = $bouton.attr('idHomologation');
 
-  $bouton.on('click', () => {
-    declencheValidation('form#mesures');
-  });
-
-  $('form#mesures').on('submit', async (evenement) => {
-    evenement.preventDefault();
-
+  const sauvegardeLesMesures = async () => {
     const indiqueSauvegardeEnCours = (estEnCours) => {
       basculeEnCoursChargement($bouton, estEnCours);
       const $statut = $('#statut-enregistrement');
@@ -198,6 +192,15 @@ ${statuts}
     );
     indiqueSauvegardeEnCours(false);
     window.location = `/service/${reponse.data.idService}/mesures`;
+  };
+
+  $bouton.on('click', () => {
+    declencheValidation('form#mesures');
+  });
+
+  $('form#mesures').on('submit', async (evenement) => {
+    evenement.preventDefault();
+    await sauvegardeLesMesures();
   });
 
   const actionMesure = new ActionMesure();

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -78,8 +78,10 @@ block formulaire
                   p!= donnees.descriptionLongue
     if (!estLectureSeule)
       .enregistrement
-        button#ajout-mesure-specifique.bouton.bouton-secondaire.nouvel-item(type = 'button') Ajouter une mesure spécifique
-        button.bouton(idHomologation = service.id) Enregistrer
+        #statut-enregistrement
+        .boutons
+          button#ajout-mesure-specifique.bouton.bouton-secondaire.nouvel-item(type = 'button') Ajouter une mesure spécifique
+          button.bouton(idHomologation = service.id) Enregistrer
 
   script(id = 'donnees-mesures-generales', type = 'application/json').
     !{JSON.stringify(service.mesures.toJSON().mesuresGenerales || [])}


### PR DESCRIPTION
Cette PR ajoute de l'auto-save sur « Sécuriser » dans sa version actuellement en PROD.

Changer une valeur du formulaire déclenche la sauvegarde 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/28f79997-be12-4671-ad72-a30cb0b26a20)

Même approche que pour le composant Svelte `TableauDesMesures` : on ne **change pas** l'archi des intéractions entre front et back.

Donc cette PR :
 - utilise le code existant pour la sauvegarde
 - branche ce code sur des `event handlers` qui écoutent les `change|blur` des champs et la suppression des mesures spécifiques
 - utilise `reportValidity()` pour ne pas déclencher la sauvegarde lorsque le formulaire est invalide