### PR TITLE
[CORRECTION] Répare l'injection de dépendances de l'adaptateur chiffrement

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -14,6 +14,9 @@ const FabriqueAutorisation = require('./src/modeles/autorisations/fabriqueAutori
 const {
   EvenementCollaboratifServiceModifie,
 } = require('./src/modeles/journalMSS/evenementCollaboratifServiceModifie');
+const {
+  fabriqueAdaptateurChiffrement,
+} = require('./src/adaptateurs/fabriqueAdaptateurChiffrement');
 
 class ConsoleAdministration {
   constructor(environnementNode = process.env.NODE_ENV || 'development') {
@@ -21,6 +24,7 @@ class ConsoleAdministration {
       AdaptateurPostgres.nouvelAdaptateur(environnementNode);
     this.referentiel = Referentiel.creeReferentiel(donneesReferentiel);
     this.depotDonnees = DepotDonnees.creeDepot({
+      adaptateurChiffrement: fabriqueAdaptateurChiffrement(),
       adaptateurJWT,
       adaptateurPersistance: this.adaptateurPersistance,
       adaptateurUUID,

--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -6,6 +6,9 @@ const BusEvenements = require('./src/bus/busEvenements');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./src/adaptateurs/fabriqueAdaptateurGestionErreur');
+const {
+  fabriqueAdaptateurChiffrement,
+} = require('./src/adaptateurs/fabriqueAdaptateurChiffrement');
 
 const referentiel = Referentiel.creeReferentiel();
 const descriptionService = new DescriptionService(
@@ -51,7 +54,11 @@ const main = async () => {
     const busEvenements = new BusEvenements({
       adaptateurGestionErreur: fabriqueAdaptateurGestionErreur(),
     });
-    const depotDonnees = DepotDonnees.creeDepot({ busEvenements });
+    const adaptateurChiffrement = fabriqueAdaptateurChiffrement();
+    const depotDonnees = DepotDonnees.creeDepot({
+      adaptateurChiffrement,
+      busEvenements,
+    });
 
     /* eslint-disable no-console */
     const u = await adaptateurPersistance.utilisateurAvecEmail(


### PR DESCRIPTION


Depuis 3c68582390c7344cd6b70f171de93b3a8337f4f8 on n'utilise plus de valeur par défaut. On avait oublié de mettre à jour ces 2 appelants de `creerDepot()`.