### PR TITLE
Implémente partiellement le support du chiffrement par Vault

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,3 +49,7 @@ CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichier
 # configuration du `rate-limit`
 NB_REQUETES_MAX_PAR_MINUTE= # Nombre maximal de requêtes autorisées par IP et par minute, supprimer la variable permet de désactiver la protection
 NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes autorisées par IP et par minute pour les endpoints sensibles (connexion, inscription, modification de mot de passe, creation de service), supprimer la variable permet de désactiver la protection
+
+CHIFFREMENT_URL_BASE_DU_SERVICE= # URL de base du service de chiffrement. Tout jusqu'à `/v1` exclu.
+CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT= # Nom de la clé Transit à utiliser.
+CHIFFREMENT_TOKEN_VAULT= # Token à utiliser pour le chiffrement.

--- a/.env.template
+++ b/.env.template
@@ -42,6 +42,7 @@ AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire
 AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que le « Journal MSS » en mémoire logue les événements reçus dans la console
 AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
 AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logués dans la console
+AVEC_CHIFFREMENT_PAR_VAULT= # `true` pour utiliser l'adaptateur de chiffrement qui utilise Vault. Cela nécessite de valoriser les variables d'environnement `CHIFFREMENT_…`.
 
 # Politique de cache
 CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local
@@ -49,6 +50,7 @@ CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichier
 # configuration du `rate-limit`
 NB_REQUETES_MAX_PAR_MINUTE= # Nombre maximal de requêtes autorisées par IP et par minute, supprimer la variable permet de désactiver la protection
 NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes autorisées par IP et par minute pour les endpoints sensibles (connexion, inscription, modification de mot de passe, creation de service), supprimer la variable permet de désactiver la protection
+
 
 CHIFFREMENT_URL_BASE_DU_SERVICE= # URL de base du service de chiffrement. Tout jusqu'à `/v1` exclu.
 CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT= # Nom de la clé Transit à utiliser.

--- a/scripts/clever-cloud/post-build-clever.sh
+++ b/scripts/clever-cloud/post-build-clever.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+npx vite build --config svelte/vite.config.mts

--- a/scripts/clever-cloud/pre-run-clever.sh
+++ b/scripts/clever-cloud/pre-run-clever.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+npx knex migrate:latest
+npm run cree-utilisateur-demo

--- a/server.js
+++ b/server.js
@@ -4,7 +4,6 @@ const MoteurRegles = require('./src/moteurRegles');
 const MSS = require('./src/mss');
 const Referentiel = require('./src/referentiel');
 const { fabriqueAnnuaire } = require('./src/annuaire/serviceAnnuaire');
