### PR TITLE
Création d'un bus d'événements

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,11 +45,15 @@ const port = process.env.PORT || 3000;
 const referentiel = Referentiel.creeReferentiel();
 const moteurRegles = new MoteurRegles(referentiel);
 
-cableTousLesAbonnes(busEvenements, { adaptateurJournal });
-
 const depotDonnees = DepotDonnees.creeDepot({
   adaptateurJournalMSS: adaptateurJournal,
   busEvenements,
+});
+
+cableTousLesAbonnes(busEvenements, {
+  adaptateurTracking,
+  adaptateurJournal,
+  depotDonnees,
 });
 
 const middleware = Middleware({

--- a/src/bus/abonnements/mesuresServiceModifiees/consigneDansJournal.js
+++ b/src/bus/abonnements/mesuresServiceModifiees/consigneDansJournal.js
@@ -1,0 +1,18 @@
+const EvenementCompletudeServiceModifiee = require('../../../modeles/journalMSS/evenementCompletudeServiceModifiee');
+
+function consigneDansJournal({ adaptateurJournal }) {
+  return async (evenement) => {
+    const { service } = evenement;
+
+    const completude = new EvenementCompletudeServiceModifiee({
+      idService: service.id,
+      ...service.completudeMesures(),
+      nombreOrganisationsUtilisatrices:
+        service.descriptionService.nombreOrganisationsUtilisatrices,
+    });
+
+    await adaptateurJournal.consigneEvenement(completude.toJSON());
+  };
+}
+
+module.exports = { consigneDansJournal };

--- a/src/bus/abonnements/mesuresServiceModifiees/envoieTrackingDeCompletude.js
+++ b/src/bus/abonnements/mesuresServiceModifiees/envoieTrackingDeCompletude.js
@@ -1,0 +1,23 @@
+const {
+  fabriqueServiceTracking,
+} = require('../../../tracking/serviceTracking');
+
+function envoieTrackingCompletude({ adaptateurTracking, depotDonnees }) {
+  return async (evenement) => {
+    const serviceTracking = fabriqueServiceTracking();
+    const { utilisateur } = evenement;
+
+    const donneesCompletude =
+      await serviceTracking.completudeDesServicesPourUtilisateur(
+        depotDonnees,
+        utilisateur.id
+      );
+
+    await adaptateurTracking.envoieTrackingCompletudeService(
+      utilisateur.email,
+      donneesCompletude
+    );
+  };
+}
+
+module.exports = { envoieTrackingCompletude };

--- a/src/bus/busEvenements.js
+++ b/src/bus/busEvenements.js
@@ -9,14 +9,16 @@ class BusEvenements {
     this.handlers[classeEvenement.name].push(handler);
   }
 
-  publie(evenement) {
-    this.handlers[evenement.constructor.name].forEach((handler) => {
+  async publie(evenement) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const handler of this.handlers[evenement.constructor.name]) {
       try {
-        handler(evenement);
+        // eslint-disable-next-line no-await-in-loop
+        await handler(evenement);
       } catch (e) {
         this.adaptateurGestionErreur.logueErreur(e);
       }
-    });
+    }
   }
 }
 

