### PR TITLE
[SECURISER] Emission de l'évenement `mesure-modifiee`

### DIFF
--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -30,4 +30,9 @@ $(() => {
       propsDuBundle
     );
   });
+
+  $(document.body).on('mesure-modifiee', (e) => {
+    const { doitFermerTiroir } = e.detail;
+    if (doitFermerTiroir) gestionnaireTiroir.basculeOuvert(false);
+  });
 });

--- a/public/service/mesures-v2.js
+++ b/public/service/mesures-v2.js
@@ -32,7 +32,7 @@ $(() => {
   });
 
   $(document.body).on('mesure-modifiee', (e) => {
-    const { doitFermerTiroir } = e.detail;
+    const doitFermerTiroir = e.detail?.sourceDeModification === 'tiroir';
     if (doitFermerTiroir) gestionnaireTiroir.basculeOuvert(false);
   });
 });

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -231,4 +231,6 @@ ${statuts}
       }
     );
   });
+
+  $(document.body).on('mesure-modifiee', () => window.location.reload());
 });

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -19,7 +19,13 @@
     enCoursEnvoi = true;
     await enregistreMesures(idService, mesuresExistantes, $store);
     enCoursEnvoi = false;
-    window.location.reload();
+    document.body.dispatchEvent(
+      new CustomEvent('mesure-modifiee', {
+        detail: {
+          doitFermerTiroir: true,
+        },
+      })
+    );
   };
 </script>
 

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -21,9 +21,7 @@
     enCoursEnvoi = false;
     document.body.dispatchEvent(
       new CustomEvent('mesure-modifiee', {
-        detail: {
-          doitFermerTiroir: true,
-        },
+        detail: { sourceDeModification: 'tiroir' },
       })
     );
   };

--- a/svelte/lib/mesure/suppression/SuppressionMesureSpecifique.svelte
+++ b/svelte/lib/mesure/suppression/SuppressionMesureSpecifique.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { store } from '../mesure.store';
-  import {supprimeMesureSpecifique} from "../mesure.api";
-  import type {MesuresExistantes} from "../mesure.d";
+  import { supprimeMesureSpecifique } from '../mesure.api';
+  import type { MesuresExistantes } from '../mesure.d';
 
   export let idService: string;
   export let mesuresExistantes: MesuresExistantes;
@@ -9,9 +9,19 @@
   let enCoursEnvoi = false;
   const supprimeMesure = async () => {
     enCoursEnvoi = true;
-    await supprimeMesureSpecifique(idService, mesuresExistantes, $store.mesureEditee.metadonnees.idMesure as number);
+    await supprimeMesureSpecifique(
+      idService,
+      mesuresExistantes,
+      $store.mesureEditee.metadonnees.idMesure as number
+    );
     enCoursEnvoi = false;
-    window.location.reload();
+    document.body.dispatchEvent(
+      new CustomEvent('mesure-modifiee', {
+        detail: {
+          doitFermerTiroir: true,
+        },
+      })
+    );
   };
 </script>
 

--- a/svelte/lib/mesure/suppression/SuppressionMesureSpecifique.svelte
+++ b/svelte/lib/mesure/suppression/SuppressionMesureSpecifique.svelte
@@ -17,9 +17,7 @@
     enCoursEnvoi = false;
     document.body.dispatchEvent(
       new CustomEvent('mesure-modifiee', {
-        detail: {
-          doitFermerTiroir: true,
-        },
+        detail: { sourceDeModification: 'tiroir' },
       })
     );
   };

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -30,10 +30,10 @@
   export let estLectureSeule: boolean;
 
   let mesures: Mesures;
-  const rafraichitMesures = async () => {
+  const rafraichisMesures = async () => {
     mesures = await recupereMesures(idService);
   };
-  onMount(rafraichitMesures);
+  onMount(rafraichisMesures);
 
   let etatEnregistrement: EtatEnregistrement = Jamais;
   const metAJourMesures = async () => {
@@ -66,7 +66,7 @@
   };
 </script>
 
-<svelte:body on:mesure-modifiee={rafraichitMesures} />
+<svelte:body on:mesure-modifiee={rafraichisMesures} />
 {#if !estLectureSeule}
   <div class="barre-actions">
     <button class="bouton" on:click={() => afficheTiroirDeMesure()}>
@@ -115,10 +115,7 @@
         on:click={() =>
           afficheTiroirDeMesure({
             mesure,
-            metadonnees: {
-              typeMesure: 'SPECIFIQUE',
-              idMesure: index,
-            },
+            metadonnees: { typeMesure: 'SPECIFIQUE', idMesure: index },
           })}
         {estLectureSeule}
       />

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -30,9 +30,10 @@
   export let estLectureSeule: boolean;
 
   let mesures: Mesures;
-  onMount(async () => {
+  const rafraichitMesures = async () => {
     mesures = await recupereMesures(idService);
-  });
+  };
+  onMount(rafraichitMesures);
 
   let etatEnregistrement: EtatEnregistrement = Jamais;
   const metAJourMesures = async () => {
@@ -64,6 +65,7 @@
   };
 </script>
 
+<svelte:body on:mesure-modifiee={rafraichitMesures} />
 {#if !estLectureSeule}
   <div class="barre-actions">
     <button class="bouton" on:click={() => afficheTiroirDeMesure()}>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -40,6 +40,7 @@
     etatEnregistrement = EnCours;
     await enregistreMesures(idService, mesures);
     etatEnregistrement = Fait;
+    document.body.dispatchEvent(new CustomEvent('mesure-modifiee'));
   };
 
   type MesureAEditer = {


### PR DESCRIPTION
On utilise un évenement du DOM sur `document.body` intitulé `mesure-modifiee` afin de communiquer entre tous les composants.

Cet évenement est émit par :
- Le tableau des mesures lors de la modification d'un statut
- Le tiroir de mesure lors de l'ajout, la modification ou la suppression d'une mesure

Il est écouté par :
- Le tableau des mesures pour recharger toutes les mesures
- Les indicateurs (Dans le PR #1235) pour recharger leur valeurs
- Le script `mesure.js` et `mesure-v2.js` pour fermer le tiroir si besoin

L'évenement porte un champ facultatif `doitFermerTiroir` pour instruire une action coté jQuery.