### PR TITLE
[CORRECTION] Cesse de planter si l'exception n'a pas de `response`

### DIFF
--- a/src/adaptateurs/adaptateurTrackingSendinblue.js
+++ b/src/adaptateurs/adaptateurTrackingSendinblue.js
@@ -25,7 +25,7 @@ const envoieTracking = (destinataire, typeEvenement, donneesEvenement = {}) =>
     )
     .catch((e) => {
       fabriqueAdaptateurGestionErreur().logueErreur(e, {
-        'Erreur renvoyée par API Tracking Brevo': e.response.data,
+        'Erreur renvoyée par API Tracking Brevo': e.response?.data,
       });
       // On veut ici délibérement ignorer l'erreur car l'echec de tracking ne devrait pas entrainer une dégradation de l'expérience utilisateur
       return Promise.resolve();


### PR DESCRIPTION
… comme ça arrive parfois sur les erreurs de PROD. Sans le `?.` on se retrouve à planter à cause du code dans le `catch`…