### PR TITLE
Utilisation de `busEvenements` dans `ajouteDescriptionService`

### DIFF
--- a/src/bus/abonnements/consigneAutorisationsModifieesDansJournal.js
+++ b/src/bus/abonnements/consigneAutorisationsModifieesDansJournal.js
@@ -2,8 +2,17 @@ const {
   EvenementCollaboratifServiceModifie,
 } = require('../../modeles/journalMSS/evenementCollaboratifServiceModifie');
 
+const leveException = (raison) => {
+  throw new Error(
+    `Impossible de consigner des autorisations modifées dans le journal MSS sans avoir ${raison} en paramètre.`
+  );
+};
+
 function consigneAutorisationsModifieesDansJournal({ adaptateurJournal }) {
   return async ({ idService, autorisations }) => {
+    if (!idService) leveException("l'ID du service");
+    if (!autorisations) leveException('les autorisations');
+
     const collaboratifServiceModifie = new EvenementCollaboratifServiceModifie({
       idService,
       autorisations,

--- a/src/bus/abonnements/consigneCompletudeDansJournal.js
+++ b/src/bus/abonnements/consigneCompletudeDansJournal.js
@@ -1,8 +1,16 @@
 const EvenementCompletudeServiceModifiee = require('../../modeles/journalMSS/evenementCompletudeServiceModifiee');
 
+const leveException = (raison) => {
+  throw new Error(
+    `Impossible de consigner la complétude dans le journal MSS sans avoir le ${raison} en paramètre.`
+  );
+};
+
 function consigneCompletudeDansJournal({ adaptateurJournal }) {
   return async (evenement) => {
     const { service } = evenement;
+
+    if (!service) leveException('service');
 
     const completude = new EvenementCompletudeServiceModifiee({
       idService: service.id,

--- a/src/bus/abonnements/consigneNouveauServiceDansJournal.js
+++ b/src/bus/abonnements/consigneNouveauServiceDansJournal.js
@@ -1,8 +1,17 @@
 const EvenementNouveauServiceCree = require('../../modeles/journalMSS/evenementNouveauServiceCree');
 
+const leveException = (raison) => {
+  throw new Error(
+    `Impossible de consigner un nouveau service dans le journal MSS sans avoir le ${raison} en paramètre.`
+  );
+};
+
 function consigneNouveauServiceDansJournal({ adaptateurJournal }) {
   return async (evenement) => {
     const { service, utilisateur } = evenement;
+
+    if (!service) leveException('service');
+    if (!utilisateur) leveException('créateur');
 
     const creation = new EvenementNouveauServiceCree({
       idService: service.id,

--- a/src/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.js
+++ b/src/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.js
@@ -5,9 +5,18 @@ const Autorisation = require('../../modeles/autorisations/autorisation');
 
 const { PROPRIETAIRE } = Autorisation.RESUME_NIVEAU_DROIT;
 
+const leveException = (raison) => {
+  throw new Error(
+    `Impossible de consigner le lien entre un créateur et son service dans le journal MSS sans avoir le ${raison} en paramètre.`
+  );
+};
+
 function consigneProprietaireCreeUnServiceDansJournal({ adaptateurJournal }) {
   return async (evenement) => {
     const { service, utilisateur } = evenement;
+
+    if (!service) leveException('service');
+    if (!utilisateur) leveException('créateur');
 
     const nouveauProprietaire = new EvenementCollaboratifServiceModifie({
       idService: service.id,

--- a/src/bus/abonnements/envoieTrackingDeCompletude.js
+++ b/src/bus/abonnements/envoieTrackingDeCompletude.js
@@ -1,9 +1,17 @@
 const { fabriqueServiceTracking } = require('../../tracking/serviceTracking');
 
+const leveException = (raison) => {
+  throw new Error(
+    `Impossible d'envoyer les données de complétude à Brevo sans avoir ${raison} en paramètre.`
+  );
+};
 function envoieTrackingCompletude({ adaptateurTracking, depotDonnees }) {
   return async (evenement) => {
-    const serviceTracking = fabriqueServiceTracking();
     const { utilisateur } = evenement;
+
+    if (!utilisateur) leveException("l'utilisateur");
+
+    const serviceTracking = fabriqueServiceTracking();
 
     const donneesCompletude =
       await serviceTracking.completudeDesServicesPourUtilisateur(

--- a/src/bus/abonnements/envoieTrackingDeNouveauService.js
+++ b/src/bus/abonnements/envoieTrackingDeNouveauService.js
@@ -1,6 +1,14 @@
+const leveException = (raison) => {
+  throw new Error(
+    `Impossible d'envoyer le nombre de services d'un utilisateur à Brevo sans avoir ${raison} en paramètre.`
+  );
+};
+
 function envoieTrackingDeNouveauService({ adaptateurTracking, depotDonnees }) {
   return async (evenement) => {
     const { utilisateur } = evenement;
+
+    if (!utilisateur) leveException("l'utilisateur");
 
     const services = await depotDonnees.homologations(utilisateur.id);
 

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -21,6 +21,9 @@ const {
 const {
   consigneAutorisationsModifieesDansJournal,
 } = require('./abonnements/consigneAutorisationsModifieesDansJournal');
+const {
+  EvenementDescriptionServiceModifiee,
+} = require('./evenementDescriptionServiceModifiee');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -35,6 +38,11 @@ const cableTousLesAbonnes = (
   ]);
 
   busEvenements.abonnePlusieurs(EvenementMesuresServiceModifiees, [
+    consigneCompletudeDansJournal({ adaptateurJournal }),
+    envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
+  ]);
+
+  busEvenements.abonnePlusieurs(EvenementDescriptionServiceModifiee, [
     consigneCompletudeDansJournal({ adaptateurJournal }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
   ]);

--- a/src/bus/evenementDescriptionServiceModifiee.js
+++ b/src/bus/evenementDescriptionServiceModifiee.js
@@ -1,0 +1,13 @@
+class EvenementDescriptionServiceModifiee {
+  constructor({ service, utilisateur }) {
+    if (!service)
+      throw Error("Impossible d'instancier l'événement sans service");
+    if (!utilisateur)
+      throw Error("Impossible d'instancier l'événement sans utilisateur");
+
+    this.service = service;
+    this.utilisateur = utilisateur;
+  }
+}
+
+module.exports = { EvenementDescriptionServiceModifiee };

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -2,7 +2,6 @@ const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
 const fabriqueAdaptateurJournalMSS = require('./adaptateurs/fabriqueAdaptateurJournalMSS');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
-const fabriqueAdaptateurTracking = require('./adaptateurs/fabriqueAdaptateurTracking');
 const Referentiel = require('./referentiel');
 const depotDonneesAutorisations = require('./depots/depotDonneesAutorisations');
 const depotDonneesHomologations = require('./depots/depotDonneesHomologations');
@@ -15,7 +14,6 @@ const creeDepot = (config = {}) => {
     adaptateurJournalMSS = fabriqueAdaptateurJournalMSS(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
-    adaptateurTracking = fabriqueAdaptateurTracking(),
     adaptateurUUID = adaptateurUUIDParDefaut,
     referentiel = Referentiel.creeReferentiel(),
     busEvenements,
@@ -25,7 +23,6 @@ const creeDepot = (config = {}) => {
     adaptateurChiffrement,
     adaptateurJournalMSS,
     adaptateurPersistance,
-    adaptateurTracking,
     adaptateurUUID,
     busEvenements,
     referentiel,

--- a/test/bus/abonnements/consigneAutorisationsModifieesDansJournal.spec.js
+++ b/test/bus/abonnements/consigneAutorisationsModifieesDansJournal.spec.js
@@ -28,4 +28,32 @@ describe("L'abonnement qui consigne (dans le journal MSS) la modification d'auto
     expect(autorisations[0].idUtilisateur).not.to.be(undefined);
     expect(autorisations[0].droit).to.be('PROPRIETAIRE');
   });
+
+  it("lève une exception s'il ne reçoit pas d'ID de service", async () => {
+    try {
+      await consigneAutorisationsModifieesDansJournal({ adaptateurJournal })({
+        idService: null,
+        autorisations: [{ droit: 'PROPRIETAIRE', idUtilisateur: 'U1' }],
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de consigner des autorisations modifées dans le journal MSS sans avoir l'ID du service en paramètre."
+      );
+    }
+  });
+
+  it("lève une exception s'il ne reçoit pas d'autorisations", async () => {
+    try {
+      await consigneAutorisationsModifieesDansJournal({ adaptateurJournal })({
+        idService: 'S1',
+        autorisations: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        'Impossible de consigner des autorisations modifées dans le journal MSS sans avoir les autorisations en paramètre.'
+      );
+    }
+  });
 });

--- a/test/bus/abonnements/consigneCompletudeDansJournal.spec.js
+++ b/test/bus/abonnements/consigneCompletudeDansJournal.spec.js
@@ -24,4 +24,17 @@ describe("L'abonnement qui consigne la complétude dans le journal MSS", () => {
 
     expect(evenementRecu.type).to.equal('COMPLETUDE_SERVICE_MODIFIEE');
   });
+
+  it("lève une exception s'il ne reçoit pas de service", async () => {
+    try {
+      await consigneCompletudeDansJournal({ adaptateurJournal })({
+        service: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        'Impossible de consigner la complétude dans le journal MSS sans avoir le service en paramètre.'
+      );
+    }
+  });
 });

--- a/test/bus/abonnements/consigneNouveauServiceDansJournal.spec.js
+++ b/test/bus/abonnements/consigneNouveauServiceDansJournal.spec.js
@@ -28,4 +28,32 @@ describe("L'abonnement qui consigne la création d'un nouveau service dans le jo
 
     expect(evenementRecu.type).to.equal('NOUVEAU_SERVICE_CREE');
   });
+
+  it("lève une exception s'il ne reçoit pas de service", async () => {
+    try {
+      await consigneNouveauServiceDansJournal({ adaptateurJournal })({
+        service: null,
+        utilisateur: unUtilisateur().avecId('ABC').construis(),
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        'Impossible de consigner un nouveau service dans le journal MSS sans avoir le service en paramètre.'
+      );
+    }
+  });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await consigneNouveauServiceDansJournal({ adaptateurJournal })({
+        service: unService().avecId('123').construis(),
+        utilisateur: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        'Impossible de consigner un nouveau service dans le journal MSS sans avoir le créateur en paramètre.'
+      );
+    }
+  });
 });

--- a/test/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.spec.js
+++ b/test/bus/abonnements/consigneProprietaireCreeUnServiceDansJournal.spec.js
@@ -32,4 +32,36 @@ describe("L'abonnement qui consigne (dans le journal MSS) le lien entre un propr
     expect(autorisations[0].idUtilisateur).not.to.be(undefined);
     expect(autorisations[0].droit).to.be('PROPRIETAIRE');
   });
+
+  it("lève une exception s'il ne reçoit pas de service", async () => {
+    try {
+      await consigneProprietaireCreeUnServiceDansJournal({ adaptateurJournal })(
+        {
+          service: null,
+          utilisateur: unUtilisateur().avecId('ABC').construis(),
+        }
+      );
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        'Impossible de consigner le lien entre un créateur et son service dans le journal MSS sans avoir le service en paramètre.'
+      );
+    }
+  });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await consigneProprietaireCreeUnServiceDansJournal({ adaptateurJournal })(
+        {
+          service: unService().avecId('123').construis(),
+          utilisateur: null,
+        }
+      );
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        'Impossible de consigner le lien entre un créateur et son service dans le journal MSS sans avoir le créateur en paramètre.'
+      );
+    }
+  });
 });

--- a/test/bus/abonnements/envoieTrackingDeCompletude.spec.js
+++ b/test/bus/abonnements/envoieTrackingDeCompletude.spec.js
@@ -55,4 +55,17 @@ describe("L'abonnement qui envoie au tracking les informations de complétude", 
       },
     });
   });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await envoieTrackingCompletude({ adaptateurTracking, depotDonnees })({
+        utilisateur: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible d'envoyer les données de complétude à Brevo sans avoir l'utilisateur en paramètre."
+      );
+    }
+  });
 });

--- a/test/bus/abonnements/envoieTrackingDeNouveauService.spec.js
+++ b/test/bus/abonnements/envoieTrackingDeNouveauService.spec.js
@@ -45,4 +45,20 @@ describe("L'abonnement qui envoie au tracking les informations d'un nouveau serv
       donneesEvenement: { nombreServices: 3 },
     });
   });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await envoieTrackingDeNouveauService({
+        adaptateurTracking,
+        depotDonnees,
+      })({
+        utilisateur: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible d'envoyer le nombre de services d'un utilisateur à Brevo sans avoir l'utilisateur en paramètre."
+      );
+    }
+  });
 });

