### PR TITLE
Modifie le seuil à partir duquel on masque les indicateurs

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -26,7 +26,7 @@
   align-items: center;
   gap: 1em;
   position: sticky;
-  top: 16px;
+  top: 10px;
   right: 0;
   z-index: 2;
   margin-top: -6em;
@@ -70,7 +70,7 @@
   color: white;
 }
 
-@container conteneur-mesures (max-width: 1060px) {
+@container conteneur-mesures (max-width: 1160px) {
   .cartouche-progression-mesures,
   .cartouche-indice-cyber {
     display: none;


### PR DESCRIPTION
... dans la page SÉCURISER, pour prendre en compte l'ouverture/fermeture du menu de navigation.

[Screencast from 28-02-2024 16:53:36.webm](https://github.com/betagouv/mon-service-securise/assets/1643465/1bbbf7b4-b001-481c-9335-605422b0375d)
