### PR TITLE
[CORRECTION] Diagramme camembert de la synthèse sécurité

### DIFF
--- a/src/pdf/graphiques/camembert.js
+++ b/src/pdf/graphiques/camembert.js
@@ -10,15 +10,26 @@ const recalculPourFin360 = (angles) => {
   const { fait, enCours, nonFait, aLancer, aRemplir } = angles;
 
   const depassement = fait.fin - 360;
-  const nbAnglesAModifier = Object.values(angles)
-    .map(({ debut, fin }) => fin - debut === ANGLE_MINIMUM)
+  let nbAnglesAModifier = Object.values(angles)
+    .map(({ debut, fin }) => fin - debut === ANGLE_MINIMUM || fin === debut)
     .filter((estAngleMinimum) => estAngleMinimum === false).length;
-  const angleASoustraire = depassement / nbAnglesAModifier;
+  let angleASoustraire = depassement / nbAnglesAModifier;
+  Object.values(angles).forEach((detail) => {
+    const angle = detail.fin - detail.debut;
+    if (angle > ANGLE_MINIMUM && angle - angleASoustraire < ANGLE_MINIMUM) {
+      detail.nePeutEtreModifie = true;
+      nbAnglesAModifier -= 1;
+      angleASoustraire = depassement / nbAnglesAModifier;
+    }
+  });
 
-  const valeurRevisee = (angle) =>
-    angle.fin - angle.debut === ANGLE_MINIMUM
+  const valeurRevisee = (angle) => {
+    if (angle.nePeutEtreModifie) return angle.fin - angle.debut;
+    if (angle.fin - angle.debut === 0) return 0;
+    return angle.fin - angle.debut === ANGLE_MINIMUM
       ? ANGLE_MINIMUM
       : angle.fin - angle.debut - angleASoustraire;
+  };
 
   const valeurRevisees = {
     enCours: valeurRevisee(enCours),

--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -779,7 +779,7 @@ p {
 }
 
 .synthese-securite .mesures-par-categorie .graphique .faites {
-  background-color: #172738;
+  background-color: #173b62;
   color: #fff;
 }
 

--- a/src/pdf/modeles/syntheseSecurite.pug
+++ b/src/pdf/modeles/syntheseSecurite.pug
@@ -70,7 +70,7 @@ block page
             dt Statut :
             dd= service.descriptionStatutDeploiement()
           dl
-          - const presentation = service.presentation();
+          - const presentation = service.presentation() ?? "";
           - const tailleMaximale = 500;
             dt Présentation :
             dd= presentation.length > tailleMaximale ? presentation.substring(0, tailleMaximale) + '…' : presentation

--- a/test/pdf/graphiques/camembert.spec.js
+++ b/test/pdf/graphiques/camembert.spec.js
@@ -47,6 +47,23 @@ describe('Les graphiques camembert', () => {
       });
     });
 
+    it("ne modifie pas les angles inférieur à l'angle minimum, ou les angles nuls", () => {
+      const statistiques = {
+        enCours: 4,
+        nonFait: 2,
+        fait: 37,
+        aRemplir: 0,
+        aLancer: 2,
+      };
+
+      const resultat = genereGradientConique(statistiques).angles;
+      expect(resultat.enCours).to.eql({ debut: 0, milieu: 16, fin: 32 });
+      expect(resultat.nonFait).to.eql({ debut: 32, milieu: 47, fin: 62 });
+      expect(resultat.aLancer).to.eql({ debut: 62, milieu: 77, fin: 92 });
+      expect(resultat.aRemplir).to.eql({ debut: 92, milieu: 92, fin: 92 });
+      expect(resultat.fait).to.eql({ debut: 92, milieu: 226, fin: 360 });
+    });
+
     it("s'assurent qu'une portion avec valeur fasse au moins 30 degrés pour rester visible", () => {
       const verifieAngleMinimum = (statistiques, identifiantStatut) => {
         const { angles } = genereGradientConique(statistiques);


### PR DESCRIPTION
Corrige les camemberts lorsque les angles sont supérieurs mais proche de l'angle minimum

...car sinon, l'angle "corrigé" devient inférieur à l'angle miminum. De plus, on corrige :
- un problème au niveau de l'affichage des statuts qui n'ont aucune mesure
- un problème de couleur dans les "barres" par catégorie
- un problème lorsque la "présentation" du service est vide

![Screenshot from 2024-02-12 14-06-54](https://github.com/betagouv/mon-service-securise/assets/1643465/12a6b369-3522-499b-81ac-38c202d6e7b9)

