### PR TITLE
Améliore les performances de l'enregistrement des mesures générales

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -183,12 +183,9 @@ const creeDepot = (config = {}) => {
       return Promise.resolve(h.dossierCourant());
     });
 
-  const ajouteMesuresGeneralesAHomologation = async (
-    idHomologation,
-    mesures
-  ) => {
-    const h = await p.lis.une(idHomologation);
-    const donneesAPersister = h.donneesAPersister().toutes();
+  const ajouteMesuresGeneralesAService = async (idService, mesures) => {
+    const s = await p.lis.une(idService);
+    const donneesAPersister = s.donneesAPersister().toutes();
     donneesAPersister.mesuresGenerales ||= [];
 
     mesures.forEach((mesure) => {
@@ -290,7 +287,7 @@ const creeDepot = (config = {}) => {
     generales,
     specifiques
   ) => {
-    await ajouteMesuresGeneralesAHomologation(idHomologation, generales);
+    await ajouteMesuresGeneralesAService(idHomologation, generales);
     await remplaceMesuresSpecifiquesPourHomologation(
       idHomologation,
       specifiques


### PR DESCRIPTION
... en appellant la persistance qu'une fois, à la fin.

Cette optimisation permet de passer, en local, de ≈ 2 secondes par appel à 500ms.
Le plus gros du temps consommé est maintenant dans le fait qu'on `await` tous les consommateurs dans le bus d'événement