### PR TITLE
Ajout du tiroir de téléchargement du tampon d'homologation

### DIFF
--- a/public/assets/images/icone_telecharger_tampon.svg
+++ b/public/assets/images/icone_telecharger_tampon.svg
@@ -1,0 +1,6 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 4.5V11.5L17 9.5" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 11.5L13 9.5" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.98047 15.5H9.39047C9.77047 15.5 10.1105 15.71 10.2805 16.05L11.4505 18.39C11.7905 19.07 12.4805 19.5 13.2405 19.5H16.7705C17.5305 19.5 18.2205 19.07 18.5605 18.39L19.7305 16.05C19.9005 15.71 20.2505 15.5 20.6205 15.5H24.9805" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 6.62891C6.46 7.14891 5 9.22891 5 13.4989V17.4989C5 22.4989 7 24.4989 12 24.4989H18C23 24.4989 25 22.4989 25 17.4989V13.4989C25 9.22891 23.54 7.14891 20 6.62891" stroke="#0079D0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/styles/etapesDossier.css
+++ b/public/assets/styles/etapesDossier.css
@@ -2,7 +2,7 @@
   padding-bottom: 0;
 }
 
-h2 {
+.homologation h2 {
   font-size: 1em;
   font-weight: normal;
 }
@@ -196,4 +196,11 @@ section.autorite {
   background: #fff;
 
   color: var(--bleu-mise-en-avant);
+}
+
+#bouton-tampon-homologation:before {
+  content: url('/statique/assets/images/icone_telecharger_tampon.svg');
+  width: 30px;
+  height: 30px;
+  margin-right: -4px;
 }

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -355,3 +355,28 @@
 .selectize-control.multi .selectize-input.has-items {
   padding: 0.8em;
 }
+
+#contenu-telechargement-tampon-homologation code {
+  font-size: 14px;
+  background: var(--fond-bleu-pale);
+  padding: 2px;
+  border-radius: 4px;
+}
+
+#contenu-telechargement-tampon-homologation :is(ul, li) {
+  margin-top: 8px;
+}
+
+#contenu-telechargement-tampon-homologation .conteneur-actions {
+  justify-content: center;
+  margin-top: 32px;
+}
+
+#contenu-telechargement-tampon-homologation
+  #lien-archive-tampon-homologation:before {
+  content: url('/statique/assets/images/icone_telecharger_tampon.svg');
+  filter: brightness(0) invert();
+  width: 30px;
+  height: 30px;
+  margin-right: -4px;
+}

--- a/public/modules/tableauDeBord/actions/ActionTelechargementTamponHomologation.js
+++ b/public/modules/tableauDeBord/actions/ActionTelechargementTamponHomologation.js
@@ -1,0 +1,22 @@
+import ActionAbstraite from './Action.mjs';
+
+class ActionTelechargementTamponHomologation extends ActionAbstraite {
+  constructor() {
+    super('#contenu-telechargement-tampon-homologation');
+    this.appliqueContenu({
+      titre: 'Comment utiliser le tampon d’homologation',
+      texteSimple: '',
+      texteMultiple: '',
+    });
+  }
+
+  initialise({ idService }) {
+    super.initialise();
+    $('#lien-archive-tampon-homologation').attr(
+      'href',
+      `/api/service/${idService}/archive/tamponHomologation.zip`
+    );
+  }
+}
+
+export default ActionTelechargementTamponHomologation;

--- a/public/service/homologation/dossiers.js
+++ b/public/service/homologation/dossiers.js
@@ -1,5 +1,18 @@
 import brancheComportemenFormulaireEtape from './formulaireEtape.js';
