### PR TITLE
[SÉCURITÉ] Ajoute un filtrage d'IP

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,8 @@ SENDINBLUE_TEMPLATE_REINITIALISATION_MOT_DE_PASSE= # id de template
 SENDINBLUE_TEMPLATE_TENTATIVE_REINSCRIPTION= # id de template
 SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE= # l'ID de la liste de contacts utilisée pour les mails transactionnels de relance
 
+ADRESSES_IP_AUTORISEES= # Seules ces IP seront autorisées. Les autres ne seront pas servies. Séparées par des ',' s'il y en a plusieurs. Supprimer la variable d'env pour désactiver le filtrage.
+
 SENTRY_DSN= # Le « DSN » du projet Sentry sur lequel envoyer les exceptions. Laisser commenté pour ne pas utiliser Sentry.
 SENTRY_ENVIRONNEMENT= # L'environnement Sentry auquel seront associées les exceptions loguées, si Sentry est utilisé.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "express-ip-access-control": "^1.1.3",
+        "express-ipfilter": "^1.3.1",
         "express-rate-limit": "^6.7.0",
         "express-validator": "^6.14.2",
         "html-entities": "^2.3.3",
@@ -3516,6 +3517,20 @@
         "ipaddr.js": "^1.0.1"
       }
     },
+    "node_modules/express-ipfilter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
+      "integrity": "sha512-9WZC8wGkI6I6ygZNzuZ2MbFJiGoDXs1dM+E8LKtSP13pdgqrnkonWlgvvbxG3YZpa7Haz7Ndum9/J6qkj52OqA==",
+      "dependencies": {
+        "ip": "^1.1.8",
+        "lodash": "^4.17.11",
+        "proxy-addr": "^2.0.7",
+        "range_check": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/express-rate-limit": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
@@ -4410,6 +4425,19 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+    },
+    "node_modules/ip6": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
+      "integrity": "sha512-1LdpyKjhvepd6EbAU6rW4g14vuYtx5TnJX9TfZZBhsM6DsyPQLNzW12rtbUqXBMwqFrLVV/Gcxv0GNFvJp2cYA==",
+      "bin": {
+        "ip6": "ip6-cli.js"
       }
     },
     "node_modules/ipaddr.js": {
@@ -6973,6 +7001,18 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range_check": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/range_check/-/range_check-2.0.4.tgz",
+      "integrity": "sha512-aed0ocXXj+SIiNNN9b+mZWA3Ow2GXHtftOGk2xQwshK5GbEZAvUcPWNQBLTx/lPcdFRIUFlFCRtHTQNIFMqynQ==",
+      "dependencies": {
+        "ip6": "^0.2.0",
+        "ipaddr.js": "^1.9.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/range-parser": {
@@ -11199,6 +11239,17 @@
         "ipaddr.js": "^1.0.1"
       }
     },
+    "express-ipfilter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/express-ipfilter/-/express-ipfilter-1.3.1.tgz",
+      "integrity": "sha512-9WZC8wGkI6I6ygZNzuZ2MbFJiGoDXs1dM+E8LKtSP13pdgqrnkonWlgvvbxG3YZpa7Haz7Ndum9/J6qkj52OqA==",
+      "requires": {
+        "ip": "^1.1.8",
+        "lodash": "^4.17.11",
+        "proxy-addr": "^2.0.7",
+        "range_check": "^2.0.4"
+      }
+    },
     "express-rate-limit": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
@@ -11833,6 +11884,16 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+    },
+    "ip": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+    },
+    "ip6": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/ip6/-/ip6-0.2.10.tgz",
+      "integrity": "sha512-1LdpyKjhvepd6EbAU6rW4g14vuYtx5TnJX9TfZZBhsM6DsyPQLNzW12rtbUqXBMwqFrLVV/Gcxv0GNFvJp2cYA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -13691,6 +13752,15 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "range_check": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/range_check/-/range_check-2.0.4.tgz",
+      "integrity": "sha512-aed0ocXXj+SIiNNN9b+mZWA3Ow2GXHtftOGk2xQwshK5GbEZAvUcPWNQBLTx/lPcdFRIUFlFCRtHTQNIFMqynQ==",
+      "requires": {
+        "ip6": "^0.2.0",
+        "ipaddr.js": "^1.9.1"
       }
     },
     "range-parser": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-ip-access-control": "^1.1.3",
+    "express-ipfilter": "^1.3.1",
     "express-rate-limit": "^6.7.0",
     "express-validator": "^6.14.2",
     "html-entities": "^2.3.3",

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -8,6 +8,11 @@ const journalMSS = () => ({
     process.env.AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE === 'true',
 });
 
+const filtrageIp = () => ({
+  ipAutorisees: () => process.env.ADRESSES_IP_AUTORISEES?.split(',') ?? [],
+  activerFiltrageIp: () => filtrageIp().ipAutorisees().length > 0,
+});
+
 const matomo = () => ({
   urlTagManager: () => process.env.MATOMO_URL_TAG_MANAGER,
 });
