### PR TITLE
Cesse de loguer les erreurs `Navigation` dans Sentry

### DIFF
--- a/src/adaptateurs/adaptateurProtection.js
+++ b/src/adaptateurs/adaptateurProtection.js
@@ -9,10 +9,18 @@ const parametresCommuns = (typeRequete, doitFermerConnexion = false) => ({
   windowMs: uneMinute,
   handler: (requete, reponse) => {
     const attaque = requete.headers['x-real-ip']?.replaceAll('.', '*');
-    fabriqueAdaptateurGestionErreur().logueErreur(
-      new Error(`[${typeRequete}] Limite de trafic atteinte par une IP.`),
-      { typeRequete, 'IP de la requete': attaque }
-    );
+
+    if (typeRequete === 'Navigation')
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[${typeRequete}] Limite de trafic atteinte par l'IP ${attaque}.`
+      );
+    else
+      fabriqueAdaptateurGestionErreur().logueErreur(
+        new Error(`[${typeRequete}] Limite de trafic atteinte par une IP.`),
+        { typeRequete, 'IP de la requete': attaque }
+      );
+
     if (doitFermerConnexion) reponse.end();
     else reponse.render('erreurTropDeTrafic');
   },


### PR DESCRIPTION
On sait que MSS se fait parfois scanner.
Ça pollue notre Sentry car chaque scan donne lieu à + de 2 500 events Sentry. Et ces events ne nous servent à rien.

Donc on passe en `console.warn` pour ces events.