### PR TITLE
[ADMIN] Répare la génération d'événements de complétude pour tous les services

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -49,21 +49,20 @@ class ConsoleAdministration {
     return this.depotDonnees.supprimeUtilisateur(id);
   }
 
-  genereTousEvenementsCompletude(persisteEvenements = false) {
+  async genereTousEvenementsCompletude(persisteEvenements = false) {
     const journal = persisteEvenements
       ? this.adaptateurJournalMSS
       : this.journalConsole;
 
-    const evenements = this.depotDonnees
-      .tousLesServices()
-      .then((hs) =>
-        hs.map((h) => ({ idService: h.id, ...h.completudeMesures() }))
-      )
-      .then((stats) =>
-        stats.map((s) => new EvenementCompletudeServiceModifiee(s).toJSON())
-      );
+    const services = await this.depotDonnees.tousLesServices();
+    const evenements = services.map((s) =>
+      new EvenementCompletudeServiceModifiee({
+        idService: s.id,
+        ...s.completudeMesures(),
+      }).toJSON()
+    );
 
-    return avecPMapPourChaqueElement(evenements, journal.consigneEvenement);
+    await avecPMapPourChaqueElement(evenements, journal.consigneEvenement);
   }
 
   genereTousEvenementsNouvelUtilisateurInscrit(persisteEvenements = false) {

--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -55,14 +55,21 @@ class ConsoleAdministration {
       : this.journalConsole;
 
     const services = await this.depotDonnees.tousLesServices();
-    const evenements = services.map((s) =>
-      new EvenementCompletudeServiceModifiee({
-        idService: s.id,
-        ...s.completudeMesures(),
-      }).toJSON()
-    );
+    const evenements = services
+      .map((s) =>
+        new EvenementCompletudeServiceModifiee({
+          idService: s.id,
+          ...s.completudeMesures(),
+          nombreOrganisationsUtilisatrices:
+            s.descriptionService.nombreOrganisationsUtilisatrices,
+        }).toJSON()
+      )
+      .map((e) => ({ ...e, genereParAdministrateur: true }));
 
-    await avecPMapPourChaqueElement(evenements, journal.consigneEvenement);
+    await avecPMapPourChaqueElement(
+      Promise.resolve(evenements),
+      journal.consigneEvenement
+    );
   }
 
   genereTousEvenementsNouvelUtilisateurInscrit(persisteEvenements = false) {

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -79,6 +79,11 @@ const nouvelAdaptateur = (
       Promise.all(as.map(({ idHomologation }) => homologation(idHomologation)))
     );
 
+  const tousLesServices = async () => {
+    const lesIds = donnees.services.map((s) => s.id);
+    return lesIds.map(homologation);
+  };
+
   const homologationAvecNomService = (
     idUtilisateur,
     nomService,
@@ -268,6 +273,7 @@ const nouvelAdaptateur = (
     supprimeService,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    tousLesServices,
     tousUtilisateurs,
     utilisateur,
     utilisateurAvecEmail,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -131,6 +131,13 @@ const nouvelAdaptateur = (env) => {
     return avecPMapPourChaqueElement(idsHomologations, homologation);
   };
 
+  const tousLesServices = async () => {
+    const lignes = await knex('services').select({ id: 'id' });
+    const ids = lignes.map(({ id }) => id);
+
+    return avecPMapPourChaqueElement(Promise.resolve(ids), homologation);
+  };
+
   const metsAJourHomologation = (...params) =>
     metsAJourTable('homologations', ...params);
   const metsAJourService = (...params) => metsAJourTable('services', ...params);
@@ -332,6 +339,7 @@ const nouvelAdaptateur = (env) => {
     supprimeHomologations,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    tousLesServices,
     tousUtilisateurs,
     utilisateur,
     utilisateurAvecEmail,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -63,7 +63,10 @@ const fabriquePersistance = (
           .map((h) => new Homologation(h, referentiel))
           .sort((h1, h2) => h1.nomService().localeCompare(h2.nomService()));
       },
-      toutes: async () => persistance.lis.cellesDeUtilisateur(),
+      toutes: async () => {
+        const donneesServices = await adaptateurPersistance.tousLesServices();
+        return donneesServices.map((s) => new Homologation(s, referentiel));
+      },
       celleAvecNomService: async (...params) =>
         adaptateurPersistance.homologationAvecNomService(...params),
     },

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -95,13 +95,11 @@ describe('Le dépôt de données des homologations', () => {
     expect(homologations[0].referentiel).to.equal(referentiel);
   });
 
-  it("utilise l'adaptateur de persistance sans `idUtilisateur` pour récupérer toutes les homologations du système", async () => {
+  it("utilise l'adaptateur de persistance pour récupérer tous les services du système", async () => {
     let adaptateurAppele;
-    let idRecu;
     const adaptateurPersistance = unePersistanceMemoire().construis();
-    adaptateurPersistance.homologations = async (idUtilisateur) => {
+    adaptateurPersistance.tousLesServices = async () => {
       adaptateurAppele = true;
-      idRecu = idUtilisateur;
       return [];
     };
 
@@ -112,7 +110,6 @@ describe('Le dépôt de données des homologations', () => {
     await depot.tousLesServices();
 
     expect(adaptateurAppele).to.be(true);
-    expect(idRecu).to.be(undefined);
   });
 
   it('trie les homologations par ordre alphabétique du nom du service', async () => {


### PR DESCRIPTION
## Contexte 
Nous avons besoin de générer manuellement des événements de `EvenementCompletudeServiceModifiee` pour tous les services.
De cette façon nous aurons dans Metabase les données de complétude à jour après le déploiement du référentiel CNIL qui a eu lieu il y a quelques semaines.

## Préparation
Cette PR répare la `consoleAdministration` car la génération d'événements de complétude n'avait pas été maintenue.