### PR TITLE
[SECURISER] Derniers correctifs UI

### DIFF
--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -139,6 +139,8 @@
     content: '*';
     color: var(--rose-anssi);
     transform: translate(6px, -3px);
+    margin-left: -10px;
+    margin-right: 4px;
   }
 
   .conteneur-actions {

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -79,6 +79,7 @@
     font-weight: 500;
     text-align: left;
     cursor: pointer;
+    word-break: break-word;
   }
 
   .titre img {

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -66,5 +66,7 @@
     content: '*';
     color: var(--rose-anssi);
     transform: translate(6px, -3px);
+    margin-left: -10px;
+    margin-right: 4px;
   }
 </style>

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -33,6 +33,10 @@
 </label>
 
 <style>
+  label {
+    margin-bottom: 16px;
+  }
+
   select {
     appearance: auto;
     margin-top: 8px;


### PR DESCRIPTION
Suite à des retours de l'équipe, on corrige: 
- L'espacement entre les astérisques rouges des champs requis et le label
- L'espacement au dessus du bouton "Enregistrer" dans le tiroir
- Un titre de mesure spécifique trop long et sans espace peut entrainer un dépassement dans le tableau