### PR TITLE
Flou indice cyber page securiser

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -21,6 +21,7 @@
   gap: 0;
   align-items: center;
   cursor: default;
+  position: relative;
 }
 
 .conteneur-indice-cyber:not(.flou) {
@@ -57,4 +58,20 @@
 .conteneur-indice-cyber:not(.flou):active .cartouche-indice-cyber {
   background: #08416a;
   color: white;
+}
+
+.conteneur-indice-cyber .cartouche-indice-cyber-insuffisant {
+  position: absolute;
+  z-index: 1;
+  color: #2f3a43;
+  font-size: 0.8em;
+  font-weight: 500;
+  border-radius: 4px;
+  background: #f1f5f9;
+  padding: 8px;
+  display: none;
+}
+
+.conteneur-indice-cyber:hover .cartouche-indice-cyber-insuffisant {
+  display: flex;
 }

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -23,6 +23,10 @@
   cursor: pointer;
 }
 
+.conteneur-indice-cyber.flou :is(svg, .cartouche-indice-cyber) {
+  filter: blur(4px);
+}
+
 .conteneur-indice-cyber svg {
   width: 4.2em;
   height: 4.2em;

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -20,6 +20,10 @@
   flex-direction: row;
   gap: 0;
   align-items: center;
+  cursor: default;
+}
+
+.conteneur-indice-cyber:not(.flou) {
   cursor: pointer;
 }
 
@@ -46,11 +50,11 @@
   white-space: nowrap;
 }
 
-.conteneur-indice-cyber:hover .cartouche-indice-cyber {
+.conteneur-indice-cyber:not(.flou):hover .cartouche-indice-cyber {
   background: #dbecf1;
 }
 
-.conteneur-indice-cyber:active .cartouche-indice-cyber {
+.conteneur-indice-cyber:not(.flou):active .cartouche-indice-cyber {
   background: #08416a;
   color: white;
 }

--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -75,3 +75,22 @@
 .conteneur-indice-cyber:hover .cartouche-indice-cyber-insuffisant {
   display: flex;
 }
+
+.conteneur-indice-cyber .cartouche-indice-cyber.passage-visible {
+  animation: fond-vert-pale 1s ease-in-out;
+}
+
+@keyframes fond-vert-pale {
+  0% {
+    background: #f1f5f9;
+    box-shadow: 0 0 50px 10px rgba(212, 244, 219, 0);
+  }
+  50% {
+    background: #d4f4db;
+    box-shadow: 0 0 50px 10px rgba(212, 244, 219, 1);
+  }
+  100% {
+    background: #f1f5f9;
+    box-shadow: 0 0 50px 10px rgba(212, 244, 219, 0);
+  }
+}

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -6,7 +6,9 @@ $(() => {
   const statuts = JSON.parse($('#referentiel-statuts-mesures').text());
   const estLectureSeule = JSON.parse($('#securiser-lecture-seule').text());
   const idService = $('.page-service').data('id-service');
-  const { indiceCyber, noteMax } = JSON.parse($('#indice-cyber').text());
+  const { indiceCyber, noteMax, completudeSuffisante } = JSON.parse(
+    $('#indice-cyber').text()
+  );
   const pourcentageCompletude = JSON.parse($('#completude-mesure').text());
 
   document.body.dispatchEvent(
@@ -17,7 +19,7 @@ $(() => {
 
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-indice-cyber', {
-      detail: { indiceCyber, noteMax, idService },
+      detail: { indiceCyber, completudeSuffisante, noteMax, idService },
     })
   );
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -119,6 +119,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const coefficientIndiceCyberMesuresRecommandees = () =>
     donnees.indiceCyber?.coefficientRecommandees || 0.5;
 
+  const completudeNecessairePourAfficherIndiceCyber = () =>
+    donnees.completudeRequisePourAfficherIndiceCyber;
   const completudeSuffisantePourAfficherIndiceCyber = (completude) =>
     completude >= donnees.completudeRequisePourAfficherIndiceCyber;
 
@@ -252,6 +254,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     codeDepartements,
     coefficientIndiceCyberMesuresIndispensables,
     coefficientIndiceCyberMesuresRecommandees,
+    completudeNecessairePourAfficherIndiceCyber,
     completudeSuffisantePourAfficherIndiceCyber,
     indiceCyberNoteMax,
     definitionRisque,

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -585,8 +585,19 @@ const routesApiService = ({
     middleware.trouveService({ [SECURISER]: LECTURE }),
     middleware.aseptise('id'),
     (requete, reponse) => {
-      const { homologation } = requete;
-      reponse.json(homologation.indiceCyber());
+      const { homologation: service } = requete;
+      const completude = service.completudeMesures();
+      const pourcentageProgression = Math.round(
+        (completude.nombreMesuresCompletes / completude.nombreTotalMesures) *
+          100
+      );
+      reponse.json({
+        indiceCyber: service.indiceCyber(),
+        completudeSuffisantePourAfficherIndiceCyber:
+          referentiel.completudeSuffisantePourAfficherIndiceCyber(
+            pourcentageProgression
+          ),
+      });
     }
   );
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -21,7 +21,7 @@ block append scripts
   script(id = 'securiser-lecture-seule', type = 'application/json').
     !{JSON.stringify(autorisationsService.SECURISER.estLectureSeule)}
   script(id = 'indice-cyber', type = 'application/json').
-    !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax() })}
+    !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax(), completudeSuffisante: referentiel.completudeSuffisantePourAfficherIndiceCyber(pourcentageProgression) })}
   script(id = 'completude-mesure', type = 'application/json').
     !{JSON.stringify(pourcentageProgression)}
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -35,6 +35,8 @@ block titre
   .conteneur-indicateurs
     #conteneur-completude-mesure
     a.conteneur-indice-cyber(href=`${tauxCompletudeSuffisant ? 'indiceCyber' : '#'}`, class=`${tauxCompletudeSuffisant ? '' : 'flou'}`)