-const adaptateurChiffrement = require('./src/adaptateurs/adaptateurChiffrement');
 const adaptateurCsv = require('./src/adaptateurs/adaptateurCsv');
 const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
 const {
@@ -31,10 +30,14 @@ const { fabriqueProcedures } = require('./src/routes/procedures');
 const BusEvenements = require('./src/bus/busEvenements');
 const fabriqueAdaptateurJournalMSS = require('./src/adaptateurs/fabriqueAdaptateurJournalMSS');
 const { cableTousLesAbonnes } = require('./src/bus/cablage');
+const {
+  fabriqueAdaptateurChiffrement,
+} = require('./src/adaptateurs/fabriqueAdaptateurChiffrement');
 
 const adaptateurGestionErreur = fabriqueAdaptateurGestionErreur();
 const adaptateurTracking = fabriqueAdaptateurTracking();
 const adaptateurJournal = fabriqueAdaptateurJournalMSS();
+const adaptateurChiffrement = fabriqueAdaptateurChiffrement();
 const serviceAnnuaire = fabriqueAnnuaire({
   adaptateurRechercheEntreprise: adaptateurRechercheEntrepriseAPI,
   adaptateurPersistance,
@@ -46,6 +49,7 @@ const referentiel = Referentiel.creeReferentiel();
 const moteurRegles = new MoteurRegles(referentiel);
 
 const depotDonnees = DepotDonnees.creeDepot({
+  adaptateurChiffrement,
   adaptateurJournalMSS: adaptateurJournal,
   busEvenements,
 });

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -22,6 +22,25 @@ const chiffre = async (chaine) => {
   return reponse.data.data.ciphertext;
 };
 
+const dechiffre = async (chaine) => {
+  const env = chiffrement();
+  const base = env.urlBaseDuService();
+  const cleTransit = env.cleDuMoteurTransit();
+
+  const reponse = await axios.put(
+    `${base}/v1/transit/decrypt/${cleTransit}`,
+    { ciphertext: chaine },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Vault-Token': env.tokenVault(),
+      },
+    }
+  );
+
+  return reponse.data.data.plaintext;
+};
+
 const NOMBRE_DE_PASSES = 10;
 const hacheBCrypt = (chaineEnClair) =>
   bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
@@ -36,6 +55,7 @@ const nonce = () =>
 
 module.exports = {
   chiffre,
+  dechiffre,
   compareBCrypt: compare,
   hacheBCrypt,
   hacheSha256,

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,50 +1,9 @@
-const axios = require('axios');
 const { createHash } = require('crypto');
 const bcrypt = require('bcrypt');
-const { chiffrement } = require('./adaptateurEnvironnement');
 
-const chiffre = async (chaineOuObjet) => {
-  const env = chiffrement();
-  const base = env.urlBaseDuService();
-  const cleTransit = env.cleDuMoteurTransit();
+const chiffre = async (chaineOuObjet) => chaineOuObjet;
 
-  const brut = JSON.stringify(chaineOuObjet);
-  const base64 = Buffer.from(brut).toString('base64');
-
-  const reponse = await axios.put(
-    `${base}/v1/transit/encrypt/${cleTransit}`,
-    { plaintext: base64 },
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Vault-Token': env.tokenVault(),
-      },
-    }
-  );
-
-  return reponse.data.data.ciphertext;
-};
-
-const dechiffre = async (chaineChiffree) => {
-  const env = chiffrement();
-  const base = env.urlBaseDuService();
-  const cleTransit = env.cleDuMoteurTransit();
-
-  const reponse = await axios.put(
-    `${base}/v1/transit/decrypt/${cleTransit}`,
-    { ciphertext: chaineChiffree },
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Vault-Token': env.tokenVault(),
-      },
-    }
-  );
-
-  const base64 = Buffer.from(reponse.data.data.plaintext, 'base64');
-  const brut = base64.toString('utf-8');
-  return JSON.parse(brut);
-};
+const dechiffre = async (chaineChiffree) => chaineChiffree;
 
 const NOMBRE_DE_PASSES = 10;
 const hacheBCrypt = (chaineEnClair) =>

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -3,14 +3,17 @@ const { createHash } = require('crypto');
 const bcrypt = require('bcrypt');
 const { chiffrement } = require('./adaptateurEnvironnement');
 
