### PR TITLE
[CORRECTION] Reinitialise la mesure par défaut au moment de l'instanciation du bundle

### DIFF
--- a/svelte/lib/mesure/mesure.store.ts
+++ b/svelte/lib/mesure/mesure.store.ts
@@ -12,9 +12,7 @@ export type MesureStore = {
   mesureEditee: MesureEditee;
 };
 
-const { subscribe, set, update } = writable<MesureStore>();
-
-const mesureEditeeParDefaut: MesureEditee = {
+const mesureEditeeParDefaut = (): MesureEditee => ({
   mesure: {
     categorie: '',
     description: '',
@@ -25,7 +23,9 @@ const mesureEditeeParDefaut: MesureEditee = {
     typeMesure: 'SPECIFIQUE',
     idMesure: 0,
   },
-};
+});
+const { subscribe, set, update } = writable<MesureStore>();
+
 export const store = {
   set,
   subscribe,
@@ -37,7 +37,7 @@ export const store = {
       : 'EditionSpecifique';
     set({
       etape,
-      mesureEditee: mesureEditee ?? mesureEditeeParDefaut,
+      mesureEditee: mesureEditee ?? mesureEditeeParDefaut(),
     });
   },
   afficheEtapeSuppression: () =>


### PR DESCRIPTION
... sinon le store passe la valeur par référence, qui sera donc elle même modifié lors des modifications apportées dans le tiroir.
Cette valeur est par la suite réutilisée au moment de l'instanciation, elle garde donc les anciennes valeurs.

Pour reproduire :
- Ajouter une mesure
- Remplir les champs et enregistrer
- Ajouter une nouvelle mesure
- :arrow_right: Le tiroir est bien vide