### PR TITLE
[SECURISER] Lecture seule des mesures

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -73,6 +73,12 @@ form input[type='checkbox'][disabled]:before {
   border-color: black;
 }
 
+select[disabled] {
+  color: #667892;
+  background: #dbecf1;
+  appearance: none !important;
+}
+
 fieldset {
   margin: 0 0 1em 0;
   padding: 0 0 2em;

--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -43,6 +43,7 @@ form input {
 }
 
 form :is(input, textarea)[readonly] {
+  color: #667892;
   background: #dbecf1;
   user-select: none;
   cursor: not-allowed;
@@ -77,6 +78,7 @@ select[disabled] {
   color: #667892;
   background: #dbecf1;
   appearance: none !important;
+  cursor: not-allowed;
 }
 
 fieldset {

--- a/public/modules/tableauDeBord/actions/ActionMesure.mjs
+++ b/public/modules/tableauDeBord/actions/ActionMesure.mjs
@@ -10,6 +10,7 @@ class ActionMesure extends ActionAbstraite {
     idService,
     categories,
     statuts,
+    estLectureSeule,
     mesuresExistantes,
     mesureAEditer,
   }) {
@@ -20,6 +21,7 @@ class ActionMesure extends ActionAbstraite {
           idService,
           categories,
           statuts,
+          estLectureSeule,
           mesuresExistantes,
           mesureAEditer,
         },

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -4,11 +4,12 @@ import ActionMesure from '../modules/tableauDeBord/actions/ActionMesure.mjs';
 $(() => {
   const categories = JSON.parse($('#referentiel-categories-mesures').text());
   const statuts = JSON.parse($('#referentiel-statuts-mesures').text());
+  const estLectureSeule = JSON.parse($('#securiser-lecture-seule').text());
   const idService = $('.page-service').data('id-service');
 
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-tableau-mesures', {
-      detail: { categories, statuts, idService },
+      detail: { categories, statuts, idService, estLectureSeule },
     })
   );
 
@@ -18,6 +19,7 @@ $(() => {
       idService,
       categories,
       statuts,
+      estLectureSeule,
       mesuresExistantes: e.detail.mesuresExistantes,
       mesureAEditer: e.detail.mesureAEditer,
     };

--- a/src/vues/service/mesures-v2.pug
+++ b/src/vues/service/mesures-v2.pug
@@ -16,6 +16,8 @@ block append scripts
     !{JSON.stringify(referentiel.categoriesMesures())}
   script(id = 'referentiel-statuts-mesures', type = 'application/json').
     !{JSON.stringify(referentiel.statutsMesures())}
+  script(id = 'securiser-lecture-seule', type = 'application/json').
+    !{JSON.stringify(autorisationsService.SECURISER.estLectureSeule)}
 
 block header-titre-page
   h3
@@ -35,5 +37,4 @@ block sous-titre
   h2 Mettre en oeuvre des mesures de sécurité adaptées
 
 block formulaire
-  - const estLectureSeule  = autorisationsService.SECURISER.estLectureSeule
   #tableau-des-mesures

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -9,6 +9,8 @@
   export let categories: Record<string, string>;
   export let statuts: Record<string, string>;
   export let mesuresExistantes: MesuresExistantes;
+  export let estLectureSeule: boolean;
+
 
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
@@ -29,6 +31,7 @@
         id="intitule"
         placeholder="Description de la mesure"
         class="intouche"
+        readonly={estLectureSeule}
         required
         use:validationChamp={"L'intitulé est obligatoire. Veuillez le renseigner."}
       />
@@ -49,6 +52,7 @@
       id="details"
       placeholder="Modalités de mise en œuvre (facultatif)"
       class="intouche"
+      readonly={estLectureSeule}
     />
   </label>
 
@@ -60,6 +64,7 @@
         id="categorie"
         class="intouche"
         required
+        disabled={estLectureSeule}
         use:validationChamp={'Ce champ est obligatoire. Veuillez sélectionner une option.'}
       >
         <option value="" disabled selected>Non renseigné</option>
@@ -77,6 +82,7 @@
       id="statut"
       class="intouche"
       required
+      disabled={estLectureSeule}
       use:validationChamp={'Ce champ est obligatoire. Veuillez sélectionner une option.'}
     >
       <option value="" disabled selected>Non renseigné</option>
@@ -86,15 +92,17 @@
     </select>
   </label>
 
-  <div class="conteneur-bouton">
-    <button
-      type="submit"
-      class="bouton"
-      class:en-cours-chargement={enCoursEnvoi}
-      disabled={enCoursEnvoi}
-      >Enregistrer
-    </button>
-  </div>
+  {#if !estLectureSeule}
+    <div class="conteneur-bouton">
+      <button
+        type="submit"
+        class="bouton"
+        class:en-cours-chargement={enCoursEnvoi}
+        disabled={enCoursEnvoi}
+        >Enregistrer
+      </button>
+    </div>
+  {/if}
 </Formulaire>
 
 <style>

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -8,6 +8,7 @@ export type MesureProps = {
   idService: string;
   categories: Record<string, string>;
   statuts: Record<string, string>;
+  estLectureSeule: boolean;
   mesuresExistantes: MesuresExistantes;
   mesureAEditer?: MesureEditee;
 };

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -26,6 +26,7 @@
   export let idService: IdService;
   export let categories: Record<IdCategorie, string>;
   export let statuts: Record<IdStatut, string>;
+  export let estLectureSeule: boolean;
 
   let mesures: Mesures;
   onMount(async () => {
@@ -62,17 +63,19 @@
   };
 </script>
 
-<div class="barre-actions">
-  <button class="bouton" on:click={() => afficheTiroirDeMesure()}
-    >Ajouter
-  </button>
-  {#if etatEnregistrement === EnCours}
-    <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
-  {/if}
-  {#if etatEnregistrement === Fait}
-    <p class="enregistrement-termine">Enregistré</p>
-  {/if}
-</div>
+{#if !estLectureSeule}
+  <div class="barre-actions">
+    <button class="bouton" on:click={() => afficheTiroirDeMesure()}
+      >Ajouter
+    </button>
+    {#if etatEnregistrement === EnCours}
+      <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
+    {/if}
+    {#if etatEnregistrement === Fait}
+      <p class="enregistrement-termine">Enregistré</p>
+    {/if}
+  </div>
+{/if}
 <div class="tableau-des-mesures">
   {#if mesures}
     {#each Object.entries(mesures.mesuresGenerales) as [id, mesure] (id)}
@@ -99,6 +102,7 @@
               idMesure: id,
             },
           })}
+        {estLectureSeule}
       />
     {/each}
     {#each mesures.mesuresSpecifiques as mesure, index (index)}
@@ -118,6 +122,7 @@
               idMesure: index,
             },
           })}
+        {estLectureSeule}
       />
     {/each}
   {/if}

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -17,6 +17,7 @@
   export let nom: string;
   export let categorie: string;
   export let referentielStatuts: Record<string, string>;
+  export let estLectureSeule: boolean;
 
   const dispatch = createEventDispatcher<{
     modificationStatut: null;
@@ -43,7 +44,7 @@
       bind:value={mesure.statut}
       id={`statut-${id}`}
       class="intouche"
-      required
+      disabled={estLectureSeule}
       on:change={() => dispatch('modificationStatut')}
     >
       <option value="" disabled selected>--</option>

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -12,6 +12,7 @@ export type TableauDesMesuresProps = {
   idService: IdService;
   categories: Record<IdCategorie, string>;
   statuts: Record<IdStatut, string>;
+  estLectureSeule: boolean;
 };
 
 export type MesureGenerale = {


### PR DESCRIPTION
On ajoute le mode "Lecture seule" sur le tableau des mesures et le tiroir des mesures.

On réutilise les mécanismes mit en place dans le Pug et JQuery, à savoir :
- `disabled` pour les `select`
- `readonly` pour les `input` et `textarea`


![image](https://github.com/betagouv/mon-service-securise/assets/1643465/f0fb82ff-66ba-4ab1-b3b7-f861ef12e603)
