### PR TITLE
[SECURISER] Cartouche du référentiel

### DIFF
--- a/svelte/lib/mesure/entete/EnteteTiroir.svelte
+++ b/svelte/lib/mesure/entete/EnteteTiroir.svelte
@@ -1,49 +1,17 @@
 <script lang="ts">
   import { configurationAffichage } from '../mesure.store';
+  import CartoucheReferentiel from '../../ui/CartoucheReferentiel.svelte';
 
-  const contenuTexte =
-    $configurationAffichage.contenuTexteCartoucheDuReferentiel;
+  const { referentiel, indispensable } = $configurationAffichage;
 </script>
 
-<p
-  class="referentiel"
-  class:indispensable={contenuTexte === 'Indispensable'}
-  class:recommandee={contenuTexte === 'Recommandée'}
->
-  {contenuTexte}
-</p>
+<div class="conteneur">
+  <CartoucheReferentiel {referentiel} {indispensable} />
+</div>
 
 <style>
-  p {
-    padding: 4px 10px;
+  .conteneur {
     font-size: 0.6em;
-    font-weight: 500;
-    color: #08416a;
-    border-radius: 40px;
-    background: #ffffff;
-    width: fit-content;
-    margin-top: 0;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-  }
-
-  p:is(.indispensable, .recommandee):before {
-    content: '';
-    display: flex;
-    background-image: url('/statique/assets/images/logo_mss_petit.svg');
-    background-repeat: no-repeat;
-    background-size: contain;
-    width: 19px;
-    height: 16px;
-    margin-right: 6px;
-  }
-
-  .indispensable {
-    color: #7025da;
-  }
-
-  .recommandee {
-    color: #0079d0;
+    margin-bottom: 1em;
   }
 </style>

--- a/svelte/lib/mesure/mesure.store.ts
+++ b/svelte/lib/mesure/mesure.store.ts
@@ -1,5 +1,6 @@
 import { derived, writable } from 'svelte/store';
 import type { MesureEditee, MesureGeneraleEnrichie } from './mesure.d';
+import { Referentiel } from '../ui/types.d';
 
 type Etape =
   | 'Creation'
@@ -52,14 +53,16 @@ export const store = {
 };
 
 export const configurationAffichage = derived(store, ($store) => {
-  const contenuTexteCartoucheDuReferentiel: string =
-    $store.etape === 'Creation' || $store.etape === 'EditionSpecifique'
-      ? 'Spécifique'
-      : ($store.mesureEditee.mesure as MesureGeneraleEnrichie).indispensable
-      ? 'Indispensable'
-      : 'Recommandée';
+  const referentiel: Referentiel =
+    $store.etape === 'EditionGenerale'
+      ? Referentiel.ANSSI
+      : Referentiel.SPECIFIQUE;
   return {
-    contenuTexteCartoucheDuReferentiel,
+    referentiel,
+    indispensable:
+      referentiel === Referentiel.SPECIFIQUE
+        ? false
+        : ($store.mesureEditee.mesure as MesureGeneraleEnrichie).indispensable,
     doitAfficherIntitule:
       $store.etape === 'Creation' || $store.etape === 'EditionSpecifique',
     doitAfficherChoixCategorie:

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -14,6 +14,7 @@
     metEnFormeMesures,
   } from './tableauDesMesures.api';
   import { onMount } from 'svelte';
+  import { Referentiel } from '../ui/types.d';
 
   enum EtatEnregistrement {
     Jamais,
@@ -79,16 +80,10 @@
 <div class="tableau-des-mesures">
   {#if mesures}
     {#each Object.entries(mesures.mesuresGenerales) as [id, mesure] (id)}
-      {@const labelReferentiel = mesure.indispensable
-        ? 'Indispensable'
-        : 'Recommandé'}
       <LigneMesure
         {id}
-        referentiel={{
-          label: labelReferentiel,
-          classe: 'mss',
-          indispensable: mesure.indispensable,
-        }}
+        referentiel={Referentiel.ANSSI}
+        indispensable={mesure.indispensable}
         nom={mesure.description}
         categorie={categories[mesure.categorie]}
         referentielStatuts={statuts}
@@ -108,7 +103,7 @@
     {#each mesures.mesuresSpecifiques as mesure, index (index)}
       <LigneMesure
         id={`specifique-${index}`}
-        referentiel={{ label: 'Spécifique', classe: 'specifique' }}
+        referentiel={Referentiel.SPECIFIQUE}
         nom={mesure.description}
         categorie={categories[mesure.categorie]}
         referentielStatuts={statuts}

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -4,15 +4,14 @@
     MesureGenerale,
     MesureSpecifique,
   } from '../tableauDesMesures.d';
+  import CartoucheReferentiel from '../../ui/CartoucheReferentiel.svelte';
+  import type { Referentiel } from '../../ui/types.d';
 
   type IdDom = string;
 
   export let id: IdDom;
-  export let referentiel: {
-    label: string;
-    classe: string;
-    indispensable?: boolean;
-  };
+  export let referentiel: Referentiel;
+  export let indispensable = false;
   export let mesure: MesureSpecifique | MesureGenerale;
   export let nom: string;
   export let categorie: string;
@@ -26,10 +25,7 @@
 </script>
 
 <div class="ligne-de-mesure">
-  <span
-    class={`referentiel ${referentiel.classe}`}
-    class:indispensable={referentiel.indispensable}>{referentiel.label}</span
-  >
+  <CartoucheReferentiel {referentiel} {indispensable} />
   <div class="titre-mesure">
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <p class="titre" on:click={() => dispatch('click')}>
@@ -66,41 +62,6 @@
     grid-template-columns: 2fr 6fr 3fr;
     align-items: center;
     justify-content: space-between;
-  }
-
-  .referentiel {
-    border-radius: 40px;
-    padding: 4px 10px;
-    font-weight: 500;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: fit-content;
-  }
-
-  .referentiel.specifique {
-    color: #08416a;
-    background: #f1f5f9;
-  }
-
-  .referentiel.mss:not(.indispensable) {
-    color: #0079d0;
-    background: #dbeeff;
-  }
-  .referentiel.mss.indispensable {
-    color: #7025da;
-    background: #e9ddff;
-  }
-
-  .referentiel.mss:before {
-    content: '';
-    display: flex;
-    background-image: url('/statique/assets/images/logo_mss_petit.svg');
-    background-repeat: no-repeat;
-    background-size: contain;
-    width: 19px;
-    height: 16px;
-    margin-right: 6px;
   }
 
   .titre-mesure {

--- a/svelte/lib/ui/CartoucheReferentiel.svelte
+++ b/svelte/lib/ui/CartoucheReferentiel.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { Referentiel } from './types.d';
+
+  export let referentiel: Referentiel;
+  export let indispensable = false;
+
+  const label =
+    referentiel === Referentiel.SPECIFIQUE
+      ? 'Spécifique'
+      : referentiel === Referentiel.ANSSI && indispensable
+      ? 'Indispensable'
+      : 'Recommandé';
+</script>
+
+<span
+  class="referentiel"
+  class:indispensable
+  class:anssi={referentiel === Referentiel.ANSSI}
+  class:specifique={referentiel === Referentiel.SPECIFIQUE}
+>
+  {label}
+</span>
+
+<style>
+  .referentiel {
+    border-radius: 40px;
+    padding: 4px 10px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: fit-content;
+  }
+
+  .referentiel.specifique {
+    color: #08416a;
+    background: #f1f5f9;
+  }
+
+  .referentiel.anssi:not(.indispensable) {
+    color: #0079d0;
+    background: #dbeeff;
+  }
+
+  .referentiel.anssi.indispensable {
+    color: #7025da;
+    background: #e9ddff;
+  }
+
+  .referentiel.anssi:before {
+    content: '';
+    display: flex;
+    background-image: url('/statique/assets/images/logo_mss_petit.svg');
+    background-repeat: no-repeat;
+    background-size: contain;
+    width: 19px;
+    height: 16px;
+    margin-right: 6px;
+  }
+</style>

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -1,0 +1,4 @@
+export enum Referentiel {
+  ANSSI,
+  SPECIFIQUE,
+}


### PR DESCRIPTION
On harmonise les couleurs des cartouches `Référentiel` entre le tiroir des mesures et le tableau des mesures :point_down: 

Pour cela, on extrait un composant partagé `CartoucheReferentiel`
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/d248f3be-19ea-4e6e-9d1f-7b6272dcc1ea)