### PR TITLE
Ajoute `bold` sur les `nouvel-item` pour harmoniser MSS

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -407,3 +407,7 @@ button.bouton.en-cours-chargement::before {
 #ajout-element-point-acces {
   margin-top: 24px;
 }
+
+.nouvel-item {
+  font-weight: bold;
+}


### PR DESCRIPTION
... car tout les CTA "Nouvel item" sont en gras dans les maquettes.