### PR TITLE
Ajoute l'affichage conditonnel des référentiels dans la page indice cyber

### DIFF
--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -102,11 +102,17 @@ const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
     middleware.chargePreferencesUtilisateur,
     async (requete, reponse) => {
       const { homologation: service } = requete;
+      const referentiels = Object.entries(
+        service.mesures.enrichiesAvecDonneesPersonnalisees().mesuresGenerales
+      ).map(([_, mesure]) => mesure.referentiel);
+      const referentielConcernes =
+        referentiel.formatteListeDeReferentiels(referentiels);
       reponse.render('service/indiceCyber', {
         InformationsHomologation,
         service,
         etapeActive: 'mesures',
         referentiel,
+        referentielConcernes,
       });
     }
   );

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -31,7 +31,7 @@ block zone-principale
       .disque-indice
         #conteneur-indice-cyber
       .contenu-descriptif
-        p L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures faites proposées par l'ANSSI dans MonServiceSécurisé.
+        p L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures faites proposées par #{referentielConcernes} dans MonServiceSécurisé.
     .conteneur-plus-details
       details
         summary(role='button')


### PR DESCRIPTION
On réutilise le même mécanisme que pour le PDF synthèse de sécurité.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/198d309b-095a-4371-b565-24ac03a2497f)
