### PR TITLE
[SECURISER] Composant de sélection du statut

### DIFF
--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -6,6 +6,7 @@
   import { validationChamp } from '../directives/validationChamp';
   import { configurationAffichage, store } from './mesure.store';
   import { enregistreMesures } from './mesure.api';
+  import SelectionStatut from '../ui/SelectionStatut.svelte';
 
   export let idService: string;
   export let categories: Record<string, string>;
@@ -79,22 +80,14 @@
       </label>
     {/if}
 
-    <label for="statut" class="requis">
-      Statut de mise en œuvre
-      <select
-        bind:value={$store.mesureEditee.mesure.statut}
-        id="statut"
-        class="intouche"
-        required
-        disabled={estLectureSeule}
-        use:validationChamp={'Ce champ est obligatoire. Veuillez sélectionner une option.'}
-      >
-        <option value="" disabled selected>Non renseigné</option>
-        {#each Object.entries(statuts) as [valeur, label]}
-          <option value={valeur}>{label}</option>
-        {/each}
-      </select>
-    </label>
+    <SelectionStatut
+      bind:statut={$store.mesureEditee.mesure.statut}
+      id="statut"
+      {estLectureSeule}
+      referentielStatuts={statuts}
+      label="Statut de mise en œuvre"
+      requis
+    />
 
     {#if !estLectureSeule}
       <div class="conteneur-actions">

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -5,7 +5,8 @@
     MesureSpecifique,
   } from '../tableauDesMesures.d';
   import CartoucheReferentiel from '../../ui/CartoucheReferentiel.svelte';
-  import type { Referentiel } from '../../ui/types.d';
+  import type { Referentiel, ReferentielStatut } from '../../ui/types.d';
+  import SelectionStatut from '../../ui/SelectionStatut.svelte';
 
   type IdDom = string;
 
@@ -15,7 +16,7 @@
   export let mesure: MesureSpecifique | MesureGenerale;
   export let nom: string;
   export let categorie: string;
-  export let referentielStatuts: Record<string, string>;
+  export let referentielStatuts: ReferentielStatut;
   export let estLectureSeule: boolean;
 
   const dispatch = createEventDispatcher<{
@@ -35,20 +36,13 @@
     </p>
     <span class="categorie">{categorie}</span>
   </div>
-  <label for={`statut-${id}`}>
-    <select
-      bind:value={mesure.statut}
-      id={`statut-${id}`}
-      class="intouche"
-      disabled={estLectureSeule}
-      on:change={() => dispatch('modificationStatut')}
-    >
-      <option value="" disabled selected>--</option>
-      {#each Object.entries(referentielStatuts) as [valeur, label]}
-        <option value={valeur}>{label}</option>
-      {/each}
-    </select>
-  </label>
+  <SelectionStatut
+    bind:statut={mesure.statut}
+    {id}
+    {estLectureSeule}
+    {referentielStatuts}
+    on:change={() => dispatch('modificationStatut')}
+  />
 </div>
 
 <style>
@@ -91,9 +85,5 @@
     color: #667892;
     font-size: 0.9em;
     font-weight: 500;
-  }
-
-  select {
-    appearance: auto;
   }
 </style>

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { ReferentielStatut } from './types.d';
+
+  export let id: string;
+  export let statut: string | undefined;
+  export let referentielStatuts: ReferentielStatut;
+
+  export let estLectureSeule = false;
+</script>
+
+<label for={`statut-${id}`}>
+  <select
+    bind:value={statut}
+    id={`statut-${id}`}
+    class="intouche"
+    disabled={estLectureSeule}
+    on:change
+  >
+    <option value="" disabled selected>--</option>
+    {#each Object.entries(referentielStatuts) as [valeur, label]}
+      <option value={valeur}>{label}</option>
+    {/each}
+  </select>
+</label>
+
+<style>
+  select {
+    appearance: auto;
+  }
+</style>

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -1,22 +1,31 @@
 <script lang="ts">
   import type { ReferentielStatut } from './types.d';
+  import { validationChamp } from '../directives/validationChamp';
 
   export let id: string;
   export let statut: string | undefined;
   export let referentielStatuts: ReferentielStatut;
 
+  export let label = '';
   export let estLectureSeule = false;
+  export let requis = false;
 </script>
 
-<label for={`statut-${id}`}>
+<label for={`statut-${id}`} class:requis>
+  {label}
   <select
     bind:value={statut}
     id={`statut-${id}`}
-    class="intouche"
+    class="intouche {statut}"
+    class:vide={!statut}
     disabled={estLectureSeule}
+    required={requis}
+    use:validationChamp={requis
+      ? 'Ce champ est obligatoire. Veuillez sélectionner une option.'
+      : ''}
     on:change
   >
-    <option value="" disabled selected>--</option>
+    <option value="" disabled selected>-</option>
     {#each Object.entries(referentielStatuts) as [valeur, label]}
       <option value={valeur}>{label}</option>
     {/each}
@@ -26,5 +35,36 @@
 <style>
   select {
     appearance: auto;
+    margin-top: 8px;
+    --couleur: transparent;
+    border: 1px solid var(--couleur);
+    border-right: 8px solid var(--couleur);
+    background: var(--couleur);
+  }
+
+  select.fait {
+    --couleur: #d4f4db;
+  }
+
+  select.enCours {
+    --couleur: #dbeeff;
+  }
+
+  select.nonFait {
+    --couleur: #fff2de;
+  }
+
+  select.vide {
+    --couleur: #f1f5f9;
+  }
+
+  option {
+    background: white;
+  }
+
+  label.requis:before {
+    content: '*';
+    color: var(--rose-anssi);
+    transform: translate(6px, -3px);
   }
 </style>

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -2,3 +2,7 @@ export enum Referentiel {
   ANSSI,
   SPECIFIQUE,
 }
+
+export type IdStatut = string;
+
+export type ReferentielStatut = Record<IdStatut, string>;


### PR DESCRIPTION
On extrait un composant réutilisable pour la sélection de statut (Tableau et tiroir des mesures).
On en profite pour styliser le composant en fonction de la valeur sélectionée.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/2b2506e2-0126-4996-a86d-dc04ed37712a)