+      if !tauxCompletudeSuffisant
+        .cartouche-indice-cyber-insuffisant= `Indice cyber disponible dès ${referentiel.completudeNecessairePourAfficherIndiceCyber()}% des mesures complétées`
       .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
       #conteneur-indice-cyber
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -34,7 +34,7 @@ block titre
   h1 Sécuriser
   .conteneur-indicateurs
     #conteneur-completude-mesure
-    a.conteneur-indice-cyber(href="indiceCyber", class=`${tauxCompletudeSuffisant ? '' : 'flou'}`)
+    a.conteneur-indice-cyber(href=`${tauxCompletudeSuffisant ? 'indiceCyber' : '#'}`, class=`${tauxCompletudeSuffisant ? '' : 'flou'}`)
       .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
       #conteneur-indice-cyber
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -21,7 +21,7 @@ block append scripts
   script(id = 'securiser-lecture-seule', type = 'application/json').
     !{JSON.stringify(autorisationsService.SECURISER.estLectureSeule)}
   script(id = 'indice-cyber', type = 'application/json').
-    !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax()})}
+    !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax() })}
   script(id = 'completude-mesure', type = 'application/json').
     !{JSON.stringify(pourcentageProgression)}
 
@@ -30,10 +30,11 @@ block header-titre-page
     +texteTronque({texte: service.nomService() || ''})
 
 block titre
+  - const tauxCompletudeSuffisant = referentiel.completudeSuffisantePourAfficherIndiceCyber(pourcentageProgression)
   h1 Sécuriser
   .conteneur-indicateurs
     #conteneur-completude-mesure
-    a.conteneur-indice-cyber(href="indiceCyber")
+    a.conteneur-indice-cyber(href="indiceCyber", class=`${tauxCompletudeSuffisant ? '' : 'flou'}`)
       .cartouche-indice-cyber Indice cyber&nbsp;&nbsp;
       #conteneur-indice-cyber
 

