### PR TITLE
[CORRECTION] Ajoute le `await` manquant

### DIFF
--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -306,7 +306,7 @@ const creeDepot = (config = {}) => {
       ),
     });
 
-    adaptateurJournalMSS.consigneEvenement(evenement.toJSON());
+    await adaptateurJournalMSS.consigneEvenement(evenement.toJSON());
   };
 
   const nouveauService = async (idUtilisateur, donneesService) => {


### PR DESCRIPTION
Sans ça, la consignation d'événement ne se faisait pas.