--- a/src/bus/busEvenements.js
+++ b/src/bus/busEvenements.js
@@ -1,0 +1,23 @@
+class BusEvenements {
+  constructor({ adaptateurGestionErreur }) {
+    this.handlers = {};
+    this.adaptateurGestionErreur = adaptateurGestionErreur;
+  }
+
+  abonne(classeEvenement, handler) {
+    this.handlers[classeEvenement.name] ??= [];
+    this.handlers[classeEvenement.name].push(handler);
+  }
+
+  publie(evenement) {
+    this.handlers[evenement.constructor.name].forEach((handler) => {
+      try {
+        handler(evenement);
+      } catch (e) {
+        this.adaptateurGestionErreur.logueErreur(e);
+      }
+    });
+  }
+}
+
+module.exports = BusEvenements;

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -1,0 +1,13 @@
+const EvenementMesuresServiceModifiees = require('./evenementMesuresServiceModifiees');
+const {
+  consigneDansJournal,
+} = require('./abonnements/mesuresServiceModifiees/consigneDansJournal');
+
+const cableTousLesAbonnes = (busEvenements, { adaptateurJournal }) => {
+  busEvenements.abonne(
+    EvenementMesuresServiceModifiees,
+    consigneDansJournal({ adaptateurJournal })
+  );
+};
+
+module.exports = { cableTousLesAbonnes };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -2,11 +2,22 @@ const EvenementMesuresServiceModifiees = require('./evenementMesuresServiceModif
 const {
   consigneDansJournal,
 } = require('./abonnements/mesuresServiceModifiees/consigneDansJournal');
+const {
+  envoieTrackingCompletude,
+} = require('./abonnements/mesuresServiceModifiees/envoieTrackingDeCompletude');
 
-const cableTousLesAbonnes = (busEvenements, { adaptateurJournal }) => {
+const cableTousLesAbonnes = (
+  busEvenements,
+  { adaptateurTracking, adaptateurJournal, depotDonnees }
+) => {
   busEvenements.abonne(
     EvenementMesuresServiceModifiees,
     consigneDansJournal({ adaptateurJournal })
+  );
+
+  busEvenements.abonne(
+    EvenementMesuresServiceModifiees,
+    envoieTrackingCompletude({ adaptateurTracking, depotDonnees })
   );
 };
 

--- a/src/bus/evenementMesuresServiceModifiees.js
+++ b/src/bus/evenementMesuresServiceModifiees.js
@@ -1,0 +1,3 @@
+class EvenementMesuresServiceModifiees {}
+
+module.exports = EvenementMesuresServiceModifiees;

--- a/src/bus/evenementMesuresServiceModifiees.js
+++ b/src/bus/evenementMesuresServiceModifiees.js
@@ -1,3 +1,7 @@
-class EvenementMesuresServiceModifiees {}
+class EvenementMesuresServiceModifiees {
+  constructor({ service }) {
+    this.service = service;
+  }
+}
 
 module.exports = EvenementMesuresServiceModifiees;

--- a/src/bus/evenementMesuresServiceModifiees.js
+++ b/src/bus/evenementMesuresServiceModifiees.js
@@ -1,6 +1,7 @@
 class EvenementMesuresServiceModifiees {
-  constructor({ service }) {
+  constructor({ service, utilisateur }) {
     this.service = service;
+    this.utilisateur = utilisateur;
   }
 }
 

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -19,6 +19,7 @@ const creeDepot = (config = {}) => {
     adaptateurTracking = fabriqueAdaptateurTracking(),
     adaptateurUUID = adaptateurUUIDParDefaut,
     referentiel = Referentiel.creeReferentiel(),
+    busEvenements,
   } = config;
 
   const depotHomologations = depotDonneesHomologations.creeDepot({
@@ -27,6 +28,7 @@ const creeDepot = (config = {}) => {
     adaptateurPersistance,
     adaptateurTracking,
     adaptateurUUID,
+    busEvenements,
     referentiel,
   });
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -286,15 +286,8 @@ const creeDepot = (config = {}) => {
       idHomologation,
       specifiques
     );
-    const h = await p.lis.une(idHomologation);
-    await adaptateurJournalMSS.consigneEvenement(
-      new EvenementCompletudeServiceModifiee({
-        idService: h.id,
-        ...h.completudeMesures(),
-        nombreOrganisationsUtilisatrices:
-          h.descriptionService.nombreOrganisationsUtilisatrices,
-      }).toJSON()
-    );
+    const service = await p.lis.une(idHomologation);
+
     const tauxCompletude =
       await serviceTracking.completudeDesServicesPourUtilisateur(
         { homologations },
@@ -305,7 +298,9 @@ const creeDepot = (config = {}) => {
       utilisateur.email,
       tauxCompletude
     );
-    await busEvenements.publie(new EvenementMesuresServiceModifiees());
+    await busEvenements.publie(
+      new EvenementMesuresServiceModifiees({ service })
+    );
   };
 
   const toutesHomologations = () => p.lis.toutes();

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -14,6 +14,7 @@ const EvenementNouvelleHomologationCreee = require('../modeles/journalMSS/evenem
 const EvenementServiceSupprime = require('../modeles/journalMSS/evenementServiceSupprime');
 const { fabriqueServiceTracking } = require('../tracking/serviceTracking');
 const Autorisation = require('../modeles/autorisations/autorisation');
+const EvenementMesuresServiceModifiees = require('../bus/evenementMesuresServiceModifiees');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -90,6 +91,7 @@ const creeDepot = (config = {}) => {
     adaptateurPersistance,
     adaptateurTracking = fabriqueAdaptateurTracking(),
     adaptateurUUID,
+    busEvenements,
     referentiel,
     serviceTracking = fabriqueServiceTracking(),
   } = config;
@@ -303,6 +305,7 @@ const creeDepot = (config = {}) => {
       utilisateur.email,
       tauxCompletude
     );
+    busEvenements.publie(new EvenementMesuresServiceModifiees());
   };
 
   const toutesHomologations = () => p.lis.toutes();

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -286,20 +286,12 @@ const creeDepot = (config = {}) => {
       idHomologation,
       specifiques
     );
-    const service = await p.lis.une(idHomologation);
 
-    const tauxCompletude =
-      await serviceTracking.completudeDesServicesPourUtilisateur(
-        { homologations },
-        idUtilisateur
-      );
+    const service = await p.lis.une(idHomologation);
     const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
-    await adaptateurTracking.envoieTrackingCompletudeService(
-      utilisateur.email,
-      tauxCompletude
-    );
+
     await busEvenements.publie(
-      new EvenementMesuresServiceModifiees({ service })
+      new EvenementMesuresServiceModifiees({ service, utilisateur })
     );
   };
 

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -305,7 +305,7 @@ const creeDepot = (config = {}) => {
       utilisateur.email,
       tauxCompletude
     );
-    busEvenements.publie(new EvenementMesuresServiceModifiees());
+    await busEvenements.publie(new EvenementMesuresServiceModifiees());
   };
 
   const toutesHomologations = () => p.lis.toutes();

--- a/test/bus/abonnements/mesuresServiceModifiees/consigneDansJournal.spec.js
+++ b/test/bus/abonnements/mesuresServiceModifiees/consigneDansJournal.spec.js
@@ -1,0 +1,42 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const BusEvenements = require('../../../../src/bus/busEvenements');
+const EvenementMesuresServiceModifiees = require('../../../../src/bus/evenementMesuresServiceModifiees');
+const { unService } = require('../../../constructeurs/constructeurService');
+const {
+  consigneDansJournal,
+} = require('../../../../src/bus/abonnements/mesuresServiceModifiees/consigneDansJournal');
+
+describe("L'abonnement à `EvenementMesuresServiceModifiees` qui consigne dans le journal MSS", () => {
+  let bus;
+  let adaptateurJournal;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+    bus = new BusEvenements({
+      adaptateurGestionErreur: {
+        logueErreur: (e) => {
+          throw e;
+        },
+      },
+    });
+  });
+
+  it('consigne un événement de changement de complétude du service', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    bus.abonne(
+      EvenementMesuresServiceModifiees,
+      consigneDansJournal({ adaptateurJournal })
+    );
+
+    await bus.publie(
+      new EvenementMesuresServiceModifiees({ service: unService().construis() })
+    );
+
+    expect(evenementRecu.type).to.equal('COMPLETUDE_SERVICE_MODIFIEE');
+  });
+});

