### PR TITLE
Acceptation de l'infolettre lors de l'invitation

### DIFF
--- a/public/motDePasse/edition.js
+++ b/public/motDePasse/edition.js
@@ -23,12 +23,16 @@ $(() => {
     e.preventDefault();
 
     const challenge = JSON.parse($('#challenge-mot-de-passe').text());
+    const { estInvitation } = JSON.parse($('#invitation-contributeur').text());
     const estInitialisation = !challenge.afficheChallengeMotDePasse;
     if (estInitialisation) {
       axios
         .put('/api/motDePasse', {
           motDePasse: $('#mot-de-passe').val(),
           cguAcceptees: reponseAcceptee('cguAcceptees'),
+          ...(estInvitation && {
+            infolettreAcceptee: reponseAcceptee('infolettreAcceptee'),
+          }),
         })
         .then(() => (window.location = '/tableauDeBord'));
     } else {

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -142,11 +142,14 @@ const routesApiPrivee = ({
 
   routes.put(
     '/motDePasse',
-    middleware.aseptise('cguAcceptees'),
+    middleware.aseptise('cguAcceptees', 'infolettreAcceptee'),
     async (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       const cguDejaAcceptees = requete.cguAcceptees;
       const cguEnCoursDAcceptation = valeurBooleenne(requete.body.cguAcceptees);
+      const infolettreAcceptee = valeurBooleenne(
+        requete.body.infolettreAcceptee
+      );
       const { motDePasse } = requete.body;
 
       if (!cguDejaAcceptees && !cguEnCoursDAcceptation) {
@@ -167,6 +170,12 @@ const routesApiPrivee = ({
         u = await depotDonnees.valideAcceptationCGUPourUtilisateur(u);
         await depotDonnees.supprimeIdResetMotDePassePourUtilisateur(u);
         await adaptateurMail.inscrisEmailsTransactionnels(u.email);
+        if (infolettreAcceptee) {
+          await adaptateurMail.inscrisInfolettre(u.email);
+          await depotDonnees.metsAJourUtilisateur(u.id, {
+            infolettreAcceptee: true,
+          });
+        }
         requete.session.token = u.genereToken();
         reponse.json({ idUtilisateur });
       } catch (e) {

--- a/src/routes/publiques/routesApiPublique.js
+++ b/src/routes/publiques/routesApiPublique.js
@@ -220,7 +220,6 @@ const routesApiPublique = ({
         }
         depotDonnees
           .metsAJourUtilisateur(utilisateur.id, {
-            ...utilisateur,
             infolettreAcceptee: false,
           })
           .then(() => reponse.sendStatus(200))

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -1,4 +1,5 @@
 include ./inputChoix
+include ./utilisateur/preferencesCommunication
 
 block append styles
   link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
@@ -158,29 +159,4 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule, forceEmailsTransa
             )
             .message-erreur Ce champ est obligatoire. Veuillez sélectionner une ou plusieurs options.
 
-      .preferences-communication
-        label Préférences de communication
-        .conteneur-checkbox
-          div
-            input(
-              id = 'infolettreAcceptee',
-              name = 'infolettreAcceptee',
-              checked = donnees.infolettreAcceptee,
-              type = 'checkbox'
-              class = 'input-checkbox'
-            )
-            label.label-checkbox(for = 'infolettreAcceptee') J'accepte de recevoir la lettre d'information MonServiceSécurisé.
-
-          if forceEmailsTransactionnels
-            input(type='hidden' id='transactionnelAccepte' value='true')
-          else
-            .separateur
-            div
-              input(
-                id = 'transactionnelAccepte',
-                name = 'transactionnelAccepte',
-                checked = donnees.transactionnelAccepte,
-                type = 'checkbox'
-                class = 'input-checkbox'
-              )
-              label.label-checkbox(for = 'transactionnelAccepte') J'accepte de recevoir des informations relatives à l'utilisation de MonServiceSécurisé
+      +preferencesCommunication(donnees, forceEmailsTransactionnels)

--- a/src/vues/fragments/utilisateur/preferencesCommunication.pug
+++ b/src/vues/fragments/utilisateur/preferencesCommunication.pug
@@ -1,0 +1,27 @@
+mixin preferencesCommunication(donnees, forceEmailsTransactionnels)
+  .preferences-communication
+    label Préférences de communication
+    .conteneur-checkbox
+      div
+        input(
+          id = 'infolettreAcceptee',
+          name = 'infolettreAcceptee',
+          checked = donnees.infolettreAcceptee,
+          type = 'checkbox'
+          class = 'input-checkbox'
+        )
+        label.label-checkbox(for = 'infolettreAcceptee') J'accepte de recevoir la lettre d'information MonServiceSécurisé.
+
+      if forceEmailsTransactionnels
+        input(type='hidden' id='transactionnelAccepte' value='true')
+      else
+        .separateur
+        div
+          input(
+            id = 'transactionnelAccepte',
+            name = 'transactionnelAccepte',
+            checked = donnees.transactionnelAccepte,
+            type = 'checkbox'
+            class = 'input-checkbox'
+          )
+          label.label-checkbox(for = 'transactionnelAccepte') J'accepte de recevoir des informations relatives à l'utilisation de MonServiceSécurisé

--- a/src/vues/motDePasse/edition.pug
+++ b/src/vues/motDePasse/edition.pug
@@ -1,5 +1,6 @@
 extends ../mssConnecte
 
+include ../fragments/utilisateur/preferencesCommunication
 include ../fragments/utilisateur/questionCgu
 
 block title
@@ -52,6 +53,7 @@ block main
         .message-erreur Les deux mots de passe sont différents
 
       if !utilisateur.accepteCGU()
+        +preferencesCommunication({ infolettreAcceptee: false }, true)
         +questionCgu
 
     button(type = 'submit').bouton Valider
@@ -60,3 +62,5 @@ block main
   script(type = 'module', src = '/statique/motDePasse/edition.js')
   script(id = 'challenge-mot-de-passe', type = 'application/json').
     !{JSON.stringify({ afficheChallengeMotDePasse })}
+  script(id = 'invitation-contributeur', type = 'application/json').
+    !{JSON.stringify({ estInvitation: !utilisateur.accepteCGU() })}

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -368,7 +368,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
     it('aseptise les paramètres de la requête', (done) => {
       testeur.middleware().verifieAseptisationParametres(
-        ['cguAcceptees'],
+        ['cguAcceptees', 'infolettreAcceptee'],
         {
           method: 'put',
           url: 'http://localhost:1234/api/motDePasse',
@@ -439,6 +439,33 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
 
       expect(inscriptionEffectuee).to.equal('jean.dujardin@beta.gouv.fr');
+    });
+
+    it("ajoute l'utilisateur à la newsletter Brevo si l'utilisateur le souhaite et persiste ce choix", async () => {
+      let inscriptionEffectuee;
+      let utilisateurPersiste;
+
+      testeur.adaptateurMail().inscrisInfolettre = async (emailUtilisateur) => {
+        inscriptionEffectuee = emailUtilisateur;
+      };
+
+      testeur.depotDonnees().metsAJourUtilisateur = async (
+        idUtilisateur,
+        donnees
+      ) => {
+        utilisateurPersiste = { idUtilisateur, donnees };
+      };
+
+      await axios.put('http://localhost:1234/api/motDePasse', {
+        motDePasse: 'mdp_ABC12345',
+        infolettreAcceptee: 'true',
+      });
+
+      expect(inscriptionEffectuee).to.equal('jean.dujardin@beta.gouv.fr');
+      expect(utilisateurPersiste).to.eql({
+        idUtilisateur: '123',
+        donnees: { infolettreAcceptee: true },
+      });
     });
 
     it("invalide l'identifiant de réinitialisation de mot de passe", async () => {

--- a/test/routes/publiques/routesApiPublique.spec.js
+++ b/test/routes/publiques/routesApiPublique.spec.js
@@ -6,6 +6,9 @@ const {
   ErreurUtilisateurExistant,
   ErreurEmailManquant,
 } = require('../../../src/erreurs');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
 
 describe('Le serveur MSS des routes publiques /api/*', () => {
   const testeur = testeurMSS();
@@ -688,15 +691,17 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
 
     it("désabonne l'utilisateur de l'infolettre", (done) => {
-      const utilisateur = { id: '123', infolettreAcceptee: true };
+      const utilisateur = unUtilisateur()
+        .avecId('123')
+        .quiAccepteInfolettre()
+        .construis();
       testeur.depotDonnees().utilisateurAvecEmail = (email) => {
         expect(email).to.equal('jean.dujardin@mail.com');
         return Promise.resolve(utilisateur);
       };
       testeur.depotDonnees().metsAJourUtilisateur = (id, donnees) => {
         expect(id).to.equal('123');
-        expect(donnees.id).to.equal('123');
-        expect(donnees.infolettreAcceptee).to.be(false);
+        expect(donnees).to.eql({ infolettreAcceptee: false });
         return Promise.resolve();
       };
 


### PR DESCRIPTION
Afin de pouvoir proposer l'inscription à l'infolettre pour des utilisateurs qui ont étés invités, on rajoute les préférences de communication dans l'écran de création de mot de passe :point_down: 

<img src="https://github.com/betagouv/mon-service-securise/assets/1643465/44644148-0749-47a6-ae90-b0cfbc5b4f60" width=300>
