### PR TITLE
[SÉCURISER] Barre sticky - Masquage lors de l'ouverture du menu de navigation

### DIFF
--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -56,7 +56,7 @@ const repliMenu = () => {
 
   const cookie = () => {
     const cookieAvecAge = (ageEnSecondes) =>
-      `etat-menu-navigation=ferme; path=/; max-age=${ageEnSecondes}`;
+      `etat-menu-navigation=ferme; SameSite=Strict; path=/; max-age=${ageEnSecondes}`;
     const unAn = 3600 * 24 * 365;
     return {
       poserPourUnAn: () => (document.cookie = cookieAvecAge(unAn)),

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -8,6 +8,7 @@
     rechercheReferentiel,
     rechercheStatut,
   } from '../tableauDesMesures.store';
+  import { menuNavigationOuvert } from '../../ui/menuNavigation.store';
 
   export let categories: Record<IdCategorie, string>;
   export let statuts: Record<IdStatut, string>;
@@ -155,7 +156,10 @@
   class:visible={$nombreResultats.aDesFiltresAppliques}
 >
   <strong>{$nombreResultats.filtrees}&nbsp;</strong
-  >/&nbsp;{$nombreResultats.total} mesures affichées
+  >/&nbsp;{$nombreResultats.total}
+  {#if !$menuNavigationOuvert}
+    <span>mesures affichées</span>
+  {/if}
 </p>
 
 <style>

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -44,7 +44,10 @@
 
 <MenuFlottant parDessusDeclencheur={true}>
   <div slot="declencheur">
-    <button class="bouton bouton-secondaire bouton-filtre">
+    <button
+      class="bouton bouton-secondaire bouton-filtre"
+      class:actif={$nombreResultats.aDesFiltresAppliques}
+    >
       <img src="/statique/assets/images/icone_filtre.svg" alt="" />
       Filtres
     </button>
@@ -166,6 +169,16 @@
   .bouton-filtre {
     display: flex;
     gap: 8px;
+  }
+
+  .bouton-filtre.actif {
+    color: #08416a;
+    border-color: #08416a;
+  }
+
+  .bouton-filtre.actif img {
+    filter: brightness(0) invert(15%) sepia(24%) saturate(4604%)
+      hue-rotate(184deg) brightness(107%) contrast(94%);
   }
 
   .titre-filtres {

--- a/svelte/lib/ui/menuNavigation.store.ts
+++ b/svelte/lib/ui/menuNavigation.store.ts
@@ -1,0 +1,24 @@
+import { readable } from 'svelte/store';
+
+const menuEl = document.getElementsByClassName('menu-navigation')[0];
+const menuEstOuvert = () => !menuEl.classList.contains('ferme');
+
+export const menuNavigationOuvert = readable<boolean>(
+  menuEstOuvert(),
+  (set) => {
+    const observateur = new MutationObserver((mutations) =>
+      mutations.forEach((mutation) => {
+        if (mutation.target === menuEl) set(menuEstOuvert());
+      })
+    );
+
+    observateur.observe(menuEl, {
+      attributes: true,
+      subtree: false,
+      childList: false,
+      attributeFilter: ['class'],
+    });
+
+    return () => observateur.disconnect();
+  }
+);


### PR DESCRIPTION
On masque "mesure affichées" lorsque le menu de navigation est ouvert, pour éviter le chevauchement avec les indicateurs.

[Screencast from 30-01-2024 10:05:43.webm](https://github.com/betagouv/mon-service-securise/assets/1643465/7023579a-40a1-4167-9754-a3cd753f7239)


Pour cela, on observe l'élément `menu-navigation` grâce au [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver). Cela nous permet de créer un `store` Svelte qui est capable de connaitre l'état d'ouverture du menu, alors que le composant du menu n'est pas dans les bundles Svelte.

On en profite pour ajouter le statut "actif" sur le bouton du filtre.

Au passage on rajoute `SameSite=strict` au cookie du menu de navigation, car Firefox se plaint :
```
Cookie “etat-menu-navigation” does not have a proper “SameSite” attribute value.
Soon, cookies without the “SameSite” attribute or with an invalid value will be treated as “Lax”.
This means that the cookie will no longer be sent in third-party contexts.
If your application depends on this cookie being available in such contexts, please add the “SameSite=None“ attribute to it.
To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
```