### PR TITLE
Câble les modifications d'autorisations vers un envoi au journal MSS

### DIFF
--- a/src/bus/abonnements/consigneAutorisationsModifieesDansJournal.js
+++ b/src/bus/abonnements/consigneAutorisationsModifieesDansJournal.js
@@ -1,0 +1,18 @@
+const {
+  EvenementCollaboratifServiceModifie,
+} = require('../../modeles/journalMSS/evenementCollaboratifServiceModifie');
+
+function consigneAutorisationsModifieesDansJournal({ adaptateurJournal }) {
+  return async ({ idService, autorisations }) => {
+    const collaboratifServiceModifie = new EvenementCollaboratifServiceModifie({
+      idService,
+      autorisations,
+    });
+
+    await adaptateurJournal.consigneEvenement(
+      collaboratifServiceModifie.toJSON()
+    );
+  };
+}
+
+module.exports = { consigneAutorisationsModifieesDansJournal };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -1,5 +1,8 @@
 const EvenementMesuresServiceModifiees = require('./evenementMesuresServiceModifiees');
 const {
+  EvenementAutorisationsServiceModifiees,
+} = require('./evenementAutorisationsServiceModifiees');
+const {
   consigneCompletudeDansJournal,
 } = require('./abonnements/consigneCompletudeDansJournal');
 const {
@@ -15,6 +18,9 @@ const {
 const {
   consigneProprietaireCreeUnServiceDansJournal,
 } = require('./abonnements/consigneProprietaireCreeUnServiceDansJournal');
+const {
+  consigneAutorisationsModifieesDansJournal,
+} = require('./abonnements/consigneAutorisationsModifieesDansJournal');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -32,6 +38,11 @@ const cableTousLesAbonnes = (
     consigneCompletudeDansJournal({ adaptateurJournal }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
   ]);
+
+  busEvenements.abonne(
+    EvenementAutorisationsServiceModifiees,
+    consigneAutorisationsModifieesDansJournal({ adaptateurJournal })
+  );
 };
 
 module.exports = { cableTousLesAbonnes };

--- a/test/bus/abonnements/consigneAutorisationsModifieesDansJournal.spec.js
+++ b/test/bus/abonnements/consigneAutorisationsModifieesDansJournal.spec.js
@@ -1,0 +1,31 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const {
+  consigneAutorisationsModifieesDansJournal,
+} = require('../../../src/bus/abonnements/consigneAutorisationsModifieesDansJournal');
+
+describe("L'abonnement qui consigne (dans le journal MSS) la modification d'autorisations pour un service", () => {
+  let adaptateurJournal;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+  });
+
+  it("consigne un événement de 'collaboratif de service modifié' indiquant le résumé des autorisations du service", async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneAutorisationsModifieesDansJournal({ adaptateurJournal })({
+      idService: 'S1',
+      autorisations: [{ droit: 'PROPRIETAIRE', idUtilisateur: 'U1' }],
+    });
+
+    expect(evenementRecu.type).to.be('COLLABORATIF_SERVICE_MODIFIE');
+    const { autorisations } = evenementRecu.donnees;
+    expect(autorisations.length).to.be(1);
+    expect(autorisations[0].idUtilisateur).not.to.be(undefined);
+    expect(autorisations[0].droit).to.be('PROPRIETAIRE');
+  });
+});


### PR DESCRIPTION
On câble les événements de modification/ajout/suppression du collaboratif vers l'adaptateur Journal MSS, afin de stocker cette donnée coté Metabase.

Tous les événements on été développé dans des PRs précédentes.
Il s'agit juste ici de "brancher" l'adaptateur `JournalMSS ` depuis le `bus`.

On en profite pour rajouter une méthode à la `consoleAdministration` pour pouvoir faire un rattrapage des autorisations des services existants.