### PR TITLE
[CORRECTION] Ajoute un paramètre pour positionner le menu flottant à la demande

### DIFF
--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -39,7 +39,7 @@
   };
 </script>
 
-<MenuFlottant>
+<MenuFlottant parDessusDeclencheur={true}>
   <div slot="declencheur">
     <button class="bouton bouton-secondaire bouton-filtre">
       <img src="/statique/assets/images/icone_filtre.svg" alt="" />
@@ -182,10 +182,6 @@
 
   .filtres-disponibles legend {
     text-align: left;
-  }
-
-  :global(.svelte-menu-flottant) {
-    transform: translate(0, -1px) !important;
   }
 
   .bouton-effacer-filtre {

--- a/svelte/lib/ui/MenuFlottant.svelte
+++ b/svelte/lib/ui/MenuFlottant.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import FermetureSurClicEnDehors from './FermetureSurClicEnDehors.svelte';
 
+  export let parDessusDeclencheur = false;
+
   let menuOuvert = false;
   let menuEl: HTMLDivElement;
 </script>
@@ -8,7 +10,11 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div class="conteneur" on:click={() => (menuOuvert = true)} bind:this={menuEl}>
   <slot name="declencheur" />
-  <div class="svelte-menu-flottant" class:invisible={!menuOuvert}>
+  <div
+    class="svelte-menu-flottant"
+    class:invisible={!menuOuvert}
+    class:parDessusDeclencheur
+  >
     <slot />
   </div>
 </div>
@@ -27,6 +33,10 @@
     left: -2px;
     transform: translateX(-100%);
     z-index: 100;
+  }
+
+  .svelte-menu-flottant.parDessusDeclencheur {
+    transform: translate(0, -1px);
   }
 
   .invisible {


### PR DESCRIPTION
Le menu flottant n'était plus positionné correctement dans le tiroir des contributeurs.
Comme on a maintenant une seule feuille de style pour tous les bundles Svelte, les css `:global` s'applique à tous les composants.

On choisit de pouvoir paramétrer la position du menu flottant.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/0ab0575b-b8c8-4f41-8cf4-b6a2d48a47f2)
