### PR TITLE
Modifie la couleur de l'indice cyber entre 4,1 et 4,9

### DIFF
--- a/src/pdf/modeles/indiceCyber/scoreIndiceCyber.pug
+++ b/src/pdf/modeles/indiceCyber/scoreIndiceCyber.pug
@@ -1,5 +1,5 @@
 mixin scoreIndiceCyber(indiceCyber, noteMax)
-  - const tranchesIndiceCyber = [{min: 0, max: 1, gradientDebut: '#A226B8', gradientFin: '#8926C9'}, {min: 1, max: 2, gradientDebut: '#513AC8', gradientFin: '#8C26C7'}, {min: 2, max: 3, gradientDebut: '#326FC0', gradientFin: '#4D3DC5'}, {min: 3, max: 4, gradientDebut: '#54B8F6', gradientFin: '#3479C9'}, {min: 4, max: 5, gradientDebut: '#D2DFE6', gradientFin: '#9CACB5'}, {min: 5, max: 6, gradientDebut: '#F2CA5A', gradientFin: '#DBAF2C'}]
+  - const tranchesIndiceCyber = [{min: 0, max: 1, gradientDebut: '#A226B8', gradientFin: '#8926C9'}, {min: 1, max: 2, gradientDebut: '#513AC8', gradientFin: '#8C26C7'}, {min: 2, max: 3, gradientDebut: '#326FC0', gradientFin: '#4D3DC5'}, {min: 3, max: 4, gradientDebut: '#54B8F6', gradientFin: '#3479C9'}, {min: 4, max: 5, gradientDebut: '#18EAC4', gradientFin: '#445CDE'}, {min: 5, max: 6, gradientDebut: '#F2CA5A', gradientFin: '#DBAF2C'}]
   - const cheminCirculaire = (cx, cy, r) => `M ${cx - r}, ${cy} a ${r},${r} 0 1,0 ${r * 2},0 a ${r},${r} 0 1,0 -${r * 2},0`
   - const cheminDemiCercle = (cx, cy, r) => `M ${cx - r}, ${cy} a ${r},${r} 0 1,0 ${r * 2},0`
   - const [rotationFlecheMin, rotationFlecheMax] = [-13, 164]

--- a/svelte/lib/indiceCyber/IndiceCyber.svelte
+++ b/svelte/lib/indiceCyber/IndiceCyber.svelte
@@ -18,7 +18,7 @@
     { min: 1, max: 2, gradientDebut: '#513AC8', gradientFin: '#8C26C7' },
     { min: 2, max: 3, gradientDebut: '#326FC0', gradientFin: '#4D3DC5' },
     { min: 3, max: 4, gradientDebut: '#54B8F6', gradientFin: '#3479C9' },
-    { min: 4, max: 5, gradientDebut: '#D2DFE6', gradientFin: '#9CACB5' },
+    { min: 4, max: 5, gradientDebut: '#18EAC4', gradientFin: '#445CDE' },
     { min: 5, max: 6, gradientDebut: '#F2CA5A', gradientFin: '#DBAF2C' },
   ];
   $: idxInterval = tranchesIndiceCyber.findIndex(


### PR DESCRIPTION
Car l'ancienne couleur était grise et parait "disabled".

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/f036bb52-dd5d-4206-aa7e-933d4ca3a972)
