### PR TITLE
[SECURISER] Composant Svelte de complétude des mesures

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -229,36 +229,10 @@ main {
 .conteneur-indicateurs {
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: 1em;
   position: absolute;
   right: 0;
-}
-
-.jauge-progression-mesures {
-  width: 4.2em;
-  height: 4.2em;
-}
-
-.conteneur-jauge-progression {
-  display: flex;
-  flex-direction: row;
-  gap: 0;
-  align-items: center;
-  user-select: none;
-}
-
-.conteneur-jauge-progression .cartouche-progression-mesures {
-  border-radius: 8px;
-  background: #f1f5f9;
-  padding: 8px 12px 8px 68px;
-  color: #08416a;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.conteneur-jauge-progression .jauge-progression-mesures {
-  position: absolute;
-  left: 5px;
 }
 
 .conteneur-indice-cyber {

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -7,6 +7,7 @@ $(() => {
   const estLectureSeule = JSON.parse($('#securiser-lecture-seule').text());
   const idService = $('.page-service').data('id-service');
   const { indiceCyber, noteMax } = JSON.parse($('#indice-cyber').text());
+  const pourcentageCompletude = JSON.parse($('#completude-mesure').text());
 
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-tableau-mesures', {
@@ -17,6 +18,12 @@ $(() => {
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-indice-cyber', {
       detail: { indiceCyber, noteMax, idService },
+    })
+  );
+
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-recharge-completude-mesure', {
+      detail: { progression: pourcentageCompletude },
     })
   );
 

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -23,7 +23,7 @@ $(() => {
 
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-completude-mesure', {
-      detail: { progression: pourcentageCompletude },
+      detail: { progression: pourcentageCompletude, idService },
     })
   );
 

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -21,6 +21,12 @@ $(() => {
   const referentielStatutsMesures = JSON.parse(
     $('#referentiel-statuts-mesures').text()
   );
+  const pourcentageCompletude = JSON.parse($('#completude-mesure').text());
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-recharge-completude-mesure', {
+      detail: { progression: pourcentageCompletude },
+    })
+  );
 
   const $boutonSave = $('.bouton[idHomologation]');
   const identifiantService = $boutonSave.attr('idHomologation');

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -22,14 +22,16 @@ $(() => {
     $('#referentiel-statuts-mesures').text()
   );
   const pourcentageCompletude = JSON.parse($('#completude-mesure').text());
-  document.body.dispatchEvent(
-    new CustomEvent('svelte-recharge-completude-mesure', {
-      detail: { progression: pourcentageCompletude },
-    })
-  );
-
   const $boutonSave = $('.bouton[idHomologation]');
   const identifiantService = $boutonSave.attr('idHomologation');
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-recharge-completude-mesure', {
+      detail: {
+        progression: pourcentageCompletude,
+        idService: identifiantService,
+      },
+    })
+  );
 
   const { indiceCyber, noteMax } = JSON.parse($('#indice-cyber').text());
   document.body.dispatchEvent(

--- a/src/vues/fragments/jaugeProgressionMesures.pug
+++ b/src/vues/fragments/jaugeProgressionMesures.pug
@@ -1,9 +1,0 @@
-mixin jaugeProgressionMesures(progression)
-  - const taille = 100;
-  svg.jauge-progression-mesures(viewbox=`0 0 ${taille} ${taille}`)
-    - const tailleCercle = taille * 0.85
-    - const perimetreCercle = (2 * Math.PI * (tailleCercle / 2))
-    circle(cx=taille/2 cy=taille/2 r=tailleCercle/2 fill='white' stroke='#DBEEFF' stroke-width=4)
-    circle(cx=taille/2 cy=taille/2 r=tailleCercle/2 fill='none' stroke='#0079D0' stroke-width=6 stroke-linecap='round' transform=`rotate(90 ${taille/2} ${taille/2})` stroke-dasharray=`${progression * perimetreCercle / 100} ${perimetreCercle}`)
-
-    text(x=taille/2 y=taille/2+8 text-anchor='middle' fill='#0C5C98' font-weight='bold' font-size=`${taille*0.22}px`)= `${progression} %`

--- a/src/vues/service/mesures-v2.pug
+++ b/src/vues/service/mesures-v2.pug
@@ -1,6 +1,5 @@
 extends ../parcoursService
 include ../fragments/texteTronque
-include ../fragments/jaugeProgressionMesures
 
 block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
@@ -9,6 +8,7 @@ block append styles
 block append scripts
   script(type = 'module', src = '/statique/composants-svelte/mesure.js')
   script(type = 'module', src = '/statique/composants-svelte/tableauDesMesures.js')
+  script(type = 'module', src = '/statique/composants-svelte/completudeMesure.js')
   script(type = 'module', src = '/statique/composants-svelte/indiceCyber.js')
   script(type = 'module', src = '/statique/service/mesures-v2.js')
   script(id = 'referentiel-categories-mesures', type = 'application/json').
@@ -19,6 +19,8 @@ block append scripts
     !{JSON.stringify(autorisationsService.SECURISER.estLectureSeule)}
   script(id = 'indice-cyber', type = 'application/json').
     !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax()})}
