### PR TITLE
[CORRECTION] Corrige l'alignement des légendes de filtre dans chrome

### DIFF
--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -180,6 +180,10 @@
     margin: 0 0 24px;
   }
 
+  .filtres-disponibles legend {
+    text-align: left;
+  }
+
   :global(.svelte-menu-flottant) {
     transform: translate(0, -1px) !important;
   }


### PR DESCRIPTION
... car les légendes s'affiche "centrées" par défaut sur chrome.