### PR TITLE
[CORRECTION] Décorde les caractères HTML des documents annexes de l'homologation

### DIFF
--- a/src/vues/service/etapeDossier/documents.pug
+++ b/src/vues/service/etapeDossier/documents.pug
@@ -41,7 +41,7 @@ block formulaire
       .message-erreur Ce champ est obligatoire. Veuillez le renseigner. 
     ul#liste-documents
       each document in documents.documents
-        li.element-document(data-document=document)
+        li.element-document(data-document!=document)
           .contenu!= document
           if(!estLectureSeule)
             .bouton-supprimer


### PR DESCRIPTION
... car sinon on affiche des caractères HTML non décodés.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/5c090203-13b6-4743-8ffe-0b073be705ad)
