### PR TITLE
[TDB] Affiche un "-" sur l'indice cyber si le taux de complétude n'est pas suffisant

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -15,6 +15,8 @@ module.exports = {
     noteMax: 5,
   },
 
+  completudeRequisePourAfficherIndiceCyber: 50,
+
   nouvellesFonctionnalites: [
     {
       id: 'tableauDeBord',

--- a/src/modeles/objetsApi/objetGetIndicesCyber.js
+++ b/src/modeles/objetsApi/objetGetIndicesCyber.js
@@ -2,15 +2,24 @@ const Autorisation = require('../autorisations/autorisation');
 
 const { DROITS_VOIR_INDICE_CYBER } = Autorisation;
 
-const donnees = (services, autorisations) => {
-  const servicesIndiceCyberCalcules = services.map((s) => ({
-    id: s.id,
-    ...(autorisations
-      .find((a) => a.idService === s.id)
-      .aLesPermissions(DROITS_VOIR_INDICE_CYBER) && {
-      indiceCyber: s.indiceCyber().total,
-    }),
-  }));
+const donnees = (services, autorisations, referentiel) => {
+  const servicesIndiceCyberCalcules = services.map((s) => {
+    const completude = s.completudeMesures();
+    const pourcentageCompletude = Math.round(
+      (completude.nombreMesuresCompletes / completude.nombreTotalMesures) * 100
+    );
+    return {
+      id: s.id,
+      ...(autorisations
+        .find((a) => a.idService === s.id)
+        .aLesPermissions(DROITS_VOIR_INDICE_CYBER) &&
+        referentiel.completudeSuffisantePourAfficherIndiceCyber(
+          pourcentageCompletude
+        ) && {
+          indiceCyber: s.indiceCyber().total,
+        }),
+    };
+  });
 
   const servicesAvecIndiceCyber = servicesIndiceCyberCalcules.filter(
     (s) => s.indiceCyber && s.indiceCyber > 0

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -119,6 +119,9 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const coefficientIndiceCyberMesuresRecommandees = () =>
     donnees.indiceCyber?.coefficientRecommandees || 0.5;
 
+  const completudeSuffisantePourAfficherIndiceCyber = (completude) =>
+    completude >= donnees.completudeRequisePourAfficherIndiceCyber;
+
   const indiceCyberNoteMax = () => donnees.indiceCyber?.noteMax || 10;
 
   const verifieIndiceEstDansTranche = (indiceCyber, tranche) =>
@@ -249,6 +252,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     codeDepartements,
     coefficientIndiceCyberMesuresIndispensables,
     coefficientIndiceCyberMesuresRecommandees,
+    completudeSuffisantePourAfficherIndiceCyber,
     indiceCyberNoteMax,
     definitionRisque,
     delaisAvantImpactCritique,

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -94,7 +94,8 @@ const routesApiPrivee = ({
         );
         const indicesCyber = objetGetIndicesCyber.donnees(
           services,
-          autorisations
+          autorisations,
+          referentiel
         );
 
         return zipTableaux(

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -70,7 +70,11 @@ const routesApiPrivee = ({
       const autorisations = await depotDonnees.autorisations(
         requete.idUtilisateurCourant
       );
-      const donnees = objetGetIndicesCyber.donnees(services, autorisations);
+      const donnees = objetGetIndicesCyber.donnees(
+        services,
+        autorisations,
+        referentiel
+      );
       reponse.json(donnees);
     }
   );

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -839,4 +839,29 @@ describe('Le référentiel', () => {
       ).to.be('id-autorisee-pour-tous');
     });
   });
+
+  describe("sur demande de complétude suffisante pour afficher l'indice cyber", () => {
+    it('retourne `false` si la complétude est inférieure à la complétude requise', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        completudeRequisePourAfficherIndiceCyber: 50,
+      });
+
+      expect(referentiel.completudeSuffisantePourAfficherIndiceCyber(10)).to.be(
+        false
+      );
+    });
+
+    it('retourne `true` si la complétude est supérieure ou égale à la complétude requise', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        completudeRequisePourAfficherIndiceCyber: 50,
+      });
+
+      expect(referentiel.completudeSuffisantePourAfficherIndiceCyber(50)).to.be(
+        true
+      );
+      expect(
+        referentiel.completudeSuffisantePourAfficherIndiceCyber(100)
+      ).to.be(true);
+    });
+  });
 });


### PR DESCRIPTION
Afin de préparer l'arrivée du flou de l'indice cyber, on masque les indices cyber du tableau de bord pour les services dont le taux de complétude est inférieur au taux requis :point_down: 

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/d1813850-a460-4366-bd8a-010579a62856)
