### PR TITLE
[TDB] Lien vers la rubrique HOMOLOGUER

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -517,6 +517,9 @@ label[for='recherche-service'] {
   display: inline-flex;
   gap: 0.5em;
   white-space: nowrap;
+  color: var(--texte-fonce);
+  text-decoration: none;
+  font-weight: 500;
 }
 
 .tableau-services td .statut-homologation.enCoursEdition::after {
@@ -791,7 +794,9 @@ label[for='recherche-service'] {
   filter: none;
 }
 
-.tableau-services td :is(.contributeurs, .conteneur-indice-cyber):hover {
+.tableau-services
+  td
+  :is(.contributeurs, .conteneur-indice-cyber, a.statut-homologation):hover {
   background: #0c5c98;
   color: white;
 }
@@ -800,7 +805,9 @@ label[for='recherche-service'] {
   filter: brightness(0) invert(100%);
 }
 
-.tableau-services td :is(.contributeurs, .conteneur-indice-cyber):active {
+.tableau-services
+  td
+  :is(.contributeurs, .conteneur-indice-cyber, a.statut-homologation):active {
   background: #08416a;
   color: white;
 }
@@ -811,7 +818,12 @@ label[for='recherche-service'] {
 
 .tableau-services
   td
-  :is(.contributeurs, .conteneur-indice-cyber, .selection-service) {
+  :is(
+    .contributeurs,
+    .conteneur-indice-cyber,
+    .selection-service,
+    a.statut-homologation
+  ) {
   position: relative;
   z-index: 2;
 }

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -246,13 +246,19 @@ const tableauDesServices = {
       $ligne.append(
         $(`<td class="cellule-indice-cyber">${contenuIndiceCyber}</td>`)
       );
+      const typeElementHtml = service.statutHomologation ? 'a' : 'div';
+      const lienHomologation = service.statutHomologation?.enCoursEdition
+        ? `/service/${service.id}/homologation/edition/etape/${service.statutHomologation.etapeCourante}`
+        : `/service/${service.id}/dossiers`;
       $ligne.append(
         $(
-          `<td><div class='statut-homologation statut-${
+          `<td><${typeElementHtml} class='statut-homologation statut-${
             service.statutHomologation?.id ?? 'inconnu'
           } ${
             service.statutHomologation?.enCoursEdition ? 'enCoursEdition' : ''
-          }'>${service.statutHomologation?.libelle ?? '-'}</div></td>`
+          }' href='${lienHomologation}'>${
+            service.statutHomologation?.libelle ?? '-'
+          }</${typeElementHtml}></td>`
         )
       );
       tableauDesServices.$tableau.append($ligne);

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -3,31 +3,40 @@ const Autorisation = require('../autorisations/autorisation');
 
 const { DROITS_VOIR_STATUT_HOMOLOGATION } = Autorisation;
 
-const donnees = (service, autorisation, referentiel) => ({
-  id: service.id,
-  nomService: service.nomService(),
-  organisationsResponsables:
-    service.descriptionService.organisationsResponsables ?? [],
-  contributeurs: service.contributeurs.map((c) => ({
-    id: c.id,
-    prenomNom: c.prenomNom(),
-    initiales: c.initiales(),
-    poste: c.posteDetaille(),
-    estUtilisateurCourant: autorisation.designeUtilisateur(c.id),
-  })),
-  ...(autorisation.aLesPermissions(DROITS_VOIR_STATUT_HOMOLOGATION) && {
-    statutHomologation: {
-      id: service.dossiers.statutHomologation(),
-      enCoursEdition: service.dossiers.statutSaisie() === Dossiers.A_COMPLETER,
-      ...referentiel.statutHomologation(service.dossiers.statutHomologation()),
+const donnees = (service, autorisation, referentiel) => {
+  const enCoursEdition =
+    service.dossiers.statutSaisie() === Dossiers.A_COMPLETER;
+  return {
+    id: service.id,
+    nomService: service.nomService(),
+    organisationsResponsables:
+      service.descriptionService.organisationsResponsables ?? [],
+    contributeurs: service.contributeurs.map((c) => ({
+      id: c.id,
+      prenomNom: c.prenomNom(),
+      initiales: c.initiales(),
+      poste: c.posteDetaille(),
+      estUtilisateurCourant: autorisation.designeUtilisateur(c.id),
+    })),
+    ...(autorisation.aLesPermissions(DROITS_VOIR_STATUT_HOMOLOGATION) && {
+      statutHomologation: {
+        id: service.dossiers.statutHomologation(),
+        enCoursEdition,
+        ...(enCoursEdition && {
+          etapeCourante: service.dossiers.dossierCourant()?.etapeCourante(),
+        }),
+        ...referentiel.statutHomologation(
+          service.dossiers.statutHomologation()
+        ),
+      },
+    }),
+    nombreContributeurs: service.contributeurs.length,
+    estProprietaire: autorisation.estProprietaire,
+    documentsPdfDisponibles: service.documentsPdfDisponibles(autorisation),
+    permissions: {
+      gestionContributeurs: autorisation.peutGererContributeurs(),
     },
-  }),
-  nombreContributeurs: service.contributeurs.length,
-  estProprietaire: autorisation.estProprietaire,
-  documentsPdfDisponibles: service.documentsPdfDisponibles(autorisation),
-  permissions: {
-    gestionContributeurs: autorisation.peutGererContributeurs(),
-  },
-});
+  };
+};
 
 module.exports = { donnees };

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -13,18 +13,28 @@ const { unService } = require('../../constructeurs/constructeurService');
 const {
   unUtilisateur,
 } = require('../../constructeurs/constructeurUtilisateur');
+const { unDossier } = require('../../constructeurs/constructeurDossier');
 
 describe("L'objet d'API de `GET /service`", () => {
   const referentiel = Referentiel.creeReferentiel({
     statutsHomologation: {
       nonRealisee: { libelle: 'Non réalisée', ordre: 1 },
     },
+    echeancesRenouvellement: { unAn: {} },
+    statutsAvisDossierHomologation: { favorable: {} },
+    etapesParcoursHomologation: [
+      {
+        numero: 1,
+        libelle: 'Autorité',
+        id: 'autorite',
+      },
+    ],
   });
   const lectureSurHomologuer = uneAutorisation()
     .avecDroits({ [HOMOLOGUER]: LECTURE })
     .construis();
 
-  const service = unService()
+  const service = unService(referentiel)
     .avecId('123')
     .avecNomService('Un service')
     .avecOrganisationResponsable('Une organisation')
@@ -42,6 +52,9 @@ describe("L'objet d'API de `GET /service`", () => {
         .quiSAppelle('Pierre Lecoux')
         .avecPostes(['Maire']).donnees
     )
+    .avecDossiers([
+      unDossier(referentiel).quiEstComplet().quiEstNonFinalise().donnees,
+    ])
     .construis();
 
   it('fournit les données nécessaires', () => {
@@ -68,7 +81,8 @@ describe("L'objet d'API de `GET /service`", () => {
         },
       ],
       statutHomologation: {
-        enCoursEdition: false,
+        enCoursEdition: true,
+        etapeCourante: 'autorite',
         libelle: 'Non réalisée',
         id: 'nonRealisee',
         ordre: 1,

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1531,7 +1531,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
             estUtilisateurCourant: false,
           },
         ],
-        statutHomologation: { id: 'nonRealisee', enCoursEdition: true },
+        statutHomologation: {
+          id: 'nonRealisee',
+          enCoursEdition: true,
+          etapeCourante: 'autorite',
+        },
         nombreContributeurs: 2,
         estProprietaire: false,
         documentsPdfDisponibles: [],


### PR DESCRIPTION
On ajoute un lien vers la rubrique `HOMOLOGUER` depuis le statut d'homologation du tableau de bord, avec un lien direct vers l'étape courante si elle existe.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/547cbc8a-f32b-4f67-88f0-a74989731c30)