-const chiffre = async (chaine) => {
+const chiffre = async (chaineOuObjet) => {
   const env = chiffrement();
   const base = env.urlBaseDuService();
   const cleTransit = env.cleDuMoteurTransit();
 
+  const brut = JSON.stringify(chaineOuObjet);
+  const base64 = Buffer.from(brut).toString('base64');
+
   const reponse = await axios.put(
     `${base}/v1/transit/encrypt/${cleTransit}`,
-    { plaintext: chaine },
+    { plaintext: base64 },
     {
       headers: {
         'Content-Type': 'application/json',
@@ -22,14 +25,14 @@ const chiffre = async (chaine) => {
   return reponse.data.data.ciphertext;
 };
 
-const dechiffre = async (chaine) => {
+const dechiffre = async (chaineChiffree) => {
   const env = chiffrement();
   const base = env.urlBaseDuService();
   const cleTransit = env.cleDuMoteurTransit();
 
   const reponse = await axios.put(
     `${base}/v1/transit/decrypt/${cleTransit}`,
-    { ciphertext: chaine },
+    { ciphertext: chaineChiffree },
     {
       headers: {
         'Content-Type': 'application/json',
@@ -38,7 +41,9 @@ const dechiffre = async (chaine) => {
     }
   );
 
-  return reponse.data.data.plaintext;
+  const base64 = Buffer.from(reponse.data.data.plaintext, 'base64');
+  const brut = base64.toString('utf-8');
+  return JSON.parse(brut);
 };
 
 const NOMBRE_DE_PASSES = 10;

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,7 +1,7 @@
 const { createHash } = require('crypto');
 const bcrypt = require('bcrypt');
 
-const chiffre = (chaine) => chaine;
+const chiffre = async (chaine) => chaine;
 
 const NOMBRE_DE_PASSES = 10;
 const hacheBCrypt = (chaineEnClair) =>

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,7 +1,26 @@
+const axios = require('axios');
 const { createHash } = require('crypto');
 const bcrypt = require('bcrypt');
+const { chiffrement } = require('./adaptateurEnvironnement');
 
-const chiffre = async (chaine) => chaine;
+const chiffre = async (chaine) => {
+  const env = chiffrement();
+  const base = env.urlBaseDuService();
+  const cleTransit = env.cleDuMoteurTransit();
+
+  const reponse = await axios.put(
+    `${base}/v1/transit/encrypt/${cleTransit}`,
+    { plaintext: chaine },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Vault-Token': env.tokenVault(),
+      },
+    }
+  );
+
+  return reponse.data.data.ciphertext;
+};
 
 const NOMBRE_DE_PASSES = 10;
 const hacheBCrypt = (chaineEnClair) =>

--- a/src/adaptateurs/adaptateurChiffrementVault.js
+++ b/src/adaptateurs/adaptateurChiffrementVault.js
@@ -1,0 +1,60 @@
+const axios = require('axios');
+const { chiffrement } = require('./adaptateurEnvironnement');
+const {
+  compareBCrypt,
+  hacheBCrypt,
+  hacheSha256,
+  nonce,
+} = require('./adaptateurChiffrement');
+
+const chiffre = async (chaineOuObjet) => {
+  const env = chiffrement();
+  const base = env.urlBaseDuService();
+  const cleTransit = env.cleDuMoteurTransit();
+
+  const brut = JSON.stringify(chaineOuObjet);
+  const base64 = Buffer.from(brut).toString('base64');
+
+  const reponse = await axios.put(
+    `${base}/v1/transit/encrypt/${cleTransit}`,
+    { plaintext: base64 },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Vault-Token': env.tokenVault(),
+      },
+    }
+  );
+
+  return reponse.data.data.ciphertext;
+};
+
+const dechiffre = async (chaineChiffree) => {
+  const env = chiffrement();
+  const base = env.urlBaseDuService();
+  const cleTransit = env.cleDuMoteurTransit();
+
+  const reponse = await axios.put(
+    `${base}/v1/transit/decrypt/${cleTransit}`,
+    { ciphertext: chaineChiffree },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Vault-Token': env.tokenVault(),
+      },
+    }
+  );
+
+  const base64 = Buffer.from(reponse.data.data.plaintext, 'base64');
+  const brut = base64.toString('utf-8');
+  return JSON.parse(brut);
+};
+
+module.exports = {
+  chiffre,
+  dechiffre,
+  compareBCrypt,
+  hacheBCrypt,
+  hacheSha256,
+  nonce,
+};

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -37,6 +37,8 @@ const statistiques = () => ({
 });
 
 const chiffrement = () => ({
+  utiliseChiffrementVault: () =>
+    process.env.AVEC_CHIFFREMENT_PAR_VAULT === 'true',
   urlBaseDuService: () => process.env.CHIFFREMENT_URL_BASE_DU_SERVICE,
   cleDuMoteurTransit: () => process.env.CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT,
   tokenVault: () => process.env.CHIFFREMENT_TOKEN_VAULT,

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -36,7 +36,14 @@ const statistiques = () => ({
       : '',
 });
 
+const chiffrement = () => ({
+  urlBaseDuService: () => process.env.CHIFFREMENT_URL_BASE_DU_SERVICE,
+  cleDuMoteurTransit: () => process.env.CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT,
+  tokenVault: () => process.env.CHIFFREMENT_TOKEN_VAULT,
+});
+
 module.exports = {
+  chiffrement,
   emailMemoire,
   filtrageIp,
   journalMSS,

--- a/src/adaptateurs/fabriqueAdaptateurChiffrement.js
+++ b/src/adaptateurs/fabriqueAdaptateurChiffrement.js
@@ -1,8 +1,11 @@
 const { chiffrement } = require('./adaptateurEnvironnement');
 const adaptateurChiffrement = require('./adaptateurChiffrement');
+const adaptateurChiffrementVault = require('./adaptateurChiffrementVault');
 
 const fabriqueAdaptateurChiffrement = () => {
-  if (chiffrement().utiliseChiffrementVault()) return adaptateurChiffrement;
+  if (chiffrement().utiliseChiffrementVault())
+    return adaptateurChiffrementVault;
+
   return adaptateurChiffrement;
 };
 

--- a/src/adaptateurs/fabriqueAdaptateurChiffrement.js
+++ b/src/adaptateurs/fabriqueAdaptateurChiffrement.js
@@ -1,0 +1,9 @@
+const { chiffrement } = require('./adaptateurEnvironnement');
+const adaptateurChiffrement = require('./adaptateurChiffrement');
+
+const fabriqueAdaptateurChiffrement = () => {
+  if (chiffrement().utiliseChiffrementVault()) return adaptateurChiffrement;
+  return adaptateurChiffrement;
+};
+
+module.exports = { fabriqueAdaptateurChiffrement };

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -1,4 +1,3 @@
-const adaptateurChiffrementParDefaut = require('./adaptateurs/adaptateurChiffrement');
 const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurJournalMSS = require('./adaptateurs/fabriqueAdaptateurJournalMSS');
@@ -12,7 +11,7 @@ const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 
 const creeDepot = (config = {}) => {
   const {
-    adaptateurChiffrement = adaptateurChiffrementParDefaut,
+    adaptateurChiffrement,
     adaptateurJournalMSS = fabriqueAdaptateurJournalMSS(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
@@ -33,6 +32,7 @@ const creeDepot = (config = {}) => {
   });
 
   const depotUtilisateurs = depotDonneesUtilisateurs.creeDepot({
+    adaptateurChiffrement,
     adaptateurJournalMSS,
     adaptateurJWT,
     adaptateurPersistance,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -21,22 +21,13 @@ const fabriqueChiffrement = (adaptateurChiffrement) => {
 
   return {
     chiffre: {
-      donneesService: (donnees) => {
+      donneesService: async (donnees) => {
         const { descriptionService } = donnees;
         return {
           ...donnees,
           descriptionService: {
             ...descriptionService,
-            nomService: chiffre(descriptionService.nomService),
-            presentation: chiffre(descriptionService.presentation),
-            organisationsResponsables:
-              descriptionService.organisationsResponsables.map(
-                adaptateurChiffrement.chiffre
-              ),
-            pointsAcces: descriptionService.pointsAcces.map((p) => ({
-              ...p,
-              description: chiffre(p.description),
-            })),
+            nomService: await chiffre(descriptionService.nomService),
           },
         };
       },
@@ -71,7 +62,7 @@ const fabriquePersistance = (
         adaptateurPersistance.homologationAvecNomService(...params),
     },
     sauvegarde: async (id, donneesService) => {
-      const donneesChiffrees = chiffre.donneesService(donneesService);
+      const donneesChiffrees = await chiffre.donneesService(donneesService);
       return Promise.all([
         adaptateurPersistance.sauvegardeService(id, donneesChiffrees),
         adaptateurPersistance.sauvegardeHomologation(id, donneesChiffrees),

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -25,10 +25,7 @@ const fabriqueChiffrement = (adaptateurChiffrement) => {
         const { descriptionService } = donnees;
         return {
           ...donnees,
-          descriptionService: {
-            ...descriptionService,
-            nomService: await chiffre(descriptionService.nomService),
-          },
+          descriptionService: await chiffre(descriptionService),
         };
       },
     },
@@ -37,10 +34,7 @@ const fabriqueChiffrement = (adaptateurChiffrement) => {
         const { descriptionService } = donnees;
         return {
           ...donnees,
-          descriptionService: {
-            ...descriptionService,
-            nomService: await dechiffre(descriptionService.nomService),
-          },
+          descriptionService: await dechiffre(descriptionService),
         };
       },
     },

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -1,4 +1,3 @@
-const adaptateurChiffrementParDefaut = require('../adaptateurs/adaptateurChiffrement');
 const fabriqueAdaptateurTracking = require('../adaptateurs/fabriqueAdaptateurTracking');
 const {
   ErreurDonneesObligatoiresManquantes,
@@ -80,7 +79,7 @@ const fabriquePersistance = (
 
 const creeDepot = (config = {}) => {
   const {
-    adaptateurChiffrement = adaptateurChiffrementParDefaut,
+    adaptateurChiffrement,
     adaptateurJournalMSS,
     adaptateurPersistance,
     adaptateurTracking = fabriqueAdaptateurTracking(),

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -1,4 +1,3 @@
-const adaptateurChiffrementParDefaut = require('../adaptateurs/adaptateurChiffrement');
 const adaptateurJWTParDefaut = require('../adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('../adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateurPersistance');
@@ -15,7 +14,7 @@ const Utilisateur = require('../modeles/utilisateur');
 
 const creeDepot = (config = {}) => {
   const {
-    adaptateurChiffrement = adaptateurChiffrementParDefaut,
+    adaptateurChiffrement,
     adaptateurJournalMSS,
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -113,10 +113,10 @@ const middleware = (configuration = {}) => {
     verificationAcceptationCGU(requete, reponse, () =>
       depotDonnees
         .homologation(idService)
-        .then((homologation) => {
+        .then((service) => {
           const idUtilisateur = requete.idUtilisateurCourant;
 
-          if (!homologation) reponse.status(404).send('Service non trouvé');
+          if (!service) reponse.status(404).send('Service non trouvé');
           else {
             depotDonnees
               .accesAutorise(idUtilisateur, idService, droitsRequis)
@@ -124,7 +124,7 @@ const middleware = (configuration = {}) => {
                 if (!accesAutorise)
                   reponse.status(403).render('erreurAccesRefuse');
                 else {
-                  requete.homologation = homologation;
+                  requete.homologation = service;
                   suite();
                 }
               });

--- a/src/modeles/journalMSS/evenement.js
+++ b/src/modeles/journalMSS/evenement.js
@@ -1,11 +1,13 @@
-const AdaptateurChiffrement = require('../../adaptateurs/adaptateurChiffrement');
+const {
+  fabriqueAdaptateurChiffrement,
+} = require('../../adaptateurs/fabriqueAdaptateurChiffrement');
 
 class Evenement {
   static optionsParDefaut(options) {
     return {
       date: options.date ?? Date.now(),
       adaptateurChiffrement:
-        options.adaptateurChiffrement ?? AdaptateurChiffrement,
+        options.adaptateurChiffrement ?? fabriqueAdaptateurChiffrement(),
     };
   }
 

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -10,6 +10,7 @@ const {
 const {
   fabriqueServiceTracking,
 } = require('../../src/tracking/serviceTracking');
+const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 class ConstructeurDepotDonneesServices {
   constructor() {
@@ -54,6 +55,7 @@ class ConstructeurDepotDonneesServices {
 
   construis() {
     return DepotDonneesHomologations.creeDepot({
+      adaptateurChiffrement: fauxAdaptateurChiffrement(),
       adaptateurJournalMSS: this.adaptateurJournalMSS,
       adaptateurPersistance: this.constructeurAdaptateurPersistance.construis(),
       adaptateurTracking: this.adaptateurTracking,

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -24,6 +24,7 @@ const {
   EvenementAutorisationsServiceModifiees,
 } = require('../../src/bus/evenementAutorisationsServiceModifiees');
 const { fabriqueBusPourLesTests } = require('../bus/aides/busPourLesTests');
+const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 const { ECRITURE, LECTURE } = Permissions;
@@ -34,6 +35,7 @@ describe('Le dépôt de données des autorisations', () => {
       adaptateurPersistance,
       adaptateurUUID,
       depotHomologations: DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
       }),
       depotUtilisateurs: DepotDonneesUtilisateurs.creeDepot({

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -717,7 +717,7 @@ describe('Le dépôt de données des homologations', () => {
         .catch(done);
     });
 
-    it('chiffre les données métier avant de les stocker', (done) => {
+    it('chiffre les données métier avant de les stocker', async () => {
       let donneesPersistees;
 
       const persistanceReelle = adaptateurPersistance.sauvegardeHomologation;
@@ -726,7 +726,7 @@ describe('Le dépôt de données des homologations', () => {
         return persistanceReelle(id, donnees);
       };
 
-      adaptateurChiffrement.chiffre = (chaine) => `${chaine} - chiffré`;
+      adaptateurChiffrement.chiffre = async (chaine) => `${chaine} - chiffré`;
 
       const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Service A')
@@ -736,26 +736,11 @@ describe('Le dépôt de données des homologations', () => {
         .construis()
         .donneesSerialisees();
 
-      depot
-        .nouveauService('123', { descriptionService })
-        .then(() => {
-          const {
-            nomService,
-            organisationsResponsables,
-            presentation,
-            pointsAcces,
-          } = donneesPersistees.descriptionService;
+      await depot.nouveauService('123', { descriptionService });
 
-          expect(nomService).to.equal('Service A - chiffré');
-          expect(organisationsResponsables).to.eql(['ANSSI - chiffré']);
-          expect(presentation).to.eql('Le service fait A & B - chiffré');
-          expect(pointsAcces).to.eql([
-            { description: 'https://site.fr - chiffré' },
-            { description: 'https://autre.site.fr - chiffré' },
-          ]);
-          done();
-        })
-        .catch(done);
+      const { nomService } = donneesPersistees.descriptionService;
+
+      expect(nomService).to.equal('Service A - chiffré');
     });
 
     it('ajoute en copie un nouveau service au dépôt', (done) => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -516,6 +516,7 @@ describe('Le dépôt de données des homologations', () => {
       }
     );
     const depot = DepotDonneesHomologations.creeDepot({
+      adaptateurChiffrement: fauxAdaptateurChiffrement(),
       adaptateurPersistance,
     });
 
@@ -557,6 +558,7 @@ describe('Le dépôt de données des homologations', () => {
           services: [copie(donneesHomologation)],
         });
       const depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
       });
 
@@ -589,6 +591,7 @@ describe('Le dépôt de données des homologations', () => {
       }
     );
     const depot = DepotDonneesHomologations.creeDepot({
+      adaptateurChiffrement: fauxAdaptateurChiffrement(),
       adaptateurPersistance,
     });
 
@@ -620,6 +623,7 @@ describe('Le dépôt de données des homologations', () => {
       }
     );
     const depot = DepotDonneesHomologations.creeDepot({
+      adaptateurChiffrement: fauxAdaptateurChiffrement(),
       adaptateurPersistance,
     });
 
@@ -1091,6 +1095,7 @@ describe('Le dépôt de données des homologations', () => {
           services: [copie(donneesHomologations)],
         });
       const depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
         adaptateurUUID,
       });
@@ -1115,6 +1120,7 @@ describe('Le dépôt de données des homologations', () => {
         });
       adaptateurUUID.genereUUID = () => '999';
       const depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
         adaptateurUUID,
       });
@@ -1174,6 +1180,7 @@ describe('Le dépôt de données des homologations', () => {
           services: [copie(donneesHomologations)],
         });
       const depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
         adaptateurUUID,
         referentiel,
@@ -1216,6 +1223,7 @@ describe('Le dépôt de données des homologations', () => {
           services: [copie(donneesHomologations)],
         });
       const depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
         adaptateurUUID,
         referentiel,
@@ -1252,6 +1260,7 @@ describe('Le dépôt de données des homologations', () => {
           services: [copie(donneesService)],
         });
       const depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
         adaptateurUUID,
         referentiel,
@@ -1288,6 +1297,7 @@ describe('Le dépôt de données des homologations', () => {
       adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
       adaptateurPersistance = unePersistanceMemoire().construis();
       depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurJournalMSS,
         adaptateurPersistance,
         referentiel,
@@ -1381,6 +1391,7 @@ describe('Le dépôt de données des homologations', () => {
         });
 
       depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurJournalMSS: AdaptateurJournalMSSMemoire.nouvelAdaptateur(),
         adaptateurPersistance,
         adaptateurTracking: unAdaptateurTracking().construis(),

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -148,11 +148,19 @@ describe('Le dépôt de données des homologations', () => {
   });
 
   it('peut retrouver une homologation à partir de son identifiant', async () => {
+    const adaptateurChiffrement = {
+      dechiffre: async (chaine) => chaine.replace(' - chiffré', ''),
+    };
+
     const adaptateurPersistance = unePersistanceMemoire()
-      .ajouteUnService({ id: '789', descriptionService: { nomService: 'nom' } })
+      .ajouteUnService({
+        id: '789',
+        descriptionService: { nomService: 'nom - chiffré' },
+      })
       .construis();
     const referentiel = Referentiel.creeReferentielVide();
     const depot = DepotDonneesHomologations.creeDepot({
+      adaptateurChiffrement,
       adaptateurPersistance,
       referentiel,
     });
@@ -162,6 +170,7 @@ describe('Le dépôt de données des homologations', () => {
     expect(homologation).to.be.a(Homologation);
     expect(homologation.id).to.equal('789');
     expect(homologation.referentiel).to.equal(referentiel);
+    expect(homologation.nomService()).to.be('nom');
   });
 
   it("associe ses contributeurs à l'homologation", async () => {
@@ -181,6 +190,7 @@ describe('Le dépôt de données des homologations', () => {
       }
     );
     const depot = DepotDonneesHomologations.creeDepot({
+      adaptateurChiffrement: fauxAdaptateurChiffrement(),
       adaptateurPersistance,
     });
 
@@ -1072,6 +1082,7 @@ describe('Le dépôt de données des homologations', () => {
           services: [copie(donneesHomologations)],
         });
       const depot = DepotDonneesHomologations.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
         adaptateurPersistance,
         adaptateurUUID,
       });

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -1,5 +1,5 @@
 const fauxAdaptateurChiffrement = () => ({
-  chiffre: (chaine) => chaine,
+  chiffre: async (chaine) => chaine,
   hacheBCrypt: (chaine) => Promise.resolve(`${chaine}-haché`),
   compareBCrypt: (enClair, chiffreeReference) =>
     fauxAdaptateurChiffrement()

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -1,5 +1,6 @@
 const fauxAdaptateurChiffrement = () => ({
   chiffre: async (chaine) => chaine,
+  dechiffre: async (chaine) => chaine,
   hacheBCrypt: (chaine) => Promise.resolve(`${chaine}-haché`),
   compareBCrypt: (enClair, chiffreeReference) =>
     fauxAdaptateurChiffrement()


### PR DESCRIPTION
### 🪧 Contexte
Nous allons bientôt avoir un « Vault as a service » à disposition. Le code chiffrera donc les données métier avant de les stocker.
Le but est que le code puisse supporter cette fonctionnalité dès que le Vault sera disponible.
Cette PR est la première sur ce chemin du support total du chiffrement.

### 🛠️  PR
Ici on ajoute le support de `chiffre` et `dechiffre` dans `adaptateurChiffrementVault`.
Ce nouvel adaptateur est utilisé si `AVEC_CHIFFREMENT_VAULT=true`. Sinon, c'est le chiffrement déjà en place (qui ne fait rien, donc) qui est utilisé.
La PR modifie `depotDonneesHomologations` pour que la sauvegarde et la lecture de **un** service passe par le chiffrement / déchiffrement.

### 🗺️  Feuille de route

- [ ] POCer le support du chiffrement / déchiffrement **⬅️ cette PR**.
- [ ] Chiffrer / déchiffrer tous les points d'entrée de la persistance.
  - attention particulière sur la duplication de services, qui requête les noms de service en BDD : ce ne sera plus possible.
- [ ] Étendre le chiffrement de TOUTES les données métiers.
- [ ] Une migration des données qui chiffre tous les services.
- [ ] Pour travailler en local : s'assurer que `mss-crypto` en mode Docker permet de faire fonctionner le chiffrement. 
  - L'adaptateur Vault doit parler à `mss-crypto` en local. 
  - Ça veut dire aussi documenter la partie « mise en route de Vault » dans le `README`.