### PR TITLE
[SECURISER] Ajout des filtres

### DIFF
--- a/public/assets/images/icone_filtre.svg
+++ b/public/assets/images/icone_filtre.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 7H21" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M6 12H18" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M10 17H14" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -20,6 +20,7 @@
     mesuresFiltrees,
     nombreResultats,
     rechercheCategorie,
+    rechercheStatut,
   } from './tableauDesMesures.store';
   import MenuFlottant from '../ui/MenuFlottant.svelte';
 
@@ -72,6 +73,7 @@
 
   const effaceFiltres = () => {
     rechercheCategorie.set([]);
+    rechercheStatut.set([]);
   };
 </script>
 
@@ -111,6 +113,21 @@
               value={id}
             />
             <label for={id}>{categorie}</label>
+          </div>
+        {/each}
+      </fieldset>
+      <fieldset>
+        <legend>Statut</legend>
+        {#each Object.entries( { ...statuts, nonRenseignee: 'Non renseignée' } ) as [id, statut]}
+          <div>
+            <input
+              type="checkbox"
+              {id}
+              name={id}
+              bind:group={$rechercheStatut}
+              value={id}
+            />
+            <label for={id}>{statut}</label>
           </div>
         {/each}
       </fieldset>
@@ -301,8 +318,8 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    margin: 0;
     padding: 0;
+    margin: 0 0 24px;
   }
 
   :global(.svelte-menu-flottant) {
@@ -310,6 +327,6 @@
   }
 
   .bouton-effacer-filtre {
-    margin-top: 32px;
+    margin-top: 8px;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -69,6 +69,10 @@
       })
     );
   };
+
+  const effaceFiltres = () => {
+    rechercheCategorie.set([]);
+  };
 </script>
 
 <svelte:body on:mesure-modifiee={rafraichisMesures} />
@@ -110,6 +114,12 @@
           </div>
         {/each}
       </fieldset>
+      <button
+        class="bouton bouton-secondaire bouton-effacer-filtre"
+        on:click={effaceFiltres}
+      >
+        Effacer les filtres
+      </button>
     </div>
   </MenuFlottant>
 </div>
@@ -297,5 +307,9 @@
 
   :global(.svelte-menu-flottant) {
     transform: translate(0, -1px) !important;
+  }
+
+  .bouton-effacer-filtre {
+    margin-top: 32px;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -139,6 +139,13 @@
       </button>
     </div>
   </MenuFlottant>
+  <p
+    class="nombre-resultat"
+    class:visible={$nombreResultats.aDesFiltresAppliques}
+  >
+    <strong>{$nombreResultats.filtrees}&nbsp;</strong
+    >/&nbsp;{$nombreResultats.total} mesures affichées
+  </p>
 </div>
 {#if !estLectureSeule}
   <div class="barre-actions">
@@ -207,6 +214,7 @@
     flex-direction: row;
     margin-bottom: 1em;
     gap: 16px;
+    align-items: center;
   }
 
   label[for='recherche'] {
@@ -328,5 +336,14 @@
 
   .bouton-effacer-filtre {
     margin-top: 8px;
+  }
+
+  .nombre-resultat {
+    color: #0079d0;
+    opacity: 0;
+  }
+
+  .nombre-resultat.visible {
+    opacity: 1;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -19,10 +19,8 @@
     rechercheTextuelle,
     mesuresFiltrees,
     nombreResultats,
-    rechercheCategorie,
-    rechercheStatut,
   } from './tableauDesMesures.store';
-  import MenuFlottant from '../ui/MenuFlottant.svelte';
+  import MenuFiltres from './filtres/MenuFiltres.svelte';
 
   enum EtatEnregistrement {
     Jamais,
@@ -70,11 +68,6 @@
       })
     );
   };
-
-  const effaceFiltres = () => {
-    rechercheCategorie.set([]);
-    rechercheStatut.set([]);
-  };
 </script>
 
 <svelte:body on:mesure-modifiee={rafraichisMesures} />
@@ -88,64 +81,7 @@
       placeholder="ex : chiffrer, sauvegarde, données..."
     />
   </label>