--- a/test/bus/abonnements/mesuresServiceModifiees/envoieTrackingDeCompletude.spec.js
+++ b/test/bus/abonnements/mesuresServiceModifiees/envoieTrackingDeCompletude.spec.js
@@ -1,0 +1,75 @@
+const expect = require('expect.js');
+const BusEvenements = require('../../../../src/bus/busEvenements');
+const EvenementMesuresServiceModifiees = require('../../../../src/bus/evenementMesuresServiceModifiees');
+const { unService } = require('../../../constructeurs/constructeurService');
+const {
+  unAdaptateurTracking,
+} = require('../../../constructeurs/constructeurAdaptateurTracking');
+const {
+  unUtilisateur,
+} = require('../../../constructeurs/constructeurUtilisateur');
+const {
+  unDepotDeDonneesServices,
+} = require('../../../constructeurs/constructeurDepotDonneesServices');
+const {
+  bouchonneMesures,
+} = require('../../../constructeurs/constructeurMesures');
+const {
+  envoieTrackingCompletude,
+} = require('../../../../src/bus/abonnements/mesuresServiceModifiees/envoieTrackingDeCompletude');
+
+describe("L'abonnement à `EvenementMesuresServiceModifiees` qui envoie au tracking les informations de complétude", () => {
+  let bus;
+  let adaptateurTracking;
+  let depotDonnees;
+
+  beforeEach(() => {
+    adaptateurTracking = unAdaptateurTracking().construis();
+    depotDonnees = unDepotDeDonneesServices().construis();
+    bus = new BusEvenements({
+      adaptateurGestionErreur: {
+        logueErreur: (e) => {
+          throw e;
+        },
+      },
+    });
+  });
+
+  it('envoie les données de complétude au tracking', async () => {
+    let donneesDeTracking;
+    adaptateurTracking.envoieTrackingCompletudeService = async (
+      destinataire,
+      donneesEvenement
+    ) => {
+      donneesDeTracking = { destinataire, donneesEvenement };
+    };
+    depotDonnees.homologations = async () => [
+      unService()
+        .avecNContributeurs(3)
+        .avecMesures(bouchonneMesures().avecUneCompletude(100, 18).construis())
+        .construis(),
+    ];
+
+    bus.abonne(
+      EvenementMesuresServiceModifiees,
+      envoieTrackingCompletude({ adaptateurTracking, depotDonnees })
+    );
+
+    await bus.publie(
+      new EvenementMesuresServiceModifiees({
+        utilisateur: unUtilisateur()
+          .avecEmail('jean.dupont@mail.fr')
+          .construis(),
+      })
+    );
+
+    expect(donneesDeTracking).to.eql({
+      destinataire: 'jean.dupont@mail.fr',
+      donneesEvenement: {
+        nombreServices: 1,
+        nombreMoyenContributeurs: 3,
+        tauxCompletudeMoyenTousServices: 18,
+      },
+    });
+  });
+});

