### PR TITLE
[MESURES] Ajoute une méthode pour enrichir les mesures

### DIFF
--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -73,6 +73,30 @@ class Mesures extends InformationsHomologation {
       .filter((m) => m.statut !== '')
       .map((m) => ({ idMesure: m.id, statut: m.statut }));
   }
+
+  enrichiesAvecDonneesPersonnalisees() {
+    const mesuresEnrichies = Object.entries(this.mesuresPersonnalisees).reduce(
+      (acc, mesurePersonnalisee) => {
+        const [id, donnees] = mesurePersonnalisee;
+        let generale = this.mesuresGenerales.avecId(id);
+        if (generale) {
+          generale = generale.toJSON();
+          delete generale.id;
+        }
+
+        return {
+          ...acc,
+          [id]: { ...donnees, ...(generale && { ...generale }) },
+        };
+      },
+      {}
+    );
+
+    return {
+      mesuresGenerales: mesuresEnrichies,
+      mesuresSpecifiques: this.mesuresSpecifiques.toJSON(),
+    };
+  }
 }
 
 module.exports = Mesures;

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -93,6 +93,10 @@ class MesuresGenerales extends ElementsConstructibles {
     }
     return MesuresGenerales.A_COMPLETER;
   }
+
+  avecId(idMesure) {
+    return this.toutes().find((m) => m.id === idMesure);
+  }
 }
 
 module.exports = MesuresGenerales;

--- a/src/modeles/objetsApi/objetGetMesures.js
+++ b/src/modeles/objetsApi/objetGetMesures.js
@@ -1,34 +1,4 @@
-const fusionneGeneraleEtPersonnalisee = (
-  mesureGenerale,
-  mesurePersonnalisee
-) => {
-  const [id, donnees] = mesurePersonnalisee;
-  delete mesureGenerale?.id;
-  return {
-    [id]: { ...donnees, ...(mesureGenerale && { ...mesureGenerale }) },
-  };
-};
-
-const donnees = (service, moteurRegles) => {
-  const { mesuresGenerales, mesuresSpecifiques } = service.mesures.toJSON();
-
-  const mesuresPersonnalisees = Object.entries(
-    moteurRegles.mesures(service.descriptionService)
-  ).reduce(
-    (acc, mesurePersonnalisee) => ({
-      ...acc,
-      ...fusionneGeneraleEtPersonnalisee(
-        mesuresGenerales.find((m) => m.id === mesurePersonnalisee[0]),
-        mesurePersonnalisee
-      ),
-    }),
-    {}
-  );
-
-  return {
-    mesuresGenerales: mesuresPersonnalisees,
-    mesuresSpecifiques,
-  };
-};
+const donnees = (service) =>
+  service.mesures.enrichiesAvecDonneesPersonnalisees();
 
 module.exports = { donnees };

