### PR TITLE
[SECURISER] Ajoute une route pour obtenir le pourcentage de complétude des mesures d'un service

### DIFF
--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -566,6 +566,21 @@ const routesApiService = ({
   );
 
   routes.get(
+    '/:id/completude',
+    middleware.trouveService({ [SECURISER]: LECTURE }),
+    middleware.aseptise('id'),
+    (requete, reponse) => {
+      const { homologation: service } = requete;
+      const completude = service.completudeMesures();
+      const pourcentageProgression = Math.round(
+        (completude.nombreMesuresCompletes / completude.nombreTotalMesures) *
+          100
+      );
+      reponse.json({ completude: pourcentageProgression });
+    }
+  );
+
+  routes.get(
     '/:id/indiceCyber',
     middleware.trouveService({ [SECURISER]: LECTURE }),
     middleware.aseptise('id'),

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1962,4 +1962,45 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(data.total).to.be(1.5);
     });
   });
+
+  describe('quand requête GET sur `/api/service/:id/completude', () => {
+    it('recherche le service correspondant', (done) => {
+      testeur.middleware().verifieRechercheService(
+        [{ niveau: LECTURE, rubrique: SECURISER }],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/service/456/completude',
+        },
+        done
+      );
+    });
+
+    it("aseptise l'id du service", (done) => {
+      testeur.middleware().verifieAseptisationParametres(
+        ['id'],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/service/456/completude',
+        },
+        done
+      );
+    });
+
+    it('renvoie la complétude des mesures du service', async () => {
+      const serviceARenvoyer = unService().construis();
+      serviceARenvoyer.completudeMesures = () => ({
+        nombreMesuresCompletes: 2,
+        nombreTotalMesures: 10,
+      });
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: serviceARenvoyer,
+      });
+
+      const { data } = await axios.get(
+        'http://localhost:1234/api/service/456/completude'
+      );
+
+      expect(data.completude).to.be(20);
+    });
+  });
 });


### PR DESCRIPTION
... afin de préparer l'implémentation des indicateurs "autonomes" de la page SECURISER.

On veut pouvoir rafraichir les valeurs des indicateurs de l'indice cyber et du taux de complétude.
Pour cela, on aura besoin d'une route dedié afin que les composants Svelte puisse eux-même faire les appels API.
