### PR TITLE
[REMANIEMENT] Événement de complétude du service modifiée

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -65,13 +65,7 @@ class ConsoleAdministration {
     const services = await this.depotDonnees.tousLesServices();
     const evenements = services
       .map((s) =>
-        new EvenementCompletudeServiceModifiee({
-          service: s,
-          idService: s.id,
-          ...s.completudeMesures(),
-          nombreOrganisationsUtilisatrices:
-            s.descriptionService.nombreOrganisationsUtilisatrices,
-        }).toJSON()
+        new EvenementCompletudeServiceModifiee({ service: s }).toJSON()
       )
       .map(({ donnees, ...reste }) => ({
         donnees: { ...donnees, genereParAdministrateur: true },

--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -66,6 +66,7 @@ class ConsoleAdministration {
     const evenements = services
       .map((s) =>
         new EvenementCompletudeServiceModifiee({
+          service: s,
           idService: s.id,
           ...s.completudeMesures(),
           nombreOrganisationsUtilisatrices:

--- a/src/bus/abonnements/consigneCompletudeDansJournal.js
+++ b/src/bus/abonnements/consigneCompletudeDansJournal.js
@@ -12,13 +12,7 @@ function consigneCompletudeDansJournal({ adaptateurJournal }) {
 
     if (!service) leveException('service');
 
-    const completude = new EvenementCompletudeServiceModifiee({
-      service,
-      idService: service.id,
-      ...service.completudeMesures(),
-      nombreOrganisationsUtilisatrices:
-        service.descriptionService.nombreOrganisationsUtilisatrices,
-    });
+    const completude = new EvenementCompletudeServiceModifiee({ service });
 
     await adaptateurJournal.consigneEvenement(completude.toJSON());
   };

--- a/src/bus/abonnements/consigneCompletudeDansJournal.js
+++ b/src/bus/abonnements/consigneCompletudeDansJournal.js
@@ -13,6 +13,7 @@ function consigneCompletudeDansJournal({ adaptateurJournal }) {
     if (!service) leveException('service');
 
     const completude = new EvenementCompletudeServiceModifiee({
+      service,
       idService: service.id,
       ...service.completudeMesures(),
       nombreOrganisationsUtilisatrices:

--- a/src/modeles/journalMSS/erreurs.js
+++ b/src/modeles/journalMSS/erreurs.js
@@ -1,30 +1,20 @@
 class ErreurJournal extends Error {}
 class ErreurAutorisationsServiceManquantes extends ErreurJournal {}
 class ErreurDateHomologationManquante extends ErreurJournal {}
-class ErreurDetailMesuresManquant extends ErreurJournal {}
 class ErreurDureeHomologationManquante extends ErreurJournal {}
 class ErreurIdentifiantServiceManquant extends ErreurJournal {}
 class ErreurIdentifiantUtilisateurManquant extends ErreurJournal {}
 class ErreurIdentifiantMesureManquant extends ErreurJournal {}
 class ErreurIdentifiantRetourUtilisateurManquant extends ErreurJournal {}
-class ErreurIndiceCyberManquant extends ErreurJournal {}
-class ErreurNombreOrganisationsUtilisatricesManquant extends ErreurJournal {}
-class ErreurNombreMesuresCompletesManquant extends ErreurJournal {}
-class ErreurNombreTotalMesuresManquant extends ErreurJournal {}
 class ErreurServiceManquant extends ErreurJournal {}
 
 module.exports = {
   ErreurAutorisationsServiceManquantes,
   ErreurDateHomologationManquante,
-  ErreurDetailMesuresManquant,
   ErreurDureeHomologationManquante,
   ErreurIdentifiantServiceManquant,
   ErreurIdentifiantUtilisateurManquant,
   ErreurIdentifiantMesureManquant,
   ErreurIdentifiantRetourUtilisateurManquant,
-  ErreurIndiceCyberManquant,
-  ErreurNombreOrganisationsUtilisatricesManquant,
-  ErreurNombreMesuresCompletesManquant,
-  ErreurNombreTotalMesuresManquant,
   ErreurServiceManquant,
 };

--- a/src/modeles/journalMSS/erreurs.js
+++ b/src/modeles/journalMSS/erreurs.js
@@ -11,6 +11,7 @@ class ErreurIndiceCyberManquant extends ErreurJournal {}
 class ErreurNombreOrganisationsUtilisatricesManquant extends ErreurJournal {}
 class ErreurNombreMesuresCompletesManquant extends ErreurJournal {}
 class ErreurNombreTotalMesuresManquant extends ErreurJournal {}
+class ErreurServiceManquant extends ErreurJournal {}
 
 module.exports = {
   ErreurAutorisationsServiceManquantes,
@@ -25,4 +26,5 @@ module.exports = {
   ErreurNombreOrganisationsUtilisatricesManquant,
   ErreurNombreMesuresCompletesManquant,
   ErreurNombreTotalMesuresManquant,
+  ErreurServiceManquant,
 };

--- a/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
+++ b/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
@@ -6,6 +6,7 @@ const {
   ErreurNombreOrganisationsUtilisatricesManquant,
   ErreurNombreTotalMesuresManquant,
   ErreurIndiceCyberManquant,
+  ErreurServiceManquant,
 } = require('./erreurs');
 
 class EvenementCompletudeServiceModifiee extends Evenement {
@@ -15,6 +16,7 @@ class EvenementCompletudeServiceModifiee extends Evenement {
     const valide = () => {
       const manque = (donnee) => typeof donnee === 'undefined';
 
+      if (manque(donnees.service)) throw new ErreurServiceManquant();
       if (manque(donnees.idService))
         throw new ErreurIdentifiantServiceManquant();
       if (manque(donnees.nombreTotalMesures))
@@ -36,7 +38,7 @@ class EvenementCompletudeServiceModifiee extends Evenement {
 
     valide();
 
-    const { idService, indiceCyber, ...donneesBrutes } = donnees;
+    const { idService, indiceCyber, service, ...donneesBrutes } = donnees;
 
     super(
       'COMPLETUDE_SERVICE_MODIFIEE',

--- a/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
+++ b/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
@@ -1,13 +1,5 @@
 const Evenement = require('./evenement');
-const {
-  ErreurDetailMesuresManquant,
-  ErreurIdentifiantServiceManquant,
-  ErreurNombreMesuresCompletesManquant,
-  ErreurNombreOrganisationsUtilisatricesManquant,
-  ErreurNombreTotalMesuresManquant,
-  ErreurIndiceCyberManquant,
-  ErreurServiceManquant,
-} = require('./erreurs');
+const { ErreurServiceManquant } = require('./erreurs');
 
 class EvenementCompletudeServiceModifiee extends Evenement {
   constructor(donnees, options = {}) {
@@ -17,17 +9,6 @@ class EvenementCompletudeServiceModifiee extends Evenement {
       const manque = (donnee) => typeof donnee === 'undefined';
 
       if (manque(donnees.service)) throw new ErreurServiceManquant();
-      if (manque(donnees.idService))
-        throw new ErreurIdentifiantServiceManquant();
-      if (manque(donnees.nombreTotalMesures))
-        throw new ErreurNombreTotalMesuresManquant();
-      if (manque(donnees.nombreMesuresCompletes))
-        throw new ErreurNombreMesuresCompletesManquant();
-      if (manque(donnees.detailMesures))
-        throw new ErreurDetailMesuresManquant();
-      if (manque(donnees.indiceCyber)) throw new ErreurIndiceCyberManquant();
-      if (manque(donnees.nombreOrganisationsUtilisatrices))
-        throw new ErreurNombreOrganisationsUtilisatricesManquant();
     };
 
     const enTableau = (donneesIndiceCyber) =>
@@ -38,19 +19,23 @@ class EvenementCompletudeServiceModifiee extends Evenement {
 
     valide();
 
-    const { idService, indiceCyber, service, ...donneesBrutes } = donnees;
+    const { service } = donnees;
+    const { indiceCyber, ...autreDonneesCompletude } =
+      service.completudeMesures();
+    const { borneBasse, borneHaute } =
+      service.descriptionService.nombreOrganisationsUtilisatrices;
+
+    const nombreOuUn = (nombre) => Number(nombre) || 1;
 
     super(
       'COMPLETUDE_SERVICE_MODIFIEE',
       {
-        idService: adaptateurChiffrement.hacheSha256(idService),
+        idService: adaptateurChiffrement.hacheSha256(service.id),
         detailIndiceCyber: enTableau(indiceCyber),
-        ...donneesBrutes,
+        ...autreDonneesCompletude,
         nombreOrganisationsUtilisatrices: {
-          borneBasse:
-            Number(donnees.nombreOrganisationsUtilisatrices.borneBasse) || 1,
-          borneHaute:
-            Number(donnees.nombreOrganisationsUtilisatrices.borneHaute) || 1,
+          borneBasse: nombreOuUn(borneBasse),
+          borneHaute: nombreOuUn(borneHaute),
         },
       },
       date

--- a/test/modeles/journalMSS/constructeurEvenementCompletudeServiceModifiee.js
+++ b/test/modeles/journalMSS/constructeurEvenementCompletudeServiceModifiee.js
@@ -1,8 +1,11 @@
 const EvenementCompletudeServiceModifiee = require('../../../src/modeles/journalMSS/evenementCompletudeServiceModifiee');
+const { unService } = require('../../constructeurs/constructeurService');
 
 class ConstructeurEvenementCompletudeServiceModifiee {
   constructor() {
+    const service = unService().avecId('abc').donnees;
     this.donnees = {
+      service,
       idService: 'abc',
       nombreTotalMesures: 54,
       nombreMesuresCompletes: 38,

--- a/test/modeles/journalMSS/constructeurEvenementCompletudeServiceModifiee.js
+++ b/test/modeles/journalMSS/constructeurEvenementCompletudeServiceModifiee.js
@@ -3,27 +3,19 @@ const { unService } = require('../../constructeurs/constructeurService');
 
 class ConstructeurEvenementCompletudeServiceModifiee {
   constructor() {
-    const service = unService().avecId('abc').donnees;
-    this.donnees = {
-      service,
-      idService: 'abc',
-      nombreTotalMesures: 54,
-      nombreMesuresCompletes: 38,
-      detailMesures: [{ idMesure: 'analyseRisques', statut: 'fait' }],
-      indiceCyber: { total: 4.1 },
-      nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
-    };
+    const service = unService().avecId('abc').construis();
+    this.donnees = { service };
     this.date = '14/02/2023';
     this.adaptateurChiffrement = { hacheSha256: (valeur) => valeur };
   }
 
-  avecIdService(idService) {
-    this.donnees.idService = idService;
+  avecService(service) {
+    this.donnees.service = service;
     return this;
   }
 
-  avecIndiceCyber(indiceCyber) {
-    this.donnees.indiceCyber = indiceCyber;
+  avecIdService(idService) {
+    this.donnees.service.id = idService;
     return this;
   }
 
@@ -38,8 +30,10 @@ class ConstructeurEvenementCompletudeServiceModifiee {
   }
 
   avecNombreOrganisationsUtilisatricesInconnu() {
-    this.donnees.nombreOrganisationsUtilisatrices.borneBasse = '0';
-    this.donnees.nombreOrganisationsUtilisatrices.borneHaute = '0';
+    this.donnees.service.descriptionService.nombreOrganisationsUtilisatrices.borneBasse =
+      '0';
+    this.donnees.service.descriptionService.nombreOrganisationsUtilisatrices.borneHaute =
+      '0';
     return this;
   }
 

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -32,18 +32,10 @@ describe('Un événement de complétude modifiée', () => {
       indiceCyber: { noteMax: 5 },
     });
     const mesuresPersonnalises = {
-      mesureA: {
-        description: 'Mesure A',
-        referentiel: 'ANSSI',
-        categorie: 'gouvernance',
-      },
+      mesureA: { categorie: 'gouvernance' },
     };
     const mesures = new Mesures(
-      {
-        mesuresGenerales: [
-          { id: 'mesureA', statut: 'fait', modalites: 'un commentaire' },
-        ],
-      },
+      { mesuresGenerales: [{ id: 'mesureA', statut: 'fait' }] },
       referentiel,
       mesuresPersonnalises
     );
@@ -54,7 +46,7 @@ describe('Un événement de complétude modifiée', () => {
 
     const evenement = new EvenementCompletudeServiceModifiee(
       { service },
-      { date: '17/11/2022', adaptateurChiffrement: hacheEnMajuscules }
+      { date: '08/03/2024', adaptateurChiffrement: hacheEnMajuscules }
     );
 
     expect(evenement.toJSON()).to.eql({
@@ -68,12 +60,9 @@ describe('Un événement de complétude modifiée', () => {
           { categorie: 'total', indice: 5 },
           { categorie: 'gouvernance', indice: 5 },
         ],
-        nombreOrganisationsUtilisatrices: {
-          borneBasse: 1,
-          borneHaute: 5,
-        },
+        nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
       },
-      date: '17/11/2022',
+      date: '08/03/2024',
     });
   });
 
@@ -84,19 +73,9 @@ describe('Un événement de complétude modifiée', () => {
       statutsMesures: { fait: 'Faite' },
       indiceCyber: { noteMax: 5 },
     });
-    const mesuresPersonnalises = {
-      mesureA: {
-        description: 'Mesure A',
-        referentiel: 'ANSSI',
-        categorie: 'gouvernance',
-      },
-    };
+    const mesuresPersonnalises = { mesureA: { categorie: 'gouvernance' } };
     const mesures = new Mesures(
-      {
-        mesuresGenerales: [
-          { id: 'mesureA', statut: 'fait', modalites: 'un commentaire' },
-        ],
-      },
+      { mesuresGenerales: [{ id: 'mesureA', statut: 'fait' }] },
       referentiel,
       mesuresPersonnalises
     );

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -8,7 +8,9 @@ const {
   ErreurNombreMesuresCompletesManquant,
   ErreurIndiceCyberManquant,
   ErreurNombreOrganisationsUtilisatricesManquant,
+  ErreurServiceManquant,
 } = require('../../../src/modeles/journalMSS/erreurs');
+const { unService } = require('../../constructeurs/constructeurService');
 
 describe('Un événement de complétude modifiée', () => {
   const unEvenement = () =>
@@ -29,6 +31,7 @@ describe('Un événement de complétude modifiée', () => {
   it('sait se convertir en JSON', () => {
     const evenement = new EvenementCompletudeServiceModifiee(
       {
+        service: unService().avecId('abc').construis(),
         idService: 'abc',
         nombreTotalMesures: 54,
         nombreMesuresCompletes: 38,
@@ -81,6 +84,19 @@ describe('Un événement de complétude modifiée', () => {
       borneBasse: 1,
       borneHaute: 1,
     });
+  });
+
+  it('exige que le service soit renseigné', (done) => {
+    try {
+      unEvenement().sans('service').construis();
+
+      done(
+        Error("L'instanciation de l'événement aurait dû lever une exception")
+      );
+    } catch (e) {
+      expect(e).to.be.an(ErreurServiceManquant);
+      done();
+    }
   });
 
   it("exige que l'identifiant du service soit renseigné", (done) => {


### PR DESCRIPTION
En vue de rajouter des nouvelles données dans l'événement `EvenementCompletudeServiceModifiee`, on remanie son fonctionnement.
Comme toutes les données proviennent du `service`, on ne passe plus que ce dernier en `donnees`.