### PR TITLE
[HOMOLOGUER] Coche verte dans le menu de navigation

### DIFF
--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -68,6 +68,7 @@ class Dossiers extends ElementsConstructibles {
 
   statutSaisie() {
     if (this.dossierCourant()) return Dossiers.A_COMPLETER;
+    if (this.aUnDossierEnCoursDeValidite()) return Dossiers.COMPLETES;
     return Dossiers.A_SAISIR;
   }
 

--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -24,6 +24,13 @@ class Dossiers extends ElementsConstructibles {
     super(Dossier, { items: dossiers }, referentiel);
   }
 
+  aUnDossierEnCoursDeValidite() {
+    const dossierActif = this.dossierActif();
+
+    if (!dossierActif) return false;
+    return dossierActif.statutHomologation() === Dossiers.ACTIVEE;
+  }
+
   dossierCourant() {
     return this.items.find((i) => !i.finalise);
   }

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -11,7 +11,6 @@ const {
 const Autorisation = require('../../modeles/autorisations/autorisation');
 const Service = require('../../modeles/service');
 const { dateYYYYMMDD } = require('../../utilitaires/date');
-const Dossiers = require('../../modeles/dossiers');
 
 const { LECTURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
@@ -201,13 +200,10 @@ const routesService = ({
     (requete, reponse) => {
       const { homologation: service, autorisationService } = requete;
 
-      const dossierActif = service.dossiers.dossierActif();
       const peutVoirTamponHomologation =
         autorisationService.aLesPermissions(
           Autorisation.DROIT_TAMPON_HOMOLOGATION_ZIP
-        ) &&
-        dossierActif &&
-        dossierActif.statutHomologation() === Dossiers.ACTIVEE;
+        ) && service.dossiers.aUnDossierEnCoursDeValidite();
 
       reponse.render('service/dossiers', {
         InformationsHomologation,

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -2,6 +2,7 @@ const expect = require('expect.js');
 
 const {
   ConstructeurDossierFantaisie,
+  unDossier,
 } = require('../constructeurs/constructeurDossier');
 const {
   ErreurDossiersInvalides,
@@ -192,6 +193,46 @@ describe('Les dossiers liés à un service', () => {
           expect(e.message).to.equal('Aucun dossier courant à finaliser');
         }
       );
+    });
+  });
+
+  describe("sur demande de présence d'un dossier actif et en cours de validité", () => {
+    it("retourne `false` s'il n'y a pas de dossier actif", () => {
+      const dossiersSansDossierActif = new Dossiers(
+        { dossiers: [unDossier(referentiel).quiEstNonFinalise().donnees] },
+        referentiel
+      );
+      expect(dossiersSansDossierActif.aUnDossierEnCoursDeValidite()).to.be(
+        false
+      );
+    });
+
+    it("retourne `false` si le dossier actif n'est pas en cours de validité", () => {
+      const dossiersAvecDossierActifExpire = new Dossiers(
+        {
+          dossiers: [
+            unDossier(referentiel).quiEstComplet().quiEstExpire().donnees,
+          ],
+        },
+        referentiel
+      );
+      expect(
+        dossiersAvecDossierActifExpire.aUnDossierEnCoursDeValidite()
+      ).to.be(false);
+    });
+
+    it('retourne `true` si le dossier actif est en corus de validité', () => {
+      const dossiersAvecDossierActifExpire = new Dossiers(
+        {
+          dossiers: [
+            unDossier(referentiel).quiEstComplet().quiEstActif().donnees,
+          ],
+        },
+        referentiel
+      );
+      expect(
+        dossiersAvecDossierActifExpire.aUnDossierEnCoursDeValidite()
+      ).to.be(true);
     });
   });
 });

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -126,6 +126,17 @@ describe('Les dossiers liés à un service', () => {
 
       expect(dossiers.statutSaisie()).to.equal(Dossiers.A_COMPLETER);
     });
+
+    it("considèrent que l'action est « complète » s'il y a un dossier actif et en cours de validité", () => {
+      const dossierActifEnCoursDeValidite =
+        unDossierComplet().quiEstActif().donnees;
+      const dossiers = new Dossiers(
+        { dossiers: [dossierActifEnCoursDeValidite] },
+        referentiel
+      );
+
+      expect(dossiers.statutSaisie()).to.equal(Dossiers.COMPLETES);
+    });
   });
 
   describe("concernant le statut d'homologation", () => {

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -232,7 +232,7 @@ describe('Les dossiers liés à un service', () => {
       ).to.be(false);
     });
 
-    it('retourne `true` si le dossier actif est en corus de validité', () => {
+    it('retourne `true` si le dossier actif est en cours de validité', () => {
       const dossiersAvecDossierActifExpire = new Dossiers(
         {
           dossiers: [


### PR DESCRIPTION
On corrige ici un problème `legacy` du statut de saisie des dossiers d'homologation.

Depuis le commit [5fbbb68](https://github.com/betagouv/mon-service-securise/commit/5fbbb68a86519449a4c1dd66edbecc61c63c9eee) il est maintenant possible de savoir précisément si un dossier est en cours de validité ou non.