### PR TITLE
[SECURISER] Ajoute une route pour obtenir l'indice cyber d'un service

### DIFF
--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -565,6 +565,16 @@ const routesApiService = ({
     }
   );
 
+  routes.get(
+    '/:id/indiceCyber',
+    middleware.trouveService({ [SECURISER]: LECTURE }),
+    middleware.aseptise('id'),
+    (requete, reponse) => {
+      const { homologation } = requete;
+      reponse.json(homologation.indiceCyber());
+    }
+  );
+
   return routes;
 };
 

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1924,4 +1924,42 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(data[1].idUtilisateur).to.equal('DEF');
     });
   });
+
+  describe('quand requête GET sur `/api/service/:id/indiceCyber', () => {
+    it('recherche le service correspondant', (done) => {
+      testeur.middleware().verifieRechercheService(
+        [{ niveau: LECTURE, rubrique: SECURISER }],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/service/456/indiceCyber',
+        },
+        done
+      );
+    });
+
+    it("aseptise l'id du service", (done) => {
+      testeur.middleware().verifieAseptisationParametres(
+        ['id'],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/service/456/indiceCyber',
+        },
+        done
+      );
+    });
+
+    it("renvoie l'indice cyber du service", async () => {
+      const serviceARenvoyer = unService().construis();
+      serviceARenvoyer.indiceCyber = () => ({ total: 1.5 });
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: serviceARenvoyer,
+      });
+
+      const { data } = await axios.get(
+        'http://localhost:1234/api/service/456/indiceCyber'
+      );
+
+      expect(data.total).to.be(1.5);
+    });
+  });
 });


### PR DESCRIPTION
... afin de préparer l'implémentation des indicateurs "autonomes" de la page SECURISER.

On veut pouvoir rafraichir les valeurs des indicateurs de l'indice cyber et du taux de complétude.
Pour cela, on aura besoin d'une route dedié afin que les composants Svelte puisse eux-même faire les appels API.