### PR TITLE
Consigne autorisations dans bus

### DIFF
--- a/src/bus/evenementAutorisationsServiceModifiees.js
+++ b/src/bus/evenementAutorisationsServiceModifiees.js
@@ -1,0 +1,3 @@
+class EvenementAutorisationsServiceModifiees {}
+
+module.exports = { EvenementAutorisationsServiceModifiees };

--- a/src/bus/evenementAutorisationsServiceModifiees.js
+++ b/src/bus/evenementAutorisationsServiceModifiees.js
@@ -1,3 +1,13 @@
-class EvenementAutorisationsServiceModifiees {}
+class EvenementAutorisationsServiceModifiees {
+  constructor({ idService, autorisations }) {
+    if (!idService)
+      throw Error("Impossible d'instancier l'événement sans ID de service");
+    if (!autorisations || autorisations.length === 0)
+      throw Error("Impossible d'instancier l'événement sans autorisations");
+
+    this.idService = idService;
+    this.autorisations = autorisations;
+  }
+}
 
 module.exports = { EvenementAutorisationsServiceModifiees };

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -8,6 +8,9 @@ const {
   ErreurSuppressionImpossible,
 } = require('../erreurs');
 const FabriqueAutorisation = require('../modeles/autorisations/fabriqueAutorisation');
+const {
+  EvenementAutorisationsServiceModifiees,
+} = require('../bus/evenementAutorisationsServiceModifiees');
 
 const creeDepot = (config = {}) => {
   const {
@@ -15,6 +18,7 @@ const creeDepot = (config = {}) => {
     adaptateurUUID = adaptateurUUIDParDefaut,
     depotHomologations,
     depotUtilisateurs,
+    busEvenements,
   } = config;
 
   const autorisations = (idUtilisateur) =>
@@ -91,6 +95,8 @@ const creeDepot = (config = {}) => {
       idAutorisation,
       nouvelleAutorisation.donneesAPersister()
     );
+
+    await busEvenements.publie(new EvenementAutorisationsServiceModifiees());
   };
 
   const supprimeContributeur = async (

--- a/test/bus/aides/busPourLesTests.js
+++ b/test/bus/aides/busPourLesTests.js
@@ -2,8 +2,8 @@ const fabriqueBusPourLesTests = () => {
   const evenementsRecus = [];
   return {
     publie: async (e) => evenementsRecus.push(e),
-    aRecuUnEvenement: (attendu) => {
-      if (evenementsRecus.find((e) => e instanceof attendu)) return true;
+    aRecuUnEvenement: (typeAttendu) => {
+      if (evenementsRecus.find((e) => e instanceof typeAttendu)) return true;
 
       throw new Error(
         `Événement attendu non reçu. Reçu : ${evenementsRecus
@@ -11,6 +11,8 @@ const fabriqueBusPourLesTests = () => {
           .join(' ')}`
       );
     },
+    recupereEvenement: (typeAttendu) =>
+      evenementsRecus.find((e) => e instanceof typeAttendu),
   };
 };
 

--- a/test/bus/evenementAutorisationsServiceModifiees.spec.js
+++ b/test/bus/evenementAutorisationsServiceModifiees.spec.js
@@ -1,0 +1,30 @@
+const expect = require('expect.js');
+const {
+  EvenementAutorisationsServiceModifiees,
+} = require('../../src/bus/evenementAutorisationsServiceModifiees');
+
+describe("L'événement `autorisationsServicesModifiees", () => {
+  it("lève une exception s'il est instancié sans ID de service", () => {
+    expect(
+      () => new EvenementAutorisationsServiceModifiees({ idService: null })
+    ).to.throwError((e) => {
+      expect(e.message).to.be(
+        "Impossible d'instancier l'événement sans ID de service"
+      );
+    });
+  });
+
+  it("lève une exception s'il est instancié sans autorisations", () => {
+    expect(
+      () =>
+        new EvenementAutorisationsServiceModifiees({
+          idService: 'abc',
+          autorisations: null,
+        })
+    ).to.throwError((e) => {
+      expect(e.message).to.be(
+        "Impossible d'instancier l'événement sans autorisations"
+      );
+    });
+  });
+});

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -255,6 +255,15 @@ describe('Le dépôt de données des autorisations', () => {
       expect(
         bus.aRecuUnEvenement(EvenementAutorisationsServiceModifiees)
       ).to.be(true);
+
+      const recu = bus.recupereEvenement(
+        EvenementAutorisationsServiceModifiees
+      );
+      expect(recu.idService).to.be('123');
+      expect(recu.autorisations).to.eql([
+        { idUtilisateur: '999', droit: 'PROPRIETAIRE' },
+        { idUtilisateur: '000', droit: 'ECRITURE' },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Contexte
On veut désormais avoir des infos sur le collaboratif dans notre Metabase : savoir combien de collaborateurs ont les services, avec quel type de rôle, etc.

## 🗺️ Chemin
- [ ] Consigner le lien entre propriétaire et nouveau service
  - #1323  
- [ ] **Consigner un ajout d'autorisation sur UN service   ⬅️ cette PR**
- [ ] Consigner un ajout d'autorisation sur PLUSIEURS services simultanément
- [ ] Consigner une modification d'autorisation
- [ ] Consigner une suppression d'autorisation
- [ ] [JOURNAL] Créer le modèle qui permet d'exploiter la nouvelle donnée
- [ ] [CONSOLE ADMIN] Faire un rattrapage du collaboratif sur TOUS les services

## PR
Cette PR implémente les flèches & briques montrées en jaune à droite dans le schéma 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/253ad8fe-ecdb-4265-8de5-4ba36a7bf03b)

Il s'agit de publier – depuis `depotDonneesAutorisations.ajouteContributeurAuService()` – un événement MSS `EvenementAutorisationsServiceModifiees`.
Cet événement a la payload suivante :
```js
{ 
  idService: 'ABC',
  autorisations: [ 
    { idUtilisateur: 'DUPONT', droit: 'ECRITURE' },
    { idUtilisateur: 'MARTIN', droit: 'LECTURE' },
    … 
  ]
}
```

Il restera à câbler cet événement à un abonné qui enverra les informations vers Metabase.