### PR TITLE
[Svelte] Feuille de style unique pour les composants

### DIFF
--- a/src/vues/parcoursService.pug
+++ b/src/vues/parcoursService.pug
@@ -5,7 +5,7 @@ block append styles
   link(href = '/statique/assets/styles/parcoursService.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/menuNavigation.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/tiroir.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/gestionContributeurs.css', rel = 'stylesheet')
+  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/selectize.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/homologation/formulaire.css', rel = 'stylesheet')

--- a/src/vues/service/mesures-v2.pug
+++ b/src/vues/service/mesures-v2.pug
@@ -5,8 +5,7 @@ include ../fragments/jaugeProgressionMesures
 
 block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/mesure.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/tableauDesMesures.css', rel = 'stylesheet')
+  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
 
 block append scripts
   script(type = 'module', src = '/statique/composants-svelte/mesure.js')

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -18,7 +18,7 @@ mixin inputMesure({ nom, titre, indispensable, lectureSeule = false })
 block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/mesure.css', rel = 'stylesheet')
+  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
 
 block append scripts
   script(type = 'module', src = '/statique/composants-svelte/mesure.js')

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -22,7 +22,7 @@ block append styles
   link(href = '/statique/assets/styles/modules/selectize.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/tableauDeBord.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/tiroir.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/gestionContributeurs.css', rel = 'stylesheet')
+  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
 
 block append scripts
   script(src = "/statique/bibliotheques/selectize-0.15.2.min.js")

--- a/svelte/vite.config.mts
+++ b/svelte/vite.config.mts
@@ -18,7 +18,7 @@ export default defineConfig({
       fileName: (_, entryname) => `${entryname}.js`,
       formats: ['es'],
     },
-    cssCodeSplit: true,
+    cssCodeSplit: false,
     emptyOutDir: true,
   },
 });


### PR DESCRIPTION
On remarque un problème avec les composants "Partagés" en Svelte :
Leur feuilles de styles CSS respectives sont compilés dans des fichiers séparés, ce qui créer des dépendences entre le contexte d'utilisation et la déclaration de `style` associée.

On choisit donc de compiler tous les styles des composants `Svelte` dans un fichier unique : `style.css`