### PR TITLE
[ACCESSIBILITÉ] Menu des contributeurs - Rôle

### DIFF
--- a/svelte/lib/gestionContributeurs/invitation/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/invitation/InvitationContributeur.svelte
@@ -79,21 +79,21 @@
         callbackDeRecherche={api.rechercheContributeurs}
         on:contributeurChoisi={ajouteInvitation}
       />
-      <ListeInvitations
-        invitations={Object.values(invitations)}
-        on:droitsChange={({ detail: nouveauxDroits }) => {
-          invitations[nouveauxDroits.utilisateur.email].droits =
-            nouveauxDroits.droits;
-          invitations = invitations;
-        }}
-        on:choixPersonnalisation={({ detail: utilisateur }) => {
-          enPersonnalisation = utilisateur;
-          etapeCourante = 'Personnalisation';
-        }}
-        on:supprimerInvitation={({ detail: aSupprimer }) =>
-          supprimeInvitation(aSupprimer)}
-      />
     </label>
+    <ListeInvitations
+      invitations={Object.values(invitations)}
+      on:droitsChange={({ detail: nouveauxDroits }) => {
+        invitations[nouveauxDroits.utilisateur.email].droits =
+          nouveauxDroits.droits;
+        invitations = invitations;
+      }}
+      on:choixPersonnalisation={({ detail: utilisateur }) => {
+        enPersonnalisation = utilisateur;
+        etapeCourante = 'Personnalisation';
+      }}
+      on:supprimerInvitation={({ detail: aSupprimer }) =>
+        supprimeInvitation(aSupprimer)}
+    />
     {#if afficheLesBoutonsAction}
       <BoutonsActions
         afficherBoutonEnvoyer={Object.values(invitations).length > 0}

--- a/svelte/lib/gestionContributeurs/invitation/ListeInvitations.svelte
+++ b/svelte/lib/gestionContributeurs/invitation/ListeInvitations.svelte
@@ -67,9 +67,11 @@
     display: flex;
     justify-content: space-between;
   }
+
   .contenu-nom-prenom {
     display: flex;
     align-items: center;
     gap: 8px;
+    font-weight: 500;
   }
 </style>

--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -24,7 +24,7 @@
     {STATUS_DROITS[niveau]}
   </div>
 {:else}
-  <MenuFlottant>
+  <MenuFlottant fermeMenuSiClicInterne={true}>
     <span slot="declencheur" class="role role-modifiable {niveau}">
       {STATUS_DROITS[niveau]}
     </span>

--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -74,6 +74,7 @@
     background: transparent;
     padding: 0;
     text-align: left;
