### PR TITLE
[CORRECTION] Affiche correctement les éléments de connexion au format mobile

### DIFF
--- a/public/assets/styles/entete.responsive.css
+++ b/public/assets/styles/entete.responsive.css
@@ -75,6 +75,7 @@
 
   header nav.visible .utilisateur-courant {
     display: flex;
+    flex-direction: column-reverse;
   }
 
   header nav.visible .utilisateur-courant .connexion {


### PR DESCRIPTION
...car les éléments s'affichaient sur la même ligne 

| Avant | Après |
|--------|--------|
| ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/74673ea6-ede4-499b-87bc-231919d0f744) | ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/b941b7f5-02a7-4fa3-bde2-812fb0f7fef4) | 