### PR TITLE
Ajoute "et la CNIL" dans les PDFs

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -385,6 +385,11 @@ module.exports = {
     nonFait: 'Non prise en compte',
   },
 
+  articlesDefinisReferentielsMesure: {
+    ANSSI: "l'",
+    CNIL: 'la ',
+  },
+
   mesures: {
     analyseRisques: {
       description:

--- a/src/modeles/objetsPDF/objetPDFAnnexeMesures.js
+++ b/src/modeles/objetsPDF/objetPDFAnnexeMesures.js
@@ -1,19 +1,32 @@
 const Referentiel = require('../../referentiel');
 
 class ObjetPDFAnnexeMesures {
-  constructor(homologation, referentiel = Referentiel.creeReferentielVide()) {
+  constructor(service, referentiel = Referentiel.creeReferentielVide()) {
     this.referentiel = referentiel;
-    this.homologation = homologation;
+    this.service = service;
   }
 
   donnees() {
+    const { mesuresGenerales } =
+      this.service.mesures.enrichiesAvecDonneesPersonnalisees();
+    const mesuresGeneralesNonRenseignes = Object.entries(
+      mesuresGenerales
+    ).filter(([_, mesure]) => !mesure.statut);
+
+    const referentielsConcernes = mesuresGeneralesNonRenseignes.map(
+      ([_, mesure]) => mesure.referentiel
+    );
+    const referentielsConcernesMesuresNonRenseignees =
+      this.referentiel.formatteListeDeReferentiels(referentielsConcernes);
+
     return {
       statuts: this.referentiel.statutsMesures(),
       categories: this.referentiel.categoriesMesures(),
-      nomService: this.homologation.nomService(),
-      mesuresParStatut: this.homologation.mesuresParStatutEtCategorie(),
+      nomService: this.service.nomService(),
+      mesuresParStatut: this.service.mesuresParStatutEtCategorie(),
       nbMesuresARemplirToutesCategories:
-        this.homologation.nombreTotalMesuresARemplirToutesCategories(),
+        this.service.nombreTotalMesuresARemplirToutesCategories(),
+      referentielsConcernesMesuresNonRenseignees,
     };
   }
 }

--- a/src/pdf/modeles/annexeMesures.pug
+++ b/src/pdf/modeles/annexeMesures.pug
@@ -24,4 +24,4 @@ block page
       p.
         Il reste #{donneesMesures.nbMesuresARemplirToutesCategories}
         mesure#{donneesMesures.nbMesuresARemplirToutesCategories > 1 ? 's': ''} 
-        proposées par l'ANSSI à compléter.
+        proposées par #{donneesMesures.referentielsConcernesMesuresNonRenseignees} à compléter.

--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -705,10 +705,15 @@ p {
   white-space: nowrap;
 }
 
+.synthese-securite .total-mesures {
+  white-space: break-spaces;
+}
+
 .synthese-securite .total .legende {
   display: flex;
   justify-content: flex-end;
   column-gap: 1em;
+  white-space: nowrap;
 }
 
 .synthese-securite .total .legende > *::before {

--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -34,8 +34,8 @@ mixin totalMesures(totalMesuresGenerales, totalMesuresSpecifiques)
   .total.conteneur
     .contenu
       strong Total :
-      span.
-        &nbsp;#{totalMesuresGenerales} #{totalMesuresGenerales <= 1 ? `mesure proposée`: `mesures proposées`} par l'ANSSI
+      span.total-mesures
+        | &nbsp;#{totalMesuresGenerales} #{totalMesuresGenerales <= 1 ? `mesure proposée`: `mesures proposées`} par #{donnees.referentielConcernes}
       if totalMesuresSpecifiques
         span &nbsp;+ #{totalMesuresSpecifiques} #{totalMesuresSpecifiques <= 1 ? `ajoutée`: `ajoutées`} par l'équipe.
       else
@@ -138,6 +138,6 @@ block page
       .conteneur-pied-page
         p.
           L'indice cyber est calculé sur la base des informations renseignées par l'équipe 
-          concernant les mesures de sécurité proposées par l'ANSSI et à l'exclusion des mesures 
+          concernant les mesures de sécurité proposées par #{donnees.referentielConcernes}, et à l'exclusion des mesures
           spécifiques ajoutées. Il fournit une évaluation indicative du niveau de sécurisation 
           du service.

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -63,6 +63,17 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const estIdentifiantStatutAvisDossierHomologationConnu = (idStatut) =>
     identifiantsStatutAvisDossierHomologation().includes(idStatut);
   const fonctionnalites = () => donnees.fonctionnalites;
+  const formatteListeDeReferentiels = (referentiels) => {
+    const formatte = new Intl.ListFormat('fr', {
+      type: 'conjunction',
+    });
+    const referentielsSansDoublon = new Set(
+      referentiels.map(
+        (r) => `${donnees.articlesDefinisReferentielsMesure[r] ?? ''}${r}`
+      )
+    );
+    return formatte.format(referentielsSansDoublon);
+  };
   const descriptionFonctionnalite = (id) => fonctionnalites()[id]?.description;
   const descriptionsFonctionnalites = (ids) =>
     ids
@@ -278,6 +289,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     etapesParcoursHomologation,
     etapeSuffisantePourDossierDecision,
     fonctionnalites,
+    formatteListeDeReferentiels,
     identifiantsCategoriesMesures,
     identifiantsEcheancesRenouvellement,
     identifiantsLocalisationsDonnees,

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -2,6 +2,7 @@ const { ErreurDonneesReferentielIncorrectes } = require('./erreurs');
 const donneesParDefaut = require('../donneesReferentiel');
 
 const donneesReferentielVide = {
+  articlesDefinisReferentielsMesure: {},
   categoriesMesures: {},
   indiceCyber: {},
   delaisAvantImpactCritique: {},

--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -41,15 +41,21 @@ const routesApiServicePdf = ({
     return adaptateurPdf.genereDossierDecision(donnees);
   };
 
-  const generePdfSyntheseSecurite = (homologation) => {
+  const generePdfSyntheseSecurite = (service) => {
+    const referentiels = Object.entries(
+      service.mesures.enrichiesAvecDonneesPersonnalisees().mesuresGenerales
+    ).map(([_, mesure]) => mesure.referentiel);
+    const referentielConcernes =
+      referentiel.formatteListeDeReferentiels(referentiels);
     const donnees = {
-      service: homologation,
+      service,
       camembertIndispensables: genereGradientConique(
-        homologation.statistiquesMesuresIndispensables()
+        service.statistiquesMesuresIndispensables()
       ),
       camembertRecommandees: genereGradientConique(
-        homologation.statistiquesMesuresRecommandees()
+        service.statistiquesMesuresRecommandees()
       ),
+      referentielConcernes,
       referentiel,
     };
 

--- a/test/modeles/objetsPDF/objetPDFAnnexeMesures.spec.js
+++ b/test/modeles/objetsPDF/objetPDFAnnexeMesures.spec.js
@@ -3,6 +3,7 @@ const expect = require('expect.js');
 const Homologation = require('../../../src/modeles/homologation');
 const Referentiel = require('../../../src/referentiel');
 const VueAnnexePDFMesures = require('../../../src/modeles/objetsPDF/objetPDFAnnexeMesures');
+const { unService } = require('../../constructeurs/constructeurService');
 
 describe("L'objet PDF de l'annexe des mesures", () => {
   const donneesReferentiel = {
@@ -10,6 +11,10 @@ describe("L'objet PDF de l'annexe des mesures", () => {
     mesures: { mesure1: {} },
     niveauxGravite: { grave: {} },
     statutsMesures: { fait: 'Fait', enCours: 'En cours' },
+    articlesDefinisReferentielsMesure: {
+      ANSSI: "l'",
+      CNIL: 'la ',
+    },
   };
   const referentiel = Referentiel.creeReferentiel(donneesReferentiel);
   const homologation = new Homologation(
@@ -88,5 +93,23 @@ describe("L'objet PDF de l'annexe des mesures", () => {
 
     expect(donnees).to.have.key('nbMesuresARemplirToutesCategories');
     expect(donnees.nbMesuresARemplirToutesCategories).to.equal(6);
+  });
+
+  it('fournit une chaine de caractères indiquant les référentiels concernés par les mesures non renseignées', () => {
+    const service = unService().construis();
+    service.mesures.enrichiesAvecDonneesPersonnalisees = () => ({
+      mesuresGenerales: {
+        mesureA: { referentiel: 'ANSSI' },
+        mesureB: { referentiel: 'CNIL' },
+        mesureC: { referentiel: 'CNIL' },
+      },
+    });
+    const vueAnnexePDFMesures = new VueAnnexePDFMesures(service, referentiel);
+
+    const donnees = vueAnnexePDFMesures.donnees();
+
+    expect(donnees.referentielsConcernesMesuresNonRenseignees).to.equal(
+      "l'ANSSI et la CNIL"
+    );
   });
 });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -839,4 +839,41 @@ describe('Le référentiel', () => {
       ).to.be('id-autorisee-pour-tous');
     });
   });
+
+  describe("sur demande de formattage d'une liste de référentiels", () => {
+    it('utilise les articles définis devant les référentiels', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        articlesDefinisReferentielsMesure: {
+          ANSSI: "l'",
+          CNIL: 'la ',
+        },
+      });
+
+      expect(
+        referentiel.formatteListeDeReferentiels(['ANSSI', 'CNIL'])
+      ).to.equal("l'ANSSI et la CNIL");
+    });
+
+    it('supprime les doublons', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        articlesDefinisReferentielsMesure: {
+          ANSSI: "l'",
+        },
+      });
+
+      expect(
+        referentiel.formatteListeDeReferentiels(['ANSSI', 'ANSSI'])
+      ).to.equal("l'ANSSI");
+    });
+
+    it("reste robuste si le référentiel n'existe pas", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        articlesDefinisReferentielsMesure: {},
+      });
+
+      expect(referentiel.formatteListeDeReferentiels(['ANSSI'])).to.equal(
+        'ANSSI'
+      );
+    });
+  });
 });


### PR DESCRIPTION
... afin de prendre en compte l'arrivé d'un nouveau référentiel.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/a30aa2be-d13e-4a4a-a959-a7c55cfec0b9)
