### PR TITLE
[SÉCURITÉ] Verification du format de `idReset`

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -147,21 +147,20 @@ const creeServeur = (
   app.get(
     '/initialisationMotDePasse/:idReset',
     middleware.aseptise('idReset'),
-    (requete, reponse) => {
+    async (requete, reponse) => {
       const { idReset } = requete.params;
-      depotDonnees.utilisateurAFinaliser(idReset).then((utilisateur) => {
-        if (!utilisateur) {
-          reponse
-            .status(404)
-            .send(
-              `Identifiant d'initialisation de mot de passe "${idReset}" inconnu`
-            );
-          return;
-        }
+      const utilisateur = await depotDonnees.utilisateurAFinaliser(idReset);
+      if (!utilisateur) {
+        reponse
+          .status(404)
+          .send(
+            `Identifiant d'initialisation de mot de passe "${idReset}" inconnu`
+          );
+        return;
+      }
 
-        requete.session.token = utilisateur.genereToken();
-        reponse.render('motDePasse/edition', { utilisateur });
-      });
+      requete.session.token = utilisateur.genereToken();
+      reponse.render('motDePasse/edition', { utilisateur });
     }
   );
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -161,9 +161,7 @@ const creeServeur = (
       if (!utilisateur) {
         reponse
           .status(404)
-          .send(
-            `Identifiant d'initialisation de mot de passe "${idReset}" inconnu`
-          );
+          .send(`Identifiant d'initialisation de mot de passe inconnu`);
         return;
       }
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -1,3 +1,4 @@
+const uuid = require('uuid');
 const cookieSession = require('cookie-session');
 const cookieParser = require('cookie-parser');
 const express = require('express');
@@ -149,6 +150,13 @@ const creeServeur = (
     middleware.aseptise('idReset'),
     async (requete, reponse) => {
       const { idReset } = requete.params;
+
+      const pasUnUUID = !uuid.validate(idReset);
+      if (pasUnUUID) {
+        reponse.status(400).send(`UUID requis`);
+        return;
+      }
+
       const utilisateur = await depotDonnees.utilisateurAFinaliser(idReset);
       if (!utilisateur) {
         reponse

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -103,21 +103,23 @@ describe('Le serveur MSS', () => {
       };
 
       beforeEach(() => {
-        testeur.depotDonnees().utilisateurAFinaliser = () =>
-          Promise.resolve(utilisateur);
-        testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
+        testeur.depotDonnees().utilisateurAFinaliser = async () => utilisateur;
+        testeur.depotDonnees().utilisateur = async () => utilisateur;
       });
 
-      it('dépose le jeton dans un cookie', (done) => {
-        testeur.depotDonnees().utilisateurAFinaliser = (idReset) => {
-          expect(idReset).to.equal('999');
-          return Promise.resolve(utilisateur);
+      it('dépose le jeton dans un cookie', async () => {
+        let idRecu;
+        testeur.depotDonnees().utilisateurAFinaliser = async (idReset) => {
+          idRecu = idReset;
+          return utilisateur;
         };
 
-        axios
-          .get('http://localhost:1234/initialisationMotDePasse/999')
-          .then((reponse) => testeur.verifieJetonDepose(reponse, done))
-          .catch(done);
+        const reponse = await axios.get(
+          'http://localhost:1234/initialisationMotDePasse/999'
+        );
+
+        expect(idRecu).to.be('999');
+        await testeur.verifieJetonDepose(reponse, () => {});
       });
     });
 
@@ -132,8 +134,7 @@ describe('Le serveur MSS', () => {
     });
 
     it('retourne une erreur HTTP 404 si idReset inconnu', (done) => {
-      testeur.depotDonnees().utilisateurAFinaliser = () =>
-        Promise.resolve(undefined);
+      testeur.depotDonnees().utilisateurAFinaliser = async () => {};
 
       testeur.verifieRequeteGenereErreurHTTP(
         404,

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -149,7 +149,7 @@ describe('Le serveur MSS', () => {
 
       testeur.verifieRequeteGenereErreurHTTP(
         404,
-        `Identifiant d'initialisation de mot de passe "${uuid}" inconnu`,
+        `Identifiant d'initialisation de mot de passe inconnu`,
         `http://localhost:1234/initialisationMotDePasse/${uuid}`,
         done
       );

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -95,6 +95,8 @@ describe('Le serveur MSS', () => {
   });
 
   describe('quand requête GET sur `/initialisationMotDePasse/:idReset`', () => {
+    const uuid = '109156be-c4fb-41ea-b1b4-efe1671c5836';
+
     describe('avec idReset valide', () => {
       const utilisateur = {
         id: '123',
@@ -115,10 +117,10 @@ describe('Le serveur MSS', () => {
         };
 
         const reponse = await axios.get(
-          'http://localhost:1234/initialisationMotDePasse/999'
+          `http://localhost:1234/initialisationMotDePasse/${uuid}`
         );
 
-        expect(idRecu).to.be('999');
+        expect(idRecu).to.be(uuid);
         await testeur.verifieJetonDepose(reponse, () => {});
       });
     });
@@ -128,9 +130,18 @@ describe('Le serveur MSS', () => {
         .middleware()
         .verifieAseptisationParametres(
           ['idReset'],
-          'http://localhost:1234/initialisationMotDePasse/999',
+          `http://localhost:1234/initialisationMotDePasse/${uuid}`,
           done
         );
+    });
+
+    it("retourne une erreur HTTP 400 sur idReset n'est pas un UUID valide", (done) => {
+      testeur.verifieRequeteGenereErreurHTTP(
+        400,
+        'UUID requis',
+        'http://localhost:1234/initialisationMotDePasse/999',
+        done
+      );
     });
 
     it('retourne une erreur HTTP 404 si idReset inconnu', (done) => {
@@ -138,8 +149,8 @@ describe('Le serveur MSS', () => {
 
       testeur.verifieRequeteGenereErreurHTTP(
         404,
-        'Identifiant d\'initialisation de mot de passe "999" inconnu',
-        'http://localhost:1234/initialisationMotDePasse/999',
+        `Identifiant d'initialisation de mot de passe "${uuid}" inconnu`,
+        `http://localhost:1234/initialisationMotDePasse/${uuid}`,
         done
       );
     });


### PR DESCRIPTION
Cette PR vérifie le format de `idReset` dans la route `/initialisationMotDePasse/:idReset`.

S'il ne s'agit pas d'un `UUID` alors le dépôt de données n'est pas sollicité. Une erreur `400` est retournée directement.

On se passe d'adaptateur ici. On se branche directement sur `uuid.validate()` par souci de simplicité.