+  script(id = 'completude-mesure', type = 'application/json').
+    !{JSON.stringify(pourcentageProgression)}
 
 block header-titre-page
   h3
@@ -27,9 +29,7 @@ block header-titre-page
 block titre
   h1 Sécuriser
   .conteneur-indicateurs
-    .conteneur-jauge-progression
-      .cartouche-progression-mesures des mesures renseignées
-      +jaugeProgressionMesures(pourcentageProgression)
+    #conteneur-completude-mesure
     a.conteneur-indice-cyber(href="indiceCyber")
       .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
       #conteneur-indice-cyber

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -2,7 +2,6 @@ extends ../parcoursService
 include ../fragments/inputChoix
 include ../fragments/cartesInformations
 include ../fragments/texteTronque
-include ../fragments/jaugeProgressionMesures
 
 mixin inputMesure({ nom, titre, indispensable, lectureSeule = false })
   +inputChoix({
@@ -21,7 +20,10 @@ block append styles
 
 block append scripts
   script(type = 'module', src = '/statique/composants-svelte/mesure.js')
+  script(type = 'module', src = '/statique/composants-svelte/completudeMesure.js')
   script(type = 'module', src = '/statique/composants-svelte/indiceCyber.js')
+  script(id = 'completude-mesure', type = 'application/json').
+    !{JSON.stringify(pourcentageProgression)}
   script(id = 'indice-cyber', type = 'application/json').
     !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax()})}
 
@@ -32,9 +34,7 @@ block header-titre-page
 block titre
   h1 Sécuriser
   .conteneur-indicateurs
-    .conteneur-jauge-progression
-      .cartouche-progression-mesures des mesures renseignées
-      +jaugeProgressionMesures(pourcentageProgression)
+    #conteneur-completude-mesure
     a.conteneur-indice-cyber(href="indiceCyber")
       .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
       #conteneur-indice-cyber

--- a/svelte/lib/completudeMesures/CompletudeMesures.svelte
+++ b/svelte/lib/completudeMesures/CompletudeMesures.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  export let progression: number;
+
+  const taille = 100;
+  const tailleCercle = taille * 0.85;
+  const perimetreCercle = 2 * Math.PI * (tailleCercle / 2);
+</script>
+
+<div class="conteneur-jauge-progression">
+  <div class="cartouche-progression-mesures">des mesures renseignées</div>
+  <svg class="jauge-progression-mesures" viewBox="0 0 {taille} {taille}">
+    <circle
+      cx={taille / 2}
+      cy={taille / 2}
+      r={tailleCercle / 2}
+      fill="white"
+      stroke="#DBEEFF"
+      stroke-width="4"
+    />
+    <circle
+      cx={taille / 2}
+      cy={taille / 2}
+      r={tailleCercle / 2}
+      fill="none"
+      stroke="#0079D0"
+      stroke-width="6"
+      stroke-linecap="round"
+      transform="rotate(90 {taille / 2} {taille / 2})"
+      stroke-dasharray="{(progression * perimetreCercle) /
+        100} {perimetreCercle}"
+    />
+    <text
+      x={taille / 2}
+      y={taille / 2 + 8}
+      text-anchor="middle"
+      fill="#0C5C98"
+      font-weight="bold"
+      font-size="{taille * 0.22}px"
+    >
+      {progression} %
+    </text>
+  </svg>
+</div>
+
+<style>
+  .jauge-progression-mesures {
+    width: 4.2em;
+    height: 4.2em;
+  }
+
+  .conteneur-jauge-progression {
+    display: flex;
+    flex-direction: row;
+    gap: 0;
+    align-items: center;
+    user-select: none;
+  }
+
+  .conteneur-jauge-progression .cartouche-progression-mesures {
+    border-radius: 8px;
+    background: #f1f5f9;
+    padding: 8px 12px 8px 68px;
+    color: #08416a;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .conteneur-jauge-progression .jauge-progression-mesures {
+    position: absolute;
+    left: 5px;
+  }
+</style>

