### PR TITLE
Ajoute un header sticky pour le tableau des mesures

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -1,9 +1,13 @@
+.zone-principale {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .titre-page {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: flex-start;
-  position: relative;
 }
 
 .conteneur-indicateurs {
@@ -11,8 +15,13 @@
   flex-direction: row;
   align-items: center;
   gap: 1em;
-  position: absolute;
+  position: sticky;
+  top: 16px;
   right: 0;
+  z-index: 2;
+  margin-top: -6em;
+  width: fit-content;
+  margin-left: auto;
 }
 
 .conteneur-indice-cyber {

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -33,14 +33,14 @@ block header-titre-page
 
 block titre
   h1 Sécuriser
-  .conteneur-indicateurs
-    #conteneur-completude-mesure
-    a.conteneur-indice-cyber(href="indiceCyber")
-      .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
-      #conteneur-indice-cyber
 
 block sous-titre
   h2 Mettre en oeuvre des mesures de sécurité adaptées
 
 block formulaire
+  .conteneur-indicateurs
+    #conteneur-completude-mesure
+    a.conteneur-indice-cyber(href="indiceCyber")
+      .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
+      #conteneur-indice-cyber
   #tableau-des-mesures

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -72,35 +72,37 @@
 </script>
 
 <svelte:body on:mesure-modifiee={rafraichisMesures} />
-<div class="barre-filtres">
-  <label for="recherche">
-    Rechercher
-    <input
-      type="search"
-      id="recherche"
-      bind:value={$rechercheTextuelle}
-      placeholder="Intitulé, description"
-    />
-  </label>
+<div class="barre-outils-sticky">
+  <div class="barre-filtres">
+    <label for="recherche">
+      Rechercher
+      <input
+        type="search"
+        id="recherche"
+        bind:value={$rechercheTextuelle}
+        placeholder="Intitulé, description"
+      />
+    </label>
   <MenuFiltres {categories} {statuts} {avecMesuresCNIL} />
-</div>
-{#if !estLectureSeule}
-  <div class="barre-actions">
-    <button
-      class="bouton"
-      on:click={() => afficheTiroirDeMesure()}
-      disabled={etatEnregistrement === EnCours}
-    >
-      Ajouter une mesure
-    </button>
-    {#if etatEnregistrement === EnCours}
-      <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
-    {/if}
-    {#if etatEnregistrement === Fait}
-      <p class="enregistrement-termine">Enregistré</p>
-    {/if}
   </div>
-{/if}
+  {#if !estLectureSeule}
+    <div class="barre-actions">
+      <button
+        class="bouton"
+        on:click={() => afficheTiroirDeMesure()}
+        disabled={etatEnregistrement === EnCours}
+      >
+        Ajouter une mesure
+      </button>
+      {#if etatEnregistrement === EnCours}
+        <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
+      {/if}
+      {#if etatEnregistrement === Fait}
+        <p class="enregistrement-termine">Enregistré</p>
+      {/if}
+    </div>
+  {/if}
+</div>
 <div class="tableau-des-mesures">
   {#if $nombreResultats.aucunResultat}
     <div class="aucun-resultat">
@@ -156,10 +158,18 @@
 </div>
 
 <style>
+  .barre-outils-sticky {
+    position: sticky;
+    padding: 24px 0;
+    top: 0;
+    background: white;
+    z-index: 1;
+  }
+
   .barre-filtres {
     display: flex;
     flex-direction: row;
-    margin-bottom: 1em;
+    margin-bottom: 24px;
     gap: 16px;
     align-items: center;
   }
@@ -181,7 +191,6 @@
     display: flex;
     align-items: center;
     gap: 1em;
-    padding: 1em 0;
   }
 
   .barre-actions p {

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -179,7 +179,7 @@
   }
 
   .filtres-disponibles {
-    width: 260px;
+    width: 280px;
     border-radius: 8px;
     border: 1px solid #cbd5e1;
     background: white;
@@ -205,6 +205,8 @@
   .nombre-resultat {
     color: #0079d0;
     opacity: 0;
+    position: relative;
+    z-index: 101;
   }
 
   .nombre-resultat.visible {


### PR DESCRIPTION
On utilise une barre "sticky" pour la barre d'actions de SÉCURISER.
On en profite pour afficher le nombre de mesures filtrées à l'intérieur du menu.
    
[Screencast from 19-01-2024 14:38:11.webm](https://github.com/betagouv/mon-service-securise/assets/1643465/ac1388d1-a6eb-43f4-8a4e-451a9137de9c)

