### PR TITLE
Ajout du filtre pour le référentiel CNIL

### DIFF
--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -8,10 +8,17 @@ $(() => {
   const idService = $('.page-service').data('id-service');
   const { indiceCyber, noteMax } = JSON.parse($('#indice-cyber').text());
   const pourcentageCompletude = JSON.parse($('#completude-mesure').text());
+  const featureFlags = JSON.parse($('#feature-flags').text());
 
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-tableau-mesures', {
-      detail: { categories, statuts, idService, estLectureSeule },
+      detail: {
+        categories,
+        statuts,
+        idService,
+        estLectureSeule,
+        ...featureFlags,
+      },
     })
   );
 

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -200,6 +200,13 @@ const middleware = (configuration = {}) => {
     suite();
   };
 
+  const chargeFeatureFlags = (_requete, reponse, suite) => {
+    reponse.locals.featureFlags = {
+      avecMesuresCNIL: adaptateurEnvironnement.referentiel().avecMesuresCNIL(),
+    };
+    suite();
+  };
+
   const chargeAutorisationsService = (requete, reponse, suite) => {
     if (!requete.idUtilisateurCourant || !requete.homologation)
       throw new ErreurChainageMiddleware(
@@ -268,6 +275,7 @@ const middleware = (configuration = {}) => {
     aseptiseListe,
     aseptiseListes,
     chargeAutorisationsService,
+    chargeFeatureFlags,
     chargePreferencesUtilisateur,
     positionneHeaders,
     positionneHeadersAvecNonce,

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -73,6 +73,7 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
     middleware.trouveService({ [SECURISER]: LECTURE }),
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
+    middleware.chargeFeatureFlags,
     async (requete, reponse) => {
       const { homologation } = requete;
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -24,6 +24,8 @@ block append scripts
     !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax()})}
   script(id = 'completude-mesure', type = 'application/json').
     !{JSON.stringify(pourcentageProgression)}
+  script(id = 'feature-flags', type = 'application/json').
+    !{JSON.stringify(featureFlags)}
 
 block header-titre-page
   h3

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -34,6 +34,7 @@
   export let categories: Record<IdCategorie, string>;
   export let statuts: Record<IdStatut, string>;
   export let estLectureSeule: boolean;
+  export let avecMesuresCNIL: boolean;
 
   const rafraichisMesures = async () =>
     mesures.reinitialise(await recupereMesures(idService));
@@ -81,7 +82,7 @@
       placeholder="Intitulé, description"
     />
   </label>
-  <MenuFiltres {categories} {statuts} />
+  <MenuFiltres {categories} {statuts} {avecMesuresCNIL} />
 </div>
 {#if !estLectureSeule}
   <div class="barre-actions">

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -11,6 +11,7 @@
 
   export let categories: Record<IdCategorie, string>;
   export let statuts: Record<IdStatut, string>;
+  export let avecMesuresCNIL: boolean;
 
   const effaceFiltres = () => {
     rechercheCategorie.set([]);
@@ -118,16 +119,18 @@
         />
         <label for="anssi-recommandee">Recommandée</label>
       </div>
-      <div>
-        <input
-          type="checkbox"
-          id="mesure-cnil"
-          name="mesure-cnil"
-          bind:group={$rechercheReferentiel}
-          value={IdReferentiel.CNIL}
-        />
-        <label for="mesure-cnil">CNIL</label>
-      </div>
+      {#if avecMesuresCNIL}
+        <div>
+          <input
+            type="checkbox"
+            id="mesure-cnil"
+            name="mesure-cnil"
+            bind:group={$rechercheReferentiel}
+            value={IdReferentiel.CNIL}
+          />
+          <label for="mesure-cnil">CNIL</label>
+        </div>
+      {/if}
       <div>
         <input
           type="checkbox"

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -121,6 +121,16 @@
       <div>
         <input
           type="checkbox"
+          id="mesure-cnil"
+          name="mesure-cnil"
+          bind:group={$rechercheReferentiel}
+          value={IdReferentiel.CNIL}
+        />
+        <label for="mesure-cnil">CNIL</label>
+      </div>
+      <div>
+        <input
+          type="checkbox"
           id="mesure-ajoutee"
           name="mesure-ajoutee"
           bind:group={$rechercheReferentiel}

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -15,6 +15,7 @@ export type TableauDesMesuresProps = {
   categories: Record<IdCategorie, string>;
   statuts: Record<IdStatut, string>;
   estLectureSeule: boolean;
+  avecMesuresCNIL: boolean;
 };
 
 export type MesureGenerale = {

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.store.ts
@@ -1,4 +1,4 @@
-import { writable, derived } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 import type {
   IdCategorie,
   IdStatut,
@@ -6,6 +6,7 @@ import type {
   Mesures,
   MesureSpecifique,
 } from './tableauDesMesures.d';
+import { Referentiel } from '../ui/types.d';
 
 const mesuresParDefaut = (): Mesures => ({
   mesuresGenerales: {},
@@ -36,6 +37,7 @@ export const rechercheStatut = writable<IdStatut[]>([]);
 export enum IdReferentiel {
   ANSSIRecommandee,
   ANSSIIndispensable,
+  CNIL,
   MesureAjoutee,
 }
 const {
@@ -138,6 +140,9 @@ export const predicats = derived<
           ($rechercheReferentiel.includes(IdReferentiel.ANSSIIndispensable) &&
             estMesureGenerale(mesure) &&
             mesure.indispensable) ||
+          ($rechercheReferentiel.includes(IdReferentiel.CNIL) &&
+            estMesureGenerale(mesure) &&
+            mesure.referentiel === Referentiel.CNIL) ||
           ($rechercheReferentiel.includes(IdReferentiel.ANSSIRecommandee) &&
             estMesureGenerale(mesure) &&
             !mesure.indispensable),

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -705,6 +705,32 @@ describe('Le middleware MSS', () => {
     });
   });
 
+  describe('sur demande de chargement des `feature flags`', () => {
+    it('ajoute un objet de feature flags à `reponse.locals`, le rendant ainsi accessible aux `.pug`', (done) => {
+      const middleware = Middleware();
+
+      middleware.chargeFeatureFlags(requete, reponse, () => {
+        expect(reponse.locals.featureFlags).not.to.be(undefined);
+        done();
+      });
+    });
+
+    it("lit l'état d'activation des mesures CNIL via l'adaptateur environnement", (done) => {
+      const adaptateurEnvironnement = {
+        referentiel: () => ({
+          avecMesuresCNIL: () => true,
+        }),
+      };
+      const middleware = Middleware({ adaptateurEnvironnement });
+
+      middleware.chargeFeatureFlags(requete, reponse, () => {
+        const { featureFlags } = reponse.locals;
+        expect(featureFlags.avecMesuresCNIL).to.be(true);
+        done();
+      });
+    });
+  });
+
   describe('sur demande de chargement des autorisations pour un service', () => {
     beforeEach(() => {
       requete.idUtilisateurCourant = '999';

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -54,6 +54,7 @@ let listesAseptisees = [];
 let listeAdressesIPsAutorisee = [];
 let parametresAseptises = [];
 let preferencesChargees = false;
+let featureFlagsCharges = false;
 let rechercheDossierCourantEffectuee = false;
 let suppressionCookieEffectuee = false;
 let traficProtege = false;
@@ -83,6 +84,7 @@ const middlewareFantaisie = {
     listeAdressesIPsAutorisee = [];
     parametresAseptises = [];
     preferencesChargees = false;
+    featureFlagsCharges = false;
     rechercheDossierCourantEffectuee = false;
     suppressionCookieEffectuee = false;
     traficProtege = false;
@@ -127,6 +129,12 @@ const middlewareFantaisie = {
   chargePreferencesUtilisateur: (_requete, reponse, suite) => {
     reponse.locals.preferencesUtilisateur = {};
     preferencesChargees = true;
+    suite();
+  },
+
+  chargeFeatureFlags: (_requete, reponse, suite) => {
+    reponse.locals.featureFlags = {};
+    featureFlagsCharges = true;
     suite();
   },
 
@@ -234,6 +242,13 @@ const middlewareFantaisie = {
   verifieChargementDesPreferences: (...params) => {
     verifieRequeteChangeEtat(
       { lectureEtat: () => preferencesChargees },
+      ...params
+    );
+  },
+
+  verifieChargementDesFeatureFlags: (...params) => {
+    verifieRequeteChangeEtat(
+      { lectureEtat: () => featureFlagsCharges },
       ...params
     );
   },

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -210,6 +210,15 @@ describe('Le serveur MSS des routes /service/*', () => {
         );
     });
 
+    it('charge les feature flags', (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesFeatureFlags(
+          'http://localhost:1234/service/456/mesures',
+          done
+        );
+    });
+
     it('interroge le moteur de règles pour obtenir les mesures personnalisées', async () => {
       let descriptionRecue;
       const requete = {};


### PR DESCRIPTION
On ajoute le filtre pour le référentiel CNIL.
Ce filtre est affiché conditonnelement via un feature flag `avecMesuresCNIL`, exposé dans les `locals` du pug.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/efa73ffc-8db8-4c9e-9d7a-0a3ee17ab828)