--- a/svelte/lib/completudeMesures/CompletudeMesures.svelte
+++ b/svelte/lib/completudeMesures/CompletudeMesures.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
+  import { recupereCompletudeMesure } from './completudeMesure.api';
+
   export let progression: number;
+  export let idService: string;
 
   const taille = 100;
   const tailleCercle = taille * 0.85;
   const perimetreCercle = 2 * Math.PI * (tailleCercle / 2);
+
+  const metAJourCompletude = async () => {
+    progression = await recupereCompletudeMesure(idService);
+  };
 </script>
 
+<svelte:body on:mesure-modifiee={metAJourCompletude} />
 <div class="conteneur-jauge-progression">
   <div class="cartouche-progression-mesures">des mesures renseignées</div>
   <svg class="jauge-progression-mesures" viewBox="0 0 {taille} {taille}">

--- a/svelte/lib/completudeMesures/CompletudeMesures.svelte
+++ b/svelte/lib/completudeMesures/CompletudeMesures.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { recupereCompletudeMesure } from './completudeMesure.api';
+  import Confetti from './confetti/Confetti.svelte';
 
   export let progression: number;
   export let idService: string;
@@ -8,16 +9,28 @@
   const tailleCercle = taille * 0.85;
   const perimetreCercle = 2 * Math.PI * (tailleCercle / 2);
 
+  let passage50Pourcent = false;
+  let nbConfettis = 0;
   const metAJourCompletude = async () => {
+    const ancienneProgression = progression;
     progression = await recupereCompletudeMesure(idService);
+    if (progression >= 50 && ancienneProgression < 50) {
+      passage50Pourcent = true;
+      nbConfettis = 30;
+    }
   };
 </script>
 
 <svelte:body on:mesure-modifiee={metAJourCompletude} />
-<div class="conteneur-jauge-progression">
+
+<div class="conteneur-jauge-progression" class:passage50Pourcent>
+  {#each new Array(nbConfettis).fill(0) as _}
+    <Confetti />
+  {/each}
   <div class="cartouche-progression-mesures">des mesures renseignées</div>
   <svg class="jauge-progression-mesures" viewBox="0 0 {taille} {taille}">
     <circle
+      id="cercle-fond"
       cx={taille / 2}
       cy={taille / 2}
       r={tailleCercle / 2}
@@ -26,6 +39,7 @@
       stroke-width="4"
     />
     <circle
+      id="cercle-progression"
       cx={taille / 2}
       cy={taille / 2}
       r={tailleCercle / 2}
@@ -62,6 +76,7 @@
     gap: 0;
     align-items: center;
     user-select: none;
+    position: relative;
   }
 
   .conteneur-jauge-progression .cartouche-progression-mesures {
@@ -76,5 +91,62 @@
   .conteneur-jauge-progression .jauge-progression-mesures {
     position: absolute;
     left: 5px;
+  }
+
+  .passage50Pourcent {
+    --duree-animation: 1000ms;
+    --type-animation: ease-in-out;
+  }
+
+  .passage50Pourcent .cartouche-progression-mesures {
+    animation: fond-vert-pale var(--duree-animation) var(--type-animation);
+  }
+
+  .passage50Pourcent #cercle-progression {
+    animation: couleur-svg-vert-fonce var(--duree-animation)
+      var(--type-animation);
+  }
+
+  .passage50Pourcent text {
+    animation: fond-svg-vert-fonce var(--duree-animation) var(--type-animation);
+  }
+
+  @keyframes fond-vert-pale {
+    0% {
+      background: #f1f5f9;
+      box-shadow: 0 0 50px 10px rgba(212, 244, 219, 0);
+    }
+    50% {
+      background: #d4f4db;
+      box-shadow: 0 0 50px 10px rgba(212, 244, 219, 1);
+    }
+    100% {
+      background: #f1f5f9;
+      box-shadow: 0 0 50px 10px rgba(212, 244, 219, 0);
+    }
+  }
+
+  @keyframes couleur-svg-vert-fonce {
+    0% {
+      stroke: #0079d0;
+    }
+    50% {
+      stroke: #0e972b;
+    }
+    100% {
+      stroke: #0079d0;
+    }
+  }
+
+  @keyframes fond-svg-vert-fonce {
+    0% {
+      fill: #0079d0;
+    }
+    50% {
+      fill: #0e972b;
+    }
+    100% {
+      fill: #0079d0;
+    }
   }
 </style>

