### PR TITLE
[PERFORMANCE] N'attends pas l'exécution de tous les handlers lors de la publication

### DIFF
--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -48,8 +48,10 @@ const main = async () => {
     const adaptateurPersistance = fabriqueAdaptateurPersistance(
       process.env.NODE_ENV
     );
-
-    const depotDonnees = DepotDonnees.creeDepot();
+    const busEvenements = new BusEvenements({
+      adaptateurGestionErreur: fabriqueAdaptateurGestionErreur(),
+    });
+    const depotDonnees = DepotDonnees.creeDepot({ busEvenements });
 
     /* eslint-disable no-console */
     const u = await adaptateurPersistance.utilisateurAvecEmail(

--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -2,6 +2,10 @@ const fabriqueAdaptateurPersistance = require('./src/adaptateurs/fabriqueAdaptat
 const DepotDonnees = require('./src/depotDonnees');
 const DescriptionService = require('./src/modeles/descriptionService');
 const Referentiel = require('./src/referentiel');
+const BusEvenements = require('./src/bus/busEvenements');
+const {
+  fabriqueAdaptateurGestionErreur,
+} = require('./src/adaptateurs/fabriqueAdaptateurGestionErreur');
 
 const referentiel = Referentiel.creeReferentiel();
 const descriptionService = new DescriptionService(
@@ -39,25 +43,29 @@ const creeDonnees = async (depotDonnees) => {
   });
 };
 
-if (process.env.CREATION_UTILISATEUR_DEMO) {
-  const adaptateurPersistance = fabriqueAdaptateurPersistance(
-    process.env.NODE_ENV
-  );
-  const depotDonnees = DepotDonnees.creeDepot();
+const main = async () => {
+  if (process.env.CREATION_UTILISATEUR_DEMO) {
+    const adaptateurPersistance = fabriqueAdaptateurPersistance(
+      process.env.NODE_ENV
+    );
 
-  /* eslint-disable no-console */
-  adaptateurPersistance
-    .utilisateurAvecEmail(process.env.EMAIL_UTILISATEUR_DEMO)
-    .then((u) => {
-      if (u) {
-        console.log('Utilisateur déjà existant !…');
-        process.exit(0);
-      }
+    const depotDonnees = DepotDonnees.creeDepot();
 
-      creeDonnees(depotDonnees).then(() => {
-        console.log('Utilisateur de démonstration créé !');
-        process.exit(0);
-      });
-    });
-  /* eslint-enable no-console */
-}
+    /* eslint-disable no-console */
+    const u = await adaptateurPersistance.utilisateurAvecEmail(
+      process.env.EMAIL_UTILISATEUR_DEMO
+    );
+
+    if (u) {
+      console.log('Utilisateur déjà existant !…');
+      process.exit(0);
+    }
+
+    await creeDonnees(depotDonnees);
+    console.log('Utilisateur de démonstration créé !');
+    process.exit(0);
+    /* eslint-enable no-console */
+  }
+};
+
+main().then(() => {});

--- a/src/bus/busEvenements.js
+++ b/src/bus/busEvenements.js
@@ -14,15 +14,13 @@ class BusEvenements {
   }
 
   async publie(evenement) {
-    // eslint-disable-next-line no-restricted-syntax
-    for (const handler of this.handlers[evenement.constructor.name]) {
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        await handler(evenement);
-      } catch (e) {
+    // On fonctionne exprès en `fire & forget` pour les handlers.
+    // Dans un souci de performance : on ne veut pas attendre les exécutions.
+    this.handlers[evenement.constructor.name].forEach((handler) => {
+      handler(evenement).catch((e) => {
         this.adaptateurGestionErreur.logueErreur(e);
-      }
-    }
+      });
+    });
   }
 }
 