--- a/test/bus/busEvenements.spec.js
+++ b/test/bus/busEvenements.spec.js
@@ -1,0 +1,108 @@
+// eslint-disable-next-line max-classes-per-file
+const expect = require('expect.js');
+const BusEvenements = require('../../src/bus/busEvenements');
+
+class EvenementTestA {
+  constructor(increment) {
+    this.increment = increment;
+  }
+}
+
+class EvenementTestB {}
+
+describe("Le bus d'événements", () => {
+  const creeBusEvenements = (
+    adaptateurGestionErreur = { logueErreur: () => {} }
+  ) => new BusEvenements({ adaptateurGestionErreur });
+
+  it("permet de s'abonner à un type d'événement", () => {
+    let compteur = 0;
+
+    const bus = creeBusEvenements();
+    bus.abonne(EvenementTestA, () => {
+      compteur += 1;
+    });
+
+    bus.publie(new EvenementTestA());
+
+    expect(compteur).to.be(1);
+  });
+
+  it('fait la différence entre les événements', () => {
+    let compteur = 0;
+
+    const bus = creeBusEvenements();
+    bus.abonne(EvenementTestA, () => {
+      compteur += 1;
+    });
+    bus.abonne(EvenementTestB, () => {
+      compteur += 100;
+    });
+
+    bus.publie(new EvenementTestA());
+
+    expect(compteur).to.be(1);
+  });
+
+  it("appelle tous les abonnés du type d'événement publié", () => {
+    let compteur = 0;
+
+    const bus = creeBusEvenements();
+    bus.abonne(EvenementTestA, () => {
+      compteur += 1;
+    });
+    bus.abonne(EvenementTestA, () => {
+      compteur += 10;
+    });
+
+    bus.publie(new EvenementTestA());
+
+    expect(compteur).to.be(11);
+  });
+
+  it("passe l'événement reçu en paramètre aux abonnés", () => {
+    let compteur = 0;
+
+    const bus = creeBusEvenements();
+    bus.abonne(EvenementTestA, (e) => {
+      compteur += e.increment;
+    });
+
+    bus.publie(new EvenementTestA(30));
+
+    expect(compteur).to.be(30);
+  });
+
+  it("éxecute tous les handlers même en cas d'exception", () => {
+    let compteur = 0;
+
+    const bus = creeBusEvenements({ logueErreur: () => {} });
+    bus.abonne(EvenementTestA, () => {
+      throw new Error('BOUM');
+    });
+    bus.abonne(EvenementTestA, () => {
+      compteur += 1;
+    });
+
+    bus.publie(new EvenementTestA());
+
+    expect(compteur).to.be(1);
+  });
+
+  it("envoie les erreurs des handlers à l'adaptateur de gestion d'erreur", () => {
+    let erreurEnregistree;
+
+    const bus = creeBusEvenements({
+      logueErreur: (e) => {
+        erreurEnregistree = e;
+      },
+    });
+    bus.abonne(EvenementTestA, () => {
+      throw new Error('BOUM');
+    });
+
+    bus.publie(new EvenementTestA());
+
+    expect(erreurEnregistree).to.eql(new Error('BOUM'));
+  });
+});

