### PR TITLE
[SECURISER] Recherche des mesures

### DIFF
--- a/svelte/lib/directives/surligneTexte.ts
+++ b/svelte/lib/directives/surligneTexte.ts
@@ -1,0 +1,19 @@
+type TypeNoeud = HTMLParagraphElement;
+
+export const surlgineTexte = (noeud: TypeNoeud, terme: string) => {
+  const surligne = (terme: string) => {
+    const texte = noeud.innerText;
+    noeud.innerHTML = texte.replace(
+      new RegExp(terme, 'i'),
+      (texte) => `<mark>${texte}</mark>`
+    );
+  };
+  surligne(terme);
+
+  return {
+    update(terme: string) {
+      surligne(terme);
+    },
+    destroy() {},
+  };
+};

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -8,6 +8,8 @@
   import { Referentiel, type ReferentielStatut } from '../../ui/types.d';
   import SelectionStatut from '../../ui/SelectionStatut.svelte';
   import CartoucheIndispensable from '../../ui/CartoucheIndispensable.svelte';
+  import { rechercheTextuelle } from '../tableauDesMesures.store';
+  import { surlgineTexte } from '../../directives/surligneTexte';
 
   type IdDom = string;
 
@@ -20,20 +22,15 @@
   export let referentielStatuts: ReferentielStatut;
   export let estLectureSeule: boolean;
 
-  const dispatch = createEventDispatcher<{
-    modificationStatut: null;
-    click: null;
-  }>();
+  const dispatch = createEventDispatcher<{ modificationStatut: null }>();
 </script>
 
-<div class="ligne-de-mesure">
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<div class="ligne-de-mesure" on:click>
   <CartoucheReferentiel {referentiel} />
   <div class="titre-mesure">
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <p class="titre" on:click={() => dispatch('click')}>
+    <p class="titre" use:surlgineTexte={$rechercheTextuelle}>
       {nom}
-      <!-- svelte-ignore a11y-missing-attribute -->
-      <img src="/statique/assets/images/chevron_noir.svg" />
     </p>
     <div class="conteneur-cartouches">
       <span class="categorie">{categorie}</span>
@@ -62,6 +59,7 @@
     grid-template-columns: 2fr 6fr 3fr;
     align-items: center;
     justify-content: space-between;
