### PR TITLE
[SOIN] Utilise le constructeur de `depot`

### DIFF
--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -20,7 +20,7 @@ class ConstructeurAutorisation {
     return this;
   }
 
-  deProprietaireDeService(idUtilisateur, idService) {
+  deProprietaire(idUtilisateur, idService) {
     this.donnees.estProprietaire = true;
     this.donnees.idUtilisateur = idUtilisateur;
     this.donnees.idService = idService;
@@ -28,7 +28,7 @@ class ConstructeurAutorisation {
     return this;
   }
 
-  deContributeurDeService(idUtilisateur, idService) {
+  deContributeur(idUtilisateur, idService) {
     this.donnees.estProprietaire = false;
     this.donnees.idUtilisateur = idUtilisateur;
     this.donnees.idService = idService;

--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -11,14 +11,14 @@ class ConstructeurService {
       contributeurs: [],
     };
     this.mesures = undefined;
+    this.risques = undefined;
     this.referentiel = referentiel;
   }
 
   construis() {
     const service = new Service(this.donnees, this.referentiel);
-    if (this.mesures !== undefined) {
-      service.mesures = this.mesures;
-    }
+    if (this.mesures !== undefined) service.mesures = this.mesures;
+    if (this.risques !== undefined) service.risques = this.risques;
     return service;
   }
 
@@ -34,6 +34,11 @@ class ConstructeurService {
 
   avecMesures(mesures) {
     this.mesures = mesures;
+    return this;
+  }
+
+  avecRisques(risques) {
+    this.risques = risques;
     return this;
   }
 

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -57,7 +57,7 @@ describe('Le dépôt de données des autorisations', () => {
       const avecDroitEcriture = unePersistanceMemoire()
         .ajouteUneAutorisation(
           uneAutorisation()
-            .deProprietaireDeService('456', '123')
+            .deProprietaire('456', '123')
             .avecDroits({ [DECRIRE]: ECRITURE }).donnees
         )
         .construis();
@@ -75,7 +75,7 @@ describe('Le dépôt de données des autorisations', () => {
       const avecDroitLecture = unePersistanceMemoire()
         .ajouteUneAutorisation(
           uneAutorisation()
-            .deContributeurDeService('456', '123')
+            .deContributeur('456', '123')
             .avecDroits({ [DECRIRE]: LECTURE }).donnees
         )
         .construis();
@@ -98,8 +98,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-            .donnees
+          uneAutorisation().avecId('456').deProprietaire('999', '123').donnees
         )
         .construis();
 
@@ -131,8 +130,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-            .donnees
+          uneAutorisation().avecId('456').deProprietaire('999', '123').donnees
         )
         .construis();
 
@@ -140,7 +138,7 @@ describe('Le dépôt de données des autorisations', () => {
 
       try {
         await depot.ajouteContributeurAuService(
-          uneAutorisation().deContributeurDeService('000', '123').construis()
+          uneAutorisation().deContributeur('000', '123').construis()
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
@@ -159,7 +157,7 @@ describe('Le dépôt de données des autorisations', () => {
 
       try {
         await depot.ajouteContributeurAuService(
-          uneAutorisation().deContributeurDeService('000', '123').construis()
+          uneAutorisation().deContributeur('000', '123').construis()
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
@@ -176,8 +174,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-            .donnees
+          uneAutorisation().avecId('456').deProprietaire('999', '123').donnees
         )
         .construis();
 
@@ -185,7 +182,7 @@ describe('Le dépôt de données des autorisations', () => {
 
       try {
         await depot.ajouteContributeurAuService(
-          uneAutorisation().deContributeurDeService('999', '123').construis()
+          uneAutorisation().deContributeur('999', '123').construis()
         );
         expect().to.fail("L'ajout aurait du lever une erreur");
       } catch (erreur) {
@@ -203,8 +200,7 @@ describe('Le dépôt de données des autorisations', () => {
           descriptionService: { nomService: 'Un service' },
         })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deContributeurDeService('999', '123')
-            .donnees
+          uneAutorisation().avecId('456').deContributeur('999', '123').donnees
         )
         .construis();
 
@@ -213,7 +209,7 @@ describe('Le dépôt de données des autorisations', () => {
 
       await depot.ajouteContributeurAuService(
         uneAutorisation()
-          .deContributeurDeService('000', '123')
+          .deContributeur('000', '123')
           .avecTousDroitsEcriture()
           .construis()
       );
@@ -238,8 +234,7 @@ describe('Le dépôt de données des autorisations', () => {
         .ajouteUnService({ id: '123', descriptionService: { nomService: 'X' } })
         .ajouteUnUtilisateur({ id: '999', email: 'jean.dupont@mail.fr' })
         .ajouteUneAutorisation(
-          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-            .donnees
+          uneAutorisation().avecId('456').deProprietaire('999', '123').donnees
         )
         .ajouteUnUtilisateur({ id: '000', email: 'contributeur@mail.fr' })
         .construis();
@@ -249,7 +244,7 @@ describe('Le dépôt de données des autorisations', () => {
 
       await depot.ajouteContributeurAuService(
         uneAutorisation()
-          .deContributeurDeService('000', '123')
+          .deContributeur('000', '123')
           .avecTousDroitsEcriture()
           .construis()
       );
@@ -277,8 +272,7 @@ describe('Le dépôt de données des autorisations', () => {
         descriptionService: { nomService: 'Un service' },
       })
       .ajouteUneAutorisation(
-        uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-          .donnees
+        uneAutorisation().avecId('456').deProprietaire('999', '123').donnees
       )
       .construis();
 
@@ -298,8 +292,7 @@ describe('Le dépôt de données des autorisations', () => {
         descriptionService: { nomService: 'Un service' },
       })
       .ajouteUneAutorisation(
-        uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-          .donnees
+        uneAutorisation().avecId('456').deProprietaire('999', '123').donnees
       )
       .construis();
 
@@ -335,7 +328,7 @@ describe('Le dépôt de données des autorisations', () => {
     it("empêche l'utilisateur de supprimer sa propre autorisation", async () => {
       const autorisationPour123 = unePersistanceMemoire()
         .ajouteUneAutorisation(
-          uneAutorisation().deProprietaireDeService('123', 'ABC').donnees
+          uneAutorisation().deProprietaire('123', 'ABC').donnees
         )
         .construis();
       const depot = creeDepot(autorisationPour123);
@@ -354,7 +347,7 @@ describe('Le dépôt de données des autorisations', () => {
     it('supprime le contributeur', async () => {
       const avecUneAutorisation = unePersistanceMemoire()
         .ajouteUneAutorisation(
-          uneAutorisation().deContributeurDeService('000', 'ABC').donnees
+          uneAutorisation().deContributeur('000', 'ABC').donnees
         )
         .construis();
 
@@ -379,10 +372,10 @@ describe('Le dépôt de données des autorisations', () => {
         descriptionService: { nomService: 'Un service' },
       })
       .ajouteUneAutorisation(
-        uneAutorisation().deProprietaireDeService('888', '123').donnees
+        uneAutorisation().deProprietaire('888', '123').donnees
       )
       .ajouteUneAutorisation(
-        uneAutorisation().deContributeurDeService('999', '123').donnees
+        uneAutorisation().deContributeur('999', '123').donnees
       )
       .construis();
 
@@ -398,7 +391,7 @@ describe('Le dépôt de données des autorisations', () => {
   it('sait sauvegarder une autorisation', async () => {
     const enEcriture = uneAutorisation()
       .avecId('uuid-a')
-      .deContributeurDeService('123', '999')
+      .deContributeur('123', '999')
       .avecTousDroitsEcriture();
     const depot = creeDepot(
       unePersistanceMemoire()

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -708,36 +708,31 @@ describe('Le dépôt de données des homologations', () => {
       expect(service.nomService()).to.equal('Service');
     });
 
-    it("déclare un accès en écriture entre l'utilisateur et le service", (done) => {
+    it("déclare un accès en écriture entre l'utilisateur et le service", async () => {
       const depotAutorisations = DepotDonneesAutorisations.creeDepot({
         adaptateurPersistance,
       });
-      const descriptionService = uneDescriptionValide(referentiel)
-        .construis()
-        .toJSON();
 
-      depotAutorisations
-        .autorisations('123')
-        .then((as) => expect(as.length).to.equal(0))
-        .then(() => depot.nouveauService('123', { descriptionService }))
-        .then(() => depotAutorisations.autorisations('123'))
-        .then((as) => {
-          expect(as.length).to.equal(1);
-          const autorisation = as[0];
-          expect(autorisation.estProprietaire).to.be(true);
-          expect(autorisation.idHomologation).to.equal('unUUID');
-          expect(autorisation.idService).to.equal('unUUID');
-          expect(autorisation.idUtilisateur).to.equal('123');
-          expect(autorisation.droits).to.eql({
-            [DECRIRE]: ECRITURE,
-            [SECURISER]: ECRITURE,
-            [HOMOLOGUER]: ECRITURE,
-            [RISQUES]: ECRITURE,
-            [CONTACTS]: ECRITURE,
-          });
-          done();
-        })
-        .catch(done);
+      const avant = await depotAutorisations.autorisations('123');
+      expect(avant.length).to.equal(0);
+
+      const descriptionService = uneDescriptionValide(referentiel).donnees;
+      await depot.nouveauService('123', { descriptionService });
+
+      const apres = await depotAutorisations.autorisations('123');
+      expect(apres.length).to.equal(1);
+      const autorisation = apres[0];
+      expect(autorisation.estProprietaire).to.be(true);
+      expect(autorisation.idHomologation).to.equal('unUUID');
+      expect(autorisation.idService).to.equal('unUUID');
+      expect(autorisation.idUtilisateur).to.equal('123');
+      expect(autorisation.droits).to.eql({
+        [DECRIRE]: ECRITURE,
+        [SECURISER]: ECRITURE,
+        [HOMOLOGUER]: ECRITURE,
+        [RISQUES]: ECRITURE,
+        [CONTACTS]: ECRITURE,
+      });
     });
 
     it('publie un événement de "Nouveau service créé"', async () => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -617,12 +617,11 @@ describe('Le dépôt de données des homologations', () => {
     beforeEach(() => {
       adaptateurChiffrement = fauxAdaptateurChiffrement();
       adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
-      adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
-        utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
-        homologations: [],
-        services: [],
-        autorisations: [],
-      });
+      adaptateurPersistance = unePersistanceMemoire()
+        .ajouteUnUtilisateur(
+          unUtilisateur().avecId('123').avecEmail('jean.dupont@mail.fr').donnees
+        )
+        .construis();
       adaptateurTracking = unAdaptateurTracking().construis();
       adaptateurUUID = { genereUUID: () => 'unUUID' };
       busEvenements = fabriqueBusPourLesTests();

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -206,18 +206,14 @@ describe('Le dépôt de données des homologations', () => {
 
     beforeEach(() => {
       busEvenements = fabriqueBusPourLesTests();
-      const utilisateur = unUtilisateur().avecId('789').donnees;
-      const autorisation = uneAutorisation().deProprietaire(
-        '789',
-        '123'
-      ).donnees;
-      const service = unService(referentiel)
-        .avecId('123')
-        .avecNomService('nom').donnees;
       adaptateurPersistance = unePersistanceMemoire()
-        .ajouteUnService(service)
-        .ajouteUneAutorisation(autorisation)
-        .ajouteUnUtilisateur(utilisateur);
+        .ajouteUnUtilisateur(unUtilisateur().avecId('789').donnees)
+        .ajouteUnService(
+          unService(referentiel).avecId('123').avecNomService('nom').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('789', '123').donnees
+        );
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
         .avecAdaptateurPersistance(adaptateurPersistance)

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -169,32 +169,28 @@ describe('Le dépôt de données des homologations', () => {
   });
 
   it("associe ses contributeurs à l'homologation", async () => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
-      {
-        utilisateurs: [
-          { id: '111', email: 'createur@mail.fr' },
-          { id: '999', email: 'contributeur@mail.fr' },
-        ],
-        homologations: [
-          { id: '789', descriptionService: { nomService: 'nom' } },
-        ],
-        autorisations: [
-          uneAutorisation().deProprietaire('111', '789').donnees,
-          uneAutorisation().deContributeur('999', '789').donnees,
-        ],
-      }
-    );
-    const depot = DepotDonneesHomologations.creeDepot({
-      adaptateurChiffrement: fauxAdaptateurChiffrement(),
-      adaptateurPersistance,
-    });
+    const r = Referentiel.creeReferentielVide();
+    const persistance = unePersistanceMemoire()
+      .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+      .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
+      .ajouteUnService(unService(r).avecId('S1').donnees)
+      .ajouteUneAutorisation(
+        uneAutorisation().deProprietaire('U1', 'S1').donnees
+      )
+      .ajouteUneAutorisation(
+        uneAutorisation().deContributeur('U2', 'S1').donnees
+      );
+    const depot = unDepotDeDonneesServices()
+      .avecReferentiel(r)
+      .avecAdaptateurPersistance(persistance)
+      .construis();
 
-    const homologation = await depot.homologation('789');
+    const homologation = await depot.homologation('S1');
 
     const { contributeurs } = homologation;
     expect(contributeurs.length).to.equal(2);
-    expect(contributeurs[0].id).to.equal('111');
-    expect(contributeurs[1].id).to.equal('999');
+    expect(contributeurs[0].id).to.equal('U1');
+    expect(contributeurs[1].id).to.equal('U2');
   });
 
   describe("sur demande d'associations de mesures à un service", () => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -573,7 +573,7 @@ describe('Le dépôt de données des homologations', () => {
     expect(risquesSpecifiques.item(0).description).to.equal('Un risque');
   });
 
-  it('supprime les risques spécifiques précédemment associés', (done) => {
+  it('supprime les risques spécifiques précédemment associés', async () => {
     const donneesHomologations = {
       id: '123',
       descriptionService: { nomService: 'nom' },
@@ -593,18 +593,14 @@ describe('Le dépôt de données des homologations', () => {
     const risques = new RisquesSpecifiques({
       risquesSpecifiques: [{ description: 'Un nouveau risque' }],
     });
-    depot
-      .remplaceRisquesSpecifiquesDuService('123', risques)
-      .then(() => depot.homologation('123'))
-      .then(({ risques: { risquesSpecifiques } }) => {
-        expect(risquesSpecifiques.nombre()).to.equal(1);
-        expect(risquesSpecifiques.item(0)).to.be.a(RisqueSpecifique);
-        expect(risquesSpecifiques.item(0).description).to.equal(
-          'Un nouveau risque'
-        );
-        done();
-      })
-      .catch(done);
+    await depot.remplaceRisquesSpecifiquesDuService('123', risques);
+
+    const {
+      risques: { risquesSpecifiques },
+    } = await depot.homologation('123');
+    expect(risquesSpecifiques.nombre()).to.equal(1);
+    expect(risquesSpecifiques.item(0)).to.be.a(RisqueSpecifique);
+    expect(risquesSpecifiques.item(0).description).to.be('Un nouveau risque');
   });
 
   describe("quand il reçoit une demande d'enregistrement d'un nouveau service", () => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -61,31 +61,23 @@ const { ECRITURE } = Permissions;
 
 describe('Le dépôt de données des homologations', () => {
   it("connaît toutes les homologations d'un utilisateur donné", async () => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
-      {
-        homologations: [
-          { id: '123', descriptionService: { nomService: 'Super Service' } },
-          { id: '789', descriptionService: { nomService: 'Autre service' } },
-        ],
-        utilisateurs: [
-          {
-            id: '456',
-            prenom: 'Jean',
-            nom: 'Dupont',
-            email: 'jean.dupont@mail.fr',
-          },
-        ],
-        autorisations: [
-          uneAutorisation().deProprietaireDeService('456', '123').donnees,
-          uneAutorisation().deProprietaireDeService('999', '789').donnees,
-        ],
-      }
-    );
     const referentiel = Referentiel.creeReferentielVide();
-    const depot = DepotDonneesHomologations.creeDepot({
-      adaptateurPersistance,
-      referentiel,
-    });
+
+    const adaptateurPersistance = unePersistanceMemoire()
+      .ajouteUnService(unService(referentiel).avecId('123').donnees)
+      .ajouteUnService(unService(referentiel).avecId('789').donnees)
+      .ajouteUnUtilisateur(unUtilisateur().avecId('456').donnees)
+      .ajouteUneAutorisation(
+        uneAutorisation().deProprietaireDeService('456', '123').donnees
+      )
+      .ajouteUneAutorisation(
+        uneAutorisation().deProprietaireDeService('999', '789').donnees
+      );
+
+    const depot = unDepotDeDonneesServices()
+      .avecAdaptateurPersistance(adaptateurPersistance)
+      .avecReferentiel(referentiel)
+      .construis();
 
     const homologations = await depot.homologations('456');
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -497,7 +497,7 @@ describe('Le dépôt de données des homologations', () => {
     });
   });
 
-  it('sait associer des rôles et responsabilités à une homologation', (done) => {
+  it('sait associer des rôles et responsabilités à une homologation', async () => {
     const donneesHomologation = {
       id: '123',
       descriptionService: { nomService: 'nom' },
@@ -516,16 +516,10 @@ describe('Le dépôt de données des homologations', () => {
     const roles = new RolesResponsabilites({
       autoriteHomologation: 'Jean Dupont',
     });
-    depot
-      .ajouteRolesResponsabilitesAService('123', roles)
-      .then(() => depot.homologation('123'))
-      .then(({ rolesResponsabilites }) => {
-        expect(rolesResponsabilites.autoriteHomologation).to.equal(
-          'Jean Dupont'
-        );
-        done();
-      })
-      .catch(done);
+    await depot.ajouteRolesResponsabilitesAService('123', roles);
+
+    const { rolesResponsabilites } = await depot.homologation('123');
+    expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean Dupont');
   });
 
   describe('concernant les risques généraux', () => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -528,30 +528,23 @@ describe('Le dépôt de données des homologations', () => {
     it('sait associer un risque général à une homologation', async () => {
       RisqueGeneral.valide = () => {};
 
-      const donneesHomologation = {
-        id: '123',
-        descriptionService: { nomService: 'nom' },
-      };
-      const adaptateurPersistance =
-        AdaptateurPersistanceMemoire.nouvelAdaptateur({
-          homologations: [copie(donneesHomologation)],
-          services: [copie(donneesHomologation)],
-        });
-      const depot = DepotDonneesHomologations.creeDepot({
-        adaptateurChiffrement: fauxAdaptateurChiffrement(),
-        adaptateurPersistance,
-      });
+      const r = Referentiel.creeReferentielVide();
+      const depot = unDepotDeDonneesServices()
+        .avecReferentiel(r)
+        .avecAdaptateurPersistance(
+          unePersistanceMemoire().ajouteUnService(
+            unService(r).avecId('S1').donnees
+          )
+        )
+        .construis();
 
-      const risque = new RisqueGeneral({
-        id: 'unRisque',
-        commentaire: 'Un commentaire',
-      });
-      await depot.ajouteRisqueGeneralAService('123', risque);
+      const risque = new RisqueGeneral({ id: 'R1' });
+      await depot.ajouteRisqueGeneralAService('S1', risque);
 
-      const { risques } = await depot.homologation('123');
+      const { risques } = await depot.homologation('S1');
       expect(risques.risquesGeneraux.nombre()).to.equal(1);
       expect(risques.risquesGeneraux.item(0)).to.be.a(RisqueGeneral);
-      expect(risques.risquesGeneraux.item(0).id).to.equal('unRisque');
+      expect(risques.risquesGeneraux.item(0).id).to.equal('R1');
     });
   });
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -653,27 +653,16 @@ describe('Le dépôt de données des homologations', () => {
       expect(apres[0].nomService()).to.equal('Super Service');
     });
 
-    it('génère un UUID pour le service créée', (done) => {
+    it('génère un UUID pour le service créée', async () => {
       adaptateurUUID.genereUUID = () => '11111111-1111-1111-1111-111111111111';
 
-      const descriptionService = uneDescriptionValide(referentiel)
-        .avecNomService('Super Service')
-        .construis()
-        .toJSON();
+      const idService = await depot.nouveauService('123', {
+        descriptionService: uneDescriptionValide(referentiel).donnees,
+      });
 
-      depot
-        .nouveauService('123', { descriptionService })
-        .then((idService) =>
-          expect(idService).to.equal('11111111-1111-1111-1111-111111111111')
-        )
-        .then(() => depot.homologations('123'))
-        .then((homologations) => {
-          expect(homologations[0].id).to.equal(
-            '11111111-1111-1111-1111-111111111111'
-          );
-          done();
-        })
-        .catch(done);
+      expect(idService).to.be('11111111-1111-1111-1111-111111111111');
+      const services = await depot.homologations('123');
+      expect(services[0].id).to.be('11111111-1111-1111-1111-111111111111');
     });
 
     it('chiffre les données métier avant de les stocker', async () => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -638,23 +638,19 @@ describe('Le dépôt de données des homologations', () => {
       });
     });
 
-    it('ajoute le nouveau service au dépôt', (done) => {
+    it('ajoute le nouveau service au dépôt', async () => {
+      const avant = await depot.homologations('123');
+      expect(avant.length).to.equal(0);
+
       const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Super Service')
         .construis()
         .toJSON();
+      await depot.nouveauService('123', { descriptionService });
 
-      depot
-        .homologations('123')
-        .then((homologations) => expect(homologations.length).to.equal(0))
-        .then(() => depot.nouveauService('123', { descriptionService }))
-        .then(() => depot.homologations('123'))
-        .then((services) => {
-          expect(services.length).to.equal(1);
-          expect(services[0].nomService()).to.equal('Super Service');
-          done();
-        })
-        .catch(done);
+      const apres = await depot.homologations('123');
+      expect(apres.length).to.equal(1);
+      expect(apres[0].nomService()).to.equal('Super Service');
     });
 
     it('génère un UUID pour le service créée', (done) => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -373,20 +373,16 @@ describe('Le dépôt de données des homologations', () => {
 
     beforeEach(() => {
       referentiel = Referentiel.creeReferentielVide();
-      const utilisateur = unUtilisateur()
-        .avecId('999')
-        .avecEmail('jean.dupont@mail.fr').donnees;
-      const autorisation = uneAutorisation().deProprietaire(
-        '999',
-        '123'
-      ).donnees;
-      const service = unService(referentiel)
-        .avecId('123')
-        .avecNomService('Super Service').donnees;
       adaptateurPersistance = unePersistanceMemoire()
-        .ajouteUnService(service)
-        .ajouteUneAutorisation(autorisation)
-        .ajouteUnUtilisateur(utilisateur);
+        .ajouteUnUtilisateur(
+          unUtilisateur().avecId('U1').avecEmail('jean.dupont@mail.fr').donnees
+        )
+        .ajouteUnService(
+          unService(referentiel).avecId('S1').avecNomService('Service').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('U1', 'S1').donnees
+        );
       adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
@@ -400,9 +396,9 @@ describe('Le dépôt de données des homologations', () => {
         .avecNomService('Nouveau Nom')
         .construis();
 
-      await depot.ajouteDescriptionService('999', '123', description);
+      await depot.ajouteDescriptionService('U1', 'S1', description);
 
-      const { descriptionService } = await depot.homologation('123');
+      const { descriptionService } = await depot.homologation('S1');
       expect(descriptionService.nomService).to.equal('Nouveau Nom');
     });
 
@@ -415,9 +411,9 @@ describe('Le dépôt de données des homologations', () => {
         .avecNomService('Nouveau Nom')
         .construis();
 
-      await depot.ajouteDescriptionService('999', '123', description);
+      await depot.ajouteDescriptionService('U1', 'S1', description);
 
-      const { descriptionService } = await depotServices.service('123');
+      const { descriptionService } = await depotServices.service('S1');
       expect(descriptionService.nomService).to.equal('Nouveau Nom');
     });
 
@@ -427,7 +423,7 @@ describe('Le dépôt de données des homologations', () => {
         .construis();
 
       depot
-        .ajouteDescriptionService('999', '123', descriptionIncomplete)
+        .ajouteDescriptionService('U1', 'S1', descriptionIncomplete)
         .then(() =>
           done(
             'La mise à jour de la description du service aurait dû lever une exception'
@@ -443,14 +439,14 @@ describe('Le dépôt de données des homologations', () => {
         .catch(done);
     });
 
-    it("ne détecte pas de doublon sur le nom de service pour l'homologation en cours de mise à jour", async () => {
+    it('ne détecte pas de doublon sur le nom de service pour le service en cours de mise à jour', async () => {
       const description = uneDescriptionValide(referentiel)
         .avecPresentation('Une autre présentation')
         .construis();
 
-      await depot.ajouteDescriptionService('999', '123', description);
+      await depot.ajouteDescriptionService('U1', 'S1', description);
 
-      const { descriptionService } = await depot.homologation('123');
+      const { descriptionService } = await depot.homologation('S1');
       expect(descriptionService.presentation).to.equal(
         'Une autre présentation'
       );
@@ -464,7 +460,7 @@ describe('Le dépôt de données des homologations', () => {
       };
       const description = uneDescriptionValide(referentiel).construis();
 
-      await depot.ajouteDescriptionService('999', '123', description);
+      await depot.ajouteDescriptionService('U1', 'S1', description);
 
       expect(evenementRecu.type).to.equal('COMPLETUDE_SERVICE_MODIFIEE');
     });
@@ -488,7 +484,7 @@ describe('Le dépôt de données des homologations', () => {
         )
         .construis();
 
-      await depot.ajouteDescriptionService('999', '123', description);
+      await depot.ajouteDescriptionService('U1', 'S1', description);
 
       expect(donneesPassees).to.eql({
         destinataire: 'jean.dupont@mail.fr',

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -839,39 +839,29 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     it('ne considère pas le service en cours de mise à jour', async () => {
-      const adaptateurPersistance =
-        AdaptateurPersistanceMemoire.nouvelAdaptateur({
-          utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
-          homologations: [
-            {
-              id: '888',
-              descriptionService: { nomService: 'Un service existant' },
-            },
-            {
-              id: '999',
-              descriptionService: { nomService: 'Un nom de service' },
-            },
-          ],
-          autorisations: [
-            uneAutorisation().deProprietaire('123', '888').donnees,
-            uneAutorisation().deProprietaire('123', '999').donnees,
-          ],
-        });
-      const depot = DepotDonneesHomologations.creeDepot({
-        adaptateurPersistance,
-      });
+      const r = Referentiel.creeReferentielVide();
+      const persistance = unePersistanceMemoire()
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .ajouteUnService(
+          unService(r).avecId('S1').avecNomService('Le S1').donnees
+        )
+        .ajouteUnService(
+          unService(r).avecId('S2').avecNomService('Autre service').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('U1', 'S1').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('U1', 'S1').donnees
+        );
+      const depot = unDepotDeDonneesServices()
+        .avecReferentiel(r)
+        .avecAdaptateurPersistance(persistance)
+        .construis();
 
-      const considereEnCours = await depot.serviceExiste(
-        '123',
-        'Un service existant',
-        '888'
-      );
+      const considereEnCours = await depot.serviceExiste('U1', 'Le S1', 'S1');
       expect(considereEnCours).to.be(false);
-      const considereAutre = await depot.serviceExiste(
-        '123',
-        'Un service existant',
-        '999'
-      );
+      const considereAutre = await depot.serviceExiste('U1', 'Le S1', 'S2');
       expect(considereAutre).to.be(true);
     });
   });

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -838,7 +838,7 @@ describe('Le dépôt de données des homologations', () => {
       expect(existeChezU1).to.be(true);
     });
 
-    it("ne considère pas l'homologation en cours de mise à jour", (done) => {
+    it('ne considère pas le service en cours de mise à jour', async () => {
       const adaptateurPersistance =
         AdaptateurPersistanceMemoire.nouvelAdaptateur({
           utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
@@ -861,13 +861,18 @@ describe('Le dépôt de données des homologations', () => {
         adaptateurPersistance,
       });
 
-      depot
-        .serviceExiste('123', 'Un service existant', '888')
-        .then((homologationExiste) => expect(homologationExiste).to.be(false))
-        .then(() => depot.serviceExiste('123', 'Un service existant', '999'))
-        .then((homologationExiste) => expect(homologationExiste).to.be(true))
-        .then(() => done())
-        .catch(done);
+      const considereEnCours = await depot.serviceExiste(
+        '123',
+        'Un service existant',
+        '888'
+      );
+      expect(considereEnCours).to.be(false);
+      const considereAutre = await depot.serviceExiste(
+        '123',
+        'Un service existant',
+        '999'
+      );
+      expect(considereAutre).to.be(true);
     });
   });
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -815,7 +815,7 @@ describe('Le dépôt de données des homologations', () => {
       expect(existeNomCorrect).to.be(true);
     });
 
-    it("ne considère que les homologations de l'utilisateur donné", (done) => {
+    it("ne considère que les services de l'utilisateur donné", async () => {
       const adaptateurPersistance =
         AdaptateurPersistanceMemoire.nouvelAdaptateur({
           utilisateurs: [
@@ -834,11 +834,11 @@ describe('Le dépôt de données des homologations', () => {
         adaptateurPersistance,
       });
 
-      depot
-        .serviceExiste('456', 'Un service existant')
-        .then((homologationExiste) => expect(homologationExiste).to.be(false))
-        .then(() => done())
-        .catch(done);
+      const serviceExiste = await depot.serviceExiste(
+        '456',
+        'Un service existant'
+      );
+      expect(serviceExiste).to.be(false);
     });
 
     it("ne considère pas l'homologation en cours de mise à jour", (done) => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -105,33 +105,30 @@ describe('Le dépôt de données des homologations', () => {
   });
 
   it('trie les homologations par ordre alphabétique du nom du service', async () => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
-      {
-        homologations: [
-          { id: '123', descriptionService: { nomService: 'B-service' } },
-          { id: '456', descriptionService: { nomService: 'C-service' } },
-          { id: '789', descriptionService: { nomService: 'A-service' } },
-        ],
-        utilisateurs: [
-          {
-            id: '999',
-            prenom: 'Jean',
-            nom: 'Dupont',
-            email: 'jean.dupont@mail.fr',
-          },
-        ],
-        autorisations: [
-          uneAutorisation().deProprietaire('999', '123').donnees,
-          uneAutorisation().deProprietaire('999', '456').donnees,
-          uneAutorisation().deProprietaire('999', '789').donnees,
-        ],
-      }
-    );
-    const depot = DepotDonneesHomologations.creeDepot({
-      adaptateurPersistance,
-    });
+    const r = Referentiel.creeReferentielVide();
+    const persistance = unePersistanceMemoire()
+      .ajouteUnUtilisateur(unUtilisateur().avecId('U').donnees)
+      .ajouteUnService(
+        unService(r).avecId('1').avecNomService('B-service').donnees
+      )
+      .ajouteUnService(
+        unService(r).avecId('2').avecNomService('C-service').donnees
+      )
+      .ajouteUnService(
+        unService(r).avecId('3').avecNomService('A-service').donnees
+      )
+      .ajouteUneAutorisation(uneAutorisation().deProprietaire('U', '1').donnees)
+      .ajouteUneAutorisation(uneAutorisation().deProprietaire('U', '2').donnees)
+      .ajouteUneAutorisation(
+        uneAutorisation().deProprietaire('U', '3').donnees
+      );
 
-    const hs = await depot.homologations('999');
+    const depot = unDepotDeDonneesServices()
+      .avecReferentiel(r)
+      .avecAdaptateurPersistance(persistance)
+      .construis();
+
+    const hs = await depot.homologations('U');
 
     expect(hs.length).to.equal(3);
     expect(hs[0].nomService()).to.equal('A-service');

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -548,7 +548,7 @@ describe('Le dépôt de données des homologations', () => {
     });
   });
 
-  it('sait associer un risque spécifique à une homologation', (done) => {
+  it('sait associer un risque spécifique à une homologation', async () => {
     const donneesHomologation = {
       id: '123',
       descriptionService: { nomService: 'nom' },
@@ -567,16 +567,14 @@ describe('Le dépôt de données des homologations', () => {
     const risque = new RisquesSpecifiques({
       risquesSpecifiques: [{ description: 'Un risque' }],
     });
-    depot
-      .remplaceRisquesSpecifiquesDuService('123', risque)
-      .then(() => depot.homologation('123'))
-      .then(({ risques: { risquesSpecifiques } }) => {
-        expect(risquesSpecifiques.nombre()).to.equal(1);
-        expect(risquesSpecifiques.item(0)).to.be.a(RisqueSpecifique);
-        expect(risquesSpecifiques.item(0).description).to.equal('Un risque');
-        done();
-      })
-      .catch(done);
+    await depot.remplaceRisquesSpecifiquesDuService('123', risque);
+
+    const {
+      risques: { risquesSpecifiques },
+    } = await depot.homologation('123');
+    expect(risquesSpecifiques.nombre()).to.equal(1);
+    expect(risquesSpecifiques.item(0)).to.be.a(RisqueSpecifique);
+    expect(risquesSpecifiques.item(0).description).to.equal('Un risque');
   });
 
   it('supprime les risques spécifiques précédemment associés', (done) => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -498,28 +498,21 @@ describe('Le dépôt de données des homologations', () => {
   });
 
   it('sait associer des rôles et responsabilités à une homologation', async () => {
-    const donneesHomologation = {
-      id: '123',
-      descriptionService: { nomService: 'nom' },
-    };
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
-      {
-        homologations: [copie(donneesHomologation)],
-        services: [copie(donneesHomologation)],
-      }
-    );
-    const depot = DepotDonneesHomologations.creeDepot({
-      adaptateurChiffrement: fauxAdaptateurChiffrement(),
-      adaptateurPersistance,
-    });
+    const r = Referentiel.creeReferentielVide();
+    const depot = unDepotDeDonneesServices()
+      .avecReferentiel(r)
+      .avecAdaptateurPersistance(
+        unePersistanceMemoire().ajouteUnService(
+          unService(r).avecId('S1').donnees
+        )
+      )
+      .construis();
 
-    const roles = new RolesResponsabilites({
-      autoriteHomologation: 'Jean Dupont',
-    });
-    await depot.ajouteRolesResponsabilitesAService('123', roles);
+    const roles = new RolesResponsabilites({ autoriteHomologation: 'Jean' });
+    await depot.ajouteRolesResponsabilitesAService('S1', roles);
 
-    const { rolesResponsabilites } = await depot.homologation('123');
-    expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean Dupont');
+    const { rolesResponsabilites } = await depot.homologation('S1');
+    expect(rolesResponsabilites.autoriteHomologation).to.equal('Jean');
   });
 
   describe('concernant les risques généraux', () => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -525,7 +525,7 @@ describe('Le dépôt de données des homologations', () => {
 
     after(() => (RisqueGeneral.valide = valideRisque));
 
-    it('sait associer un risque général à une homologation', (done) => {
+    it('sait associer un risque général à une homologation', async () => {
       RisqueGeneral.valide = () => {};
 
       const donneesHomologation = {
@@ -546,16 +546,12 @@ describe('Le dépôt de données des homologations', () => {
         id: 'unRisque',
         commentaire: 'Un commentaire',
       });
-      depot
-        .ajouteRisqueGeneralAService('123', risque)
-        .then(() => depot.homologation('123'))
-        .then(({ risques }) => {
-          expect(risques.risquesGeneraux.nombre()).to.equal(1);
-          expect(risques.risquesGeneraux.item(0)).to.be.a(RisqueGeneral);
-          expect(risques.risquesGeneraux.item(0).id).to.equal('unRisque');
-          done();
-        })
-        .catch(done);
+      await depot.ajouteRisqueGeneralAService('123', risque);
+
+      const { risques } = await depot.homologation('123');
+      expect(risques.risquesGeneraux.nombre()).to.equal(1);
+      expect(risques.risquesGeneraux.item(0)).to.be.a(RisqueGeneral);
+      expect(risques.risquesGeneraux.item(0).id).to.equal('unRisque');
     });
   });
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -68,10 +68,10 @@ describe('Le dépôt de données des homologations', () => {
       .ajouteUnService(unService(referentiel).avecId('789').donnees)
       .ajouteUnUtilisateur(unUtilisateur().avecId('456').donnees)
       .ajouteUneAutorisation(
-        uneAutorisation().deProprietaireDeService('456', '123').donnees
+        uneAutorisation().deProprietaire('456', '123').donnees
       )
       .ajouteUneAutorisation(
-        uneAutorisation().deProprietaireDeService('999', '789').donnees
+        uneAutorisation().deProprietaire('999', '789').donnees
       );
 
     const depot = unDepotDeDonneesServices()
@@ -121,9 +121,9 @@ describe('Le dépôt de données des homologations', () => {
           },
         ],
         autorisations: [
-          uneAutorisation().deProprietaireDeService('999', '123').donnees,
-          uneAutorisation().deProprietaireDeService('999', '456').donnees,
-          uneAutorisation().deProprietaireDeService('999', '789').donnees,
+          uneAutorisation().deProprietaire('999', '123').donnees,
+          uneAutorisation().deProprietaire('999', '456').donnees,
+          uneAutorisation().deProprietaire('999', '789').donnees,
         ],
       }
     );
@@ -182,8 +182,8 @@ describe('Le dépôt de données des homologations', () => {
           { id: '789', descriptionService: { nomService: 'nom' } },
         ],
         autorisations: [
-          uneAutorisation().deProprietaireDeService('111', '789').donnees,
-          uneAutorisation().deContributeurDeService('999', '789').donnees,
+          uneAutorisation().deProprietaire('111', '789').donnees,
+          uneAutorisation().deContributeur('999', '789').donnees,
         ],
       }
     );
@@ -214,7 +214,7 @@ describe('Le dépôt de données des homologations', () => {
     beforeEach(() => {
       busEvenements = fabriqueBusPourLesTests();
       const utilisateur = unUtilisateur().avecId('789').donnees;
-      const autorisation = uneAutorisation().deProprietaireDeService(
+      const autorisation = uneAutorisation().deProprietaire(
         '789',
         '123'
       ).donnees;
@@ -387,7 +387,7 @@ describe('Le dépôt de données des homologations', () => {
       const utilisateur = unUtilisateur()
         .avecId('999')
         .avecEmail('jean.dupont@mail.fr').donnees;
-      const autorisation = uneAutorisation().deProprietaireDeService(
+      const autorisation = uneAutorisation().deProprietaire(
         '999',
         '123'
       ).donnees;
@@ -877,7 +877,7 @@ describe('Le dépôt de données des homologations', () => {
             },
           ],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('123', '789').donnees,
+            uneAutorisation().deProprietaire('123', '789').donnees,
           ],
         });
       const depot = DepotDonneesHomologations.creeDepot({
@@ -934,8 +934,8 @@ describe('Le dépôt de données des homologations', () => {
             },
           ],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('123', '888').donnees,
-            uneAutorisation().deProprietaireDeService('123', '999').donnees,
+            uneAutorisation().deProprietaire('123', '888').donnees,
+            uneAutorisation().deProprietaire('123', '999').donnees,
           ],
         });
       const depot = DepotDonneesHomologations.creeDepot({
@@ -966,8 +966,7 @@ describe('Le dépôt de données des homologations', () => {
         homologations: [copie(donneesHomologation)],
         services: [copie(donneesHomologation)],
         autorisations: [
-          uneAutorisation().avecId('456').deProprietaireDeService('999', '123')
-            .donnees,
+          uneAutorisation().avecId('456').deProprietaire('999', '123').donnees,
         ],
       });
 
@@ -1021,12 +1020,9 @@ describe('Le dépôt de données des homologations', () => {
           { id: '222', descriptionService: { nomService: 'Un autre service' } },
         ],
         autorisations: [
-          uneAutorisation().avecId('123').deProprietaireDeService('999', '111')
-            .donnees,
-          uneAutorisation().avecId('456').deContributeurDeService('000', '111')
-            .donnees,
-          uneAutorisation().avecId('789').deContributeurDeService('000', '222')
-            .donnees,
+          uneAutorisation().avecId('123').deProprietaire('999', '111').donnees,
+          uneAutorisation().avecId('456').deContributeur('000', '111').donnees,
+          uneAutorisation().avecId('789').deContributeur('000', '222').donnees,
         ],
       });
       const depot = DepotDonneesHomologations.creeDepot({
@@ -1396,7 +1392,7 @@ describe('Le dépôt de données des homologations', () => {
           homologations: [{ id: '123-1', descriptionService }],
           services: [{ id: '123-1', descriptionService }],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('123', '123-1').donnees,
+            uneAutorisation().deProprietaire('123', '123-1').donnees,
           ],
         });
 
@@ -1462,7 +1458,7 @@ describe('Le dépôt de données des homologations', () => {
           utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
           homologations: [{ id: '123', descriptionService }],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('999', '123').donnees,
+            uneAutorisation().deProprietaire('999', '123').donnees,
           ],
         });
 
@@ -1489,7 +1485,7 @@ describe('Le dépôt de données des homologations', () => {
           utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
           homologations: [{ id: '123', descriptionService: copie1 }],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('999', '123').donnees,
+            uneAutorisation().deProprietaire('999', '123').donnees,
           ],
         });
 
@@ -1523,8 +1519,8 @@ describe('Le dépôt de données des homologations', () => {
             { id: '456', descriptionService: duplication },
           ],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('999', '123').donnees,
-            uneAutorisation().deProprietaireDeService('999', '456').donnees,
+            uneAutorisation().deProprietaire('999', '123').donnees,
+            uneAutorisation().deProprietaire('999', '456').donnees,
           ],
         });
 
@@ -1551,7 +1547,7 @@ describe('Le dépôt de données des homologations', () => {
           utilisateurs: [{ id: '999', email: 'jean.dupont@mail.fr' }],
           homologations: [{ id: '123', descriptionService: original }],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('999', '123').donnees,
+            uneAutorisation().deProprietaire('999', '123').donnees,
           ],
         });
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -692,25 +692,20 @@ describe('Le dépôt de données des homologations', () => {
       expect(donneesPersistees.descriptionService.chiffre).to.equal(true);
     });
 
-    it('ajoute en copie un nouveau service au dépôt', (done) => {
+    it('ajoute en copie un nouveau service au dépôt', async () => {
       const depotDonneesServices = DepotDonneesServices.creeDepot({
         adaptateurPersistance,
         referentiel,
       });
 
-      const descriptionService = uneDescriptionValide(referentiel)
-        .avecNomService('Super Service')
-        .construis()
-        .toJSON();
+      const descriptionService =
+        uneDescriptionValide(referentiel).avecNomService('Service').donnees;
+      const idService = await depot.nouveauService('123', {
+        descriptionService,
+      });
 
-      depot
-        .nouveauService('123', { descriptionService })
-        .then((idService) => depotDonneesServices.service(idService))
-        .then((service) => {
-          expect(service.nomService()).to.equal('Super Service');
-          done();
-        })
-        .catch(done);
+      const service = await depotDonneesServices.service(idService);
+      expect(service.nomService()).to.equal('Service');
     });
 
     it("déclare un accès en écriture entre l'utilisateur et le service", (done) => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -549,29 +549,25 @@ describe('Le dépôt de données des homologations', () => {
   });
 
   it('sait associer un risque spécifique à une homologation', async () => {
-    const donneesHomologation = {
-      id: '123',
-      descriptionService: { nomService: 'nom' },
-    };
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
-      {
-        homologations: [copie(donneesHomologation)],
-        services: [copie(donneesHomologation)],
-      }
-    );
-    const depot = DepotDonneesHomologations.creeDepot({
-      adaptateurChiffrement: fauxAdaptateurChiffrement(),
-      adaptateurPersistance,
-    });
+    const r = Referentiel.creeReferentielVide();
+
+    const depot = unDepotDeDonneesServices()
+      .avecReferentiel(r)
+      .avecAdaptateurPersistance(
+        unePersistanceMemoire().ajouteUnService(
+          unService(r).avecId('S1').donnees
+        )
+      )
+      .construis();
 
     const risque = new RisquesSpecifiques({
       risquesSpecifiques: [{ description: 'Un risque' }],
     });
-    await depot.remplaceRisquesSpecifiquesDuService('123', risque);
+    await depot.remplaceRisquesSpecifiquesDuService('S1', risque);
 
     const {
       risques: { risquesSpecifiques },
-    } = await depot.homologation('123');
+    } = await depot.homologation('S1');
     expect(risquesSpecifiques.nombre()).to.equal(1);
     expect(risquesSpecifiques.item(0)).to.be.a(RisqueSpecifique);
     expect(risquesSpecifiques.item(0).description).to.equal('Un risque');

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -553,7 +553,7 @@ describe('Le dépôt de données des utilisateurs', () => {
             { id: '123', descriptionService: { nomService: 'Un service' } },
           ],
           autorisations: [
-            uneAutorisation().deProprietaireDeService('999', '123').donnees,
+            uneAutorisation().deProprietaire('999', '123').donnees,
           ],
         });
       const depot = DepotDonneesUtilisateurs.creeDepot({
@@ -606,8 +606,8 @@ describe('Le dépôt de données des utilisateurs', () => {
             { id: '123', descriptionService: { nomService: 'Un service' } },
           ],
           autorisations: [
-            uneAutorisation().deContributeurDeService('999', '123').donnees,
-            uneAutorisation().deContributeurDeService('000', '123').donnees,
+            uneAutorisation().deContributeur('999', '123').donnees,
+            uneAutorisation().deContributeur('000', '123').donnees,
           ],
         });
       const depot = DepotDonneesUtilisateurs.creeDepot({

--- a/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
+++ b/test/modeles/autorisations/ajoutContributeurSurServices.spec.js
@@ -27,9 +27,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
   const leService = (id) =>
     unService().avecId(id).avecNomService('Nom Service').construis();
 
-  const peutGererContributeurs = uneAutorisation()
-    .deProprietaireDeService()
-    .construis();
+  const peutGererContributeurs = uneAutorisation().deProprietaire().construis();
   const utilisateur = {
     id: '999',
     genereToken: () => 'un token',
@@ -85,7 +83,7 @@ describe("L'ajout d'un contributeur sur des services", () => {
 
   it("lève une exception si l'utilisateur n'a pas le droit d'ajouter un contributeur", async () => {
     const sansGestionContributeur = uneAutorisation()
-      .deContributeurDeService()
+      .deContributeur()
       .construis();
     depotDonnees.autorisationPour = async () => sansGestionContributeur;
 

--- a/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
+++ b/test/modeles/objetsApi/objetGetIndicesCyber.spec.js
@@ -18,11 +18,11 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
   let unAutreService;
   const autorisations = [
     uneAutorisation()
-      .deProprietaireDeService('999', '123')
+      .deProprietaire('999', '123')
       .avecDroits({ [SECURISER]: LECTURE })
       .construis(),
     uneAutorisation()
-      .deProprietaireDeService('999', '456')
+      .deProprietaire('999', '456')
       .avecDroits({ [SECURISER]: LECTURE })
       .construis(),
   ];
@@ -43,7 +43,7 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
 
   it("ne fournit pas l'indice cyber si les permissions ne sont pas suffisantes", () => {
     const autorisationSansSecuriser = uneAutorisation()
-      .deContributeurDeService('999', '123')
+      .deContributeur('999', '123')
       .construis();
 
     const { services } = objetGetIndicesCyber.donnees(
@@ -82,12 +82,8 @@ describe("L'objet d'API de `GET /services/indices-cyber`", () => {
 
     const services = [unService, unAutreService];
     const autorisationsSansPermission = [
-      uneAutorisation()
-        .deProprietaireDeService('999', unService.id)
-        .construis(),
-      uneAutorisation()
-        .deContributeurDeService('999', unAutreService.id)
-        .construis(),
+      uneAutorisation().deProprietaire('999', unService.id).construis(),
+      uneAutorisation().deContributeur('999', unAutreService.id).construis(),
     ];
     expect(
       objetGetIndicesCyber.donnees(services, autorisationsSansPermission).resume

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -106,7 +106,7 @@ describe("L'objet d'API de `GET /service`", () => {
       expect(
         objetGetService.donnees(
           unServiceDontAestCreateur,
-          uneAutorisation().deProprietaireDeService('A', '123').construis(),
+          uneAutorisation().deProprietaire('A', '123').construis(),
           referentiel
         ).permissions
       ).to.eql({ gestionContributeurs: true });

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -53,7 +53,7 @@ describe("L'objet d'API de `GET /services`", () => {
   it('fournit les données nécessaires', () => {
     const services = [service];
     const autorisationComplete = uneAutorisation()
-      .deProprietaireDeService('A', '123')
+      .deProprietaire('A', '123')
       .construis();
 
     expect(
@@ -99,14 +99,14 @@ describe("L'objet d'API de `GET /services`", () => {
     unAutreService.dossiers.statutHomologation = () => Dossiers.ACTIVEE;
 
     const autorisationPourUnService = uneAutorisation()
-      .deProprietaireDeService('999', service.id)
+      .deProprietaire('999', service.id)
       .avecDroits({
         [HOMOLOGUER]: LECTURE,
       })
       .construis();
 
     const autorisationPourUnAutreService = uneAutorisation()
-      .deProprietaireDeService('999', unAutreService.id)
+      .deProprietaire('999', unAutreService.id)
       .avecDroits({
         [HOMOLOGUER]: LECTURE,
       })
@@ -130,14 +130,14 @@ describe("L'objet d'API de `GET /services`", () => {
     unAutreService.dossiers.statutHomologation = () => Dossiers.ACTIVEE;
 
     const autorisationPourUnService = uneAutorisation()
-      .deContributeurDeService('999', '123')
+      .deContributeur('999', '123')
       .avecDroits({
         [HOMOLOGUER]: LECTURE,
       })
       .construis();
 
     const autorisationSansHomologuerPourUnAutreService = uneAutorisation()
-      .deContributeurDeService('999', '456')
+      .deContributeur('999', '456')
       .avecDroits({})
       .construis();
 

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -74,7 +74,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deProprietaireDeService('123', '456')
+          .deProprietaire('123', '456')
           .avecDroits({})
           .construis(),
       ];
@@ -104,7 +104,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesPassees = { idUtilisateur };
         return [
           uneAutorisation()
-            .deProprietaireDeService('123', '456')
+            .deProprietaire('123', '456')
             .avecDroits({})
             .construis(),
         ];
@@ -133,7 +133,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesPassees = { idUtilisateur };
         return [
           uneAutorisation()
-            .deProprietaireDeService('123', '456')
+            .deProprietaire('123', '456')
             .avecDroits({})
             .construis(),
         ];
@@ -149,7 +149,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deProprietaireDeService('123', '456')
+          .deProprietaire('123', '456')
           .avecDroits({})
           .construis(),
       ];
@@ -184,7 +184,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deProprietaireDeService('123', '456')
+          .deProprietaire('123', '456')
           .avecDroits({ [SECURISER]: LECTURE })
           .construis(),
       ];
@@ -218,7 +218,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesPassees = { idUtilisateur };
         return [
           uneAutorisation()
-            .deProprietaireDeService('123', '456')
+            .deProprietaire('123', '456')
             .avecDroits({})
             .construis(),
         ];
@@ -277,7 +277,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
-          .deProprietaireDeService('123', '456')
+          .deProprietaire('123', '456')
           .avecDroits({})
           .construis(),
       ];
@@ -972,7 +972,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     beforeEach(() => {
       testeur.middleware().reinitialise({ idUtilisateur: '456' });
       testeur.depotDonnees().autorisationPour = async () =>
-        uneAutorisation().deProprietaireDeService().construis();
+        uneAutorisation().deProprietaire().construis();
       testeur.depotDonnees().supprimeContributeur = async () => {};
     });
 
@@ -1003,7 +1003,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         idHomologation
       ) => {
         autorisationCherchee = { idUtilisateur, idHomologation };
-        return uneAutorisation().deProprietaireDeService().construis();
+        return uneAutorisation().deProprietaire().construis();
       };
 
       await axios.delete('http://localhost:1234/api/autorisation', {
@@ -1015,9 +1015,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("retourne une erreur HTTP 403 si l'utilisateur n'a pas le droit de supprimer un contributeur", async () => {
-      const contributeurSimple = uneAutorisation()
-        .deContributeurDeService()
-        .construis();
+      const contributeurSimple = uneAutorisation().deContributeur().construis();
       testeur.depotDonnees().autorisationPour = async () => contributeurSimple;
 
       try {

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1279,9 +1279,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas les droits de suppression du service", (done) => {
       testeur.middleware().reinitialise({
-        autorisationACharger: uneAutorisation()
-          .deContributeurDeService()
-          .construis(),
+        autorisationACharger: uneAutorisation().deContributeur().construis(),
       });
 
       testeur.verifieRequeteGenereErreurHTTP(
@@ -1379,9 +1377,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("retourne une erreur HTTP 403 si l'utilisateur courant n'est pas le créateur du service", (done) => {
       testeur.middleware().reinitialise({
-        autorisationACharger: uneAutorisation()
-          .deContributeurDeService()
-          .construis(),
+        autorisationACharger: uneAutorisation().deContributeur().construis(),
       });
 
       testeur.verifieRequeteGenereErreurHTTP(
@@ -1548,7 +1544,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     beforeEach(() => {
       testeur.middleware().reinitialise({
         autorisationACharger: uneAutorisation()
-          .deProprietaireDeService('AAA', '456')
+          .deProprietaire('AAA', '456')
           .construis(),
       });
 
@@ -1595,7 +1591,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("renvoie une erreur 422 si l'utilisateur courant tente de modifier ses propres droits", async () => {
       const monAutorisation = uneAutorisation()
-        .deProprietaireDeService('123', 'ABC')
+        .deProprietaire('123', 'ABC')
         .construis();
 
       testeur.middleware().reinitialise({
@@ -1620,7 +1616,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it("renvoie une erreur 422 si l'utilisateur tente de modifier une autorisation qui n'appartient pas au service ciblé", async () => {
       const serviceABC = unService().avecId('ABC').construis();
       const leroyProprietaireDeABC = uneAutorisation()
-        .deProprietaireDeService('LEROY', 'ABC')
+        .deProprietaire('LEROY', 'ABC')
         .construis();
 
       testeur.middleware().reinitialise({
@@ -1630,7 +1626,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
 
       const autorisationSurDEF = uneAutorisation()
-        .deContributeurDeService('DUPONT', 'DEF')
+        .deContributeur('DUPONT', 'DEF')
         .construis();
       testeur.depotDonnees().autorisation = async () => autorisationSurDEF;
 
@@ -1673,9 +1669,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       let autorisationCiblee;
       testeur.depotDonnees().autorisation = async (id) => {
         autorisationCiblee = id;
-        return uneAutorisation()
-          .deContributeurDeService('DUPONT', '456')
-          .construis();
+        return uneAutorisation().deContributeur('DUPONT', '456').construis();
       };
 
       let autorisationPersistee;
@@ -1701,10 +1695,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("renvoie la représentation API de l'autorisation mise à jour", async () => {
       testeur.depotDonnees().autorisation = async (id) =>
-        uneAutorisation()
-          .avecId(id)
-          .deContributeurDeService('888', '456')
-          .construis();
+        uneAutorisation().avecId(id).deContributeur('888', '456').construis();
 
       const droitsCible = {
         DECRIRE: 1,
@@ -1742,7 +1733,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('permet de nommer un nouveau propriétaire', async () => {
       testeur.depotDonnees().autorisation = async () =>
-        uneAutorisation().deContributeurDeService('BBB', '456').construis();
+        uneAutorisation().deContributeur('BBB', '456').construis();
 
       let autorisationPersistee;
       testeur.depotDonnees().sauvegardeAutorisation = async (autorisation) => {
@@ -1768,7 +1759,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: 'AAA',
       });
       testeur.depotDonnees().autorisationsDuService = async (idService) => [
-        uneAutorisation().deProprietaireDeService('AAA', idService).construis(),
+        uneAutorisation().deProprietaire('AAA', idService).construis(),
       ];
     });
 
@@ -1798,11 +1789,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       let donneesPassees = {};
       testeur.depotDonnees().autorisationsDuService = async (idService) => {
         donneesPassees = { idService };
-        return [
-          uneAutorisation()
-            .deProprietaireDeService('AAA', idService)
-            .construis(),
-        ];
+        return [uneAutorisation().deProprietaire('AAA', idService).construis()];
       };
 
       const serviceARenvoyer = unService(testeur.referentiel())
@@ -1823,7 +1810,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().autorisationsDuService = async () => [
         uneAutorisation()
           .avecId('uuid-a')
-          .deProprietaireDeService('AAA', '456')
+          .deProprietaire('AAA', '456')
           .construis(),
       ];
 
@@ -1851,10 +1838,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: 'AAA',
       });
       testeur.depotDonnees().autorisationsDuService = async () => [
-        uneAutorisation().deProprietaireDeService('AAA', '456').construis(),
-        uneAutorisation().deContributeurDeService('ABC', '456').construis(),
-        uneAutorisation().deContributeurDeService('DEF', '456').construis(),
-        uneAutorisation().deContributeurDeService('GHI', '456').construis(),
+        uneAutorisation().deProprietaire('AAA', '456').construis(),
+        uneAutorisation().deContributeur('ABC', '456').construis(),
+        uneAutorisation().deContributeur('DEF', '456').construis(),
+        uneAutorisation().deContributeur('GHI', '456').construis(),
       ];
 
       const reponse = await axios.get(
@@ -1874,10 +1861,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: 'DEF',
       });
       testeur.depotDonnees().autorisationsDuService = async () => [
-        uneAutorisation().deProprietaireDeService('AAA', '456').construis(),
-        uneAutorisation().deContributeurDeService('ABC', '456').construis(),
-        uneAutorisation().deContributeurDeService('DEF', '456').construis(),
-        uneAutorisation().deContributeurDeService('GHI', '456').construis(),
+        uneAutorisation().deProprietaire('AAA', '456').construis(),
+        uneAutorisation().deContributeur('ABC', '456').construis(),
+        uneAutorisation().deContributeur('DEF', '456').construis(),
+        uneAutorisation().deContributeur('GHI', '456').construis(),
       ];
 
       const { data } = await axios.get(


### PR DESCRIPTION
Pour rendre plus lisibles et plus robustes les tests.