### PR TITLE
[CORRECTION] Bordure des "ronds" de pagination du carrousel

### DIFF
--- a/public/assets/styles/nouvellesFonctionnalites/modaleNouvellesFonctionnalites.css
+++ b/public/assets/styles/nouvellesFonctionnalites/modaleNouvellesFonctionnalites.css
@@ -102,6 +102,7 @@
 
 .modale-nouvelles-fonctionnalites .pagination .rond.actif {
   background: linear-gradient(180deg, #54b8f6 0%, #3479c9 100%);
+  background-origin: border-box;
   border: 1px solid transparent;
 }
 


### PR DESCRIPTION
... afin d'afficher la pagination correctement.

L’explication :
https://stackoverflow.com/a/51785787/8526334

| Avant | Après |
|--------|--------|
| ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/863b03db-3214-435b-99ca-92c56b64baf6) | ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/f913fd95-4ef5-45dc-b9b5-15519261d1c5) |