--- a/src/mss.js
+++ b/src/mss.js
@@ -226,7 +226,6 @@ const creeServeur = (
       adaptateurZip,
       procedures,
       serviceAnnuaire,
-      moteurRegles,
     })
   );
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -37,7 +37,6 @@ const routesApiPrivee = ({
   adaptateurZip,
   procedures,
   serviceAnnuaire,
-  moteurRegles,
 }) => {
   const routes = express.Router();
 
@@ -136,7 +135,6 @@ const routesApiPrivee = ({
       adaptateurHorloge,
       adaptateurPdf,
       adaptateurZip,
-      moteurRegles,
     })
   );
 

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -42,7 +42,6 @@ const routesApiService = ({
   adaptateurHorloge,
   adaptateurPdf,
   adaptateurZip,
-  moteurRegles,
 }) => {
   const routes = express.Router();
 
@@ -158,7 +157,7 @@ const routesApiService = ({
     (requete, reponse) => {
       const { homologation: service } = requete;
 
-      reponse.json(objetGetMesures.donnees(service, moteurRegles));
+      reponse.json(objetGetMesures.donnees(service));
     }
   );
 

--- a/test/modeles/objetsApi/objetGetMesures.spec.js
+++ b/test/modeles/objetsApi/objetGetMesures.spec.js
@@ -1,87 +1,18 @@
 const expect = require('expect.js');
 const objetGetMesures = require('../../../src/modeles/objetsApi/objetGetMesures');
 const { unService } = require('../../constructeurs/constructeurService');
-const Mesures = require('../../../src/modeles/mesures');
-const referentiel = require('../../../src/referentiel');
 
 describe("L'objet d'API de `GET /mesures`", () => {
-  it('interroge le moteur de règles pour obtenir les mesures personnalisées', async () => {
-    let descriptionRecue;
+  it('fait passe-plat avec les mesures enrichies du service', async () => {
+    let passePlatEffectue = false;
 
-    const moteurRegles = {
-      mesures: (descriptionService) => {
-        descriptionRecue = descriptionService;
-        return {};
-      },
+    const service = unService().construis();
+    service.mesures.enrichiesAvecDonneesPersonnalisees = () => {
+      passePlatEffectue = true;
     };
 
-    objetGetMesures.donnees(
-      unService().avecNomService('un service').construis(),
-      moteurRegles
-    );
+    objetGetMesures.donnees(service);
 
-    expect(descriptionRecue.nomService).to.equal('un service');
-  });
-
-  it('associe les statuts et commentaires des mesures générales du service aux mesures personnalisées', async () => {
-    const service = unService()
-      .avecMesures(
-        new Mesures(
-          {
-            mesuresGenerales: [
-              { id: 'mesureA', statut: 'fait', modalites: 'un commentaire' },
-            ],
-          },
-          referentiel.creeReferentiel({ mesures: { mesureA: {} } })
-        )
-      )
-      .construis();
-
-    const moteurRegles = {
-      mesures: () => ({ mesureA: { description: 'Mesure A' } }),
-    };
-
-    const resultat = objetGetMesures.donnees(service, moteurRegles);
-
-    expect(resultat.mesuresGenerales.mesureA).to.eql({
-      description: 'Mesure A',
-      statut: 'fait',
-      modalites: 'un commentaire',
-    });
-  });
-
-  it('ne pollue pas les mesures personnalisée avec des mesures inexistantes sur le service (undefined)', async () => {
-    const service = unService()
-      .avecMesures(new Mesures({ mesuresGenerales: [] }))
-      .construis();
-
-    const moteurRegles = {
-      mesures: () => ({ mesureA: { description: 'Mesure A' } }),
-    };
-
-    const resultat = objetGetMesures.donnees(service, moteurRegles);
-
-    expect(resultat.mesuresGenerales.mesureA).to.eql({
-      description: 'Mesure A',
-    });
-  });
-
-  it('fait passe plat sur les mesures spécifiques du service', async () => {
-    const service = unService()
-      .avecMesures(
-        new Mesures({
-          mesuresGenerales: [],
-          mesuresSpecifiques: [{ description: 'une mesure' }],
-        })
-      )
-      .construis();
-
-    const moteurRegles = {
-      mesures: () => ({}),
-    };
-
-    const resultat = objetGetMesures.donnees(service, moteurRegles);
-
-    expect(resultat.mesuresSpecifiques).to.eql([{ description: 'une mesure' }]);
+    expect(passePlatEffectue).to.be(true);
   });
 });

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -306,22 +306,24 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it('retourne la représenation des mesures en utilisant `objetGetMesures`', async () => {
+    it('retourne la représentation enrichie des mesures', async () => {
+      const avecMesureA = referentiel.creeReferentiel({
+        mesures: { mesureA: {} },
+      });
       const mesures = new Mesures(
         {
           mesuresGenerales: [
             { id: 'mesureA', statut: 'fait', modalites: 'un commentaire' },
           ],
         },
-        referentiel.creeReferentiel({ mesures: { mesureA: {} } })
+        avecMesureA,
+        { mesureA: { description: 'Mesure A', referentiel: 'ANSSI' } }
       );
 
       testeur.middleware().reinitialise({
-        homologationARenvoyer: unService().avecMesures(mesures).construis(),
-      });
-
-      testeur.moteurRegles().mesures = () => ({
-        mesureA: { description: 'Mesure A' },
+        homologationARenvoyer: unService(avecMesureA)
+          .avecMesures(mesures)
+          .construis(),
       });
 
       const reponse = await axios(
@@ -334,6 +336,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
             description: 'Mesure A',
             statut: 'fait',
             modalites: 'un commentaire',
+            referentiel: 'ANSSI',
           },
         },
         mesuresSpecifiques: [],


### PR DESCRIPTION
On veut pouvoir facilement, pour un service, obtenir la liste des toutes les mesures sous un format exploitable.
Il s'agit donc de réconcilier les `mesuresGenerales` d'un service avec les données complémentaires disponible dans les `donneesReferentiel`, par le biais du `moteurRegles`.

```mermaid
graph LR
    A(Service) -- contient --> B(Mesures)
    A -- contient --> G(DescriptionService)
    B -- instancie --> C(MesuresGenerales)
    B -- instancie --> D(MesuresSpecifiques)
    E(MoteurRegles) -- conditionne --> B
    H(referentiel) -- alimenté par --> F(donnesReferentiel)
    E -- alimenté par --> H
    E -- alimenté par --> G
```

Cette méthode peut être utilisé :
- Au niveau de l'API
- Pour facilement savoir quels référentiels de mesures sont utilisés
- etc...