--- a/test/bus/evenementDescriptionServiceModifiee.spec.js
+++ b/test/bus/evenementDescriptionServiceModifiee.spec.js
@@ -1,0 +1,28 @@
+const expect = require('expect.js');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+const { unService } = require('../constructeurs/constructeurService');
+const {
+  EvenementDescriptionServiceModifiee,
+} = require('../../src/bus/evenementDescriptionServiceModifiee');
+
+describe("L'événement `descriptionServiceModifiee", () => {
+  it("lève une exception s'il est instancié sans service", () => {
+    expect(
+      () =>
+        new EvenementDescriptionServiceModifiee({
+          service: null,
+          utilisateur: unUtilisateur().construis(),
+        })
+    ).to.throwError();
+  });
+
+  it("lève une exception s'il est instancié sans utilisateur", () => {
+    expect(
+      () =>
+        new EvenementDescriptionServiceModifiee({
+          service: unService().construis(),
+          utilisateur: null,
+        })
+    ).to.throwError();
+  });
+});

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -4,23 +4,15 @@ const {
 const DepotDonneesHomologations = require('../../src/depots/depotDonneesHomologations');
 const AdaptateurJournalMSSMemoire = require('../../src/adaptateurs/adaptateurJournalMSSMemoire');
 const Referentiel = require('../../src/referentiel');
-const {
-  fabriqueAdaptateurTrackingMemoire,
-} = require('../../src/adaptateurs/adaptateurTrackingMemoire');
-const {
-  fabriqueServiceTracking,
-} = require('../../src/tracking/serviceTracking');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 class ConstructeurDepotDonneesServices {
   constructor() {
     this.constructeurAdaptateurPersistance = unePersistanceMemoire();
-    this.adaptateurTracking = fabriqueAdaptateurTrackingMemoire();
     this.adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
     this.adaptateurUUID = { genereUUID: () => 'unUUID' };
     this.busEvenements = { publie: () => {}, abonne: () => {} };
     this.referentiel = Referentiel.creeReferentielVide();
-    this.serviceTracking = fabriqueServiceTracking();
   }
 
   avecAdaptateurPersistance(constructeurAdaptateurPersistance) {
@@ -30,16 +22,6 @@ class ConstructeurDepotDonneesServices {
 
   avecJournalMSS(adaptateurJournalMSS) {
     this.adaptateurJournalMSS = adaptateurJournalMSS;
-    return this;
-  }
-
-  avecAdaptateurTracking(adaptateurTracking) {
-    this.adaptateurTracking = adaptateurTracking;
-    return this;
-  }
-
-  avecServiceTracking(serviceTracking) {
-    this.serviceTracking = serviceTracking;
     return this;
   }
 
@@ -58,11 +40,9 @@ class ConstructeurDepotDonneesServices {
       adaptateurChiffrement: fauxAdaptateurChiffrement(),
       adaptateurJournalMSS: this.adaptateurJournalMSS,
       adaptateurPersistance: this.constructeurAdaptateurPersistance.construis(),
-      adaptateurTracking: this.adaptateurTracking,
       adaptateurUUID: this.adaptateurUUID,
       busEvenements: this.busEvenements,
       referentiel: this.referentiel,
-      serviceTracking: this.serviceTracking,
     });
   }
 }

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -417,26 +417,22 @@ describe('Le dépôt de données des homologations', () => {
       expect(descriptionService.nomService).to.equal('Nouveau Nom');
     });
 
-    it('lève une exception si des propriétés obligatoires ne sont pas renseignées', (done) => {
+    it('lève une exception si des propriétés obligatoires ne sont pas renseignées', async () => {
       const descriptionIncomplete = uneDescriptionValide(referentiel)
         .avecNomService('')
         .construis();
 
-      depot
-        .ajouteDescriptionService('U1', 'S1', descriptionIncomplete)
-        .then(() =>
-          done(
-            'La mise à jour de la description du service aurait dû lever une exception'
-          )
-        )
-        .catch((e) => {
-          expect(e).to.be.an(ErreurDonneesObligatoiresManquantes);
-          expect(e.message).to.equal(
-            'Certaines données obligatoires ne sont pas renseignées'
-          );
-          done();
-        })
-        .catch(done);
+      try {
+        await depot.ajouteDescriptionService('U1', 'S1', descriptionIncomplete);
+        expect().fail(
+          'La mise à jour de la description du service aurait dû lever une exception'
+        );
+      } catch (e) {
+        expect(e).to.be.an(ErreurDonneesObligatoiresManquantes);
+        expect(e.message).to.equal(
+          'Certaines données obligatoires ne sont pas renseignées'
+        );
+      }
     });
 
     it('ne détecte pas de doublon sur le nom de service pour le service en cours de mise à jour', async () => {

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -365,7 +365,7 @@ describe('Le dépôt de données des homologations', () => {
     expect(mesure.id).to.equal('identifiantMesure');
   });
 
-  describe("sur demande de mise à jour de la description du service d'une homologation", () => {
+  describe("sur demande de mise à jour de la description d'un service", () => {
     let adaptateurPersistance;
     let adaptateurJournalMSS;
     let depot;
@@ -391,7 +391,7 @@ describe('Le dépôt de données des homologations', () => {
         .construis();
     });
 
-    it("met à jour la description du service d'une homologation", async () => {
+    it('met à jour la description du service', async () => {
       const description = uneDescriptionValide(referentiel)
         .avecNomService('Nouveau Nom')
         .construis();

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -43,9 +43,6 @@ const {
 const {
   unAdaptateurTracking,
 } = require('../constructeurs/constructeurAdaptateurTracking');
-const {
-  unServiceTracking,
-} = require('../tracking/constructeurServiceTracking');
 const { unDossier } = require('../constructeurs/constructeurDossier');
 
 const {
@@ -466,50 +463,6 @@ describe('Le dépôt de données des homologations', () => {
         EvenementDescriptionServiceModifiee
       );
       expect(evenement.service.id).to.be('S1');
-    });
-
-    it('consigne un événement de changement de complétude du service', async () => {
-      let evenementRecu = {};
-      adaptateurJournalMSS.consigneEvenement = (evenement) => {
-        evenementRecu = evenement;
-        return Promise.resolve();
-      };
-      const description = uneDescriptionValide(referentiel).construis();
-
-      await depot.ajouteDescriptionService('U1', 'S1', description);
-
-      expect(evenementRecu.type).to.equal('COMPLETUDE_SERVICE_MODIFIEE');
-    });
-
-    it("l'adaptateur de tracking est utilisé pour envoyer la complétude lors de la mise à jour d'une description du service", async () => {
-      let donneesPassees = {};
-      const description = uneDescriptionValide(referentiel).construis();
-      depot = unDepotDeDonneesServices()
-        .avecReferentiel(referentiel)
-        .avecAdaptateurPersistance(adaptateurPersistance)
-        .avecJournalMSS(adaptateurJournalMSS)
-        .avecServiceTracking(
-          unServiceTracking().avecCompletudeDesServices(2, 3, 12).construis()
-        )
-        .avecAdaptateurTracking(
-          unAdaptateurTracking()
-            .avecEnvoiTrackingCompletude((destinataire, donneesEvenement) => {
-              donneesPassees = { destinataire, donneesEvenement };
-            })
-            .construis()
-        )
-        .construis();
-
-      await depot.ajouteDescriptionService('U1', 'S1', description);
-
-      expect(donneesPassees).to.eql({
-        destinataire: 'jean.dupont@mail.fr',
-        donneesEvenement: {
-          nombreServices: 2,
-          nombreMoyenContributeurs: 3,
-          tauxCompletudeMoyenTousServices: 12,
-        },
-      });
     });
   });
 


### PR DESCRIPTION
### 🪧 CONTEXTE

On veut désormais envoyer dans Metabase des données de l'étape DÉCRIRE.
Typiquement : type de service, provenance, fonctionnalités, …

### 👷‍♂️ ARCHI
Avec le design en place, c'est l'événement Metabase `EvenementCompletudeServiceModifiee` envoyé par l'abonné `consigneCompletudeDansJournal` qui est le bon candidat pour porter ces nouvelles données.

Cet abonné est déclenché lors de la CRÉATION d'un service _(chemin du haut dans le schéma 👇 )_
Mais il n'est pas déclenché lors de la MODIFICATION d'un service _(chemin du bas dans le schéma 👇 )_

Autrement dit : on a un problème car `EvenementCompletudeServiceModifiee` est instancié à 2 endroits différents. Une fois dans l'abonné (ça, c'est bien) et une fois dans le dépôt (ça, c'est pas bien).


![image](https://github.com/betagouv/mon-service-securise/assets/24898521/03008266-6a22-402f-8c8e-b4fc0565de74)

### 🗺️ CHEMIN
 - [ ] Utiliser le `busEvenements` dans `ajouteDescriptionService` pour que la MODIFICATION de service publie un événement (à créer) `EvenementDescriptionServiceModifiee` ⬅️⬅️⬅️ **CETTE PR**
   - Après cette PR, on a donc `consigneCompletudeDansJournal` qui est exécuté à la fois à la création et à la modification de description 👍 
 - [ ] Enrichir l'abonné pour qu'il envoie davantage de données à Metabase