--- a/test/bus/busEvenements.spec.js
+++ b/test/bus/busEvenements.spec.js
@@ -44,7 +44,7 @@ describe("Le bus d'événements", () => {
     expect(compteur).to.be(1);
   });
 
-  it("appelle tous les abonnés du type d'événement publié", () => {
+  it("appelle tous les abonnés du type d'événement publié", async () => {
     let compteur = 0;
 
     const bus = creeBusEvenements();
@@ -55,7 +55,7 @@ describe("Le bus d'événements", () => {
       compteur += 10;
     });
 
-    bus.publie(new EvenementTestA());
+    await bus.publie(new EvenementTestA());
 
     expect(compteur).to.be(11);
   });
@@ -104,5 +104,19 @@ describe("Le bus d'événements", () => {
     bus.publie(new EvenementTestA());
 
     expect(erreurEnregistree).to.eql(new Error('BOUM'));
+  });
+
+  it('éxecute des handlers asynchrones', (done) => {
+    let compteur = 0;
+
+    const bus = creeBusEvenements();
+    bus.abonne(EvenementTestA, () =>
+      Promise.resolve().then(() => (compteur += 1))
+    );
+
+    bus.publie(new EvenementTestA()).then(() => {
+      expect(compteur).to.be(1);
+      done();
+    });
   });
 });

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -17,6 +17,7 @@ class ConstructeurDepotDonneesServices {
     this.adaptateurTracking = fabriqueAdaptateurTrackingMemoire();
     this.adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
     this.adaptateurUUID = { genereUUID: () => 'unUUID' };
+    this.busEvenements = { publie: () => {}, abonne: () => {} };
     this.referentiel = Referentiel.creeReferentielVide();
     this.serviceTracking = fabriqueServiceTracking();
   }
@@ -46,12 +47,18 @@ class ConstructeurDepotDonneesServices {
     return this;
   }
 
+  avecBusEvenements(busEvenements) {
+    this.busEvenements = busEvenements;
+    return this;
+  }
+
   construis() {
     return DepotDonneesHomologations.creeDepot({
       adaptateurJournalMSS: this.adaptateurJournalMSS,
       adaptateurPersistance: this.constructeurAdaptateurPersistance.construis(),
       adaptateurTracking: this.adaptateurTracking,
       adaptateurUUID: this.adaptateurUUID,
+      busEvenements: this.busEvenements,
       referentiel: this.referentiel,
       serviceTracking: this.serviceTracking,
     });

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -345,38 +345,6 @@ describe('Le dépôt de données des homologations', () => {
       );
     });
 
