### PR TITLE
[CORRECTION] Permets le décochage complet des filtres "ANSSI"

### DIFF
--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -18,7 +18,7 @@
     rechercheReferentiel.set([]);
   };
 
-  $: referentielANSSI =
+  $: cocheGlobaleANSSI =
     $rechercheReferentiel.includes(IdReferentiel.ANSSIRecommandee) &&
     $rechercheReferentiel.includes(IdReferentiel.ANSSIIndispensable);
   let selectionPartielleANSSI: boolean;
@@ -34,8 +34,9 @@
       : estIndispensable;
   }
   const gereCocheANSSI = () => {
-    if (referentielANSSI) rechercheReferentiel.ajouteReferentielANSSI();
-    else rechercheReferentiel.supprimeReferentielANSSI();
+    const devientCochee = !cocheGlobaleANSSI;
+    if (devientCochee) rechercheReferentiel.ajouteLesReferentielsANSSI();
+    else rechercheReferentiel.supprimeLesReferentielsANSSI();
   };
 </script>
 
@@ -89,13 +90,13 @@
           type="checkbox"
           id="anssi"
           name="anssi"
-          bind:checked={referentielANSSI}
+          bind:checked={cocheGlobaleANSSI}
           on:click={gereCocheANSSI}
           class:selection-partielle={selectionPartielleANSSI}
         />
         <label for="anssi">ANSSI</label>
       </div>
-      <div class:invisible={!referentielANSSI && !selectionPartielleANSSI}>
+      <div class:invisible={!cocheGlobaleANSSI && !selectionPartielleANSSI}>
         <input
           type="checkbox"
           id="anssi-indispensable"
@@ -106,7 +107,7 @@
         />
         <label for="anssi-indispensable">Indispensable</label>
       </div>
-      <div class:invisible={!referentielANSSI && !selectionPartielleANSSI}>
+      <div class:invisible={!cocheGlobaleANSSI && !selectionPartielleANSSI}>
         <input
           type="checkbox"
           id="anssi-recommandee"

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
@@ -6,6 +6,7 @@ import type {
   Mesures,
   MesureSpecifique,
 } from './tableauDesMesures.d';
+
 const mesuresParDefaut = (): Mesures => ({
   mesuresGenerales: {},
   mesuresSpecifiques: [],
@@ -45,19 +46,22 @@ const {
 export const rechercheReferentiel = {
   subscribe: subscribeReferentiel,
   set: setReferentiel,
-  ajouteReferentielANSSI: () => {
-    updateReferentiel((etat) => {
-      etat.splice(etat.indexOf(IdReferentiel.ANSSIRecommandee), 1);
-      etat.splice(etat.indexOf(IdReferentiel.ANSSIIndispensable), 1);
-      return etat;
-    });
-  },
-  supprimeReferentielANSSI: () =>
-    updateReferentiel((etat) => [
-      ...etat,
-      IdReferentiel.ANSSIRecommandee,
-      IdReferentiel.ANSSIIndispensable,
+  ajouteLesReferentielsANSSI: () =>
+    updateReferentiel((etatActuel) => [
+      ...new Set([
+        ...etatActuel,
+        IdReferentiel.ANSSIRecommandee,
+        IdReferentiel.ANSSIIndispensable,
+      ]),
     ]),
+  supprimeLesReferentielsANSSI: () =>
+    updateReferentiel((etatActuel) =>
+      etatActuel.filter(
+        (f) =>
+          f !== IdReferentiel.ANSSIIndispensable &&
+          f !== IdReferentiel.ANSSIRecommandee
+      )
+    ),
 };
 
 const contientEnMinuscule = (champ: string | undefined, recherche: string) =>


### PR DESCRIPTION
Reproduction du bug:
 - Coche "ANSSI" : les sous-filtres sont cochés
 - Décoche un sous-filtre : "ANSSI" passe en affichage "sélection partielle"
 - Clique une fois "ANSSI" : on repasse en "sélection totale"
 - Clique de nouveau "ANSSI" : on revient en "partielle" de l'étape 2

Le bug est ce retour à l'étape 2 : on veut plutôt effacer complètement les filtres ANSSI.

C'est ce que fait ce commit. Les fonctions "ajouteFiltre" et "supprimeFiltre" étaient inversées.