### PR TITLE
Tri les dossiers archives dans l'ordre décroissant des date de prochaine homologation

### DIFF
--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -26,7 +26,13 @@ class Dossiers extends ElementsConstructibles {
   }
 
   archives() {
-    return this.items.filter((i) => i.archive);
+    return this.items
+      .filter((i) => i.archive)
+      .sort(
+        (a, b) =>
+          new Date(b.dateProchaineHomologation()) -
+          new Date(a.dateProchaineHomologation())
+      );
   }
 
   aUnDossierEnCoursDeValidite() {

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -272,6 +272,30 @@ describe('Les dossiers liés à un service', () => {
       expect(archives.length).to.be(1);
       expect(archives[0].id).to.be('archive');
     });
+
+    it("retournent les dossiers archives dans l'ordre décroissant des dates d'échéances", () => {
+      const dossiers = new Dossiers(
+        {
+          dossiers: [
+            unDossier(referentiel)
+              .avecId('archive-deuxieme')
+              .quiEstComplet()
+              .avecDecision('01/01/2023', 'unAn')
+              .quiEstArchive().donnees,
+            unDossier(referentiel)
+              .avecId('archive-premier')
+              .quiEstComplet()
+              .avecDecision('01/01/2024', 'unAn')
+              .quiEstArchive().donnees,
+          ],
+        },
+        referentiel
+      );
+
+      const archives = dossiers.archives();
+      expect(archives[0].id).to.be('archive-premier');
+      expect(archives[1].id).to.be('archive-deuxieme');
+    });
   });
 
   describe('sur demande de suppression du dossier courant', () => {


### PR DESCRIPTION
…afin de les afficher dans un ordre cohérent sur le front.

| Avant | Après |
|--------|--------|
| ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/9d4a094d-f38e-451d-a014-ed234a0dad57) | ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/e6a599b9-bafd-4fa9-98a4-150e585ca9c8) |