### PR TITLE
Ne masque pas les "sous-catégories" indispensable et recommandée du référentiel ANSSI

### DIFF
--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -97,7 +97,7 @@
         />
         <label for="anssi">ANSSI</label>
       </div>
-      <div class:invisible={!cocheGlobaleANSSI && !selectionPartielleANSSI}>
+      <div>
         <input
           type="checkbox"
           id="anssi-indispensable"
@@ -108,7 +108,7 @@
         />
         <label for="anssi-indispensable">Indispensable</label>
       </div>
-      <div class:invisible={!cocheGlobaleANSSI && !selectionPartielleANSSI}>
+      <div>
         <input
           type="checkbox"
           id="anssi-recommandee"
@@ -234,9 +234,5 @@
 
   .decalage-checkbox {
     margin-left: 12px;
-  }
-
-  .invisible {
-    display: none;
   }
 </style>


### PR DESCRIPTION
On affiche systématiquement les sous-référentiels "Indispensable" et "Recommandé"

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/196754e0-8375-4098-8ccb-95ff7849bcdb)