--- a/test/bus/busEvenements.spec.js
+++ b/test/bus/busEvenements.spec.js
@@ -15,15 +15,15 @@ describe("Le bus d'événements", () => {
     adaptateurGestionErreur = { logueErreur: () => {} }
   ) => new BusEvenements({ adaptateurGestionErreur });
 
-  it("permet de s'abonner à un type d'événement", () => {
+  it("permet de s'abonner à un type d'événement", async () => {
     let compteur = 0;
 
     const bus = creeBusEvenements();
-    bus.abonne(EvenementTestA, () => {
+    bus.abonne(EvenementTestA, async () => {
       compteur += 1;
     });
 
-    bus.publie(new EvenementTestA());
+    await bus.publie(new EvenementTestA());
 
     expect(compteur).to.be(1);
   });
@@ -33,8 +33,8 @@ describe("Le bus d'événements", () => {
 
     const bus = creeBusEvenements();
     bus.abonnePlusieurs(EvenementTestA, [
-      () => (compteur += 1),
-      () => (compteur += 10),
+      async () => (compteur += 1),
+      async () => (compteur += 10),
     ]);
 
     await bus.publie(new EvenementTestA());
@@ -42,18 +42,18 @@ describe("Le bus d'événements", () => {
     expect(compteur).to.be(11);
   });
 
-  it('fait la différence entre les événements', () => {
+  it('fait la différence entre les événements', async () => {
     let compteur = 0;
 
     const bus = creeBusEvenements();
-    bus.abonne(EvenementTestA, () => {
+    bus.abonne(EvenementTestA, async () => {
       compteur += 1;
     });
-    bus.abonne(EvenementTestB, () => {
+    bus.abonne(EvenementTestB, async () => {
       compteur += 100;
     });
 
-    bus.publie(new EvenementTestA());
+    await bus.publie(new EvenementTestA());
 
     expect(compteur).to.be(1);
   });
@@ -62,10 +62,10 @@ describe("Le bus d'événements", () => {
     let compteur = 0;
 
     const bus = creeBusEvenements();
-    bus.abonne(EvenementTestA, () => {
+    bus.abonne(EvenementTestA, async () => {
       compteur += 1;
     });
-    bus.abonne(EvenementTestA, () => {
+    bus.abonne(EvenementTestA, async () => {
       compteur += 10;
     });
 
@@ -74,36 +74,36 @@ describe("Le bus d'événements", () => {
     expect(compteur).to.be(11);
   });
 
-  it("passe l'événement reçu en paramètre aux abonnés", () => {
+  it("passe l'événement reçu en paramètre aux abonnés", async () => {
     let compteur = 0;
 
     const bus = creeBusEvenements();
-    bus.abonne(EvenementTestA, (e) => {
+    bus.abonne(EvenementTestA, async (e) => {
       compteur += e.increment;
     });
 
-    bus.publie(new EvenementTestA(30));
+    await bus.publie(new EvenementTestA(30));
 
     expect(compteur).to.be(30);
   });
 
-  it("éxecute tous les handlers même en cas d'exception", () => {
+  it("éxecute tous les handlers même en cas d'exception", async () => {
     let compteur = 0;
 
     const bus = creeBusEvenements({ logueErreur: () => {} });
-    bus.abonne(EvenementTestA, () => {
+    bus.abonne(EvenementTestA, async () => {
       throw new Error('BOUM');
     });
-    bus.abonne(EvenementTestA, () => {
+    bus.abonne(EvenementTestA, async () => {
       compteur += 1;
     });
 
-    bus.publie(new EvenementTestA());
+    await bus.publie(new EvenementTestA());
 
     expect(compteur).to.be(1);
   });
 
-  it("envoie les erreurs des handlers à l'adaptateur de gestion d'erreur", () => {
+  it("envoie les erreurs des handlers à l'adaptateur de gestion d'erreur", async () => {
     let erreurEnregistree;
 
     const bus = creeBusEvenements({
@@ -111,26 +111,12 @@ describe("Le bus d'événements", () => {
         erreurEnregistree = e;
       },
     });
-    bus.abonne(EvenementTestA, () => {
+    bus.abonne(EvenementTestA, async () => {
       throw new Error('BOUM');
     });
 
-    bus.publie(new EvenementTestA());
+    await bus.publie(new EvenementTestA());
 
     expect(erreurEnregistree).to.eql(new Error('BOUM'));
-  });
-
-  it('éxecute des handlers asynchrones', (done) => {
-    let compteur = 0;
-
-    const bus = creeBusEvenements();
-    bus.abonne(EvenementTestA, () =>
-      Promise.resolve().then(() => (compteur += 1))
-    );
-
-    bus.publie(new EvenementTestA()).then(() => {
-      expect(compteur).to.be(1);
-      done();
-    });
   });
 });


### PR DESCRIPTION
... car on ne souhaite pas obtenir le résultat des promesses, mais uniquement loguer les erreurs éventuelles.

On opte donc pour une stratégie "Fire & Forget, but catch errors".

## :warning: Ceci n'est possible que parce que les consommateurs sont "non-vitaux" pour le produit, à savoir, du tracking et des events Metabase.