### PR TITLE
[CORRECTION] Incrémente le `z-index` du menu flottant de tri des contributeurs

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -562,7 +562,7 @@ label[for='recherche-service'] {
   white-space: nowrap;
   display: flex;
   flex-direction: column;
-  z-index: 1;
+  z-index: 3;
 }
 
 .tableau-services .menu-flottant.invisible {


### PR DESCRIPTION
...car sinon il passe dèrriere les liens vers le tiroir contributeurs

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/f2129f2c-c7cc-4f8b-b473-170b24f599d8)