--- a/svelte/lib/completudeMesures/completudeMesure.api.ts
+++ b/svelte/lib/completudeMesures/completudeMesure.api.ts
@@ -1,0 +1,4 @@
+export const recupereCompletudeMesure = async (idService: string) => {
+  const reponse = await axios.get(`/api/service/${idService}/completude`);
+  return reponse.data.completude as number;
+};

--- a/svelte/lib/completudeMesures/completudeMesure.d.ts
+++ b/svelte/lib/completudeMesures/completudeMesure.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface HTMLElementEventMap {
+    'svelte-recharge-completude-mesure': CustomEvent;
+  }
+}
+
+export type CompletudeMesureProps = {
+  progression: number;
+};

--- a/svelte/lib/completudeMesures/completudeMesure.ts
+++ b/svelte/lib/completudeMesures/completudeMesure.ts
@@ -1,0 +1,18 @@
+import CompletudeMesures from './CompletudeMesures.svelte';
+import type { CompletudeMesureProps } from './completudeMesure.d';
+
+document.body.addEventListener(
+  'svelte-recharge-completude-mesure',
+  (e: CustomEvent<CompletudeMesureProps>) => rechargeApp({ ...e.detail })
+);
+
+let app: CompletudeMesures;
+const rechargeApp = (props: CompletudeMesureProps) => {
+  app?.$destroy();
+  app = new CompletudeMesures({
+    target: document.getElementById('conteneur-completude-mesure')!,
+    props: props,
+  });
+};
+
+export default app!;

--- a/svelte/lib/completudeMesures/confetti/Confetti.svelte
+++ b/svelte/lib/completudeMesures/confetti/Confetti.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  const couleurs = ['#006CFA', '#05E4C5', '#ED1F7D', '#711CFF', '#FF9E2A'];
+
+  const uneCouleur = couleurs[Math.floor(Math.random() * couleurs.length)];
+  const dureeAnimation = 800;
+
+  let confettiEl: HTMLElement;
+
+  setTimeout(() => {
+    confettiEl!.parentNode!.removeChild(confettiEl);
+  }, dureeAnimation);
+
+  const random = (max: number) => Math.random() * max;
+</script>
+
+<i
+  bind:this={confettiEl}
+  style="background: {uneCouleur}; animation: bang {dureeAnimation}ms ease-out forwards; transform: translate3d({random(
+    500
+  ) - 250}px, {random(200) - 150}px, 0) rotate({random(360)}deg);"
+/>
+
+<style>
+  @keyframes -global-bang {
+    from {
+      transform: translate3d(0, 0, 0);
+      opacity: 1;
+    }
+  }
+
+  i {
+    position: absolute;
+    display: block;
+    width: 3px;
+    height: 8px;
+    opacity: 0;
+    top: 50%;
+    left: 50%;
+  }
+</style>


### PR DESCRIPTION
On créer un composant Svelte `CompletudeMesure` qui vient remplacer la jauge de progression `pug` actuelle.
On ajoute une animation au moment du passage au delà des 49% de complétude.
![Screencast from 04-01-2024 12 02 07(1)](https://github.com/betagouv/mon-service-securise/assets/1643465/67e24d78-5c00-438b-bd43-f5f00c6be215)

