### PR TITLE
Nouvelle route pour exporter en CSV les mesures d'un service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bcrypt": "^5.1.0",
         "cookie-parser": "^1.4.6",
         "cookie-session": "^2.0.0",
+        "csv-writer": "^1.6.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "express-ip-access-control": "^1.1.3",
@@ -2353,6 +2354,11 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -10307,6 +10313,11 @@
           "dev": true
         }
       }
+    },
+    "csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "pg": "^8.8.0",
         "pug": "^3.0.2",
         "puppeteer": "^19.7.3",
+        "string-strip-html": "^8.4.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -7652,6 +7653,14 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-strip-html": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-8.4.0.tgz",
+      "integrity": "sha512-ajjEpk0V1G0+/RrX08I2pSj/kfsYU5wkUKWEKPQJXVQpdahZNSljiuWVqf8UgrB2E9DvFcougbl1gPwHzkuEDg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -14175,6 +14184,11 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
       "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true
+    },
+    "string-strip-html": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-8.4.0.tgz",
+      "integrity": "sha512-ajjEpk0V1G0+/RrX08I2pSj/kfsYU5wkUKWEKPQJXVQpdahZNSljiuWVqf8UgrB2E9DvFcougbl1gPwHzkuEDg=="
     },
     "string-width": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bcrypt": "^5.1.0",
     "cookie-parser": "^1.4.6",
     "cookie-session": "^2.0.0",
+    "csv-writer": "^1.6.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-ip-access-control": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "pg": "^8.8.0",
     "pug": "^3.0.2",
     "puppeteer": "^19.7.3",
+    "string-strip-html": "^8.4.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -56,12 +56,24 @@ const genereCsvMesures = async (donneesMesures) => {
     ],
   });
 
-  const { mesuresGenerales } = donneesMesures;
-  const donneesCsv = Object.values(mesuresGenerales).map((m) => ({
-    ...m,
-    type: m.indispensable ? 'Indispensable' : 'Recommandée',
-    descriptionLongue: stripHtml(m.descriptionLongue).result,
-  }));
+  const { mesuresGenerales, mesuresSpecifiques } = donneesMesures;
+  const donneesCsv = Object.values(mesuresGenerales)
+    .map((m) => ({
+      description: m.description,
+      referentiel: m.referentiel,
+      type: m.indispensable ? 'Indispensable' : 'Recommandée',
+      categorie: m.categorie,
+      descriptionLongue: stripHtml(m.descriptionLongue).result,
+    }))
+    .concat(
+      mesuresSpecifiques.map((m) => ({
+        description: decode(m.description),
+        referentiel: 'Mesures ajoutées',
+        type: '',
+        categorie: m.categorie,
+        descriptionLongue: '',
+      }))
+    );
 
   const titre = writer.getHeaderString();
   const lignes = writer.stringifyRecords(donneesCsv);

--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -1,5 +1,6 @@
 const { decode } = require('html-entities');
 const { createObjectCsvStringifier } = require('csv-writer');
