### PR TITLE
[CORRECTION] Ajoute l'espace de `margin` du tableau des mesures à la `width`

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -1,3 +1,7 @@
+.marges-fixes {
+  width: 1290px;
+}
+
 .zone-principale {
   margin-left: 34px;
   margin-right: 56px;


### PR DESCRIPTION
… sinon les indicateurs se chevauchent avec l'affichage de "X/Y mesures filtrées"