### PR TITLE
[CORRECTION] Cartouche des catégories

### DIFF
--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -179,6 +179,6 @@
 
   .bouton {
     margin: 0;
-    padding: 0.5em 2em;
+    padding: 0.5em 1em;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -82,8 +82,11 @@
   }
 
   .categorie {
+    background: #f1f5f9;
     color: #667892;
+    padding: 1px 8px 3px 8px;
     font-size: 0.9em;
     font-weight: 500;
+    border-radius: 20px;
   }
 </style>


### PR DESCRIPTION
Les "cartouches" des catégories de mesures ne portaient pas le même style que sur le Figma :point_down: 
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/2a32605f-ed3a-458e-865a-596b218a6f38)

On corrige cet affichage :point_down: 
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/80eb484b-72c7-4ee6-804a-b05585f2e830)
