### PR TITLE
[SÉCURISER] Ajoute des `container-queries` sur les indicateurs de la barre d'outils

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -1,5 +1,7 @@
 .marges-fixes {
   width: 1290px;
+  container-type: inline-size;
+  container-name: conteneur-mesures;
 }
 
 .zone-principale {
@@ -65,4 +67,16 @@
 .conteneur-indice-cyber:active .cartouche-indice-cyber {
   background: #08416a;
   color: white;
+}
+
+@container conteneur-mesures (max-width: 1060px) {
+  .cartouche-progression-mesures,
+  .cartouche-indice-cyber {
+    display: none;
+  }
+
+  .jauge-progression-mesures {
+    left: unset !important;
+    right: -5px;
+  }
 }


### PR DESCRIPTION
...afin de masquer les cartouches textuels si le conteneur est trop petit

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/e34a7064-8350-415d-b6d3-a976d00cce66)