+import ActionTelechargementTamponHomologation from '../../modules/tableauDeBord/actions/ActionTelechargementTamponHomologation.js';
+import { gestionnaireTiroir } from '../../modules/tableauDeBord/gestionnaireTiroir.mjs';
 
 $(() => {
+  const telechargementTamponHomologation =
+    new ActionTelechargementTamponHomologation();
+  const idService = $('.page-service').data('id-service');
+
+  $('#bouton-tampon-homologation').on('click', () => {
+    gestionnaireTiroir.afficheContenuAction(
+      { action: telechargementTamponHomologation },
+      { idService }
+    );
+  });
+
   brancheComportemenFormulaireEtape(() => Promise.resolve());
 });

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -11,6 +11,7 @@ const {
 const Autorisation = require('../../modeles/autorisations/autorisation');
 const Service = require('../../modeles/service');
 const { dateYYYYMMDD } = require('../../utilitaires/date');
+const Dossiers = require('../../modeles/dossiers');
 
 const { LECTURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
@@ -198,12 +199,22 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
-      const { homologation } = requete;
+      const { homologation: service, autorisationService } = requete;
+
+      const dossierActif = service.dossiers.dossierActif();
+      const peutVoirTamponHomologation =
+        autorisationService.aLesPermissions(
+          Autorisation.DROIT_TAMPON_HOMOLOGATION_ZIP
+        ) &&
+        dossierActif &&
+        dossierActif.statutHomologation() === Dossiers.ACTIVEE;
+
       reponse.render('service/dossiers', {
         InformationsHomologation,
-        service: homologation,
+        service,
         etapeActive: 'dossiers',
         premiereEtapeParcours: referentiel.premiereEtapeParcours(),
+        peutVoirTamponHomologation,
         referentiel,
       });
     }

--- a/src/vues/parcoursService.pug
+++ b/src/vues/parcoursService.pug
@@ -43,3 +43,4 @@ block main
     include ./tiroirs/tiroirTelechargement
     include ./tiroirs/tiroirMesure
     include ./tiroirs/tiroirExportMesures
+    include ./tiroirs/tiroirTelechargementTamponHomologation

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -50,6 +50,8 @@ block bouton-etape
     const etapeSuivante = dossierCourant?.etapeCourante() ?? premiereEtapeParcours.id
     const estLectureSeule = autorisationsService.HOMOLOGUER.estLectureSeule
 
+  if(peutVoirTamponHomologation)
+    button.bouton.bouton-tertiaire.bouton-avec-icone#bouton-tampon-homologation(type='button') Télécharger le tampon d’homologation
   if(!estLectureSeule)
     button.bouton#suivant(
       data-id-homologation = service.id,

--- a/src/vues/tiroirs/tiroirTelechargementTamponHomologation.pug
+++ b/src/vues/tiroirs/tiroirTelechargementTamponHomologation.pug
@@ -1,0 +1,28 @@
+.bloc-contenu#contenu-telechargement-tampon-homologation
+  p
+    span Vous êtes sur le point de télécharger une archive&nbsp;
+    code .zip
+    span &nbsp;sur le site MonServiceSécurisé.
+  p
+    span Cette archive contient des cartouches d'homologation personnalisés pour votre service. Nous vous proposons ces cartouches en divers format, afin de faciliter leur utilisation sur votre site internet.
+  ul
+    li
+      span Au format&nbsp;
+      code .png
+      ul
+        li 3 images de cartouche d'homologation. Pour les formats téléphone, tablette et bureau.
+        li 1 image de tampon d'homologation.
+    li
+      span Au format&nbsp;
+      code .html
+      ul
+        li
+          span 3 fichiers contenants les cartouches d'homologation au format&nbsp;
+          code base64
+          span .
+        li
+          span 1 fichier contenant le tampon d'homologation au format&nbsp;
+          code base64
+          span .
+  .conteneur-actions
+    a.bouton.bouton-avec-icone#lien-archive-tampon-homologation Télécharger le tampon d’homologation


### PR DESCRIPTION
#### :heavy_plus_sign:  On ajoute un nouveau tiroir permettant le téléchargement du `.zip` depuis la route ajoutée dans la PR #1355.

#### :man_technologist:  Ce tiroir utilise le même mécanisme que les précédents, à savoir :
- une action héritant de `ActionAbstraite`
- un fichier `.pug` associé
- un déclenchement de l'ouverture via le `gestionnaireTiroir.afficheContenuAction()`

#### :closed_lock_with_key:  Le bouton de téléchargement n'est visible que si :
- un dossier d'homologation est actif et `activee` (donc non-périmé)
- l'utilisateur possède les droits requis (au moins `LECTURE` sur `DECRIRE` et `HOMOLOGUER`)

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/71d68c54-445b-4b59-a633-5b7d44c1d96c)
