### PR TITLE
Nouveau statut "À lancer"

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -388,6 +388,7 @@ module.exports = {
     fait: 'Faite',
     enCours: 'Partielle',
     nonFait: 'Non prise en compte',
+    aLancer: 'À lancer',
   },
 
   articlesDefinisReferentielsMesure: {

--- a/src/modeles/mesure.js
+++ b/src/modeles/mesure.js
@@ -10,6 +10,7 @@ const STATUTS = {
   STATUT_FAIT: 'fait',
   STATUT_EN_COURS: 'enCours',
   STATUT_NON_FAIT: 'nonFait',
+  STATUT_A_LANCER: 'aLancer',
 };
 
 class Mesure extends InformationsHomologation {

--- a/src/modeles/objetsPDF/objetPDFAnnexeMesures.js
+++ b/src/modeles/objetsPDF/objetPDFAnnexeMesures.js
@@ -1,4 +1,5 @@
 const Referentiel = require('../../referentiel');
+const Mesure = require('../mesure');
 
 class ObjetPDFAnnexeMesures {
   constructor(service, referentiel = Referentiel.creeReferentielVide()) {
@@ -21,6 +22,7 @@ class ObjetPDFAnnexeMesures {
 
     return {
       statuts: this.referentiel.statutsMesures(),
+      statutsAvecFaitALaFin: Mesure.statutsPossibles(true),
       categories: this.referentiel.categoriesMesures(),
       nomService: this.service.nomService(),
       mesuresParStatut: this.service.mesuresParStatutEtCategorie(),

--- a/src/modeles/statistiquesMesuresGenerales.js
+++ b/src/modeles/statistiquesMesuresGenerales.js
@@ -79,6 +79,10 @@ class StatistiquesMesuresGenerales {
     });
   }
 
+  aLancer(idCategorie) {
+    return this.parCategorie[idCategorie].aLancer;
+  }
+
   faites(idCategorie) {
     return this.parCategorie[idCategorie].fait;
   }

--- a/src/pdf/graphiques/camembert.js
+++ b/src/pdf/graphiques/camembert.js
@@ -1,4 +1,4 @@
-const ANGLE_MINIMUM = 20;
+const ANGLE_MINIMUM = 30;
 
 const detailAngle = (debut, fin) => ({
   debut,
@@ -7,7 +7,7 @@ const detailAngle = (debut, fin) => ({
 });
 
 const recalculPourFin360 = (angles) => {
-  const { fait, enCours, nonFait, aRemplir } = angles;
+  const { fait, enCours, nonFait, aLancer, aRemplir } = angles;
 
   const depassement = fait.fin - 360;
   const nbAnglesAModifier = Object.values(angles)
@@ -23,6 +23,7 @@ const recalculPourFin360 = (angles) => {
   const valeurRevisees = {
     enCours: valeurRevisee(enCours),
     nonFait: valeurRevisee(nonFait),
+    aLancer: valeurRevisee(aLancer),
     aRemplir: valeurRevisee(aRemplir),
     fait: valeurRevisee(fait),
   };
@@ -32,9 +33,13 @@ const recalculPourFin360 = (angles) => {
     enCoursRevise.fin,
     enCoursRevise.fin + valeurRevisees.nonFait
   );
-  const aRemplirRevise = detailAngle(
+  const aLancerRevise = detailAngle(
     nonFaitRevise.fin,
-    nonFaitRevise.fin + valeurRevisees.aRemplir
+    nonFaitRevise.fin + valeurRevisees.aLancer
+  );
+  const aRemplirRevise = detailAngle(
+    aLancerRevise.fin,
+    aLancerRevise.fin + valeurRevisees.aRemplir
   );
   const faitRevise = detailAngle(
     aRemplirRevise.fin,
@@ -44,6 +49,7 @@ const recalculPourFin360 = (angles) => {
   return {
     enCours: enCoursRevise,
     nonFait: nonFaitRevise,
+    aLancer: aLancerRevise,
     aRemplir: aRemplirRevise,
     fait: faitRevise,
   };
@@ -54,6 +60,7 @@ const genereGradientConique = (statistiques) => {
     const total =
       statistiques.enCours +
       statistiques.nonFait +
+      statistiques.aLancer +
       statistiques.aRemplir +
       statistiques.fait;
 
@@ -63,16 +70,21 @@ const genereGradientConique = (statistiques) => {
 
   const enCours = avecAngleMinimum(statistiques.enCours);
   const nonFait = avecAngleMinimum(statistiques.nonFait);
+  const aLancer = avecAngleMinimum(statistiques.aLancer);
   const aRemplir = avecAngleMinimum(statistiques.aRemplir);
   const fait = avecAngleMinimum(statistiques.fait);
 
   const anglesInitiaux = {
     enCours: detailAngle(0, enCours),
     nonFait: detailAngle(enCours, enCours + nonFait),
-    aRemplir: detailAngle(enCours + nonFait, enCours + nonFait + aRemplir),
+    aLancer: detailAngle(enCours + nonFait, enCours + nonFait + aLancer),
+    aRemplir: detailAngle(
+      enCours + nonFait + aLancer,
+      enCours + nonFait + aLancer + aRemplir
+    ),
     fait: detailAngle(
-      enCours + nonFait + aRemplir,
-      enCours + nonFait + aRemplir + fait
+      enCours + nonFait + aLancer + aRemplir,
+      enCours + nonFait + aLancer + aRemplir + fait
     ),
   };
 
@@ -84,6 +96,7 @@ const genereGradientConique = (statistiques) => {
   const seulementStatistiquesConcernes = {
     enCours: statistiques.enCours,
     nonFait: statistiques.nonFait,
+    aLancer: statistiques.aLancer,
     aRemplir: statistiques.aRemplir,
     fait: statistiques.fait,
   };

--- a/src/pdf/modeles/annexeMesures.pug
+++ b/src/pdf/modeles/annexeMesures.pug
@@ -16,9 +16,8 @@ mixin bloc-mesure(mesuresParCategorie, legende)
     .saut-page
 
 block page
-  +bloc-mesure(donneesMesures.mesuresParStatut.enCours, donneesMesures.statuts.enCours)
-  +bloc-mesure(donneesMesures.mesuresParStatut.nonFait, donneesMesures.statuts.nonFait)
-  +bloc-mesure(donneesMesures.mesuresParStatut.fait, donneesMesures.statuts.fait)
+  each statut in donneesMesures.statutsAvecFaitALaFin
+    +bloc-mesure(donneesMesures.mesuresParStatut[statut], donneesMesures.statuts[statut])
   if donneesMesures.nbMesuresARemplirToutesCategories > 0
     +boite-grise('Non renseignées', 'non-renseignees')
       p.

--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -627,8 +627,8 @@ p {
 }
 
 .synthese-securite .statistiques-mesures .graphique-camemberts {
-  width: 10em;
-  height: 10em;
+  width: 8em;
+  height: 8em;
   position: relative;
 }
 
@@ -645,25 +645,27 @@ p {
 }
 
 .synthese-securite .statistiques-mesures .camembert.bordure-reste-a-faire {
-  transform: scale(1.08);
+  transform: scale(1.1);
 }
 
 .synthese-securite .graphique-camemberts .chiffre {
   position: absolute;
-  transform: translate(calc(5em - 50%), calc(5em - 50%));
+  transform: translate(calc(4em - 50%), calc(4em - 50%)) scale(1.1);
   font-weight: bold;
+  text-align: center;
 }
 
 .synthese-securite .graphique-camemberts .chiffre.en-cours {
   color: white;
 }
 
-.synthese-securite .graphique-camemberts .chiffre:is(.non-fait, .a-remplir) {
+.synthese-securite
+  .graphique-camemberts
+  .chiffre:is(.non-fait, .a-remplir, .a-lancer) {
   color: #08416a;
 }
 
 .synthese-securite .graphique-camemberts .chiffre.fait {
-  font-weight: normal;
   color: white;
 }
 
@@ -727,16 +729,21 @@ p {
 }
 
 .synthese-securite .legende-faites::before {
-  background: #0a4c8c;
-  border: solid 1px #0a4c8c;
+  background: #173b62;
+  border: solid 1px #173b62;
 }
 
 .synthese-securite .legende-en-cours::before {
+  background: #0a498c;
+  border: solid 1px #0a498c;
+}
+
+.synthese-securite .legende-non-faites::before {
   background: #75a1e8;
   border: solid 1px #75a1e8;
 }
 
-.synthese-securite .legende-non-faites::before {
+.synthese-securite .legende-a-lancer::before {
   background: #d0e0f6;
   border: solid 1px #d0e0f6;
 }
@@ -758,6 +765,7 @@ p {
   padding: 0.8em;
   margin-top: 1em;
   text-align: center;
+  font-weight: bold;
 }
 
 .synthese-securite .mesures-par-categorie .graphique .statut:first-of-type {
@@ -771,16 +779,21 @@ p {
 }
 
 .synthese-securite .mesures-par-categorie .graphique .faites {
-  background-color: #0a4c8c;
+  background-color: #172738;
   color: #fff;
 }
 
 .synthese-securite .mesures-par-categorie .graphique .en-cours {
-  background-color: #75a1e8;
+  background-color: #0a498c;
   color: #fff;
 }
 
 .synthese-securite .mesures-par-categorie .graphique .non-faites {
+  background-color: #75a1e8;
+  color: #0a4c8c;
+}
+
+.synthese-securite .mesures-par-categorie .graphique .a-lancer {
   background-color: #d0e0f6;
   color: #0a4c8c;
 }

--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -3,15 +3,15 @@ extends base
 include ./indiceCyber/scoreIndiceCyber
 
 mixin chiffre(texte, angle, classe, estUnique)
-  - const rayon = estUnique ? '0' : '3em';
+  - const rayon = estUnique ? '0' : '2.5em';
   if(texte !== 0)
     .chiffre(class=classe, style=`top: calc(${rayon} * cos(180deg - ${angle}deg)); left: calc(${rayon} * sin(180deg - ${angle}deg));`)!= texte
 
 mixin statistiquesMesures({ id, statistiques = {},  camembert = {}, unique = null})
-  - const { total = 0, enCours = 0, nonFait = 0, fait = 0, restant = 0, aRemplir = 0 } = statistiques
-  - const chaineGradientConique = `background: conic-gradient(#75A1E8 ${camembert.enCours.debut}deg ${camembert.enCours.fin}deg, #D0E0F6 ${camembert.nonFait.debut}deg ${camembert.nonFait.fin}deg, #FFFFFF ${camembert.aRemplir.debut}deg ${camembert.aRemplir.fin}deg, transparent ${camembert.aRemplir.fin}deg 360deg);`;
-  - const chaineGradientConiqueFait = `background: conic-gradient(transparent 0deg ${camembert.fait.debut}deg, #0A4C8C ${camembert.fait.debut}deg ${camembert.fait.fin}deg);`;
-  - const decalageCamemberFait = '4px'
+  - const { total = 0, enCours = 0, nonFait = 0, aLancer = 0, fait = 0, restant = 0, aRemplir = 0 } = statistiques
+  - const chaineGradientConique = `background: conic-gradient(#0A498C ${camembert.enCours.debut}deg ${camembert.enCours.fin}deg, #75A1E8 ${camembert.nonFait.debut}deg ${camembert.nonFait.fin}deg, #D0E0F6 ${camembert.aLancer.debut}deg ${camembert.aLancer.fin}deg, #FFFFFF ${camembert.aRemplir.debut}deg ${camembert.aRemplir.fin}deg, transparent ${camembert.aRemplir.fin}deg 360deg);`;
+  - const chaineGradientConiqueFait = `background: conic-gradient(transparent 0deg ${camembert.fait.debut}deg, #173B62 ${camembert.fait.debut}deg ${camembert.fait.fin}deg);`;
+  - const decalageCamemberFait = '8px'
   - const styleDecalageCamemberFait = `top: calc(${decalageCamemberFait} * cos(180deg - ${camembert.fait.milieu}deg)); left: calc(${decalageCamemberFait} * sin(180deg - ${camembert.fait.milieu}deg));`
   .statistiques-mesures
     .details
@@ -21,6 +21,7 @@ mixin statistiquesMesures({ id, statistiques = {},  camembert = {}, unique = nul
         .camembert(style=chaineGradientConique)
         +chiffre(enCours, camembert.enCours.milieu, 'en-cours', unique === 'enCours')
         +chiffre(nonFait, camembert.nonFait.milieu, 'non-fait', unique === 'nonFait')
+        +chiffre(aLancer, camembert.aLancer.milieu, 'a-lancer', unique === 'aLancer')
         +chiffre(aRemplir, camembert.aRemplir.milieu, 'a-remplir', unique === 'aRemplir')
         .camembert.fait(style=`${chaineGradientConiqueFait}; ${styleDecalageCamemberFait}`)
         +chiffre(fait, camembert.fait.milieu, 'fait', unique == 'fait')
@@ -44,6 +45,7 @@ mixin totalMesures(totalMesuresGenerales, totalMesuresSpecifiques)
       .legende-faites Faites
       .legende-en-cours Partielles
       .legende-non-faites Non prises en compte
+      .legende-a-lancer À lancer
       .legende-a-remplir À remplir
 
 block page
@@ -116,6 +118,7 @@ block page
                 - const faites = (idCategorie) => service.statistiquesMesuresGenerales().faites(idCategorie)
                 - const enCours = (idCategorie) => service.statistiquesMesuresGenerales().enCours(idCategorie)
                 - const nonFaites = (idCategorie) => service.statistiquesMesuresGenerales().nonFaites(idCategorie)
+                - const aLancer = (idCategorie) => service.statistiquesMesuresGenerales().aLancer(idCategorie)
                 - const aRemplir = (idCategorie) => service.statistiquesMesuresGenerales().sansStatut(idCategorie)
 
                 each idCategorie in referentiel.identifiantsCategoriesMesures()
@@ -131,6 +134,9 @@ block page
                       if nonFaites(idCategorie)
                         - const nbNonFaites = nonFaites(idCategorie);
                         .statut.non-faites(style=`flex: ${nbNonFaites};`)= nbNonFaites
+                      if aLancer(idCategorie)
+                        - const nbALancer = aLancer(idCategorie);
+                        .statut.a-lancer(style=`flex: ${nbALancer};`)= nbALancer
                       if aRemplir(idCategorie)
                         - const nbARemplir = aRemplir(idCategorie);
                         .statut.a-remplir(style=`flex: ${nbARemplir};`)= nbARemplir

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -64,6 +64,10 @@
     --couleur: #fff2de;
   }
 
+  select.aLancer {
+    --couleur: #e9ddff;
+  }
+
   select.vide {
     --couleur: #f1f5f9;
   }

--- a/test/modeles/mesure.spec.js
+++ b/test/modeles/mesure.spec.js
@@ -7,7 +7,12 @@ const elle = it;
 describe('Une mesure', () => {
   describe('sur demande des statuts possibles', () => {
     elle('retourne les statuts avec `fait` en premier par défaut', () => {
-      expect(Mesure.statutsPossibles()).to.eql(['fait', 'enCours', 'nonFait']);
+      expect(Mesure.statutsPossibles()).to.eql([
+        'fait',
+        'enCours',
+        'nonFait',
+        'aLancer',
+      ]);
     });
 
     elle(
@@ -17,6 +22,7 @@ describe('Une mesure', () => {
         expect(Mesure.statutsPossibles(statutFaitALaFin)).to.eql([
           'enCours',
           'nonFait',
+          'aLancer',
           'fait',
         ]);
       }

--- a/test/modeles/mesuresGenerales.spec.js
+++ b/test/modeles/mesuresGenerales.spec.js
@@ -134,6 +134,7 @@ describe('La liste des mesures générales', () => {
       expect(Object.keys(mesures.parStatutEtCategorie())).to.eql([
         'enCours',
         'nonFait',
+        'aLancer',
         'fait',
       ]);
     });

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -103,6 +103,7 @@ describe('La liste des mesures spécifiques', () => {
     expect(Object.keys(mesures.parStatutEtCategorie())).to.eql([
       'enCours',
       'nonFait',
+      'aLancer',
       'fait',
     ]);
   });

--- a/test/modeles/statistiquesMesuresGenerales.spec.js
+++ b/test/modeles/statistiquesMesuresGenerales.spec.js
@@ -113,6 +113,35 @@ describe('Les statistiques des mesures générales', () => {
     expect(stats.nonFaites('protection')).to.eql(0);
   });
 
+  it('calculent le nombre de mesures "À lancer" par catégorie', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      categoriesMesures: {
+        gouvernance: 'Gouvernance',
+        resilience: 'Résilience',
+        protection: 'Protection',
+      },
+      mesures: { G1: {}, G2: {}, R1: {} },
+      statutsMesures: { aLancer: '' },
+    });
+
+    const stats = desStatistiques(referentiel)
+      .surLesMesuresGenerales([
+        { id: 'G1', statut: 'aLancer' },
+        { id: 'G2', statut: 'aLancer' },
+        { id: 'R1', statut: 'aLancer' },
+      ])
+      .avecMesuresPersonnalisees({
+        G1: { categorie: 'gouvernance' },
+        G2: { categorie: 'gouvernance' },
+        R1: { categorie: 'resilience' },
+      })
+      .construis();
+
+    expect(stats.aLancer('gouvernance')).to.eql(2);
+    expect(stats.aLancer('resilience')).to.eql(1);
+    expect(stats.aLancer('protection')).to.eql(0);
+  });
+
   it("calculent le nombre de mesures sans statut par catégorie : les mesures personnalisées qui sont absentes des mesures générales ou les générales sans statut (même si ce n'est pas censé arriver)", () => {
     const referentiel = Referentiel.creeReferentiel({
       categoriesMesures: {

--- a/test/pdf/graphiques/camembert.spec.js
+++ b/test/pdf/graphiques/camembert.spec.js
@@ -6,26 +6,40 @@ const {
 describe('Les graphiques camembert', () => {
   describe('quand ils sont générés via un gradient conique', () => {
     it('retournent un angle proportionel à la valeur du statut', () => {
-      const statistiques = { enCours: 5, nonFait: 5, fait: 5, aRemplir: 5 };
+      const statistiques = {
+        enCours: 5,
+        nonFait: 5,
+        fait: 5,
+        aRemplir: 5,
+        aLancer: 5,
+      };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
-          enCours: { debut: 0, milieu: 45, fin: 90 },
-          nonFait: { debut: 90, milieu: 135, fin: 180 },
-          aRemplir: { debut: 180, milieu: 225, fin: 270 },
-          fait: { debut: 270, milieu: 315, fin: 360 },
+          enCours: { debut: 0, milieu: 36, fin: 72 },
+          nonFait: { debut: 72, milieu: 108, fin: 144 },
+          aLancer: { debut: 144, milieu: 180, fin: 216 },
+          aRemplir: { debut: 216, milieu: 252, fin: 288 },
+          fait: { debut: 288, milieu: 324, fin: 360 },
         },
         unique: null,
       });
     });
 
     it("retournent un seul angle valant 360 degrés quand il n'y a qu'un seul statut possédant une valeur", () => {
-      const statistiques = { enCours: 0, nonFait: 5, fait: 0, aRemplir: 0 };
+      const statistiques = {
+        enCours: 0,
+        nonFait: 5,
+        fait: 0,
+        aRemplir: 0,
+        aLancer: 0,
+      };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
           enCours: { debut: 0, milieu: 0, fin: 0 },
           nonFait: { debut: 0, milieu: 180, fin: 360 },
+          aLancer: { debut: 360, milieu: 360, fin: 360 },
           aRemplir: { debut: 360, milieu: 360, fin: 360 },
           fait: { debut: 360, milieu: 360, fin: 360 },
         },
@@ -33,33 +47,43 @@ describe('Les graphiques camembert', () => {
       });
     });
 
-    it("s'assurent qu'une portion avec valeur fasse au moins 20 degrés pour rester visible", () => {
+    it("s'assurent qu'une portion avec valeur fasse au moins 30 degrés pour rester visible", () => {
       const verifieAngleMinimum = (statistiques, identifiantStatut) => {
         const { angles } = genereGradientConique(statistiques);
         const { debut, fin } = angles[identifiantStatut];
-        expect(fin - debut).to.equal(20);
+        expect(fin - debut).to.equal(30);
       };
 
       verifieAngleMinimum(
-        { enCours: 1, nonFait: 0, fait: 100, aRemplir: 0 },
+        { enCours: 1, nonFait: 0, aLancer: 0, fait: 100, aRemplir: 0 },
         'enCours'
       );
       verifieAngleMinimum(
-        { enCours: 0, nonFait: 1, fait: 100, aRemplir: 0 },
+        { enCours: 0, nonFait: 1, aLancer: 0, fait: 100, aRemplir: 0 },
         'nonFait'
       );
       verifieAngleMinimum(
-        { enCours: 0, nonFait: 0, fait: 100, aRemplir: 1 },
+        { enCours: 0, nonFait: 0, aLancer: 1, fait: 100, aRemplir: 0 },
+        'aLancer'
+      );
+      verifieAngleMinimum(
+        { enCours: 0, nonFait: 0, aLancer: 0, fait: 100, aRemplir: 1 },
         'aRemplir'
       );
       verifieAngleMinimum(
-        { enCours: 0, nonFait: 0, fait: 1, aRemplir: 100 },
+        { enCours: 0, nonFait: 0, aLancer: 0, fait: 1, aRemplir: 100 },
         'fait'
       );
     });
 
     it("s'assurent que les « débuts » et « fins » des angles minimum ne se chevauchent pas", () => {
-      const statistiques = { enCours: 1, nonFait: 1, aRemplir: 1, fait: 47 };
+      const statistiques = {
+        enCours: 1,
+        nonFait: 1,
+        aLancer: 1,
+        aRemplir: 1,
+        fait: 47,
+      };
 
       const { angles } = genereGradientConique(statistiques);
 
@@ -68,47 +92,74 @@ describe('Les graphiques camembert', () => {
         expect(angles[idStatut].fin).to.equal(fin);
       };
 
-      verifieDebutFin(0, 20, 'enCours');
-      verifieDebutFin(20, 40, 'nonFait');
-      verifieDebutFin(40, 60, 'aRemplir');
+      verifieDebutFin(0, 30, 'enCours');
+      verifieDebutFin(30, 60, 'nonFait');
+      verifieDebutFin(60, 90, 'aLancer');
+      verifieDebutFin(90, 120, 'aRemplir');
     });
 
     it("s'assurent de ne pas dépasser 360 degrés, même en cas d'utilisation d'angle(s) minimum(s) au début du camembert", () => {
-      const statistiques = { enCours: 1, nonFait: 1, aRemplir: 1, fait: 47 };
+      const statistiques = {
+        enCours: 1,
+        nonFait: 1,
+        aLancer: 1,
+        aRemplir: 1,
+        fait: 47,
+      };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
-          enCours: { debut: 0, milieu: 10, fin: 20 },
-          nonFait: { debut: 20, milieu: 30, fin: 40 },
-          aRemplir: { debut: 40, milieu: 50, fin: 60 },
-          fait: { debut: 60, milieu: 210, fin: 360 },
+          enCours: { debut: 0, milieu: 15, fin: 30 },
+          nonFait: { debut: 30, milieu: 45, fin: 60 },
+          aLancer: { debut: 60, milieu: 75, fin: 90 },
+          aRemplir: { debut: 90, milieu: 105, fin: 120 },
+          fait: { debut: 120, milieu: 240, fin: 360 },
         },
         unique: null,
       });
     });
 
     it("s'assurent de ne pas dépasser 360 degrés, même en cas d'utilisation d'angle(s) minimum(s) à la fin du camembert", () => {
-      const statistiques = { enCours: 47, nonFait: 1, aRemplir: 2, fait: 2 };
+      const statistiques = {
+        enCours: 47,
+        nonFait: 1,
+        aLancer: 1,
+        aRemplir: 1,
+        fait: 1,
+      };
 
       expect(genereGradientConique(statistiques)).to.eql({
         angles: {
-          enCours: { debut: 0, milieu: 150, fin: 300 },
-          nonFait: { debut: 300, milieu: 310, fin: 320 },
-          aRemplir: { debut: 320, milieu: 330, fin: 340 },
-          fait: { debut: 340, milieu: 350, fin: 360 },
+          enCours: { debut: 0, milieu: 120, fin: 240 },
+          nonFait: { debut: 240, milieu: 255, fin: 270 },
+          aLancer: { debut: 270, milieu: 285, fin: 300 },
+          aRemplir: { debut: 300, milieu: 315, fin: 330 },
+          fait: { debut: 330, milieu: 345, fin: 360 },
         },
         unique: null,
       });
     });
 
     it("s'assurent que le champs 'unique' est null si il y a au moins 2 portions non nulles", () => {
-      const statistiques = { enCours: 1, nonFait: 1, aRemplir: 0, fait: 0 };
+      const statistiques = {
+        enCours: 1,
+        nonFait: 1,
+        aLancer: 0,
+        aRemplir: 0,
+        fait: 0,
+      };
 
       expect(genereGradientConique(statistiques).unique).to.equal(null);
     });
 
     it("s'assurent que le champs 'unique' porte la clé de la portion si une seule portion est présente", () => {
-      const statistiques = { enCours: 1, nonFait: 0, aRemplir: 0, fait: 0 };
+      const statistiques = {
+        enCours: 1,
+        nonFait: 0,
+        aLancer: 0,
+        aRemplir: 0,
+        fait: 0,
+      };
 
       expect(genereGradientConique(statistiques).unique).to.equal('enCours');
     });


### PR DESCRIPTION
On rajoute le nouveau statut "A lancer" dans les mesures.
Cette PR se base sur le travail de remaniement sur les statistiques qui a été fait précédemment.

Le nouveau statut est donc disponible dans la page Sécuriser.
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/c8fb114f-e519-48bb-801b-d74ffad232cc)

On le rajoute aussi dans les PDF annexes
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/4c893326-0480-41e5-b9ff-315a41114123)

... et de synthèse sécurité
![image](https://github.com/betagouv/mon-service-securise/assets/1643465/24903738-1d44-4f3c-9e25-c2f8365368fc)