@@ -33,6 +38,7 @@ const statistiques = () => ({
 
 module.exports = {
   emailMemoire,
+  filtrageIp,
   journalMSS,
   matomo,
   sendinblue,

--- a/src/adaptateurs/adaptateurGestionErreurSentry.js
+++ b/src/adaptateurs/adaptateurGestionErreurSentry.js
@@ -1,5 +1,15 @@
 const Sentry = require('@sentry/node');
+const { IpDeniedError } = require('express-ipfilter');
 const adaptateurEnvironnement = require('./adaptateurEnvironnement');
+
+const logueErreur = (erreur, infosDeContexte = {}) => {
+  Sentry.withScope(() => {
+    Object.entries(infosDeContexte).forEach(([cle, valeur]) =>
+      Sentry.setExtra(cle, valeur)
+    );
+    Sentry.captureException(erreur);
+  });
+};
 
 const initialise = () => {
   Sentry.init({
@@ -11,6 +21,18 @@ const initialise = () => {
 const controleurRequetes = () => Sentry.Handlers.requestHandler();
 
 const controleurErreurs = (erreur, requete, reponse, suite) => {
+  const estErreurDeFiltrageIp = erreur instanceof IpDeniedError;
+  if (estErreurDeFiltrageIp) {
+    logueErreur(
+      new Error(
+        'Une IP non autorisée a été bloquée. Aucune page ne lui a été servie.'
+      ),
+      { 'IP de la requete': requete.headers['x-real-ip']?.replaceAll('.', '*') }
+    );
+    reponse.end();
+    return suite();
+  }
+
   if (requete && requete.body) {
     Object.keys(requete.body).forEach((cle) => {
       if (cle.includes('motDePasse')) requete.body[cle] = '********';
@@ -18,15 +40,6 @@ const controleurErreurs = (erreur, requete, reponse, suite) => {
   }
 
   return Sentry.Handlers.errorHandler()(erreur, requete, reponse, suite);
-};
-
-const logueErreur = (erreur, infosDeContexte = {}) => {
-  Sentry.withScope(() => {
-    Object.entries(infosDeContexte).forEach(([cle, valeur]) =>
-      Sentry.setExtra(cle, valeur)
-    );
-    Sentry.captureException(erreur);
-  });
 };
 
 module.exports = {

--- a/src/adaptateurs/adaptateurGestionErreurVide.js
+++ b/src/adaptateurs/adaptateurGestionErreurVide.js
@@ -1,6 +1,6 @@
 const initialise = () => {};
 const controleurRequetes = () => (_requete, _reponse, suite) => suite();
-const controleurErreurs = () => (_requete, _reponse, suite) => suite();
+const controleurErreurs = (erreur, _requete, _reponse, suite) => suite(erreur);
 const logueErreur = (_erreur) => {};
 
 module.exports = {

--- a/src/mss.js
+++ b/src/mss.js
@@ -43,6 +43,8 @@ const creeServeur = (
   adaptateurGestionErreur.initialise();
   app.use(adaptateurGestionErreur.controleurRequetes());
 
+  app.use(middleware.filtreIpAutorisees());
+
   app.use(express.json());
 
   app.use(

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -54,6 +54,7 @@ let listesAseptisees = [];
 let listeAdressesIPsAutorisee = [];
 let parametresAseptises = [];
 let preferencesChargees = false;
+let filtrageIpEstActif = false;
 let rechercheDossierCourantEffectuee = false;
 let suppressionCookieEffectuee = false;
 let traficProtege = false;
@@ -83,6 +84,7 @@ const middlewareFantaisie = {
     listeAdressesIPsAutorisee = [];
     parametresAseptises = [];
     preferencesChargees = false;
+    filtrageIpEstActif = false;
     rechercheDossierCourantEffectuee = false;
     suppressionCookieEffectuee = false;
     traficProtege = false;
@@ -127,6 +129,11 @@ const middlewareFantaisie = {
   chargePreferencesUtilisateur: (_requete, reponse, suite) => {
     reponse.locals.preferencesUtilisateur = {};
     preferencesChargees = true;
+    suite();
+  },
+
+  filtreIpAutorisees: () => (_requete, _reponse, suite) => {
+    filtrageIpEstActif = true;
     suite();
   },
 
@@ -234,6 +241,13 @@ const middlewareFantaisie = {
   verifieChargementDesPreferences: (...params) => {
     verifieRequeteChangeEtat(
       { lectureEtat: () => preferencesChargees },
+      ...params
+    );
+  },
+
+  verifieFiltrageIp: (...params) => {
+    verifieRequeteChangeEtat(
+      { lectureEtat: () => filtrageIpEstActif },
       ...params
     );
   },

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -20,6 +20,10 @@ describe('Le serveur MSS', () => {
       .catch(done);
   });
 
+  it('utilise un filtrage IP pour ne servir que les IP autorisées', (done) => {
+    testeur.middleware().verifieFiltrageIp('http://localhost:1234', done);
+  });
+
   describe('quand une page est servie', () => {
     it('positionne les headers', (done) => {
       testeur


### PR DESCRIPTION
… qui ne servira que les IP mentionnées dans la variable d'environnement `ADRESSES_IP_AUTORISEES`.

On en profite pour changer la signature de `controleurErreurs()` dans l'adaptateur de gestion d'erreur vide : désormais la signature correspond à celle du l'adaptateur Sentry, qui fait foi.