### PR TITLE
[COLLABORATIF] Publication des modifications d'autorisations sur le bus

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -190,7 +190,7 @@ const nouvelAdaptateur = (
   const supprimeAutorisation = (idUtilisateur, idHomologation) => {
     donnees.autorisations = donnees.autorisations.filter(
       (a) =>
-        a.idUtilisateur !== idUtilisateur && a.idHomologation !== idHomologation
+        a.idUtilisateur !== idUtilisateur || a.idHomologation !== idHomologation
     );
     return Promise.resolve();
   };

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -143,6 +143,7 @@ const creeDepot = (config = {}) => {
     await verifieAutorisationExiste();
     await verifieSuppressionPermise();
     await adaptateurPersistance.supprimeAutorisation(idContributeur, idService);
+    await publieAutorisationsDuService(idService);
   };
 
   return {

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -42,24 +42,6 @@ const creeDepot = (config = {}) => {
       .autorisation(id)
       .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
 
-  const sauvegardeAutorisation = async (uneAutorisation) => {
-    const { id, ...donnees } = uneAutorisation.donneesAPersister();
-    adaptateurPersistance.sauvegardeAutorisation(id, donnees);
-  };
-
-  const autorisationsDuService = async (id) => {
-    const as = await adaptateurPersistance.autorisationsDuService(id);
-    return as.map((a) => FabriqueAutorisation.fabrique(a));
-  };
-
-  const autorisationPour = (...params) =>
-    adaptateurPersistance
-      .autorisationPour(...params)
-      .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
-
-  const autorisationExiste = (...params) =>
-    autorisationPour(...params).then((a) => !!a);
-
   const publieAutorisationsDuService = async (idService) => {
     const donneesFraiches =
       await adaptateurPersistance.autorisationsDuService(idService);
@@ -76,6 +58,26 @@ const creeDepot = (config = {}) => {
 
     await busEvenements.publie(evenement);
   };
+
+  const sauvegardeAutorisation = async (uneAutorisation) => {
+    const { id, ...donnees } = uneAutorisation.donneesAPersister();
+    await adaptateurPersistance.sauvegardeAutorisation(id, donnees);
+
+    await publieAutorisationsDuService(uneAutorisation.idService);
+  };
+
+  const autorisationsDuService = async (id) => {
+    const as = await adaptateurPersistance.autorisationsDuService(id);
+    return as.map((a) => FabriqueAutorisation.fabrique(a));
+  };
+
+  const autorisationPour = (...params) =>
+    adaptateurPersistance
+      .autorisationPour(...params)
+      .then((a) => (a ? FabriqueAutorisation.fabrique(a) : undefined));
+
+  const autorisationExiste = (...params) =>
+    autorisationPour(...params).then((a) => !!a);
 
   const ajouteContributeurAuService = async (nouvelleAutorisation) => {
     const verifieUtilisateurExiste = async (id) => {

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -347,18 +347,21 @@ describe('Le dépôt de données des autorisations', () => {
     it('supprime le contributeur', async () => {
       const avecUneAutorisation = unePersistanceMemoire()
         .ajouteUneAutorisation(
-          uneAutorisation().deContributeur('000', 'ABC').donnees
+          uneAutorisation().deContributeur('U1', 'S1').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('U2', 'S1').donnees
         )
         .construis();
 
       const depot = creeDepot(avecUneAutorisation);
 
-      const avant = await depot.autorisationPour('000', 'ABC');
+      const avant = await depot.autorisationPour('U1', 'S1');
       expect(avant).not.to.be(undefined);
 
-      await depot.supprimeContributeur('000', 'ABC', '123');
+      await depot.supprimeContributeur('U1', 'S1', 'U2');
 
-      const apres = await depot.autorisationPour('000', 'ABC');
+      const apres = await depot.autorisationPour('U1', 'S1');
       expect(apres).to.be(undefined);
     });
   });


### PR DESCRIPTION
## Contexte
On veut désormais avoir des infos sur le collaboratif dans notre Metabase : savoir combien de collaborateurs ont les services, avec quel type de rôle, etc.

## 🗺️ Chemin
- [x] Consigner le lien entre propriétaire et nouveau service
  - #1323  
- [x] Consigner un ajout d'autorisation sur UN ou PLUSIEURS service
  - #1325 
- [ ] **Consigner une modification / suppression d'autorisation ⬅️ CETTE PR**
- [ ] [JOURNAL] Créer le modèle qui permet d'exploiter la nouvelle donnée
- [ ] [CONSOLE ADMIN] Faire un rattrapage du collaboratif sur TOUS les services

## PR
Cette PR implémente les flèches montrées en jaune à droite dans le schéma 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/2888ea5b-49b6-4de6-b35d-d502a6cfd251)


On se glisse dans le design existant, avec `await publieAutorisationsDuService()` dans le dépôt.