### PR TITLE
[SÉCURISER] Route pour les retours utilisateur sur les mesures

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -1184,5 +1184,14 @@ module.exports = {
       'testsSauvegardes',
     ],
   },
+  retoursUtilisateurMesure: {
+    mesureUtile: 'Cette mesure est utile',
+    mesurePasClaire: "Cette mesure n'est pas claire",
+    mesurePasPertinente:
+      "Cette mesure n'est pas pertinente compte tenu des caractéristiques du service",
+    mesureTropExigeante: 'Cette mesure est trop exigeante',
+    mesurePasAssezExigeante: "Cette mesure n'est pas assez exigeante",
+    autre: 'Autre',
+  },
   departements,
 };

--- a/server.js
+++ b/server.js
@@ -84,6 +84,7 @@ const serveur = MSS.creeServeur(
   adaptateurZip,
   adaptateurTracking,
   adaptateurProtection,
+  adaptateurJournal,
   procedures
 );
 

--- a/src/modeles/journalMSS/erreurs.js
+++ b/src/modeles/journalMSS/erreurs.js
@@ -4,6 +4,8 @@ class ErreurDetailMesuresManquant extends ErreurJournal {}
 class ErreurDureeHomologationManquante extends ErreurJournal {}
 class ErreurIdentifiantServiceManquant extends ErreurJournal {}
 class ErreurIdentifiantUtilisateurManquant extends ErreurJournal {}
+class ErreurIdentifiantMesureManquant extends ErreurJournal {}
+class ErreurIdentifiantRetourUtilisateurManquant extends ErreurJournal {}
 class ErreurIndiceCyberManquant extends ErreurJournal {}
 class ErreurNombreOrganisationsUtilisatricesManquant extends ErreurJournal {}
 class ErreurNombreMesuresCompletesManquant extends ErreurJournal {}
@@ -15,6 +17,8 @@ module.exports = {
   ErreurDureeHomologationManquante,
   ErreurIdentifiantServiceManquant,
   ErreurIdentifiantUtilisateurManquant,
+  ErreurIdentifiantMesureManquant,
+  ErreurIdentifiantRetourUtilisateurManquant,
   ErreurIndiceCyberManquant,
   ErreurNombreOrganisationsUtilisatricesManquant,
   ErreurNombreMesuresCompletesManquant,

--- a/src/modeles/journalMSS/evenementRetourUtilisateurMesure.js
+++ b/src/modeles/journalMSS/evenementRetourUtilisateurMesure.js
@@ -1,0 +1,41 @@
+const Evenement = require('./evenement');
+const {
+  ErreurIdentifiantServiceManquant,
+  ErreurIdentifiantUtilisateurManquant,
+  ErreurIdentifiantMesureManquant,
+  ErreurIdentifiantRetourUtilisateurManquant,
+} = require('./erreurs');
+
+class EvenementRetourUtilisateurMesure extends Evenement {
+  constructor(donnees, options = {}) {
+    const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
+
+    const valide = () => {
+      const manque = (donnee) => typeof donnee === 'undefined';
+
+      if (manque(donnees.idService))
+        throw new ErreurIdentifiantServiceManquant();
+      if (manque(donnees.idUtilisateur))
+        throw new ErreurIdentifiantUtilisateurManquant();
+      if (manque(donnees.idMesure)) throw new ErreurIdentifiantMesureManquant();
+      if (manque(donnees.idRetour))
+        throw new ErreurIdentifiantRetourUtilisateurManquant();
+    };
+
+    valide();
+
+    super(
+      'RETOUR_UTILISATEUR_MESURE_RECU',
+      {
+        idService: adaptateurChiffrement.hacheSha256(donnees.idService),
+        idUtilisateur: adaptateurChiffrement.hacheSha256(donnees.idUtilisateur),
+        idMesure: donnees.idMesure,
+        idRetour: donnees.idRetour,
+        commentaire: donnees.commentaire.substring(0, 2000),
+      },
+      date
+    );
+  }
+}
+
+module.exports = EvenementRetourUtilisateurMesure;

--- a/src/mss.js
+++ b/src/mss.js
@@ -31,6 +31,7 @@ const creeServeur = (
   adaptateurZip,
   adaptateurTracking,
   adaptateurProtection,
+  adaptateurJournalMSS,
   procedures,
   avecCookieSecurise = process.env.NODE_ENV === 'production',
   avecPageErreur = process.env.NODE_ENV === 'production'
@@ -224,6 +225,7 @@ const creeServeur = (
       adaptateurPdf,
       adaptateurCsv,
       adaptateurZip,
+      adaptateurJournalMSS,
       procedures,
       serviceAnnuaire,
     })

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -244,6 +244,10 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     return fonctionnalitesDechronologique[0];
   };
 
