### PR TITLE
Modifie le wording de la description de l'indice cyber

### DIFF
--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -31,7 +31,7 @@ block zone-principale
       .disque-indice
         #conteneur-indice-cyber
       .contenu-descriptif
-        p L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures faites proposées par #{referentielConcernes} dans MonServiceSécurisé.
+        p L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures faites proposées par #{referentielConcernes} dans MonServiceSécurisé. Il est un indicateur de la qualité de la démarche de sécurisation du service.
     .conteneur-plus-details
       details
         summary(role='button')


### PR DESCRIPTION
Afin de rajouter la mention "Il est un indicateur de la qualité de la démarche de sécurisation du service."