### PR TITLE
[CORRECTION] Place `genereParAdministrateur` dans les `donnees`

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -64,7 +64,10 @@ class ConsoleAdministration {
             s.descriptionService.nombreOrganisationsUtilisatrices,
         }).toJSON()
       )
-      .map((e) => ({ ...e, genereParAdministrateur: true }));
+      .map(({ donnees, ...reste }) => ({
+        donnees: { ...donnees, genereParAdministrateur: true },
+        ...reste,
+      }));
 
     await avecPMapPourChaqueElement(
       Promise.resolve(evenements),


### PR DESCRIPTION
… au lieu de le placer à la racine de l'objet où il sera finalement non persisté.

Avec cette PR, on a bien le champ au bon endroit 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/f7c1b110-4487-4924-a885-b0a76b8055ad)

Avant, il était placé à la racine de l'objet… et donc totalement ignoré par la persistance.