+  const retoursUtilisateurMesure = () => donnees.retoursUtilisateurMesure || {};
+  const retourUtilisateurMesure = (idRetour) =>
+    retoursUtilisateurMesure()[idRetour] ?? null;
+
   const recharge = (nouvellesDonnees) => {
     donnees = { ...donneesReferentielVide, ...nouvellesDonnees };
     valideDonnees();
@@ -316,6 +320,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     provenancesService,
     recharge,
     reglesPersonnalisation,
+    retoursUtilisateurMesure,
+    retourUtilisateurMesure,
     risques,
     descriptionStatutDeploiement,
     statutsAvisDossierHomologation,

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -245,7 +245,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   };
 
   const retoursUtilisateurMesure = () => donnees.retoursUtilisateurMesure || {};
-  const retourUtilisateurMesure = (idRetour) =>
+  const retourUtilisateurMesureAvecId = (idRetour) =>
     retoursUtilisateurMesure()[idRetour] ?? null;
 
   const recharge = (nouvellesDonnees) => {
@@ -321,7 +321,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     recharge,
     reglesPersonnalisation,
     retoursUtilisateurMesure,
-    retourUtilisateurMesure,
+    retourUtilisateurMesureAvecId,
     risques,
     descriptionStatutDeploiement,
     statutsAvisDossierHomologation,

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -87,6 +87,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     !!donnees.mesures[idMesure].indispensable;
   const mesures = () => JSON.parse(JSON.stringify(donnees.mesures));
   const identifiantsMesures = () => Object.keys(mesures());
+  const estIdentifiantMesureConnu = (id) => identifiantsMesures().includes(id);
   const mesure = (id) => mesures()[id];
   const typesService = () => donnees.typesService;
   const nbMoisDecalage = (idEcheance) =>
@@ -288,6 +289,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     estCodeDepartement,
     estDocumentHomologation,
     estIdentifiantEcheanceRenouvellementConnu,
+    estIdentifiantMesureConnu,
     estIdentifiantStatutAvisDossierHomologationConnu,
     etapeDossierAutorisee,
     etapeExiste,

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -35,6 +35,7 @@ const routesApiPrivee = ({
   adaptateurPdf,
   adaptateurCsv,
   adaptateurZip,
+  adaptateurJournalMSS,
   procedures,
   serviceAnnuaire,
 }) => {
@@ -135,6 +136,7 @@ const routesApiPrivee = ({
       adaptateurHorloge,
       adaptateurPdf,
       adaptateurZip,
+      adaptateurJournalMSS,
     })
   );
 

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -609,7 +609,7 @@ const routesApiService = ({
         return;
       }
 
-      if (!referentiel.identifiantsMesures().includes(idMesure)) {
+      if (!referentiel.estIdentifiantMesureConnu(idMesure)) {
         reponse.status(424).send({
           type: 'DONNEES_INCORRECTES',
           message: "L'identifiant de mesure est incorrect.",

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -598,7 +598,8 @@ const routesApiService = ({
     async (requete, reponse) => {
       const { homologation: service, idUtilisateurCourant } = requete;
       const { idRetour, idMesure, commentaire } = requete.body;
-      const retourUtilisateur = referentiel.retourUtilisateurMesure(idRetour);
+      const retourUtilisateur =
+        referentiel.retourUtilisateurMesureAvecId(idRetour);
 
       if (!retourUtilisateur) {
         reponse.status(424).send({

--- a/test/modeles/journalMSS/evenementRetourUtilisateurMesure.spec.js
+++ b/test/modeles/journalMSS/evenementRetourUtilisateurMesure.spec.js
@@ -1,0 +1,106 @@
+const expect = require('expect.js');
+const EvenementRetourUtilisateurMesure = require('../../../src/modeles/journalMSS/evenementRetourUtilisateurMesure');
+const {
+  ErreurIdentifiantServiceManquant,
+  ErreurIdentifiantUtilisateurManquant,
+  ErreurIdentifiantMesureManquant,
+  ErreurIdentifiantRetourUtilisateurManquant,
+} = require('../../../src/modeles/journalMSS/erreurs');
+
+describe('Un événement de retour utilisateur sur une mesure', () => {
+  const hacheEnMajuscules = { hacheSha256: (valeur) => valeur?.toUpperCase() };
+  const unEvenement = () =>
+    new EvenementRetourUtilisateurMesure(
+      {
+        idService: 'abc',
+        idUtilisateur: 'def',
+        idMesure: 'uneMesure',
+        idRetour: 'unRetour',
+        commentaire: 'unCommentaire',
+      },
+      {
+        date: '17/11/2022',
+        adaptateurChiffrement: hacheEnMajuscules,
+      }
+    );
+
+  it("chiffre l'identifiant du service qui lui est donné", () => {
+    expect(unEvenement().donnees.idService).to.be('ABC');
+  });
+
+  it("chiffre l'identifiant de l'utilisateur qui lui est donné", () => {
+    expect(unEvenement().donnees.idUtilisateur).to.be('DEF');
+  });
+
+  it('sait se convertir en JSON', () => {
+    expect(unEvenement().toJSON()).to.eql({
+      type: 'RETOUR_UTILISATEUR_MESURE_RECU',
+      donnees: {
+        idService: 'ABC',
+        idUtilisateur: 'DEF',
+        idMesure: 'uneMesure',
+        idRetour: 'unRetour',
+        commentaire: 'unCommentaire',
+      },
+      date: '17/11/2022',
+    });
+  });
+
+  const proprietesAVerifier = [
+    { propriete: 'idService', typeErreur: ErreurIdentifiantServiceManquant },
+    {
+      propriete: 'idUtilisateur',
+      typeErreur: ErreurIdentifiantUtilisateurManquant,
+    },
+    { propriete: 'idMesure', typeErreur: ErreurIdentifiantMesureManquant },
+    {
+      propriete: 'idRetour',
+      typeErreur: ErreurIdentifiantRetourUtilisateurManquant,
+    },
+  ];
+  proprietesAVerifier.forEach(({ propriete, typeErreur }) => {
+    it(`exige que \`${propriete}\` soit renseigné`, (done) => {
+      try {
+        const donnees = {
+          idService: 'abc',
+          idUtilisateur: 'def',
+          idMesure: 'uneMesure',
+          idRetour: 'unRetour',
+          commentaire: 'unCommentaire',
+        };
+        delete donnees[propriete];
+        new EvenementRetourUtilisateurMesure(donnees, {
+          date: '17/11/2022',
+          adaptateurChiffrement: hacheEnMajuscules,
+        });
+
+        done(
+          Error("L'instanciation de l'événement aurait dû lever une exception")
+        );
+      } catch (e) {
+        expect(e).to.be.an(typeErreur);
+        done();
+      }
+    });
+  });
+
+  it('limite la longueur du commentaire à 2 000 caractères pour éviter les contenus mal intentionnés', () => {
+    const tropLong = new Array(2000 + 500).fill('a').join('');
+
+    const evenement = new EvenementRetourUtilisateurMesure(
+      {
+        idService: 'abc',
+        idUtilisateur: 'def',
+        idMesure: 'uneMesure',
+        idRetour: 'unRetour',
+        commentaire: tropLong,
+      },
+      {
+        date: '17/11/2022',
+        adaptateurChiffrement: hacheEnMajuscules,
+      }
+    );
+
+    expect(evenement.toJSON().donnees.commentaire.length).to.equal(2000);
+  });
+});

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -904,12 +904,10 @@ describe('Le référentiel', () => {
   describe("sur demande d'un retour utilisateur sur une mesure par id", () => {
     it('retourne la valeur', () => {
       const referentiel = Referentiel.creeReferentiel({
-        retoursUtilisateurMesure: {
-          unAvis: { description: 'un avis' },
-        },
+        retoursUtilisateurMesure: { unAvis: { description: 'un avis' } },
       });
 
-      expect(referentiel.retourUtilisateurMesure('unAvis')).to.eql({
+      expect(referentiel.retourUtilisateurMesureAvecId('unAvis')).to.eql({
         description: 'un avis',
       });
     });
@@ -919,7 +917,9 @@ describe('Le référentiel', () => {
         retoursUtilisateurMesure: {},
       });
 
-      expect(referentiel.retourUtilisateurMesure('unAvis')).to.equal(null);
+      expect(referentiel.retourUtilisateurMesureAvecId('unAvis')).to.equal(
+        null
+      );
     });
   });
 });

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -337,6 +337,15 @@ describe('Le référentiel', () => {
     ]);
   });
 
+  it('sait dire si un identifiant de mesure fait partie du référentiel', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      mesures: { uneMesure: {} },
+    });
+
+    expect(referentiel.estIdentifiantMesureConnu('xyzMesure')).to.be(false);
+    expect(referentiel.estIdentifiantMesureConnu('uneMesure')).to.be(true);
+  });
+
   it('connaît la liste des localisations de données', () => {
     const referentiel = Referentiel.creeReferentiel({
       localisationsDonnees: { uneClef: 'une valeur' },

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -876,4 +876,50 @@ describe('Le référentiel', () => {
       );
     });
   });
+
+  describe('sur demande de tous les retours utilisateur sur une mesure', () => {
+    it('retourne toutes les valeurs possibles', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        retoursUtilisateurMesure: {
+          unAvis: { description: 'un avis' },
+          unAutreAvis: { description: 'un autre avis' },
+        },
+      });
+
+      expect(referentiel.retoursUtilisateurMesure()).to.eql({
+        unAvis: { description: 'un avis' },
+        unAutreAvis: { description: 'un autre avis' },
+      });
+    });
+
+    it('reste robuste si aucune valeurs', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        retoursUtilisateurMesure: undefined,
+      });
+
+      expect(referentiel.retoursUtilisateurMesure()).to.eql({});
+    });
+  });
+
+  describe("sur demande d'un retour utilisateur sur une mesure par id", () => {
+    it('retourne la valeur', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        retoursUtilisateurMesure: {
+          unAvis: { description: 'un avis' },
+        },
+      });
+
+      expect(referentiel.retourUtilisateurMesure('unAvis')).to.eql({
+        description: 'un avis',
+      });
+    });
+
+    it("retourne `null` si l'id est introuvable", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        retoursUtilisateurMesure: {},
+      });
+
+      expect(referentiel.retourUtilisateurMesure('unAvis')).to.equal(null);
+    });
+  });
 });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -44,8 +44,8 @@ const testeurMss = () => {
     axios(requete)
       .then(() => suite('Réponse OK inattendue'))
       .catch((erreur) => {
-        expect(erreur.response.status).to.equal(status);
-        expect(erreur.response.data).to.eql(messageErreur);
+        expect(erreur.response?.status).to.equal(status);
+        expect(erreur.response?.data).to.eql(messageErreur);
         suite();
       })
       .catch(suite);

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -20,6 +20,7 @@ const testeurMss = () => {
   let adaptateurZip;
   let adaptateurTracking;
   let adaptateurProtection;
+  let adaptateurJournalMSS;
   let depotDonnees;
   let moteurRegles;
   let referentiel;
@@ -74,6 +75,7 @@ const testeurMss = () => {
         () => (_requete, _reponse, suite) =>
           suite(),
     };
+    adaptateurJournalMSS = { consigneEvenement: async () => {} };
     middleware.reinitialise({});
     referentiel = Referentiel.creeReferentielVide();
     procedures = fabriqueProcedures({
@@ -99,6 +101,7 @@ const testeurMss = () => {
           adaptateurZip,
           adaptateurTracking,
           adaptateurProtection,
+          adaptateurJournalMSS,
           procedures,
           false,
           false
@@ -118,6 +121,7 @@ const testeurMss = () => {
     adaptateurCsv: () => adaptateurCsv,
     adaptateurZip: () => adaptateurZip,
     adaptateurTracking: () => adaptateurTracking,
+    adaptateurJournalMSS: () => adaptateurJournalMSS,
     depotDonnees: () => depotDonnees,
     middleware: () => middleware,
     moteurRegles: () => moteurRegles,


### PR DESCRIPTION
On ajoute une route afin de récupérer les "feedbacks" utilisateur sur les mesures de sécurité, depuis le tableau des mesures, via le tiroir.

Cette route agit comme un "proxy", valide les données, puis les consigne dans Metabase.

La partie front sera faite des une autre PR.