### PR TITLE
Ajout du référentiel CNIL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,6 +40,7 @@ AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire
 AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que le « Journal MSS » en mémoire logue les événements reçus dans la console
 AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
 AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logués dans la console
+AVEC_MESURES_CNIL= # `true` pour utiliser le référentiel de mesures CNIL
 
 # Politique de cache
 CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -503,7 +503,84 @@ module.exports = {
         "Lors du développement du service et, autant que possible, dans le cas de l'achat d'un service sur étagère, procéder à des tests techniques automatiques de la sécurité du service.<br>Cette mesure permet de vérifier rapidement l'existence de vulnérabilités non corrigées parmi les vulnérabilités les plus connues.",
       referentiel: 'ANSSI',
     },
-
+    registreTraitements: {
+      description: 'Remplir le registre des traitements et le tenir à jour',
+      categorie: 'gouvernance',
+      indispensable: true,
+      descriptionLongue:
+        'Rapprochez-vous de votre DPD ou de l’équipe juridique pour compléter le registre avec les 6 informations suivantes :' +
+        '<ul>' +
+        '<li>les parties prenantes (responsable de traitement, sous-traitants, catégories de destinataires) qui interviennent dans le traitement des données,</li>' +
+        '<li>les catégories de données traitées et de personnes concernées,</li>' +
+        '<li>le but poursuivi (ce que vous faites des données),</li>' +
+        '<li>qui a accès aux données et à qui elles sont communiquées,</li>' +
+        '<li>combien de temps vous les conservez,</li>' +
+        '<li>comment elles sont sécurisées.</li>' +
+        '</ul>' +
+        'Plus d’information <a href="https://www.cnil.fr/fr/RGPD-le-registre-des-activites-de-traitement" target="_blank">ici</a>.' +
+        '<br>' +
+        'Le registre est prévu par l’article 30 du RGPD, c’est un outil global avec votre organisme il participe à la documentation de la conformité. Document de recensement et d’analyse, il doit refléter la réalité de vos traitements de données personnelles.',
+      referentiel: 'CNIL',
+    },
+    minimisationCollecteDonnees: {
+      description:
+        'Minimiser la collecte des données à caractère personnel au strict nécessaire',
+      categorie: 'gouvernance',
+      indispensable: true,
+      descriptionLongue:
+        'Evaluer le but de chaque collecte de données. Ne collecter que les données strictement nécessaires pour atteindre votre objectif. Il ne faut pas collecter des données inutiles pour votre traitement en se disant qu’elles pourraient servir plus tard. Lorsque trop de données sont collectées, il faut immédiatement supprimer les données non-nécessaires.' +
+        '<br>' +
+        'Cette mesure limite la collecte des données personnelles uniquement aux informations essentielles pour réaliser un objectif spécifique. Cela réduit les risques liés à la gestion des données et renforce la protection de la vie privée des personnes.',
+      referentiel: 'CNIL',
+    },
+    dureeLimiteeConservationDonnees: {
+      description:
+        'Déterminer une durée limitée de traitement et de conservation des données à caractère personnel au strict nécessaire',
+      categorie: 'gouvernance',
+      indispensable: true,
+      descriptionLongue:
+        'Ne conserver les données en « base active » (ou environnement de production) que le temps strictement nécessaire à la réalisation de l’objectif poursuivi. Il faut ensuite détruire ou anonymiser les données ou les archiver dans le respect des obligations légales applicables en matière de conservation des archives publiques. Vous pouvez consulter le <a href="https://www.cnil.fr/sites/cnil/files/atoms/files/guide_durees_de_conservation.pdf" target="_blank">guide pratique prévu à cet effet</a>.' +
+        '<br>' +
+        "Cette mesure vise à limiter le temps pendant lequel les données personnelles sont conservées et traitées, réduisant ainsi les risques de mauvaise utilisation, d'accès non autorisé, de fuite de données ou de réutilisation non-anticipée.",
+      referentiel: 'CNIL',
+    },
+    utilisationDonneesCaracterePersonnel: {
+      description:
+        'Fournir des informations aux personnes concernées sur l’utilisation de leurs données à caractère personnel',
+      categorie: 'gouvernance',
+      indispensable: true,
+      descriptionLongue:
+        'Informer clairement les personnes lors de la collecte de leurs données de manière à ce qu’elles puissent :' +
+        '<ul>' +
+        '<li>connaître la raison de la collecte des différentes données les concernant ;</li>' +
+        '<li>comprendre le traitement qui sera fait de leurs données ;</li>' +
+        '<li>être assurer de la maîtrise de leurs données, notamment via l’exercice de leurs droits. La liste complète des informations à fournir <a href="https://www.cnil.fr/fr/reglement-europeen-protection-donnees/chapitre3#Article13" target="_blank">est disponible ici</a> .</li>' +
+        '<br>' +
+        'Les personnes doivent conserver la maîtrise des données qui les concernent. Cela suppose qu’elles soient clairement informées de l’utilisation qui sera faite de leurs données. Les personnes doivent également être informées de leurs droits et des modalités d’exercice de ces droits. Plus d’information <a href="https://www.cnil.fr/fr/conformite-rgpd-information-des-personnes-et-transparence" target="_blank">ici</a>.',
+      referentiel: 'CNIL',
+    },
+    modalitesExerciceDroits: {
+      description:
+        'Fournir des informations aux personnes concernées sur les modalités d’exercice des droits',
+      categorie: 'gouvernance',
+      indispensable: true,
+      descriptionLongue:
+        "Permettre aux personnes d’exercer leurs droits d’accès aux données qui les concernent, de rectification ou de suppression, voire d’opposition (sauf si le traitement répond à une obligation légale). Une réponse à une demande de droit d’accès doit contenir une copie des données ainsi que : l’objectif du traitement des données, si possible sa durée, l'identité des destinataires, dans le cas d’un traitement automatisé sa logique et ses conséquences. Ces droits doivent pouvoir s’exercer par voie électronique à partir d’une adresse dédiée. Plus d’informations sont disponibles <a href='https://www.cnil.fr/fr/les-droits-des-personnes-sur-leurs-donnees' target='_blank'>ici</a>." +
+        '<br>' +
+        "Les personnes ont le droit d'accéder aux données à caractère personnel qui ont été collectées à leur sujet. Elles doivent pouvoir exercer ce droit facilement et à des intervalles raisonnables, afin de prendre connaissance du traitement et d'en vérifier la licéité.",
+      referentiel: 'CNIL',
+    },
+    analyseProtectionDonnees: {
+      description:
+        'Vérifier si une Analyse sur la protection des données à caractère personnel doit être réalisée',
+      categorie: 'gouvernance',
+      indispensable: true,
+      descriptionLongue:
+        'Consulter <a href="https://www.cnil.fr/sites/cnil/files/atoms/files/liste-traitements-aipd-non-requise.pdf" target="_blank">la liste des exemptions</a>. Si votre traitement n’y figure pas, regarder s’il fait partie des traitements pour lesquels <a href="https://www.cnil.fr/fr/analyse-dimpact-relative-la-protection-des-donnees-publication-dune-liste-des-traitements-pour" target="_blank">une AIPD est obligatoire</a>. Si une AIPD est nécessaire, vous pouvez la réaliser à l’aide du <a href="https://www.cnil.fr/fr/outil-pia-telechargez-et-installez-le-logiciel-de-la-cnil" target="_blank">logiciel PIA</a>.' +
+        '<br>' +
+        "Cette analyse, aussi appelée Analyse d'Impact sur la Protection des Données (AIPD), vise à évaluer et à atténuer les risques liés au traitement des données personnelles, surtout dans le cas de traitements susceptibles de présenter des risques élevés pour les droits et libertés des individus.",
+      referentiel: 'CNIL',
+    },
     anonymisationDonnees: {
       description:
         "Anonymiser autant que possible les données conservées concernant l'activité des utilisateurs",
@@ -1031,6 +1108,26 @@ module.exports = {
       impactIndisponibiliteRapidementCritique: {
         regles: [{ presence: ['moinsUneHeure'] }],
         mesuresARendreIndispensables: ['garantieHauteDisponibilite'],
+      },
+      avecDonneesCaracterePersonnel: {
+        regles: [
+          { presence: ['contact'] },
+          { presence: ['identite'] },
+          { presence: ['document'] },
+          { presence: ['situation'] },
+          { presence: ['localisation'] },
+          { presence: ['banque'] },
+          { presence: ['mineurs'] },
+          { presence: ['sensibiliteParticuliere'] },
+        ],
+        mesuresAAjouter: [
+          'registreTraitements',
+          'minimisationCollecteDonnees',
+          'dureeLimiteeConservationDonnees',
+          'utilisationDonneesCaracterePersonnel',
+          'modalitesExerciceDroits',
+          'analyseProtectionDonnees',
+        ],
       },
     },
     mesuresBase: [

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -392,12 +392,14 @@ module.exports = {
       categorie: 'gouvernance',
       descriptionLongue:
         "Conduire ou se faire accompagner dans la réalisation d'une analyse des risques pour la sécurité du service. L'ANSSI recommande de s'appuyer pour cela sur la méthode EBIOS Risk manager. Pour évaluer l'impact des risques les plus courants, utilisez l'outil proposé par MonServiceSécurisé.<br>Cette mesure permet de mettre en place de mesures de sécurité adaptées permettant de diminuer la probabilité de survenue des risques que l'organisation choisira d'adresser.",
+      referentiel: 'ANSSI',
     },
     audit: {
       description: 'Réaliser un audit de la sécurité du service',
       categorie: 'gouvernance',
       descriptionLongue:
         "Faire réaliser un audit de la sécurité du service. Les audits réalisés par des prestataires qualifiés par l'ANSSI (PASSI) incluent un audit d'architecture, de code, de configuration et un test d'intrusion.<br>Cette mesure permet d'identifier les vulnérabilités du service et les mesures de sécurité spécifiques à mettre en œuvre en vue de les corriger et ainsi renforcer significativement sa sécurité.",
+      referentiel: 'ANSSI',
     },
     auditsSecurite: {
       description:
@@ -405,6 +407,7 @@ module.exports = {
       categorie: 'gouvernance',
       descriptionLongue:
         "Organiser des contrôles de sécurité et d'audits à intervalle régulier, par exemple, avant arrivée à échéance de la dernière homologation de sécurité.<br>Cette mesure permet d'assurer un suivi de la sécurité du service dans la durée et à permettre de corriger, le cas échéant, de nouvelles vulnérabilités identifiées.",
+      referentiel: 'ANSSI',
     },
     consignesSecurite: {
       description:
@@ -413,6 +416,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         'Diffuser les mesures de sécurité du service devant être suivies par les administrateurs technique et métier (ex. agents publics chargés de mettre à jour le contenu du service ou accédant aux données de ce dernier). Fixer, de besoin, des consignes spécifiques additionnelles relatives à leur utilisation du service. Sensibiliser régulièrement les administrateurs aux bonnes pratiques de sécurité informatique.<br>Cette mesure vise à impliquer les agents dans la mise en œuvre des mesures prévues pour sécuriser le service et à accroître leur vigilance et leurs réflexes en cas de situation à risque.',
+      referentiel: 'ANSSI',
     },
     contactSecurite: {
       description:
@@ -420,6 +424,7 @@ module.exports = {
       categorie: 'gouvernance',
       descriptionLongue:
         "Fournir publiquement une procédure permettant à une personne ou à une entité de signaler un problème de sécurité concernant le service numérique. Cette procédure doit préciser les conditions dans lesquelles un problème de sécurité peut être identifié et signalé et fournir un moyen non nominatif de contacter l'équipe en charge du service ou de sa sécurité (ex. email, formulaire de contact).<br>Cette mesure facilite l'identification et le traitement de problèmes de sécurité concernant le service.",
+      referentiel: 'ANSSI',
     },
     exigencesSecurite: {
       description:
@@ -428,6 +433,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "En cas de recours à des prestataires, fixer, dès les clauses contractuelles, les exigences de sécurité à respecter. Dans le cas où ces exigences ne peuvent pas être fixées a priori (ex. produit obtenu sur étagère), identifier l'ensemble des exigences de sécurité que s'engagent à respecter les prestataires.<br>Cette mesure permet d'éclairer la sélection des prestataires en fonction des garanties de sécurité que ces derniers s'engagent à respecter.",
+      referentiel: 'ANSSI',
     },
     hebergementUE: {
       description:
@@ -435,6 +441,7 @@ module.exports = {
       categorie: 'gouvernance',
       descriptionLongue:
         "Privilégier le recours à un hébergeur proposant la localisation au sein de l'Union européenne du service numérique et des données.<br>Cette mesure vise à renforcer la protection des données grâce aux garanties offertes par la réglementation européenne et à faciliter les actions de remédiation et d'investigation en cas d'incident de sécurité.",
+      referentiel: 'ANSSI',
     },
     identificationDonneesSensibles: {
       description: 'Identifier les données importantes à protéger',
@@ -442,6 +449,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Lister l'ensemble des données à protéger en priorité (ex. données sensibles) et identifier leur localisation (technique et géographique).<br>Cette mesure permet de connaître les données les plus sensibles à protéger, d'évaluer l'impact de leur compromission et d'identifier, de besoin, des mesures de sécurité spécifiques à mettre en œuvre en vue de les protéger.",
+      referentiel: 'ANSSI',
     },
     limitationInterconnexions: {
       description:
@@ -450,6 +458,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Configurer le service en vue de limiter, au strict nécessaire, ses interconnexions avec d'autres systèmes d'information et tenir une cartographie à jour de l'ensemble de ces interconnexions.<br>Cette mesure permet de réduire le risque de propagation d'une cyberattaque de ces systèmes vers le service et inversement.",
+      referentiel: 'ANSSI',
     },
     listeComptesPrivilegies: {
       description:
@@ -458,6 +467,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Disposer et tenir à jour une liste des comptes disposant d'un accès administrateur au service, les personnes associées et la nature de leur(s) accès. Sont concernés par cette mesure les administrateurs techniques (ex. accès à la configuration de l'hébergement du service) et les administrateurs métiers (ex. agent public ayant un droit de modification des informations affichées sur le service). <br>Cette mesure permet de gérer la liste des comptes disposant d'un accès privilégié en vue d'en limiter le nombre au strict nécessaire et ainsi réduire le risque que des comptes non nécessaires soient détournés par un acteur malveillant.",
+      referentiel: 'ANSSI',
     },
     listeEquipements: {
       description:
@@ -466,6 +476,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Créer et tenir à jour un registre des équipements et des applicatifs (ex. serveurs de base de données, annuaires, pare-feu, systèmes de gestion de contenu) participant au fonctionnement du service numérique.<br>Cette mesure est nécessaire afin d'assurer la gestion des mises à jour fonctionnelles et de sécurité du service, indispensables au maintien de la sécurité du service.",
+      referentiel: 'ANSSI',
     },
     secNumCloud: {
       description:
@@ -473,6 +484,7 @@ module.exports = {
       categorie: 'gouvernance',
       descriptionLongue:
         "Privilégier le recours à un prestataire de service en nuage (Cloud) qualifié SecNumCloud par l'ANSSI.<br>Cette mesure permet d'apporter des garanties élevées en matière de confiance et de sécurité de l'hébergement du service et de ses données.",
+      referentiel: 'ANSSI',
     },
     testIntrusion: {
       description:
@@ -480,6 +492,7 @@ module.exports = {
       categorie: 'gouvernance',
       descriptionLongue:
         "Faire réaliser un test d'intrusion et/ou une campagne de recherche de bug (bug bounty) du service, par un prestataire ou par un service compétent.<br>Cette mesure permet d'identifier des vulnérabilités du service en vue de les corriger et ainsi renforcer sa sécurité.",
+      referentiel: 'ANSSI',
     },
     verificationAutomatique: {
       description:
@@ -488,6 +501,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Lors du développement du service et, autant que possible, dans le cas de l'achat d'un service sur étagère, procéder à des tests techniques automatiques de la sécurité du service.<br>Cette mesure permet de vérifier rapidement l'existence de vulnérabilités non corrigées parmi les vulnérabilités les plus connues.",
+      referentiel: 'ANSSI',
     },
 
     anonymisationDonnees: {
@@ -496,6 +510,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Configurer le service en vue d'anonymiser autant que possible les données à caractère personnel des utilisateurs conservées pour le bon fonctionnement ou la sécurité du service (ex. log de tentatives d'accès au service) ou à des fins d'analyse (ex. statistiques).<br>Cette mesure vise à protéger les utilisateurs contre la traçabilité nominative de leurs actions dans le cadre de l'utilisation du service tout en permettant d'assurer la sécurité de ce dernier au travers du suivi et de l'imputabilité des actions.",
+      referentiel: 'ANSSI',
     },
     certificatChiffrement: {
       description:
@@ -504,6 +519,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Dans le cadre de la configuration du service, installer un certificat de sécurité serveur conforme au référentiel général de sécurité (RGS) défini par l'ANSSI, délivré par un prestataire de service de confiance qualifié.<br>Cette mesure permet de chiffrer les flux de données transitant par le service numérique avec des mécanismes de chiffrement robustes ainsi que de prouver l'identité de l'organisation détentrice du certificat.",
+      referentiel: 'ANSSI',
     },
     certificatSignature: {
       description:
@@ -512,6 +528,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Dans le cadre de la configuration du service, installer un certificat de signature électronique qualifié au sens du règlement n° 910/2014 eIDAS, délivré par un prestataire qualifié, ou recourir à un service conforme.<br>Cette mesure permet la réalisation d'une signature électronique robuste sur le plan de la sécurité, conforme à la réglementation française et européenne.",
+      referentiel: 'ANSSI',
     },
     chiffrementFlux: {
       description: 'Désactiver tout flux non chiffré',
@@ -519,12 +536,14 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Configurer le service en vue de désactiver tout flux de données qui n'est pas chiffré.<br>Cette mesure permet de protéger la confidentialité des données, dans le cas où des flux de données seraient interceptés.",
+      referentiel: 'ANSSI',
     },
     chiffrementMachineVirtuelle: {
       description: 'Chiffrer la machine virtuelle',
       categorie: 'protection',
       descriptionLongue:
         'Lors de la configuration de la machine virtuelle, activez le chiffrement de cette dernière.<br>Cette mesure vise à renforcer la confidentialité des données contenues dans la machine virtuelle.',
+      referentiel: 'ANSSI',
     },
     coffreFort: {
       description:
@@ -533,6 +552,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Recommander ou proposer aux administrateurs le recours à une ou plusieurs solutions de gestion de mots de passe sécurisés, permettant de générer des mots de passe aléatoires et robustes et de les enregistrer.<br>Cette mesure permet de faciliter la création de mots de passe différents, longs et complexes, distincts pour chaque compte d'accès, sans effort de mémorisation.",
+      referentiel: 'ANSSI',
     },
     compartimenter: {
       description: "Dissocier les rôles d'administration entre eux",
@@ -540,6 +560,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Créer des comptes d'accès d'administration différents dotés de privilèges distincts, pour les personnes devant assurer plusieurs rôles d'administration, que ceux-ci soit techniques (ex. développement, hébergement) et/ou métiers (ex. création de contenus).<br>Cette mesure permet de limiter la capacité d'action d'acteurs malveillants qui parviendraient à usurper un compte d'administration.",
+      referentiel: 'ANSSI',
     },
     configurationMinimaliste: {
       description:
@@ -548,6 +569,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Lors du développement du service ou de l'installation des applicatifs contribuant à son fonctionnement, installer uniquement les fonctionnalités nécessaires et désactiver toutes les fonctionnalités inutiles proposées par défaut. Cette mesure correspond à la règle de la « configuration minimaliste ».<br>Cette mesure permet d'éviter d'installer des fonctionnalités non nécessaires qui pourraient comporter des vulnérabilités non corrigées et servir de vecteurs à une attaque. Cette approche permet de réduire la « surface d'attaque » à savoir l'ensemble des éléments constitutifs d'un service qui pourraient être ciblés par un attaquant.",
+      referentiel: 'ANSSI',
     },
     contraintesMotDePasse: {
       description:
@@ -556,6 +578,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Fixer des règles de longueur et de complexité des mots de passe lors de la création d'un mot de passe ou de son renouvellement par un utilisateur ou un administrateur. Lorsque cela est possible, configurer le service pour interdire les mots de passe faibles.<br>Cette mesure permet de diminuer le risque de découverte et l'usurpation de mots de passe par des acteurs malveillants, par exemple en testant plusieurs mots de passe sur la base de mots du dictionnaire.",
+      referentiel: 'ANSSI',
     },
     deconnexionAutomatique: {
       description:
@@ -563,6 +586,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Configurer le service afin d'activer la déconnexion automatique des sessions des administrateurs et des utilisateurs inactifs après une durée déterminée.<br>Cette mesure vise à limiter le risque d'utilisation, par une personne malveillante, du compte d'un utilisateur, qui aurait laissé son équipement non verrouillé sans surveillance et ne se serait pas déconnecté du service.",
+      referentiel: 'ANSSI',
     },
     differentiationFiltrage: {
       description:
@@ -570,6 +594,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Configurer le service en vue de différencier le filtrage des accès utilisateurs et administrateurs, c'est-à-dire déterminer une zone délimitée (plage d'adresses IP) accessible uniquement aux personnes disposant de privilèges élevés (administrateurs).<br>Cette mesure vise à cloisonner les différents types d'accès afin d'éviter qu'un accès utilisateur puisse être détourné par un attaquant pour accéder à une zone du service réservée aux personnes chargées de l'administrer.",
+      referentiel: 'ANSSI',
     },
     dissocierComptesAdmin: {
       description:
@@ -578,6 +603,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Créer des comptes d'accès distincts aux personnes à la fois administratrices et utilisatrices du service.<br>Cette mesure permet de réduire le risque d'accès illicite à un compte utilisateur qui permettrait d'accéder également à un compte d'administration aux privilèges élevés.",
+      referentiel: 'ANSSI',
     },
     doubleAuthentAdmins: {
       description:
@@ -586,6 +612,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Activer l'authentification multifacteur et la rendre obligatoire pour l'accès des administrateurs au service. Proscrire, autant que possible, le recours à un service numérique qui ne prévoirait pas l'authentification multifacteur pour son administration.<br>Cette mesure permet de réduire le risque d'accès illicite aux fonctions d'administration du service par des acteurs malveillants et diminue, d'autant, le risque d'atteinte grave au service.",
+      referentiel: 'ANSSI',
     },
     environnementSecurise: {
       description:
@@ -593,6 +620,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Demander aux administrateurs techniques du service de n'administrer ce dernier que depuis un environnement informatique dédié et sécurisé. Le recours à des équipements personnels doit notamment être proscrit.<br>Cette mesure vise à diminuer le risque de compromission des droits d'administration service via des moyens informatiques insuffisamment sécurisés.",
+      referentiel: 'ANSSI',
     },
     gestionComptesAcces: {
       description:
@@ -600,6 +628,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Configurer le service en vue de prévoir la suppression régulière des comptes d'accès inactifs, en priorisant la suppression des comptes d'administration. Informer les personnes concernées avant toute suppression de compte.<br>Cette mesure permet d'éviter en priorité que des comptes demeurent actifs sans raison valable, afin de réduire le nombre de comptes susceptibles d'être usurpés par un acteur malveillant.",
+      referentiel: 'ANSSI',
     },
     hebergementMachineVirtuelle: {
       description: 'Héberger le service dans une machine virtuelle',
@@ -607,6 +636,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Lors du choix de la solution d'hébergement du service et de ses données, optez pour son hébergement dans une ou plusieurs machines virtuelles.<br>Cette mesure vise à renforcer la sécurité du service et des données. Elle permet de filtrer plus facilement les accès, de limiter le risque d'attaques par déni de service et les chemins d'attaques par parallélisation.",
+      referentiel: 'ANSSI',
     },
     limitationAccesAdmin: {
       description:
@@ -615,6 +645,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Créer des comptes d'administration technique et/ou métier, aux seules personnes ayant besoin de disposer de ces accès.<br>Cette mesure permet de limiter le nombre de comptes disposant de privilèges susceptibles d'être usurpés à des fins malveillantes. Cette mesure réduit la « surface d'attaque » du service.",
+      referentiel: 'ANSSI',
     },
     limitationCreationComptes: {
       description:
@@ -623,6 +654,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Demander un nom et un prénom pour toute création de compte administrateur et utilisateur et informer chaque personne ne peut pas être partagé<br>Cette mesure permet de réduire le risque de diffusion d'identifiants et de mots de passe à des personnes qui n'auraient pas le droit d'accéder au service ou à certaines de ses fonctions. Cette mesure également à la bonne gestion des comptes d'accès au service.",
+      referentiel: 'ANSSI',
     },
     limitationDroitsAdmin: {
       description:
@@ -631,6 +663,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Lors de la création ou de la modification des privilèges associés à un compte d'administration, limiter ces derniers aux seuls privilèges nécessaires au rôle d'administration visé (ex. limiter aux seules fonctions d'administration de la base de données).<br>Cette mesure permet de réduire la capacité d'action d'un acteur malveillant qui parviendrait à usurper un compte administrateur et ainsi de limiter sa capacité de nuisance.",
+      referentiel: 'ANSSI',
     },
     misesAJour: {
       description:
@@ -639,6 +672,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Identifier, tester et installer, sans délai, les mises à jour fonctionnelles et de sécurité des applicatifs et/ou équipement contribuant au fonctionnement et à l'administration du service.<br>Cette mesure vise à renforcer la sécurité du service en permettant de corriger rapidement les failles de sécurité susceptibles de l'affecter.",
+      referentiel: 'ANSSI',
     },
     moindrePrivilege: {
       description:
@@ -647,12 +681,14 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Lors de l'installation d'un applicatif contribuant au fonctionnement du service, restreindre au strict nécessaire ses privilèges - à savoir les droits l'autorisant de mener certaines actions de manière autonome - et ne conserver que les privilèges nécessaires à sa finalité.<br>Cette mesure permet d'éviter que des privilèges non nécessaires accordés à un applicatif ne soient exploités à des fins malveillantes par un attaquant.",
+      referentiel: 'ANSSI',
     },
     nomsDomaineFrUe: {
       description: "Privilégier l'achat d'un nom de domaine en .fr ou .eu",
       categorie: 'protection',
       descriptionLongue:
         "Lors de l'achat du nom de domaine du service, acheter de préférence un nom de domaine en .fr ou .eu.<br>Cette mesure permet de renforcer la confiance des utilisateurs dans le service et la protection du service au titre des règlementations européennes associées à la localisation européenne du nom de domaine.",
+      referentiel: 'ANSSI',
     },
     nomsDomaineSimilaires: {
       description:
@@ -660,6 +696,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Lors du choix du nom de domaine du service numérique, procédez à l'achat d'un ou plusieurs noms de domaines proches du nom de domaine du service numérique, par exemple en changeant des lettres ou en achetant des noms de domaine avec d'autres extensions (ex. .com ou .net).<br>Cette mesure permet de limiter le risque de typosquatting (ex. utilisation de noms de domaines proches contenant des modifications typographiques discrètes), permettant de rediriger les utilisateurs vers un site malveillant.",
+      referentiel: 'ANSSI',
     },
     portsOuverts: {
       description: 'Fermer tous les ports non strictement nécessaires',
@@ -667,6 +704,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Configurer le service en vue de fermer tous les ports réseau non strictement nécessaires à l'administration et au fonctionnement du service et fermer tous les autres ports.<br>Cette mesure permet de réduire le risque d'accès illégitime au service de la part d'acteurs malveillants.",
+      referentiel: 'ANSSI',
     },
     protectionDeniService: {
       description:
@@ -674,6 +712,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Recourir à un service permettant de protéger le service contre les attaques de type « déni de service » (ex. attaques par déni de service distribué dites « DDOS »).<br>Cette mesure vise à réduire le risque d'indisponibilité partielle ou totale du service.",
+      referentiel: 'ANSSI',
     },
     protectionMotsDePasse: {
       description: 'Protéger les mots de passe stockés sur le service',
@@ -681,6 +720,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Dans le cadre de la configuration du service au niveau du serveur d'hébergement, veiller à ne pas stocker les mots de passe « en clair ». Seule une « empreinte » des mots de passe doit être stockée.<br>L'objectif de cette mesure est de limiter la capacité d'un attaquant à accéder aux mots de passe en cas de compromission de la base de données des mots de passe.",
+      referentiel: 'ANSSI',
     },
     renouvellementMotsDePasse: {
       description:
@@ -688,6 +728,7 @@ module.exports = {
       categorie: 'protection',
       descriptionLongue:
         "Configurer ou recommander à intervalle régulier le renouvellement des mots de passe des comptes d'administration.<br>Cette mesure permet d'éviter qu'un mot de passe ancien ou proche d'un mot de passe déjà utilisé toujours utilisé ne soit découvert et utilisé par un acteur malveillant.",
+      referentiel: 'ANSSI',
     },
     securisationCode: {
       description:
@@ -696,6 +737,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         'Lors du développement du service, respecter les bonnes pratiques de développement sécurisé (ex. les normes de développement sécurisé associé à un langage de programmation, procéder à des revues régulières de code par les pairs, etc.).<br>Cette mesure vise à renforcer la sécurité du service numérique dès sa conception.',
+      referentiel: 'ANSSI',
     },
     telechargementsOfficiels: {
       description:
@@ -704,6 +746,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Publier l'application mobile permettant l'accès au service sur une ou plusieurs bibliothèques officielles (ex. AppStore, Google Play, etc.) et informer les utilisateurs que le service n'est téléchargeable que par ce moyen.<br>Cette mesure permet de faciliter les mises à jour de l'application par les utilisateurs et réduit le risque que des acteurs malveillants proposent au téléchargement une version de l'application susceptible de contenir un applicatif malveillant.",
+      referentiel: 'ANSSI',
     },
     versionRecente: {
       description:
@@ -712,6 +755,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Lors du développement ou de l'achat du service, toujours utiliser une version récente et maintenueà jour par les éditeurs, des applicatifs contribuant au fonctionnement du service (ex. une version récente et à jour d'un système de gestion de contenu (CMS), des dépendances d'une l'application).<br>Cette mesure vise à éviter d'utiliser des versions anciennes, susceptibles de comporter des vulnérabilités connues mais non corrigées ou qui ne seraient plus appelées à faire l'objet de mises à jour de sécurité à l'avenir par l'éditeur.",
+      referentiel: 'ANSSI',
     },
 
     gestionIncidents: {
@@ -719,6 +763,7 @@ module.exports = {
       categorie: 'defense',
       descriptionLongue:
         "Formaliser une procédure à suivre en cas d'incident de sécurité sur le service, pouvant inclure des éléments relatifs à la gestion technique de l'incident, la coordination des personnes concernées au sein de l'organisation, la communication aux utilisateurs et aux autres entités potentiellement impactées. Sauvegarder ce document dans un environnement sécurisé, déconnecté du service.<br>Cette mesure permet de préparer l'organisation à réagir de manière rapide et efficace en cas d'incident de sécurité affectant le service et à remédier à la situation.",
+      referentiel: 'ANSSI',
     },
     journalAcces: {
       description:
@@ -726,6 +771,7 @@ module.exports = {
       categorie: 'defense',
       descriptionLongue:
         "Lors de la configuration du service, activer la journalisation et la centralisation des accès des administrateurs, des utilisateurs et des applicatifs concourant au fonctionnement du service.<br>Cette mesure permet de faciliter la détection d'actions inhabituelles susceptibles d'être malveillantes et d'investiguer a posteriori les causes d'un incident de sécurité, en vue de faciliter sa remédiation.",
+      referentiel: 'ANSSI',
     },
     journalEvenementSecu: {
       description:
@@ -733,6 +779,7 @@ module.exports = {
       categorie: 'defense',
       descriptionLongue:
         "Lors de la configuration du service, activer, si cela est possible, la journalisation et la centralisation des événements de sécurité. A défaut, créer et maintenir à jour un document recensant l'ensemble des événements de sécurité ayant affecté le service et des mesures mises en œuvre pour y remédier.<br>Cette mesure permet de faciliter la détection d'évènements de sécurité connus et la résolution des incidents qui en découleraient.",
+      referentiel: 'ANSSI',
     },
     notificationConnexionsSuspectes: {
       description:
@@ -740,12 +787,14 @@ module.exports = {
       categorie: 'defense',
       descriptionLongue:
         "Configurer le service afin de proposer l'envoi d'une notification (ex. par email) aux utilisateurs et aux administrateurs, à chaque fois que ceux-ci se connectent. Signaler, si possible, toute tentative de connexion suspecte, par exemple, lorsque la connexion est effectuée depuis un nouvel appareil ou depuis une localisation inhabituelle. Dans le cas de l'achat d'une solution sur étagère, privilégier un service proposant l'envoi de notifications.<br>Cette mesure permet aux utilisateurs et administrateurs d'identifier des tentatives de connexion suspectes et d'empêcher de futures nouvelles tentatives de connexion illégitimes, par exemple, en changeant leur mot de passe.",
+      referentiel: 'ANSSI',
     },
     supervision: {
       description: 'Recourir à un service de supervision de la sécurité',
       categorie: 'defense',
       descriptionLongue:
         "Faire appel à un service de supervision à distance de la sécurité du service ou de plusieurs services, auprès d'un prestataire ou d'un service compétent au sein d'une organisation publique (ex. Security operation center », équipe de réponse à incident, etc.).<br>Cette mesure permet de renforcer significativement la capacité de veille, de détection et de réponse en cas d'incident de sécurité.",
+      referentiel: 'ANSSI',
     },
     testsProcedures: {
       description:
@@ -753,6 +802,7 @@ module.exports = {
       categorie: 'defense',
       descriptionLongue:
         'Réaliser à intervalle régulier (ex. une fois par an) un test de la procédure de gestion des incidents de sécurité du service ou de plusieurs services, en impliquant les personnes concernées (ex. vérifier que les coordonnées sont exactes, vérifier la disponibilité des personnes).<br>Cette mesure vise à vérifier que la procédure de gestion des incidents en place fonctionne bien dans la pratique.',
+      referentiel: 'ANSSI',
     },
     veilleSecurite: {
       description:
@@ -760,6 +810,7 @@ module.exports = {
       categorie: 'defense',
       descriptionLongue:
         "Consulter plusieurs sources d'informations sur les vulnérabilités concernant les applicatifs participant au fonctionnement du service ainsi que sur les campagnes de compromission connues (ou campagnes d'attaques informatiques), notamment les alertes de sécurité du CERT-FR.<br>Cette mesure permet d'identifier des vulnérabilités ou risques nouveaux pour le service et de mettre en œuvre les mesures de sécurité permettant d'y faire face, par exemple des mises à jour de sécurité.",
+      referentiel: 'ANSSI',
     },
 
     exerciceGestionCrise: {
@@ -767,6 +818,7 @@ module.exports = {
       categorie: 'resilience',
       descriptionLongue:
         "Organiser un exercice simulant une crise consécutive à un ou plusieurs incidents de sécurité aux conséquences particulièrement graves pour l'organisation..<br>Cette mesure permet d'entraîner les équipes, d'identifier freins à la gestion efficace d'une crise et de les corriger en vue de se préparer à la survenue d'une crise réelle.",
+      referentiel: 'ANSSI',
     },
     garantieHauteDisponibilite: {
       description:
@@ -774,6 +826,7 @@ module.exports = {
       categorie: 'resilience',
       descriptionLongue:
         "Recourir à une ou plusieurs solutions garantissant un haut niveau de disponibilité, en particulier dans le cadre de l'hébergement du service (ex. obligation de redondance de la machine virtuelle et des données).<br>Cette mesure permet d'éviter une interruption du service dépassant quelques minutes.",
+      referentiel: 'ANSSI',
     },
     sauvegardeDonnees: {
       description:
@@ -781,6 +834,7 @@ module.exports = {
       categorie: 'resilience',
       descriptionLongue:
         "Sauvegarder les données traitées par le service, au moins une fois par semaine, dans un environnement sécurisé, déconnecté de ce dernier (ex. dans une autre machine virtuelle chiffrée, sur un ordinateur ou un serveur local déconnecté d'internet).<br>Cette mesure permet une restauration rapide des données, à partir de la dernière sauvegarde des données effectuée, en cas d'incident de sécurité qui conduirait à leur suppression ou les rendrait inaccessibles, par exemple, en cas d'attaque par rançongiciel.",
+      referentiel: 'ANSSI',
     },
     sauvegardeMachineVirtuelle: {
       description:
@@ -789,6 +843,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Sauvegarder en continu la machine virtuelle sur laquelle est déployée le service.<br>Cette mesure permet la restauration rapide du service, à partir de la dernière sauvegarde de la machine virtuelle effectuée, en cas d'incident de sécurité qui conduirait à leur suppression et ou les rendrait inaccessible.",
+      referentiel: 'ANSSI',
     },
     testsSauvegardes: {
       description: 'Vérifier régulièrement les sauvegardes',
@@ -796,6 +851,7 @@ module.exports = {
       indispensable: true,
       descriptionLongue:
         "Réaliser des tests réguliers des sauvegardes (ex. tous les trois mois) afin de vérifier que celles-ci sont bien réalisées, accessibles et fonctionnelles.<br>Cette mesure permet de vérifier que les sauvegardes effectuées peuvent être utilisées pour restaurer le service et/ou ses données en cas d'incident de sécurité.",
+      referentiel: 'ANSSI',
     },
   },
 

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -31,10 +31,15 @@ const statistiques = () => ({
       : '',
 });
 
+const referentiel = () => ({
+  avecMesuresCNIL: () => process.env.AVEC_MESURES_CNIL === 'true',
+});
+
 module.exports = {
   emailMemoire,
   journalMSS,
   matomo,
+  referentiel,
   sendinblue,
   sentry,
   statistiques,

--- a/src/moteurRegles.js
+++ b/src/moteurRegles.js
@@ -1,10 +1,15 @@
 const Referentiel = require('./referentiel');
 const Profil = require('./modeles/profils/profil');
+const adaptateurEnvironnement = require('./adaptateurs/adaptateurEnvironnement');
 
 class MoteurRegles {
-  constructor(referentiel = Referentiel.creeReferentielVide()) {
+  constructor(
+    referentiel = Referentiel.creeReferentielVide(),
+    adaptateurEnv = adaptateurEnvironnement
+  ) {
     this.reglesPersonnalisation = referentiel.reglesPersonnalisation();
     this.referentiel = referentiel;
+    this.adaptateurEnvironnement = adaptateurEnv;
   }
 
   mesuresAModifier(descriptionService, mesuresACibler) {
@@ -80,11 +85,19 @@ class MoteurRegles {
         [idMesure]: mesureAvecImportanceAjustee(idsMesuresReference, idMesure),
       });
 
-    return idsMesures.reduce(
+    let mesuresAjustees = idsMesures.reduce(
       (...parametres) =>
         ajouteEtRendsIndispensable(mesuresARendreIndispensables, ...parametres),
       {}
     );
+
+    if (!this.adaptateurEnvironnement.referentiel().avecMesuresCNIL())
+      mesuresAjustees = Object.fromEntries(
+        Object.entries(mesuresAjustees).filter(
+          ([, mesure]) => mesure.referentiel !== 'CNIL'
+        )
+      );
+    return mesuresAjustees;
   }
 }
 

--- a/svelte/lib/mesure/entete/EnteteTiroir.svelte
+++ b/svelte/lib/mesure/entete/EnteteTiroir.svelte
@@ -9,7 +9,7 @@
 
 <div class="conteneur">
   <CartoucheReferentiel {referentiel} />
-  {#if referentiel === Referentiel.ANSSI}
+  {#if referentiel !== Referentiel.SPECIFIQUE}
     <CartoucheIndispensable indispensable={indispensable ?? false} />
   {/if}
 </div>

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -1,3 +1,5 @@
+import type { Referentiel } from '../ui/types.d';
+
 declare global {
   interface HTMLElementEventMap {
     'svelte-recharge-mesure': CustomEvent;
@@ -28,6 +30,7 @@ export type MesureGeneraleEnrichie = MesureGenerale & {
   descriptionLongue: string;
   categorie: string;
   indispensable?: boolean;
+  referentiel: Referentiel;
 };
 
 export type MesureSpecifique = MesureGenerale & {

--- a/svelte/lib/mesure/mesure.store.ts
+++ b/svelte/lib/mesure/mesure.store.ts
@@ -55,7 +55,7 @@ export const store = {
 export const configurationAffichage = derived(store, ($store) => {
   const referentiel: Referentiel =
     $store.etape === 'EditionGenerale'
-      ? Referentiel.ANSSI
+      ? ($store.mesureEditee.mesure as MesureGeneraleEnrichie).referentiel
       : Referentiel.SPECIFIQUE;
   return {
     referentiel,

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -109,7 +109,7 @@
     {#each Object.entries($mesuresFiltrees.mesuresGenerales) as [id, mesure] (id)}
       <LigneMesure
         {id}
-        referentiel={Referentiel.ANSSI}
+        referentiel={mesure.referentiel}
         indispensable={mesure.indispensable}
         nom={mesure.description}
         categorie={categories[mesure.categorie]}

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -40,7 +40,7 @@
     </p>
     <div class="conteneur-cartouches">
       <span class="categorie">{categorie}</span>
-      {#if referentiel === Referentiel.ANSSI}
+      {#if referentiel !== Referentiel.SPECIFIQUE}
         <CartoucheIndispensable {indispensable} />
       {/if}
     </div>

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -1,3 +1,5 @@
+import { Referentiel } from '../ui/types.d';
+
 declare global {
   interface HTMLElementEventMap {
     'svelte-recharge-tableau-mesures': CustomEvent;
@@ -22,6 +24,7 @@ export type MesureGenerale = {
   descriptionLongue: string;
   statut?: string;
   modalites?: string;
+  referentiel: Referentiel;
 };
 
 export type MesureSpecifique = {

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -1,6 +1,7 @@
 export enum Referentiel {
   ANSSI = 'ANSSI',
   SPECIFIQUE = 'Mesures ajoutées',
+  CNIL = 'CNIL',
 }
 
 export type IdStatut = string;

--- a/test/moteurRegles.spec.js
+++ b/test/moteurRegles.spec.js
@@ -309,4 +309,55 @@ describe('Le moteur de règles', () => {
       supervision: { indispensable: false },
     });
   });
+
+  describe('sur demande de toutes les mesures', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      mesures: {
+        uneMesureANSSI: { referentiel: 'ANSSI' },
+        uneMesureCNIL: { referentiel: 'CNIL' },
+      },
+      reglesPersonnalisation: {
+        clefsDescriptionServiceAConsiderer: ['donneesCaracterePersonnel'],
+        profils: {
+          unProfil: {
+            regles: [{ presence: ['uneDonnee'] }],
+            mesuresAAjouter: ['uneMesureANSSI', 'uneMesureCNIL'],
+          },
+        },
+      },
+    });
+
+    it('filtre les mesures CNIL si le feature flag est désactivé', () => {
+      const adaptateurEnvironnement = {
+        referentiel: () => ({
+          avecMesuresCNIL: () => false,
+        }),
+      };
+
+      const moteur = new MoteurRegles(referentiel, adaptateurEnvironnement);
+
+      const serviceAvecDonneesCaracterePersonnel = new DescriptionService({
+        donneesCaracterePersonnel: ['uneDonnee'],
+      });
+      expect(
+        Object.keys(moteur.mesures(serviceAvecDonneesCaracterePersonnel))
+      ).to.eql(['uneMesureANSSI']);
+    });
+
+    it('conserve les mesures CNIL si le feature flag est activé', () => {
+      const adaptateurEnvironnement = {
+        referentiel: () => ({
+          avecMesuresCNIL: () => true,
+        }),
+      };
+      const moteur = new MoteurRegles(referentiel, adaptateurEnvironnement);
+
+      const serviceAvecDonneesCaracterePersonnel = new DescriptionService({
+        donneesCaracterePersonnel: ['uneDonnee'],
+      });
+      expect(
+        Object.keys(moteur.mesures(serviceAvecDonneesCaracterePersonnel))
+      ).to.eql(['uneMesureANSSI', 'uneMesureCNIL']);
+    });
+  });
 });


### PR DESCRIPTION
On ajoute les 6 mesures CNIL au moteur de règles.
Ces mesures ont le comportement suivant :
- On affiche les mesures CNIL si au moins une case du step DECRIRE champ “Données à caractère personnel et autres données sensibles stockées par le service”
- Leurs notes impactent le calcul de l’indice cyber ANSSI
- Chaque mesure est "indispensable"
- Elles sont liées à une catégorie : gouvernance

Le moteur de règles s'occupe de filtrer ces mesures via un feature flag `AVEC_MESURES_CNIL`