-  <MenuFlottant>
-    <div slot="declencheur">
-      <button class="bouton bouton-secondaire bouton-filtre">
-        <img src="/statique/assets/images/icone_filtre.svg" />
-        Filtres
-      </button>
-    </div>
-
-    <div class="filtres-disponibles">
-      <div class="titre-filtres">
-        <img src="/statique/assets/images/icone_filtre.svg" />
-        Filtres
-      </div>
-      <fieldset>
-        <legend>Catégories de cybersécurité</legend>
-        {#each Object.entries(categories) as [id, categorie]}
-          <div>
-            <input
-              type="checkbox"
-              {id}
-              name={id}
-              bind:group={$rechercheCategorie}
-              value={id}
-            />
-            <label for={id}>{categorie}</label>
-          </div>
-        {/each}
-      </fieldset>
-      <fieldset>
-        <legend>Statut</legend>
-        {#each Object.entries( { ...statuts, nonRenseignee: 'Non renseignée' } ) as [id, statut]}
-          <div>
-            <input
-              type="checkbox"
-              {id}
-              name={id}
-              bind:group={$rechercheStatut}
-              value={id}
-            />
-            <label for={id}>{statut}</label>
-          </div>
-        {/each}
-      </fieldset>
-      <button
-        class="bouton bouton-secondaire bouton-effacer-filtre"
-        on:click={effaceFiltres}
-      >
-        Effacer les filtres
-      </button>
-    </div>
-  </MenuFlottant>
-  <p
-    class="nombre-resultat"
-    class:visible={$nombreResultats.aDesFiltresAppliques}
-  >
-    <strong>{$nombreResultats.filtrees}&nbsp;</strong
-    >/&nbsp;{$nombreResultats.total} mesures affichées
-  </p>
+  <MenuFiltres {categories} {statuts} />
 </div>
 {#if !estLectureSeule}
   <div class="barre-actions">
@@ -293,57 +229,5 @@
     border-radius: 8px;
     border: 1px solid #cbd5e1;
     padding: 9px 0;
-  }
-
-  .bouton-filtre {
-    display: flex;
-    gap: 8px;
-  }
-
-  .titre-filtres {
-    display: flex;
-    gap: 8px;
-    padding: calc(0.5em + 1px) calc(1em - 16px + 1px);
-    font-weight: 500;
-    color: #08416a;
-    margin-bottom: 8px;
-  }
-
-  .titre-filtres img {
-    filter: brightness(0) invert(16%) sepia(87%) saturate(1447%)
-      hue-rotate(183deg) brightness(91%) contrast(94%);
-  }
-
-  .filtres-disponibles {
-    width: 260px;
-    border-radius: 8px;
-    border: 1px solid #cbd5e1;
-    background: white;
-    padding: 0 16px 24px 16px;
-  }
-
-  .filtres-disponibles fieldset {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    padding: 0;
-    margin: 0 0 24px;
-  }
-
-  :global(.svelte-menu-flottant) {
-    transform: translate(0, -1px) !important;
-  }
-
-  .bouton-effacer-filtre {
-    margin-top: 8px;
-  }
-
-  .nombre-resultat {
-    color: #0079d0;
-    opacity: 0;
-  }
-
-  .nombre-resultat.visible {
-    opacity: 1;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -19,7 +19,9 @@
     rechercheTextuelle,
     mesuresFiltrees,
     nombreResultats,
+    rechercheCategorie,
   } from './tableauDesMesures.store';
+  import MenuFlottant from '../ui/MenuFlottant.svelte';
 
   enum EtatEnregistrement {
     Jamais,
@@ -80,6 +82,36 @@
       placeholder="ex : chiffrer, sauvegarde, données..."
     />
   </label>
+  <MenuFlottant>
+    <div slot="declencheur">
+      <button class="bouton bouton-secondaire bouton-filtre">
+        <img src="/statique/assets/images/icone_filtre.svg" />
+        Filtres
+      </button>
+    </div>
+
+    <div class="filtres-disponibles">
+      <div class="titre-filtres">
+        <img src="/statique/assets/images/icone_filtre.svg" />
+        Filtres
+      </div>
+      <fieldset>
+        <legend>Catégories de cybersécurité</legend>
+        {#each Object.entries(categories) as [id, categorie]}
+          <div>
+            <input
+              type="checkbox"
+              {id}
+              name={id}
+              bind:group={$rechercheCategorie}
+              value={id}
+            />
+            <label for={id}>{categorie}</label>
+          </div>
+        {/each}
+      </fieldset>
+    </div>
+  </MenuFlottant>
 </div>
 {#if !estLectureSeule}
   <div class="barre-actions">
@@ -147,6 +179,7 @@
     display: flex;
     flex-direction: row;
     margin-bottom: 1em;
+    gap: 16px;
   }
 
   label[for='recherche'] {
@@ -218,11 +251,51 @@
   .bouton {
     margin: 0;
     padding: 0.5em 1em;
+    font-weight: 500;
   }
 
   .aucun-resultat {
     border-radius: 8px;
     border: 1px solid #cbd5e1;
     padding: 9px 0;
+  }
+
+  .bouton-filtre {
+    display: flex;
+    gap: 8px;
+  }
+
+  .titre-filtres {
+    display: flex;
+    gap: 8px;
+    padding: calc(0.5em + 1px) calc(1em - 16px + 1px);
+    font-weight: 500;
+    color: #08416a;
+    margin-bottom: 8px;
+  }
+
+  .titre-filtres img {
+    filter: brightness(0) invert(16%) sepia(87%) saturate(1447%)
+      hue-rotate(183deg) brightness(91%) contrast(94%);
+  }
+
+  .filtres-disponibles {
+    width: 260px;
+    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    background: white;
+    padding: 0 16px 24px 16px;
+  }
+
+  .filtres-disponibles fieldset {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin: 0;
+    padding: 0;
+  }
+
+  :global(.svelte-menu-flottant) {
+    transform: translate(0, -1px) !important;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import MenuFlottant from '../../ui/MenuFlottant.svelte';
+  import type { IdCategorie, IdStatut } from '../tableauDesMesures.d';
+  import {
+    nombreResultats,
+    rechercheCategorie,
+    rechercheStatut,
+  } from '../tableauDesMesures.store';
+
+  export let categories: Record<IdCategorie, string>;
+  export let statuts: Record<IdStatut, string>;
+
+  const effaceFiltres = () => {
+    rechercheCategorie.set([]);
+    rechercheStatut.set([]);
+  };
+</script>
+
+<MenuFlottant>
+  <div slot="declencheur">
+    <button class="bouton bouton-secondaire bouton-filtre">
+      <img src="/statique/assets/images/icone_filtre.svg" alt="" />
+      Filtres
+    </button>
+  </div>
+
+  <div class="filtres-disponibles">
+    <div class="titre-filtres">
+      <img src="/statique/assets/images/icone_filtre.svg" alt="" />
+      Filtres
+    </div>
+    <fieldset>
+      <legend>Catégories de cybersécurité</legend>
+      {#each Object.entries(categories) as [id, categorie]}
+        <div>
+          <input
+            type="checkbox"
+            {id}
+            name={id}
+            bind:group={$rechercheCategorie}
+            value={id}
+          />
+          <label for={id}>{categorie}</label>
+        </div>
+      {/each}
+    </fieldset>
+    <fieldset>
+      <legend>Statut</legend>
+      {#each Object.entries( { ...statuts, nonRenseignee: 'Non renseignée' } ) as [id, statut]}
+        <div>
+          <input
+            type="checkbox"
+            {id}
+            name={id}
+            bind:group={$rechercheStatut}
+            value={id}
+          />
+          <label for={id}>{statut}</label>
+        </div>
+      {/each}
+    </fieldset>
+    <button
+      class="bouton bouton-secondaire bouton-effacer-filtre"
+      on:click={effaceFiltres}
+    >
+      Effacer les filtres
+    </button>
+  </div>
+</MenuFlottant>
+<p
+  class="nombre-resultat"
+  class:visible={$nombreResultats.aDesFiltresAppliques}
+>
+  <strong>{$nombreResultats.filtrees}&nbsp;</strong
+  >/&nbsp;{$nombreResultats.total} mesures affichées
+</p>
+
+<style>
+  .bouton-filtre {
+    display: flex;
+    gap: 8px;
+  }
+
+  .titre-filtres {
+    display: flex;
+    gap: 8px;
+    padding: calc(0.5em + 1px) calc(1em - 16px + 1px);
+    font-weight: 500;
+    color: #08416a;
+    margin-bottom: 8px;
+  }
+
+  .titre-filtres img {
+    filter: brightness(0) invert(16%) sepia(87%) saturate(1447%)
+      hue-rotate(183deg) brightness(91%) contrast(94%);
+  }
+
+  .filtres-disponibles {
+    width: 260px;
+    border-radius: 8px;
+    border: 1px solid #cbd5e1;
+    background: white;
+    padding: 0 16px 24px 16px;
+  }
+
+  .filtres-disponibles fieldset {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 0;
+    margin: 0 0 24px;
+  }
+
+  :global(.svelte-menu-flottant) {
+    transform: translate(0, -1px) !important;
+  }
+
+  .bouton-effacer-filtre {
+    margin-top: 8px;
+  }
+
+  .nombre-resultat {
+    color: #0079d0;
+    opacity: 0;
+  }
+
+  .nombre-resultat.visible {
+    opacity: 1;
+  }
+
+  .bouton {
+    margin: 0;
+    padding: 0.5em 1em;
+    font-weight: 500;
+  }
+</style>

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -2,8 +2,10 @@
   import MenuFlottant from '../../ui/MenuFlottant.svelte';
   import type { IdCategorie, IdStatut } from '../tableauDesMesures.d';
   import {
+    IdReferentiel,
     nombreResultats,
     rechercheCategorie,
+    rechercheReferentiel,
     rechercheStatut,
   } from '../tableauDesMesures.store';
 
@@ -13,6 +15,27 @@
   const effaceFiltres = () => {
     rechercheCategorie.set([]);
     rechercheStatut.set([]);
+    rechercheReferentiel.set([]);
+  };
+
+  $: referentielANSSI =
+    $rechercheReferentiel.includes(IdReferentiel.ANSSIRecommandee) &&
+    $rechercheReferentiel.includes(IdReferentiel.ANSSIIndispensable);
+  let selectionPartielleANSSI: boolean;
+  $: {
+    const estRecommandee = $rechercheReferentiel.includes(
+      IdReferentiel.ANSSIRecommandee
+    );
+    const estIndispensable = $rechercheReferentiel.includes(
+      IdReferentiel.ANSSIIndispensable
+    );
+    selectionPartielleANSSI = estRecommandee
+      ? !estIndispensable
+      : estIndispensable;
+  }
+  const gereCocheANSSI = () => {
+    if (referentielANSSI) rechercheReferentiel.ajouteReferentielANSSI();
+    else rechercheReferentiel.supprimeReferentielANSSI();
   };
 </script>
 
@@ -58,6 +81,50 @@
           <label for={id}>{statut}</label>
         </div>
       {/each}
+    </fieldset>
+    <fieldset>
+      <legend>Mesures par référentiel</legend>
+      <div>
+        <input
+          type="checkbox"
+          id="anssi"
+          name="anssi"
+          bind:checked={referentielANSSI}
+          on:click={gereCocheANSSI}
+          class:selection-partielle={selectionPartielleANSSI}
+        />
+        <label for="anssi">ANSSI</label>
+      </div>
+      <div>
+        <input
+          type="checkbox"
+          id="anssi-indispensable"
+          name="anssi-indispensable"
+          bind:group={$rechercheReferentiel}
+          value={IdReferentiel.ANSSIIndispensable}
+        />
+        <label for="anssi-indispensable">Indispensable</label>
+      </div>
+      <div>
+        <input
+          type="checkbox"
+          id="anssi-recommandee"
+          name="anssi-recommandee"
+          bind:group={$rechercheReferentiel}
+          value={IdReferentiel.ANSSIRecommandee}
+        />
+        <label for="anssi-recommandee">Recommandée</label>
+      </div>
+      <div>
+        <input
+          type="checkbox"
+          id="mesure-ajoutee"
+          name="mesure-ajoutee"
+          bind:group={$rechercheReferentiel}
+          value={IdReferentiel.MesureAjoutee}
+        />
+        <label for="mesure-ajoutee">Mesures ajoutées</label>
+      </div>
     </fieldset>
     <button
       class="bouton bouton-secondaire bouton-effacer-filtre"
@@ -132,5 +199,18 @@
     margin: 0;
     padding: 0.5em 1em;
     font-weight: 500;
+  }
+
+  #anssi.selection-partielle {
+    background-color: var(--bleu-mise-en-avant);
+  }
+
+  #anssi.selection-partielle::before {
+    content: '';
+    display: block;
+    margin: auto;
+    width: 0.6em;
+    height: 0.7em;
+    border-bottom: 0.15em #fff solid;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -95,23 +95,25 @@
         />
         <label for="anssi">ANSSI</label>
       </div>
-      <div>
+      <div class:invisible={!referentielANSSI && !selectionPartielleANSSI}>
         <input
           type="checkbox"
           id="anssi-indispensable"
           name="anssi-indispensable"
           bind:group={$rechercheReferentiel}
           value={IdReferentiel.ANSSIIndispensable}
+          class="decalage-checkbox"
         />
         <label for="anssi-indispensable">Indispensable</label>
       </div>
-      <div>
+      <div class:invisible={!referentielANSSI && !selectionPartielleANSSI}>
         <input
           type="checkbox"
           id="anssi-recommandee"
           name="anssi-recommandee"
           bind:group={$rechercheReferentiel}
           value={IdReferentiel.ANSSIRecommandee}
+          class="decalage-checkbox"
         />
         <label for="anssi-recommandee">Recommandée</label>
       </div>
@@ -212,5 +214,13 @@
     width: 0.6em;
     height: 0.7em;
     border-bottom: 0.15em #fff solid;
+  }
+
+  .decalage-checkbox {
+    margin-left: 12px;
+  }
+
+  .invisible {
+    display: none;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
@@ -94,19 +94,26 @@ type NombreResultats = {
   total: number;
   filtrees: number;
   aucunResultat: boolean;
+  aDesFiltresAppliques: boolean;
 };
 export const nombreResultats = derived<
   [typeof mesures, typeof mesuresFiltrees],
   NombreResultats
->([mesures, mesuresFiltrees], ([$mesures, $mesuresFiltrees]) => ({
-  total:
-    Object.keys($mesures.mesuresGenerales).length +
-    $mesures.mesuresSpecifiques.length,
-  filtrees:
-    Object.keys($mesuresFiltrees.mesuresGenerales).length +
-    $mesuresFiltrees.mesuresSpecifiques.length,
-  aucunResultat:
-    Object.keys($mesuresFiltrees.mesuresGenerales).length +
-      $mesuresFiltrees.mesuresSpecifiques.length ===
-    0,
-}));
+>([mesures, mesuresFiltrees], ([$mesures, $mesuresFiltrees]) => {
+  const nbMesuresGenerales = Object.keys($mesures.mesuresGenerales).length;
+  const nbMesuresSpecifiques = $mesures.mesuresSpecifiques.length;
+  const nbMesuresTotal = nbMesuresGenerales + nbMesuresSpecifiques;
+  const nbMesuresGeneralesFiltrees = Object.keys(
+    $mesuresFiltrees.mesuresGenerales
+  ).length;
+  const nbMesuresSpecifiquesFiltrees =
+    $mesuresFiltrees.mesuresSpecifiques.length;
+  const nbMesuresFiltreesTotal =
+    nbMesuresGeneralesFiltrees + nbMesuresSpecifiquesFiltrees;
+  return {
+    total: nbMesuresGenerales + nbMesuresSpecifiques,
+    filtrees: nbMesuresFiltreesTotal,
+    aucunResultat: nbMesuresFiltreesTotal === 0,
+    aDesFiltresAppliques: nbMesuresTotal !== nbMesuresFiltreesTotal,
+  };
+});

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
@@ -103,8 +103,7 @@ export const predicats = derived<
       filtres: {
         [IdFiltre.rechercheTextuelle]: (
           mesure: MesureSpecifique | MesureGenerale
-        ) =>
-          contientEnMinuscule(mesure.description, $rechercheTextuelle) ,
+        ) => contientEnMinuscule(mesure.description, $rechercheTextuelle),
         [IdFiltre.rechercheCategorie]: (
           mesure: MesureSpecifique | MesureGenerale
         ) => $rechercheCategorie.includes(mesure.categorie),
@@ -134,7 +133,7 @@ export const mesuresFiltrees = derived<
   Mesures
 >([mesures, predicats], ([$mesures, $predicats]) => ({
   mesuresGenerales: Object.entries($mesures.mesuresGenerales)
-    .filter(([cle, m]) =>
+    .filter(([_, m]) =>
       $predicats.actifs
         .map((idPredicat: IdFiltre) => $predicats.filtres[idPredicat])
         .every((p: Filtre) => p(m))

--- a/svelte/lib/ui/MenuFlottant.svelte
+++ b/svelte/lib/ui/MenuFlottant.svelte
@@ -2,15 +2,11 @@
   import FermetureSurClicEnDehors from './FermetureSurClicEnDehors.svelte';
 
   let menuOuvert = false;
-  let menuEl: any;
+  let menuEl: HTMLDivElement;
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<div
-  class="conteneur"
-  on:click={() => (menuOuvert = !menuOuvert)}
-  bind:this={menuEl}
->
+<div class="conteneur" on:click={() => (menuOuvert = true)} bind:this={menuEl}>
   <slot name="declencheur" />
   <div class="svelte-menu-flottant" class:invisible={!menuOuvert}>
     <slot />


### PR DESCRIPTION
On ajoute les filtres dans le tableau des mesures.

On utilise les même stores `derived` que dans la PR #1250
Le cas du référentiel `ANSSI` est particulier car il y'a des "sous-référentiels" pour `Indispensable` et `Recommandé`.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/a4783285-8482-40f2-a2fc-8628c7b2b771)
