### PR TITLE
[CORRECTION] Cible correctement le logo du `header`

### DIFF
--- a/public/assets/styles/entete.css
+++ b/public/assets/styles/entete.css
@@ -159,7 +159,7 @@ header nav a,
   mask-size: contain;
 }
 
-.deconnexion::before {
+header nav .deconnexion::before {
   width: 24px;
   height: 24px;
   margin-right: 8px;


### PR DESCRIPTION
… sinon la modale de déconnexion (contenant aussi un `.deconnexion`) est ciblée à tort par le `::before` ce qui provoque un bug d'affichage.