### PR TITLE
[CORRECTION] Ajoute un await sur les appels des méthodes `metsAJourTable` et `ajouteLigneDansTable`

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -234,8 +234,9 @@ const nouvelAdaptateur = (env) => {
       .first();
 
     const dejaConnue = ligne !== undefined;
-    if (dejaConnue) metsAJourTable('autorisations', id, donneesAutorisation);
-    else ajouteLigneDansTable('autorisations', id, donneesAutorisation);
+    if (dejaConnue)
+      await metsAJourTable('autorisations', id, donneesAutorisation);
+    else await ajouteLigneDansTable('autorisations', id, donneesAutorisation);
   };
 
   const supprimeAutorisation = (idUtilisateur, idHomologation) =>


### PR DESCRIPTION
... car sinon on n'attend pas que la méthode soit exécutée avant de continuer