### PR TITLE
[CORRECTION] Passe le `bus` au `depotDonneesAutorisations`

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -45,6 +45,7 @@ const creeDepot = (config = {}) => {
     adaptateurUUID,
     depotHomologations,
     depotUtilisateurs,
+    busEvenements,
   });
 
   const depotParcoursUtilisateurs = depotDonneesParcoursUtilisateurs.creeDepot({


### PR DESCRIPTION
… sinon `ajouteContributeurAuService()` plante.