--- a/svelte/lib/indiceCyber/IndiceCyber.svelte
+++ b/svelte/lib/indiceCyber/IndiceCyber.svelte
@@ -4,6 +4,7 @@
   import { recupereIndiceCyber } from './indiceCyber.api';
 
   export let indiceCyber: number;
+  export let completudeSuffisante: boolean;
 
   export let noteMax: number;
   export let idService: string;
@@ -48,9 +49,32 @@
   let animationFleche: SVGAnimateTransformElement;
 
   const metAJourIndiceCyber = async () => {
-    indiceCyber = await recupereIndiceCyber(idService);
+    const donnees = await recupereIndiceCyber(idService);
+    indiceCyber = donnees.indiceCyber;
+    const nouvelleCompletudeSuffisante =
+      donnees.completudeSuffisantePourAfficherIndiceCyber;
+    if (nouvelleCompletudeSuffisante && !completudeSuffisante) {
+      enleveFlou();
+    }
+    completudeSuffisante = nouvelleCompletudeSuffisante;
     animationJauge?.beginElement();
     animationFleche?.beginElement();
+  };
+
+  const enleveFlou = () => {
+    const conteneurs = document.getElementsByClassName(
+      'conteneur-indice-cyber'
+    );
+    if (conteneurs && conteneurs.length === 1) {
+      conteneurs.item(0)!.classList.remove('flou');
+    }
+
+    const cartouches = document.getElementsByClassName(
+      'cartouche-indice-cyber'
+    );
+    if (cartouches && cartouches.length === 1) {
+      cartouches.item(0)!.classList.add('passage-visible');
+    }
   };
 </script>
 

--- a/svelte/lib/indiceCyber/indiceCyber.api.ts
+++ b/svelte/lib/indiceCyber/indiceCyber.api.ts
@@ -1,4 +1,8 @@
 export const recupereIndiceCyber = async (idService: string) => {
-  const reponse = await axios.get(`/api/service/${idService}/indiceCyber`);
-  return reponse.data.total as number;
+  const { data } = await axios.get(`/api/service/${idService}/indiceCyber`);
+  return {
+    indiceCyber: data.indiceCyber.total,
+    completudeSuffisantePourAfficherIndiceCyber:
+      data.completudeSuffisantePourAfficherIndiceCyber,
+  };
 };

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1948,9 +1948,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it("renvoie l'indice cyber du service", async () => {
+    it("renvoie l'indice cyber du service et indique si le taux de complétude est suffisant", async () => {
       const serviceARenvoyer = unService().construis();
       serviceARenvoyer.indiceCyber = () => ({ total: 1.5 });
+      serviceARenvoyer.completudeMesures = () => ({
+        nombreMesuresCompletes: 5,
+        nombreTotalMesures: 10,
+      });
+      testeur
+        .referentiel()
+        .recharge({ completudeRequisePourAfficherIndiceCyber: 50 });
       testeur.middleware().reinitialise({
         homologationARenvoyer: serviceARenvoyer,
       });
@@ -1959,7 +1966,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'http://localhost:1234/api/service/456/indiceCyber'
       );
 
-      expect(data.total).to.be(1.5);
+      expect(data.indiceCyber.total).to.be(1.5);
+      expect(data.completudeSuffisantePourAfficherIndiceCyber).to.be(true);
     });
   });
 


### PR DESCRIPTION
### :warning: Cette PR dépend de #1280 

On ajoute un flou sur l'indice cyber de la page sécuriser.
Pour cela, il faut modifier l'API pour que la route `GET /indiceCyber` retourne aussi une indication sur le taux de complétude des mesures, afin de permettre de retirer le flou au bon moment.

[Screencast from 18-01-2024 14:48:55.webm](https://github.com/betagouv/mon-service-securise/assets/1643465/919c5087-5acf-4ca7-bc31-a02bbe333571)