-    it("l'adaptateur de tracking est utilisé pour envoyé la complétude lors de modification de mesures", async () => {
-      let donneesPassees = {};
-      const adaptateurTracking = unAdaptateurTracking()
-        .avecEnvoiTrackingCompletude((destinataire, donneesEvenement) => {
-          donneesPassees = { destinataire, donneesEvenement };
-        })
-        .construis();
-      const serviceTracking = unServiceTracking()
-        .avecCompletudeDesServices(1, 5, 18)
-        .construis();
-      depot = unDepotDeDonneesServices()
-        .avecAdaptateurPersistance(adaptateurPersistance)
-        .avecAdaptateurTracking(adaptateurTracking)
-        .avecServiceTracking(serviceTracking)
-        .avecReferentiel(referentiel)
-        .construis();
-      const mesures = new MesuresSpecifiques({
-        mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
-      });
-
-      await depot.ajouteMesuresAHomologation('123', '789', [], mesures);
-
-      expect(donneesPassees).to.eql({
-        destinataire: 'jean.dujardin@beta.gouv.com',
-        donneesEvenement: {
-          nombreServices: 1,
-          nombreMoyenContributeurs: 5,
-          tauxCompletudeMoyenTousServices: 18,
-        },
-      });
-    });
-
     it("publie un événement de 'Mesures service modifiées'", async () => {
       await depot.ajouteMesuresAHomologation(
         '123',

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -195,7 +195,6 @@ describe('Le dépôt de données des homologations', () => {
 
   describe("sur demande d'associations de mesures à un service", () => {
     let adaptateurPersistance;
-    let adaptateurJournalMSS;
     let depot;
     let busEvenements;
 
@@ -224,11 +223,9 @@ describe('Le dépôt de données des homologations', () => {
         .ajouteUnService(service)
         .ajouteUneAutorisation(autorisation)
         .ajouteUnUtilisateur(utilisateur);
-      adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
         .avecAdaptateurPersistance(adaptateurPersistance)
-        .avecJournalMSS(adaptateurJournalMSS)
         .avecBusEvenements(busEvenements)
         .construis();
     });
@@ -346,27 +343,6 @@ describe('Le dépôt de données des homologations', () => {
       expect(mesuresSpecifiques.item(0).description).to.equal(
         'Une mesure spécifique'
       );
-    });
-
-    it('consigne un événement de changement de complétude du service', async () => {
-      let evenementRecu = {};
-      adaptateurJournalMSS.consigneEvenement = (evenement) => {
-        evenementRecu = evenement;
-        return Promise.resolve();
-      };
-      const generales = [];
-      const specifiques = new MesuresSpecifiques({
-        mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
-      });
-
-      await depot.ajouteMesuresAHomologation(
-        '123',
-        '789',
-        generales,
-        specifiques
-      );
-
-      expect(evenementRecu.type).to.equal('COMPLETUDE_SERVICE_MODIFIEE');
     });
 
     it("l'adaptateur de tracking est utilisé pour envoyé la complétude lors de modification de mesures", async () => {


### PR DESCRIPTION
… pour déporter le code qui alimente le journal MSS et celui qui envoie les données de tracking.

📍 Avec cette PR, lorsque `depotDonneesHomologations.ajouteMesuresAHomologation()` est appelée :
 - à la fin de la fonction, un événement `EvenementMesuresServiceModifiees` est publié sur le `busEvenements`
 - les abonnées à `EvenementMesuresServiceModifiees` sont alors appelés
 - ils sont au nombre de 2
   - `consigneDansJournal()` qui alimente le journal MSS
   - `envoieTrackingCompletude()` qui envoie les données de tracking
 
---------

🎉  Ça permet d'alléger considérablement les responsabilités de la fonction du dépôt.

La PR est 100% fonctionnelle et iso-fonctionnalité : les mêmes données sont publiées sur les mêmes canaux.

Le code de dépôt devient :

```js
const ajouteMesuresAHomologation = async (
  idHomologation,
  idUtilisateur,
  generales,
  specifiques
) => {
  await ajouteMesuresGeneralesAHomologation(idHomologation, generales);
  await remplaceMesuresSpecifiquesPourHomologation(
    idHomologation,
    specifiques
  );

  const service = await p.lis.une(idHomologation);
  const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);

  await busEvenements.publie(
    new EvenementMesuresServiceModifiees({ service, utilisateur })
  );
};
```

------------

🚠  La création du bus et son câblage se font dans `server.js` :
```js
const busEvenements = new BusEvenements({ adaptateurGestionErreur });
…
cableTousLesAbonnes(busEvenements, {
  adaptateurTracking,
  adaptateurJournal,
  depotDonnees,
});
```

📝  Le pattern de câblage est :
```js
busEvenements.abonne(
  EvenementMesuresServiceModifiees, // <-- ici une classe d'événement, qui vient de `src/bus`
  consigneDansJournal({ adaptateurJournal }) // <-- ici une fonction qui renvoie
                                             // la fonction qui consommera l'événement
);
```
```js
// Exemple d'abonné :
function consigneDansJournal({ adaptateurJournal }) {
  return async (evenement) => { // <-- on retourne la fonction … 
    const { service } = evenement;  // … qui va consommer l'événement publié
    await faitQqchAvec(service);
  };
}
```