+const { stripHtml } = require('string-strip-html');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
@@ -59,6 +60,7 @@ const genereCsvMesures = async (donneesMesures) => {
   const donneesCsv = Object.values(mesuresGenerales).map((m) => ({
     ...m,
     type: m.indispensable ? 'Indispensable' : 'Recommandée',
+    descriptionLongue: stripHtml(m.descriptionLongue).result,
   }));
 
   const titre = writer.getHeaderString();

--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -1,51 +1,47 @@
-const { EOL } = require('os');
 const { decode } = require('html-entities');
 const { createObjectCsvStringifier } = require('csv-writer');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
 
-const SEPARATEUR = ';';
-
-const remplaceSeparateurParEspace = (chaine) =>
-  chaine.replaceAll(SEPARATEUR, ' ');
 const remplaceBooleen = (booleen) => (booleen ? 'Oui' : 'Non');
-
-const ligneDuService = (service) =>
-  [
-    remplaceSeparateurParEspace(decode(service.nomService)),
-    service.organisationsResponsables
-      .map((o) => decode(o))
-      .map(remplaceSeparateurParEspace)
-      .join(' - '),
-    service.nombreContributeurs,
-    remplaceBooleen(service.estProprietaire),
-    Number(service.indiceCyber) ? service.indiceCyber : '-',
-    service.statutHomologation?.libelle ?? '-',
-  ].join(SEPARATEUR);
+const avecBOM = (...contenus) => `\uFEFF${contenus.join('')}`;
 
 const genereCsvServices = (tableauServices) => {
   try {
-    const entete = [
-      'Nom du service',
-      'Organisations responsables',
-      'Nombre de contributeurs',
-      'Est propriétaire ?',
-      'Indice cyber',
-      'Statut homologation',
-    ].join(SEPARATEUR);
+    const writer = createObjectCsvStringifier({
+      // Les `id` correspondent aux noms des propriétés dans notre modèle
+      header: [
+        { id: 'service', title: 'Nom du service' },
+        { id: 'organisations', title: 'Organisations responsables' },
+        { id: 'nombreContributeurs', title: 'Nombre de contributeurs' },
+        { id: 'estProprietaire', title: 'Est propriétaire ?' },
+        { id: 'indiceCyber', title: 'Indice cyber' },
+        { id: 'statut', title: 'Statut homologation' },
+      ],
+    });
 
-    const contenu = [entete, ...tableauServices.map(ligneDuService)].join(EOL);
+    const donnnesCsv = tableauServices.map((s) => ({
+      service: decode(s.nomService),
+      organisations: s.organisationsResponsables
+        .map((o) => decode(o))
+        .join(' - '),
+      nombreContributeurs: s.nombreContributeurs,
+      estProprietaire: remplaceBooleen(s.estProprietaire),
+      indiceCyber: Number(s.indiceCyber) ? s.indiceCyber : '-',
+      statut: s.statutHomologation?.libelle ?? '-',
+    }));
 
-    const avecBOM = '\uFEFF';
-    return Buffer.from(`${avecBOM}${contenu}`, 'utf-8');
+    const titre = writer.getHeaderString();
+    const lignes = writer.stringifyRecords(donnnesCsv);
+    const csv = avecBOM(`${titre}${lignes}`);
+
+    return Buffer.from(csv, 'utf-8');
   } catch (e) {
     fabriqueAdaptateurGestionErreur().logueErreur(e);
     throw e;
   }
 };
-
-const avecBOM = (...contenus) => `\uFEFF${contenus.join('')}`;
 
 const genereCsvMesures = async (donneesMesures) => {
   const writer = createObjectCsvStringifier({

--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -44,4 +44,10 @@ const genereCsvServices = (tableauServices) => {
   }
 };
 
-module.exports = { genereCsvServices };
+const genereCsvMesures = async () => {
+  const avecBOM = '\uFEFF';
+  const contenuBouchon = ['a', 'b', 'c'].join(SEPARATEUR);
+  return Buffer.from(`${avecBOM}${contenuBouchon}`);
+};
+
+module.exports = { genereCsvMesures, genereCsvServices };

--- a/src/mss.js
+++ b/src/mss.js
@@ -241,6 +241,7 @@ const creeServeur = (
       moteurRegles,
       adaptateurCsv,
       adaptateurGestionErreur,
+      adaptateurHorloge,
     })
   );
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -234,7 +234,7 @@ const creeServeur = (
   app.use(
     '/service',
     middleware.verificationJWT,
-    routesService(middleware, referentiel, depotDonnees, moteurRegles)
+    routesService({ middleware, referentiel, depotDonnees, moteurRegles })
   );
 
   app.get(

--- a/src/mss.js
+++ b/src/mss.js
@@ -234,7 +234,14 @@ const creeServeur = (
   app.use(
     '/service',
     middleware.verificationJWT,
-    routesService({ middleware, referentiel, depotDonnees, moteurRegles })
+    routesService({
+      middleware,
+      referentiel,
+      depotDonnees,
+      moteurRegles,
+      adaptateurCsv,
+      adaptateurGestionErreur,
+    })
   );
 
   app.get(

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { decode } = require('html-entities');
 
 const InformationsHomologation = require('../../modeles/informationsHomologation');
 
@@ -118,7 +119,7 @@ const routesService = ({
           avecDonneesAdditionnelles
         );
 
-        const s = service.nomService().substring(0, 30);
+        const s = decode(service.nomService().substring(0, 30));
         const date = dateYYYYMMDD(adaptateurHorloge.maintenant());
         const perimetre = avecDonneesAdditionnelles ? 'avec' : 'sans';
         const fichier = `${s} Liste mesures ${perimetre} données additionnelles ${date}.csv`;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -118,7 +118,7 @@ const routesService = ({
           avecDonneesAdditionnelles
         );
 
-        const s = service.nomService();
+        const s = service.nomService().substring(0, 30);
         const date = dateYYYYMMDD(adaptateurHorloge.maintenant());
         const perimetre = avecDonneesAdditionnelles ? 'avec' : 'sans';
         const fichier = `${s} Liste mesures ${perimetre} données additionnelles ${date}.csv`;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -13,7 +13,12 @@ const Service = require('../../modeles/service');
 const { LECTURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
 
-const routesService = (middleware, referentiel, depotDonnees, moteurRegles) => {
+const routesService = ({
+  middleware,
+  referentiel,
+  depotDonnees,
+  moteurRegles,
+}) => {
   const routes = express.Router();
 
   routes.get(

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -111,7 +111,8 @@ const routesService = ({
 
       try {
         const bufferCsv = await adaptateurCsv.genereCsvMesures(
-          service.mesures.enrichiesAvecDonneesPersonnalisees()
+          service.mesures.enrichiesAvecDonneesPersonnalisees(),
+          requete.query.avecDonneesAdditionnelles
         );
 
         reponse

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -13,6 +13,7 @@ const {
 const { unService } = require('../../constructeurs/constructeurService');
 const {
   verifieTypeFichierServiEstCSV,
+  verifieNomFichierServi,
 } = require('../../aides/verifieFichierServi');
 
 describe('Le serveur MSS des routes /service/*', () => {
@@ -286,6 +287,18 @@ describe('Le serveur MSS des routes /service/*', () => {
     it('sert un fichier de type CSV', (done) => {
       verifieTypeFichierServiEstCSV(
         'http://localhost:1234/service/456/mesures/export.csv',
+        done
+      );
+    });
+
+    it('nomme le fichier CSV avec le nom du service et un horodatage', (done) => {
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: unService().avecNomService('Mairie').construis(),
+      });
+      testeur.adaptateurHorloge().maintenant = () => new Date(2024, 0, 23);
+      verifieNomFichierServi(
+        'http://localhost:1234/service/456/mesures/export.csv',
+        'Mairie Liste mesures sans données additionnelles 20240123.csv',
         done
       );
     });

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -303,6 +303,22 @@ describe('Le serveur MSS des routes /service/*', () => {
       );
     });
 
+    it('tronque le nom du service à 30 caractères', async () => {
+      const tropLong = new Array(150).fill('A').join('');
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: unService().avecNomService(tropLong).construis(),
+      });
+      testeur.adaptateurHorloge().maintenant = () => new Date(2024, 0, 23);
+
+      const reponse = await axios(
+        'http://localhost:1234/service/456/mesures/export.csv'
+      );
+
+      expect(reponse.headers['content-disposition']).to.contain(
+        'filename="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA Liste'
+      );
+    });
+
     it("reste robuste en cas d'erreur de génération CSV", async () => {
       testeur.adaptateurCsv().genereCsvMesures = async () => {
         throw Error('BOOM');

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -319,6 +319,21 @@ describe('Le serveur MSS des routes /service/*', () => {
       );
     });
 
+    it('décode correctement les caractères spéciaux dans le nom du service', (done) => {
+      testeur.middleware().reinitialise({
+        homologationARenvoyer: unService()
+          .avecNomService('Service d&#x27;apostrophe')
+          .construis(),
+      });
+      testeur.adaptateurHorloge().maintenant = () => new Date(2024, 0, 23);
+
+      verifieNomFichierServi(
+        'http://localhost:1234/service/456/mesures/export.csv',
+        "Service d'apostrophe Liste mesures sans données additionnelles 20240123.csv",
+        done
+      );
+    });
+
     it("reste robuste en cas d'erreur de génération CSV", async () => {
       testeur.adaptateurCsv().genereCsvMesures = async () => {
         throw Error('BOOM');

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -15,6 +15,7 @@ const testeurMss = () => {
   let serviceAnnuaire;
   let adaptateurHorloge;
   let adaptateurMail;
+  let adaptateurGestionErreur;
   let adaptateurPdf;
   let adaptateurCsv;
   let adaptateurZip;
@@ -62,6 +63,7 @@ const testeurMss = () => {
     };
     adaptateurCsv = {};
     adaptateurZip = { genereArchive: () => Promise.resolve('Archive ZIP') };
+    adaptateurGestionErreur = adaptateurGestionErreurVide;
     adaptateurTracking = {
       envoieTrackingConnexion: () => Promise.resolve(),
       envoieTrackingInscription: () => Promise.resolve(),
@@ -95,7 +97,7 @@ const testeurMss = () => {
           adaptateurMail,
           adaptateurPdf,
           adaptateurHorloge,
-          adaptateurGestionErreurVide,
+          adaptateurGestionErreur,
           serviceAnnuaire,
           adaptateurCsv,
           adaptateurZip,
@@ -115,6 +117,7 @@ const testeurMss = () => {
 
   return {
     serviceAnnuaire: () => serviceAnnuaire,
+    adaptateurGestionErreur: () => adaptateurGestionErreur,
     adaptateurHorloge: () => adaptateurHorloge,
     adaptateurMail: () => adaptateurMail,
     adaptateurPdf: () => adaptateurPdf,


### PR DESCRIPTION
### Récapitulatif

Cette PR ajoute la route `/service/:id/mesures/export.csv` qui sort les mesures dans un fichier CSV 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/ff9d50e0-5e25-46d2-9f39-ed3822eb020f)

La route a un paramètre en _query string_ : `avecDonneesAdditionnelles`.
Ce paramètre conditionne l'export des 2 dernières colonnes du CSV.

### 🔧  Librairies
Cette PR ajoute `"csv-writer"` et `"string-strip-html"` pour industrialiser l'export.
Le premier export, celui des services, est refactoré pour utiliser `csv-writer`.