+    cursor: pointer;
   }
 
   .role {

--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -25,50 +25,57 @@
   </div>
 {:else}
   <MenuFlottant>
-    <div slot="declencheur" class="role role-modifiable {niveau}">
+    <span slot="declencheur" class="role role-modifiable {niveau}">
       {STATUS_DROITS[niveau]}
-    </div>
+    </span>
 
     <div class="roles-disponibles">
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div
+      <button
         class="role-propose lecture"
         on:click={() => dispatch('droitsChange', 'LECTURE')}
       >
-        <div class="nom">Lecture</div>
-        <div class="description">Consulter uniquement les informations</div>
-      </div>
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div
+        <span class="nom">Lecture</span>
+        <br />
+        <span class="description">Consulter uniquement les informations</span>
+      </button>
+      <button
         class="role-propose ecriture"
         on:click={() => dispatch('droitsChange', 'ECRITURE')}
       >
-        <div class="nom">Édition</div>
-        <div class="description">Modifier et ajouter des informations</div>
-      </div>
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div
+        <span class="nom">Édition</span>
+        <br />
+        <span class="description">Modifier et ajouter des informations</span>
+      </button>
+      <button
         class="role-propose personnalise"
         on:click={() => dispatch('choixPersonnalisation')}
       >
-        <div class="nom">Personnalisé</div>
-        <div class="description">
+        <span class="nom">Personnalisé</span>
+        <br />
+        <span class="description">
           Avoir un droit d'accès adapté par rubrique
-        </div>
-      </div>
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div
+        </span>
+      </button>
+      <button
         class="role-propose proprietaire"
         on:click={() => dispatch('droitsChange', 'PROPRIETAIRE')}
       >
-        <div class="nom">Propriétaire</div>
-        <div class="description">Gérer le service et les contributeurs</div>
-      </div>
+        <span class="nom">Propriétaire</span>
+        <br />
+        <span class="description">Gérer le service et les contributeurs</span>
+      </button>
     </div>
   </MenuFlottant>
 {/if}
 
 <style>
+  button {
+    border: none;
+    background: transparent;
+    padding: 0;
+    text-align: left;
+  }
+
   .role {
     border-radius: 4px;
     font-weight: bold;

--- a/svelte/lib/gestionContributeurs/personnalisation/TagLectureEcriture.svelte
+++ b/svelte/lib/gestionContributeurs/personnalisation/TagLectureEcriture.svelte
@@ -27,7 +27,7 @@
   }>();
 </script>
 
-<MenuFlottant>
+<MenuFlottant fermeMenuSiClicInterne={true}>
   <div
     slot="declencheur"
     class="droit"
@@ -39,21 +39,29 @@
 
   <div class="droits-disponibles">
     {#each droitsDisponibles as { nom, description, droit }}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div
+      <button
         class="droit-propose"
         on:click={() => dispatch('droitChange', droit)}
         class:lecture={droit === 1}
         class:ecriture={droit === 2}
       >
-        <div class="nom">{nom}</div>
-        <div class="description">{description}</div>
-      </div>
+        <span class="nom">{nom}</span>
+        <br />
+        <span class="description">{description}</span>
+      </button>
     {/each}
   </div>
 </MenuFlottant>
 
 <style>
+  button {
+    border: none;
+    background: transparent;
+    padding: 0;
+    text-align: left;
+    cursor: pointer;
+  }
+
   .droit {
     border-radius: 4px;
     font-weight: bold;

--- a/svelte/lib/ui/FermetureSurClicEnDehors.svelte
+++ b/svelte/lib/ui/FermetureSurClicEnDehors.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  export let element: HTMLElement;
+  export let elements: HTMLElement[];
   export let doitEtreOuvert: boolean;
 
   const gereClic = (e: MouseEvent) => {
     const clicInterieur =
-      e.target === element || element?.contains(e.target as Node);
+      elements.includes(e.target as HTMLElement) ||
+      elements.some((el) => el.contains(e.target as Node));
     if (!clicInterieur) doitEtreOuvert = false;
   };
 </script>

--- a/svelte/lib/ui/MenuFlottant.svelte
+++ b/svelte/lib/ui/MenuFlottant.svelte
@@ -7,9 +7,10 @@
   let menuEl: HTMLDivElement;
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class="conteneur" on:click={() => (menuOuvert = true)} bind:this={menuEl}>
-  <slot name="declencheur" />
+<div class="conteneur" bind:this={menuEl}>
+  <button class="declencheur" on:click={() => (menuOuvert = true)}>
+    <slot name="declencheur" />
+  </button>
   <div
     class="svelte-menu-flottant"
     class:invisible={!menuOuvert}
@@ -41,5 +42,11 @@
 
   .invisible {
     display: none;
+  }
+
+  button {
+    border: none;
+    background: transparent;
+    padding: 0;
   }
 </style>

--- a/svelte/lib/ui/MenuFlottant.svelte
+++ b/svelte/lib/ui/MenuFlottant.svelte
@@ -2,17 +2,24 @@
   import FermetureSurClicEnDehors from './FermetureSurClicEnDehors.svelte';
 
   export let parDessusDeclencheur = false;
+  export let fermeMenuSiClicInterne = false;
 
   let menuOuvert = false;
-  let menuEl: HTMLDivElement;
+  let declencheurEl: HTMLButtonElement;
+  let contenuEl: HTMLDivElement;
 </script>
 
-<div class="conteneur" bind:this={menuEl}>
-  <button class="declencheur" on:click={() => (menuOuvert = true)}>
+<div class="conteneur">
+  <button
+    class="declencheur"
+    on:click={() => (menuOuvert = true)}
+    bind:this={declencheurEl}
+  >
     <slot name="declencheur" />
   </button>
   <div
     class="svelte-menu-flottant"
+    bind:this={contenuEl}
     class:invisible={!menuOuvert}
     class:parDessusDeclencheur
   >
@@ -20,7 +27,10 @@
   </div>
 </div>
 
-<FermetureSurClicEnDehors bind:doitEtreOuvert={menuOuvert} element={menuEl} />
+<FermetureSurClicEnDehors
+  bind:doitEtreOuvert={menuOuvert}
+  elements={[declencheurEl, ...(fermeMenuSiClicInterne ? [] : [contenuEl])]}
+/>
 
 <style>
   .conteneur {

--- a/svelte/lib/ui/MenuFlottant.svelte
+++ b/svelte/lib/ui/MenuFlottant.svelte
@@ -58,5 +58,6 @@
     border: none;
     background: transparent;
     padding: 0;
+    cursor: pointer;
   }
 </style>


### PR DESCRIPTION
On rend le menu déroulant de sélection des contributeurs accessible. (Utilisation de `button`)
On en profite pour ajouter un attribut à `MenuFlottant` qui permet de choisir si un click interne au menu doit le fermer ou non.