### PR TITLE
[COLLABORATIF] Tracker le lien entre un créateur de service et son nouveau service

### DIFF
--- a/src/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.js
+++ b/src/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.js
@@ -1,0 +1,21 @@
+const {
+  EvenementCollaboratifServiceModifie,
+} = require('../../modeles/journalMSS/evenementCollaboratifServiceModifie');
+const Autorisation = require('../../modeles/autorisations/autorisation');
+
+const { PROPRIETAIRE } = Autorisation.RESUME_NIVEAU_DROIT;
+
+function consigneProprietaireCreeUnServiceDansJournal({ adaptateurJournal }) {
+  return async (evenement) => {
+    const { service, utilisateur } = evenement;
+
+    const nouveauProprietaire = new EvenementCollaboratifServiceModifie({
+      idService: service.id,
+      autorisations: [{ idUtilisateur: utilisateur.id, droit: PROPRIETAIRE }],
+    });
+
+    await adaptateurJournal.consigneEvenement(nouveauProprietaire.toJSON());
+  };
+}
+
+module.exports = { consigneProprietaireCreeUnServiceDansJournal };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -12,6 +12,9 @@ const {
 const {
   envoieTrackingDeNouveauService,
 } = require('./abonnements/envoieTrackingDeNouveauService');
+const {
+  consigneProprietaireCreeUnServiceDansJournal,
+} = require('./abonnements/consigneProprietaireCreeUnServiceDansJournal');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -19,6 +22,7 @@ const cableTousLesAbonnes = (
 ) => {
   busEvenements.abonnePlusieurs(EvenementNouveauServiceCree, [
     consigneNouveauServiceDansJournal({ adaptateurJournal }),
+    consigneProprietaireCreeUnServiceDansJournal({ adaptateurJournal }),
     envoieTrackingDeNouveauService({ adaptateurTracking, depotDonnees }),
     consigneCompletudeDansJournal({ adaptateurJournal }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),

--- a/src/modeles/journalMSS/erreurs.js
+++ b/src/modeles/journalMSS/erreurs.js
@@ -1,4 +1,5 @@
 class ErreurJournal extends Error {}
+class ErreurAutorisationsServiceManquantes extends ErreurJournal {}
 class ErreurDateHomologationManquante extends ErreurJournal {}
 class ErreurDetailMesuresManquant extends ErreurJournal {}
 class ErreurDureeHomologationManquante extends ErreurJournal {}
@@ -12,6 +13,7 @@ class ErreurNombreMesuresCompletesManquant extends ErreurJournal {}
 class ErreurNombreTotalMesuresManquant extends ErreurJournal {}
 
 module.exports = {
+  ErreurAutorisationsServiceManquantes,
   ErreurDateHomologationManquante,
   ErreurDetailMesuresManquant,
   ErreurDureeHomologationManquante,

--- a/src/modeles/journalMSS/evenementCollaboratifServiceModifie.js
+++ b/src/modeles/journalMSS/evenementCollaboratifServiceModifie.js
@@ -1,0 +1,36 @@
+const Evenement = require('./evenement');
+const {
+  ErreurIdentifiantServiceManquant,
+  ErreurAutorisationsServiceManquantes,
+} = require('./erreurs');
+
+class EvenementCollaboratifServiceModifie extends Evenement {
+  constructor(donnees, options = {}) {
+    const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
+
+    const valide = () => {
+      const manque = (donnee) => typeof donnee === 'undefined';
+
+      if (manque(donnees.idService))
+        throw new ErreurIdentifiantServiceManquant();
+      if (manque(donnees.autorisations) || donnees.autorisations.length === 0)
+        throw new ErreurAutorisationsServiceManquantes();
+    };
+
+    valide();
+
+    super(
+      'COLLABORATIF_SERVICE_MODIFIE',
+      {
+        idService: adaptateurChiffrement.hacheSha256(donnees.idService),
+        autorisations: donnees.autorisations.map((a) => ({
+          idUtilisateur: adaptateurChiffrement.hacheSha256(a.idUtilisateur),
+          droit: a.droit,
+        })),
+      },
+      date
+    );
+  }
+}
+
+module.exports = { EvenementCollaboratifServiceModifie };

--- a/test/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.spec.js
+++ b/test/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.spec.js
@@ -1,0 +1,35 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const { unService } = require('../../constructeurs/constructeurService');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+const {
+  consigneProprietaireCreeUnServiceDansJournal,
+} = require('../../../src/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal');
+
+describe("L'abonnement qui consigne (dans le journal MSS) le lien entre un propriétaire et son nouveau service", () => {
+  let adaptateurJournal;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+  });
+
+  it('consigne un événement de "collaboratif de service modifié" indiquant que l\'utilisateur est le propriétaire du service', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneProprietaireCreeUnServiceDansJournal({ adaptateurJournal })({
+      service: unService().avecId('123').construis(),
+      utilisateur: unUtilisateur().avecId('ABC').construis(),
+    });
+
+    expect(evenementRecu.type).to.be('COLLABORATIF_SERVICE_MODIFIE');
+    const { autorisations } = evenementRecu.donnees;
+    expect(autorisations.length).to.be(1);
+    expect(autorisations[0].idUtilisateur).not.to.be(undefined);
+    expect(autorisations[0].droit).to.be('PROPRIETAIRE');
+  });
+});

--- a/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
+++ b/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
@@ -1,0 +1,73 @@
+const expect = require('expect.js');
+const {
+  ErreurIdentifiantServiceManquant,
+  ErreurAutorisationsServiceManquantes,
+} = require('../../../src/modeles/journalMSS/erreurs');
+const {
+  EvenementCollaboratifServiceModifie,
+} = require('../../../src/modeles/journalMSS/evenementCollaboratifServiceModifie');
+const {
+  RESUME_NIVEAU_DROIT,
+} = require('../../../src/modeles/autorisations/autorisation');
+
+const { PROPRIETAIRE } = RESUME_NIVEAU_DROIT;
+
+describe("Un événement de modification du collaboratif d'un service", () => {
+  const hacheEnMajuscules = { hacheSha256: (valeur) => valeur?.toUpperCase() };
+  const unEvenement = () =>
+    new EvenementCollaboratifServiceModifie(
+      {
+        idService: 'abc',
+        autorisations: [{ idUtilisateur: 'dupont', droit: PROPRIETAIRE }],
+      },
+      { date: '17/02/2024', adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+  it("chiffre l'identifiant du service qui lui est donné", () => {
+    expect(unEvenement().donnees.idService).to.be('ABC');
+  });
+
+  it('chiffre les idendifiants des collaborateurs qui lui sont donnés', () => {
+    const id = unEvenement().donnees.autorisations[0].idUtilisateur;
+    expect(id).to.be('DUPONT');
+  });
+
+  it('sait se convertir en JSON', () => {
+    expect(unEvenement().toJSON()).to.eql({
+      type: 'COLLABORATIF_SERVICE_MODIFIE',
+      donnees: {
+        idService: 'ABC',
+        autorisations: [{ idUtilisateur: 'DUPONT', droit: 'PROPRIETAIRE' }],
+      },
+      date: '17/02/2024',
+    });
+  });
+
+  const proprietesAVerifier = [
+    { propriete: 'idService', typeErreur: ErreurIdentifiantServiceManquant },
+    {
+      propriete: 'autorisations',
+      typeErreur: ErreurAutorisationsServiceManquantes,
+    },
+  ];
+  proprietesAVerifier.forEach(({ propriete, typeErreur }) => {
+    it(`exige que \`${propriete}\` soit renseigné`, (done) => {
+      try {
+        const donnees = { idService: 'abc' };
+        delete donnees[propriete];
+
+        new EvenementCollaboratifServiceModifie(donnees, {
+          date: '17/11/2022',
+          adaptateurChiffrement: hacheEnMajuscules,
+        });
+
+        done(
+          Error("L'instanciation de l'événement aurait dû lever une exception")
+        );
+      } catch (e) {
+        expect(e).to.be.an(typeErreur);
+        done();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Contexte

On veut désormais avoir des infos sur le collaboratif dans notre Metabase : savoir combien de collaborateurs ont les services, avec quel type de rôle, etc.

## 🛠️  Technique 

On va s'appuyer sur le design existant et y ajouter de nouveaux éléments :
 - Côté Journal : un nouvel événement `EvenementCollaboratifServiceModifie` qui sera consigné par `adaptateurJournal`
 - Côté MSS : un nouvel événement `EvenementAutorisationsModifiees` qui sera publié par `depotDonneesAutorisations`
 - Pour faire le lien entre les deux :
   - un nouvel abonné au Bus `consigneProprietaireCreeUnServiceDansJournal()` déclenché à la création de service
   - un nouvel abonné au Bus `consigneChangementAutorisationsDansJournal()` déclenché lors des ajouts / modifications / suppressions d'autorisations

## ✏️ Schéma
Un schéma un peu plus global, qui montre en bleu sur la droite les éléments mentionnés ☝️ 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/5660fe43-26f4-4c79-aefd-634d3c0d8fb1)

## 🗺️ Chemin
Cette PR est la première du chantier, qui devrait se dérouler comme suit :

- [ ] **Consigner le lien entre propriétaire et nouveau service  ⬅️ cette PR**
- [ ] Consigner un ajout d'autorisation sur UN service
  - #1325 
- [ ] Consigner un ajout d'autorisation sur PLUSIEURS services simultanément
- [ ] Consigner une modification d'autorisation
- [ ] Consigner une suppression d'autorisation
- [ ] [JOURNAL] Créer le modèle qui permet d'exploiter la nouvelle donnée
- [ ] [CONSOLE ADMIN] Faire un rattrapage du collaboratif sur TOUS les services

## PR
Avec cette PR on pousse un événement `COLLABORATIF_SERVICE_MODIFIE` à Metabase à chaque création de service.

Donc à la création de service, on se retrouve avec la séquence d'événements Metabase suivante 👇 
![image](https://github.com/betagouv/mon-service-securise/assets/24898521/b2b69370-d037-4ae3-8f0c-6ba7cc682851)

On voit que `COLLABORATIF_SERVICE_MODIFIE` est le second événement publié. Il contient un seul élément dans `autorisations` : le lien entre le créateur du service et le nouveau service.