### PR TITLE
[SECURISER] Ajoute le chevron sur la ligne de mesure

### DIFF
--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -52,7 +52,7 @@
   .ligne-de-mesure {
     border-radius: 8px;
     border: 1px solid #cbd5e1;
-    padding: 20px 16px;
+    padding: 20px 56px 20px 16px;
     gap: 56px;
     margin-bottom: 8px;
     display: grid;
@@ -60,6 +60,23 @@
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
+    position: relative;
+  }
+
+  .ligne-de-mesure:after {
+    content: '';
+    width: 24px;
+    height: 24px;
+    display: flex;
+    background: url('/statique/assets/images/forme_chevron_bleu.svg') no-repeat;
+    background-size: contain;
+    position: absolute;
+    right: 16px;
+    top: calc(50% - 12px);
+  }
+
+  :global(.ligne-de-mesure label) {
+    margin-bottom: 0 !important;
   }
 
   .titre-mesure {


### PR DESCRIPTION
...car ce chevron avait du disparaître lors de l'ajout du surlignage de la recherche.
On s'aligne avec la maquette Figma.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/12e7931f-c62f-4bef-b567-8d56bc2a8426)
