### PR TITLE
Harmonise la hauteur du score indice cyber dans le tableau de bord

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -760,7 +760,7 @@ label[for='recherche-service'] {
 }
 
 .tableau-services .conteneur-indice-cyber {
-  padding: 0 6px 2px 6px;
+  padding: 2px 6px 4px 6px;
   border-radius: 4px;
   background: #dbeeff;
   color: #2f3a43;


### PR DESCRIPTION
... afin qu'il ai la même taille que le cartouche "Contributeurs"

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/4f887aeb-e8f8-40ee-83df-16e74025f974)
