### PR TITLE
Modifie le wording des `placeholder` de recherche

### DIFF
--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -56,7 +56,7 @@ block main
           .nouveau-service.bouton#nouveau-service Nouveau service
         .recherche
           label(for='recherche-service') Rechercher
-            input#recherche-service(type='text', placeHolder='ex : Service Z, Agglomération de Mansart,...')
+            input#recherche-service(type='text', placeHolder='Nom du service, organisation responsable')
     .services.marges-fixes
       table.tableau-services
         colgroup

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -78,7 +78,7 @@
       type="search"
       id="recherche"
       bind:value={$rechercheTextuelle}
-      placeholder="ex : chiffrer, sauvegarde, données..."
+      placeholder="Intitulé, description"
     />
   </label>
   <MenuFiltres {categories} {statuts} />


### PR DESCRIPTION
Afin d'indiquer les champs dans lesquels on recherche, et non des exemples.