### PR TITLE
[DECRIRE] Ajout de propriétés complementaires dans l'événement `EvenementCompletudeServiceModifiee`

### DIFF
--- a/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
+++ b/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
@@ -22,8 +22,21 @@ class EvenementCompletudeServiceModifiee extends Evenement {
     const { service } = donnees;
     const { indiceCyber, ...autreDonneesCompletude } =
       service.completudeMesures();
-    const { borneBasse, borneHaute } =
-      service.descriptionService.nombreOrganisationsUtilisatrices;
+    const {
+      typeService,
+      nombreOrganisationsUtilisatrices,
+      provenanceService,
+      statutDeploiement,
+      pointsAcces,
+      fonctionnalites,
+      fonctionnalitesSpecifiques,
+      donneesCaracterePersonnel,
+      donneesSensiblesSpecifiques,
+      localisationDonnees,
+      delaiAvantImpactCritique,
+      risqueJuridiqueFinancierReputationnel,
+    } = service.descriptionService;
+    const { borneBasse, borneHaute } = nombreOrganisationsUtilisatrices;
 
     const nombreOuUn = (nombre) => Number(nombre) || 1;
 
@@ -37,6 +50,17 @@ class EvenementCompletudeServiceModifiee extends Evenement {
           borneBasse: nombreOuUn(borneBasse),
           borneHaute: nombreOuUn(borneHaute),
         },
+        typeService,
+        provenanceService,
+        statutDeploiement,
+        pointsAcces: pointsAcces.nombre(),
+        fonctionnalites,
+        fonctionnalitesSpecifiques: fonctionnalitesSpecifiques.nombre(),
+        donneesCaracterePersonnel,
+        donneesSensiblesSpecifiques: donneesSensiblesSpecifiques.nombre(),
+        localisationDonnees,
+        delaiAvantImpactCritique,
+        risqueJuridiqueFinancierReputationnel,
       },
       date
     );

--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -27,6 +27,11 @@ class ConstructeurService {
     return this;
   }
 
+  avecDescription(description) {
+    this.donnees.descriptionService = description;
+    return this;
+  }
+
   avecId(id) {
     this.donnees.id = id;
     return this;

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -42,6 +42,20 @@ describe('Un événement de complétude modifiée', () => {
     const service = unService(referentiel)
       .avecId('ABC')
       .avecMesures(mesures)
+      .avecDescription({
+        delaiAvantImpactCritique: 'uneHeure',
+        localisationDonnees: 'uneLocalisation',
+        donneesCaracterePersonnel: ['donnee A', 'donnee B'],
+        donneesSensiblesSpecifiques: ['donneeSensible A'],
+        fonctionnalites: ['reseauSocial'],
+        fonctionnalitesSpecifiques: ['feature A', 'feature B'],
+        provenanceService: 'developpement',
+        risqueJuridiqueFinancierReputationnel: true,
+        statutDeploiement: 'unStatutDeploiement',
+        typeService: ['applicationMobile'],
+        nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
+        pointsAcces: ['point A', 'point B'],
+      })
       .construis();
 
     const evenement = new EvenementCompletudeServiceModifiee(
@@ -61,6 +75,17 @@ describe('Un événement de complétude modifiée', () => {
           { categorie: 'gouvernance', indice: 5 },
         ],
         nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
+        typeService: ['applicationMobile'],
+        provenanceService: 'developpement',
+        statutDeploiement: 'unStatutDeploiement',
+        pointsAcces: 2,
+        fonctionnalites: ['reseauSocial'],
+        fonctionnalitesSpecifiques: 2,
+        donneesCaracterePersonnel: ['donnee A', 'donnee B'],
+        donneesSensiblesSpecifiques: 1,
+        localisationDonnees: 'uneLocalisation',
+        delaiAvantImpactCritique: 'uneHeure',
+        risqueJuridiqueFinancierReputationnel: true,
       },
       date: '08/03/2024',
     });


### PR DESCRIPTION
On souhaite rajouter dans l'événement `EvenementCompletudeServiceModifiee` les informations suivantes :
- Type de services
- Provenance
- Statut
- :heavy_plus_sign: Nombre d’accès
- Liste des features
- :heavy_plus_sign: Nombre features custom
- Liste des données à caractère personnel
- :heavy_plus_sign: Nombre données à caractère personnel custom
- Localisation données
- Durée maximale dysfonctionnement
- Impact si atteinte à la sécurité

_Les :heavy_plus_sign:  indiquent que ce n’est PAS la donnée brute, mais seulement le compte._

Toutes ces données sont disponible dans la `descriptionService` de l'objet `service`, qui est maintenant passé à l'événement depuis la PR #1369 