+    cursor: pointer;
   }
 
   .titre-mesure {
@@ -78,14 +76,7 @@
   .titre {
     font-weight: 500;
     text-align: left;
-    cursor: pointer;
     word-break: break-word;
-  }
-
-  .titre img {
-    width: 24px;
-    height: 24px;
-    position: absolute;
   }
 
   .categorie {
@@ -101,5 +92,9 @@
     display: flex;
     flex-direction: row;
     gap: 8px;
+  }
+
+  :global(mark) {
+    background: #d4f4db;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
@@ -1,5 +1,9 @@
-import { writable } from 'svelte/store';
-import type { Mesures } from './tableauDesMesures.d';
+import { writable, derived } from 'svelte/store';
+import type {
+  MesureGenerale,
+  Mesures,
+  MesureSpecifique,
+} from './tableauDesMesures.d';
 
 const mesuresParDefaut = (): Mesures => ({
   mesuresGenerales: {},
@@ -8,8 +12,76 @@ const mesuresParDefaut = (): Mesures => ({
 
 const { subscribe, set } = writable<Mesures>(mesuresParDefaut());
 
-export const store = {
+export const mesures = {
   set,
   subscribe,
   reinitialise: (mesures?: Mesures) => set(mesures ?? mesuresParDefaut()),
 };
+
+export const rechercheTextuelle = writable<string>('');
+
+const contientEnMinuscule = (champ: string | undefined, recherche: string) =>
+  champ ? champ.toLowerCase().includes(recherche.toLowerCase()) : false;
+
+enum IdFiltre {
+  rechercheTextuelle,
+}
+type Filtre = (mesure: MesureSpecifique | MesureGenerale) => boolean;
+type FiltresPredicats = Record<IdFiltre, Filtre>;
+
+type Predicats = { actifs: IdFiltre[]; filtres: FiltresPredicats };
+export const predicats = derived<[typeof rechercheTextuelle], Predicats>(
+  [rechercheTextuelle],
+  ([$rechercheTextuelle]) => {
+    const actifs = [];
+    if ($rechercheTextuelle) actifs.push(IdFiltre.rechercheTextuelle);
+
+    return {
+      actifs,
+      filtres: {
+        [IdFiltre.rechercheTextuelle]: (
+          mesure: MesureSpecifique | MesureGenerale
+        ) => contientEnMinuscule(mesure.description, $rechercheTextuelle),
+      },
+    };
+  }
+);
+
+export const mesuresFiltrees = derived<
+  [typeof mesures, typeof predicats],
+  Mesures
+>([mesures, predicats], ([$mesures, $predicats]) => ({
+  mesuresGenerales: Object.entries($mesures.mesuresGenerales)
+    .filter(([cle, m]) =>
+      $predicats.actifs
+        .map((idPredicat: IdFiltre) => $predicats.filtres[idPredicat])
+        .every((p: Filtre) => p(m))
+    )
+    .reduce((record, [cle, valeur]) => ({ ...record, [cle]: valeur }), {}),
+  mesuresSpecifiques: $mesures.mesuresSpecifiques.filter((m) =>
+    $predicats.actifs
+      .map((idPredicat: IdFiltre) => $predicats.filtres[idPredicat])
+      .every((p: Filtre) => p(m))
+  ),
+}));
+
+type NombreResultats = {
+  total: number;
+  filtrees: number;
+  aucunResultat: boolean;
+};
+export const nombreResultats = derived<
+  [typeof mesures, typeof mesuresFiltrees],
+  NombreResultats
+>([mesures, mesuresFiltrees], ([$mesures, $mesuresFiltrees]) => ({
+  total:
+    Object.keys($mesures.mesuresGenerales).length +
+    $mesures.mesuresSpecifiques.length,
+  filtrees:
+    Object.keys($mesuresFiltrees.mesuresGenerales).length +
+    $mesuresFiltrees.mesuresSpecifiques.length,
+  aucunResultat:
+    Object.keys($mesuresFiltrees.mesuresGenerales).length +
+      $mesuresFiltrees.mesuresSpecifiques.length ===
+    0,
+}));

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
@@ -1,0 +1,15 @@
+import { writable } from 'svelte/store';
+import type { Mesures } from './tableauDesMesures.d';
+
+const mesuresParDefaut = (): Mesures => ({
+  mesuresGenerales: {},
+  mesuresSpecifiques: [],
+});
+
+const { subscribe, set } = writable<Mesures>(mesuresParDefaut());
+
+export const store = {
+  set,
+  subscribe,
+  reinitialise: (mesures?: Mesures) => set(mesures ?? mesuresParDefaut()),
+};

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.ts
@@ -1,15 +1,20 @@
 import TableauDesMesures from './TableauDesMesures.svelte';
 import type { TableauDesMesuresProps } from './tableauDesMesures.d';
+import { store } from './tableauDesMesures.store';
 
 document.body.addEventListener(
   'svelte-recharge-tableau-mesures',
   (e: CustomEvent<TableauDesMesuresProps>) => rechargeApp({ ...e.detail })
 );
 
-let app: TableauDesMesures;
+const reinitialiseStore = () => {
+  store.reinitialise();
+};
 
+let app: TableauDesMesures;
 const rechargeApp = (props: TableauDesMesuresProps) => {
   app?.$destroy();
+  reinitialiseStore();
   app = new TableauDesMesures({
     target: document.getElementById('tableau-des-mesures')!,
     props,

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.ts
@@ -1,6 +1,6 @@
 import TableauDesMesures from './TableauDesMesures.svelte';
 import type { TableauDesMesuresProps } from './tableauDesMesures.d';
-import { store } from './tableauDesMesures.store';
+import { mesures } from './tableauDesMesures.store';
 
 document.body.addEventListener(
   'svelte-recharge-tableau-mesures',
@@ -8,7 +8,7 @@ document.body.addEventListener(
 );
 
 const reinitialiseStore = () => {
-  store.reinitialise();
+  mesures.reinitialise();
 };
 
 let app: TableauDesMesures;

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -24,6 +24,7 @@
       ? 'Ce champ est obligatoire. Veuillez sélectionner une option.'
       : ''}
     on:change
+    on:click|stopPropagation
   >
     <option value="" disabled selected>-</option>
     {#each Object.entries(referentielStatuts) as [valeur, label]}


### PR DESCRIPTION
On souhaite pouvoir rechercher des mesures, via un champ texte, en se basant sur :
- L'intitulé d'une mesure
- Le commentaire
- La description dans le cas d'une mesure générale

#### Architecture des stores
```mermaid
graph LR
    D -- dérivé --> A[$mesures] 
    C -- dérivé --> B[$rechercheTextuelle]
    D{$mesuresFiltrees} -- dérivé --> C[$predicats] 
    E[$nombreResultats] -- dérivé --> A
    E -- dérivé --> D
```

Le store `$predicats` contient :
- Une liste des predicats actifs
- Une liste des filtres à appliquer pour chaque prédicat
sous la forme :
```typescript
type Predicats = {
    actifs: IdFiltre[],
    predicats: Record<IdFiltre, () => boolean>
}
```