### PR TITLE
[CORRECTION] Corrige la sauvegarde des mesures sur Chrome

### DIFF
--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -111,7 +111,10 @@
         categorie={categories[mesure.categorie]}
         referentielStatuts={statuts}
         bind:mesure={$mesures.mesuresGenerales[id]}
-        on:modificationStatut={metAJourMesures}
+        on:modificationStatut={(e) => {
+          mesures.metAJourStatutMesureGenerale(id, e.detail.statut);
+          metAJourMesures();
+        }}
         on:click={() =>
           afficheTiroirDeMesure({
             mesure,
@@ -132,7 +135,10 @@
         categorie={categories[mesure.categorie]}
         referentielStatuts={statuts}
         bind:mesure={$mesures.mesuresSpecifiques[indexReel]}
-        on:modificationStatut={metAJourMesures}
+        on:modificationStatut={(e) => {
+          mesures.metAJourStatutMesureSpecifique(indexReel, e.detail.statut);
+          metAJourMesures();
+        }}
         on:click={() =>
           afficheTiroirDeMesure({
             mesure,

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -21,7 +21,9 @@
   export let referentielStatuts: ReferentielStatut;
   export let estLectureSeule: boolean;
 
-  const dispatch = createEventDispatcher<{ modificationStatut: null }>();
+  const dispatch = createEventDispatcher<{
+    modificationStatut: { statut: string };
+  }>();
 
   $: texteSurligne = nom.replace(
     new RegExp($rechercheTextuelle, 'ig'),
@@ -48,7 +50,8 @@
     {id}
     {estLectureSeule}
     {referentielStatuts}
-    on:change={() => dispatch('modificationStatut')}
+    on:input={(e) =>
+      dispatch('modificationStatut', { statut: e.detail.statut })}
   />
 </div>
 

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
@@ -6,18 +6,27 @@ import type {
   Mesures,
   MesureSpecifique,
 } from './tableauDesMesures.d';
-
 const mesuresParDefaut = (): Mesures => ({
   mesuresGenerales: {},
   mesuresSpecifiques: [],
 });
 
-const { subscribe, set } = writable<Mesures>(mesuresParDefaut());
+const { subscribe, set, update } = writable<Mesures>(mesuresParDefaut());
 
 export const mesures = {
   set,
   subscribe,
   reinitialise: (mesures?: Mesures) => set(mesures ?? mesuresParDefaut()),
+  metAJourStatutMesureGenerale: (idMesure: string, statut: string) =>
+    update((valeur) => {
+      valeur.mesuresGenerales[idMesure].statut = statut;
+      return valeur;
+    }),
+  metAJourStatutMesureSpecifique: (idMesure: number, statut: string) =>
+    update((valeur) => {
+      valeur.mesuresSpecifiques[idMesure].statut = statut;
+      return valeur;
+    }),
 };
 
 export const rechercheTextuelle = writable<string>('');

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ReferentielStatut } from './types.d';
   import { validationChamp } from '../directives/validationChamp';
+  import { createEventDispatcher } from 'svelte';
 
   export let id: string;
   export let statut: string | undefined;
@@ -9,6 +10,8 @@
   export let label = '';
   export let estLectureSeule = false;
   export let requis = false;
+
+  const dispatch = createEventDispatcher<{ input: { statut: string } }>();
 </script>
 
 <label for={`statut-${id}`} class:requis>
@@ -23,7 +26,9 @@
     use:validationChamp={requis
       ? 'Ce champ est obligatoire. Veuillez sélectionner une option.'
       : ''}
-    on:change
+    on:input={(e) => {
+      dispatch('input', { statut: e.target?.value });
+    }}
     on:click|stopPropagation
   >
     <option value="" disabled selected>-</option>


### PR DESCRIPTION
La propagation des évènements diffère entre Chrome et Firefox.
Sur Chrome, lors de la modification d'un statut de mesure depuis le tableau, l'élèment est supprimé du DOM avant de pouvoir propagé son évènement de modification.

On a donc affaire à un `race-condition` entre la propagation des évènements, la mise à jour du DOM et le `setter` du store

Pour corriger :
- on se branche sur l'évènement `on:input` qui est trigger avant le `on:change`
- on fait remonter la nouvelle valeur du statut
- on modifie cette valeur directement dans le store
- on enregistre les mesures