### PR TITLE
Suppression des sous titres sur les pages `Risques` et  `Contacts utiles`

### DIFF
--- a/public/assets/styles/homologation/risques.css
+++ b/public/assets/styles/homologation/risques.css
@@ -1,3 +1,8 @@
+#risques {
+  border-top: solid 1px var(--liseres);
+  padding-top: 24px;
+}
+
 .risque {
   position: relative;
 

--- a/src/vues/service/risques.pug
+++ b/src/vues/service/risques.pug
@@ -27,11 +27,6 @@ block sous-titre
 block formulaire
   - const estLectureSeule  = autorisationsService.RISQUES.estLectureSeule
   form.homologation#risques
-    p.description-risques
-      | Cliquez sur le curseur pour évaluer l'impact potentiel des risques
-      | de sécurité les plus courants sur votre service. Apportez des précisions
-      | et ajoutez des risques complémentaires, si nécessaire.
-
     +carteInformations({
       titre: 'Niveaux de gravité',
       sousTitre: "Découvrez les 5 niveaux définis par l'ANSSI.",

--- a/src/vues/service/rolesResponsabilites.pug
+++ b/src/vues/service/rolesResponsabilites.pug
@@ -23,8 +23,6 @@ block sous-titre
 block formulaire
   - const estLectureSeule  = autorisationsService.CONTACTS.estLectureSeule
   form.homologation#roles-responsabilites
-    p.informations-complementaires.
-      Listez toutes les personnes assurant le bon fonctionnement du service pour les contacter rapidement en cas de besoin.
 
     section
       nav#onglets-liens


### PR DESCRIPTION
...afin d'harmoniser toutes les pages du parcours service.