### PR TITLE
Renomme "cartouche" en "encart" pour le tampon d'homologation

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionTelechargementTamponHomologation.js
+++ b/public/modules/tableauDeBord/actions/ActionTelechargementTamponHomologation.js
@@ -4,7 +4,7 @@ class ActionTelechargementTamponHomologation extends ActionAbstraite {
   constructor() {
     super('#contenu-telechargement-tampon-homologation');
     this.appliqueContenu({
-      titre: 'Comment utiliser le tampon d’homologation',
+      titre: "Comment utiliser l'encart d’homologation",
       texteSimple: '',
       texteMultiple: '',
     });

--- a/src/adaptateurs/adaptateurPdf.configurationTamponHomologation.js
+++ b/src/adaptateurs/adaptateurPdf.configurationTamponHomologation.js
@@ -3,16 +3,16 @@ const instructionsTamponHomologation = Buffer.from(
 ------------------------
 
 Vous avez téléchargé une archive .zip sur le site MonServiceSécurisé.
-Cette archive contient des cartouches d'homologation personnalisés pour votre service.
+Cette archive contient des encarts d'homologation personnalisés pour votre service.
 
-Nous vous proposons ces cartouches en divers formats, afin de faciliter leur utilisation
+Nous vous proposons ces encarts en divers formats, afin de faciliter leur utilisation
 sur votre site internet.
 
 - Au format .png
-  - 3 images de cartouche d'homologation. Pour les formats téléphone, tablette et bureau.
+  - 3 images d'encart d'homologation. Pour les formats téléphone, tablette et bureau.
   - 1 image de tampon d'homologation.
 - Au format .html
-  - 3 fichiers contenants les cartouches d'homologation au format « base64 ».
+  - 3 fichiers contenant les encarts d'homologation au format « base64 ».
   - 1 fichier contenant le tampon d'homologation au format « base64 ».`,
   'utf-8'
 );

--- a/src/adaptateurs/adaptateurPdf.js
+++ b/src/adaptateurs/adaptateurPdf.js
@@ -189,12 +189,12 @@ const genereTamponHomologation = async (donnees) => {
 
       const bufferImage = Buffer.from(screenshotBase64, 'base64');
       fichiers.push({
-        nom: `cartoucheHomologation.${tailleDispositif}.png`,
+        nom: `encartHomologation.${tailleDispositif}.png`,
         buffer: bufferImage,
       });
 
       fichiers.push({
-        nom: `cartoucheHomologation.${tailleDispositif}.html`,
+        nom: `encartHomologation.${tailleDispositif}.html`,
         buffer: compileImageEnHTMLBase64(bufferImage, largeur, hauteur),
       });
     }

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -49,7 +49,7 @@ mixin dossier({ statut, dossier, service, indiceCyber, afficheStatutHomologation
         a.lien-etape-courante(href = `/service/${service.id}/homologation/edition/etape/${etapeCourante}`)
           img.fleche(src='/statique/assets/images/forme_chevron_bleu.svg' alt='')
     if afficheTamponHomologation
-      button.bouton.bouton-tertiaire.bouton-avec-icone#bouton-tampon-homologation(type='button') Télécharger le tampon
+      button.bouton.bouton-tertiaire.bouton-avec-icone#bouton-tampon-homologation(type='button') Télécharger l'encart d'homologation
 
 
 mixin dossierFinalise({ dossier, service, afficheStatutHomologation, afficheTamponHomologation })

--- a/src/vues/tiroirs/tiroirTelechargementTamponHomologation.pug
+++ b/src/vues/tiroirs/tiroirTelechargementTamponHomologation.pug
@@ -4,20 +4,20 @@
     code .zip
     span &nbsp;sur le site MonServiceSécurisé.
   p
-    span Cette archive contient des cartouches d'homologation personnalisés pour votre service. Nous vous proposons ces cartouches en divers format, afin de faciliter leur utilisation sur votre site internet.
+    span Cette archive contient des encarts d'homologation personnalisés pour votre service. Nous vous proposons ces encarts en divers format, afin de faciliter leur utilisation sur votre site internet.
   ul
     li
       span Au format&nbsp;
       code .png
       ul
-        li 3 images de cartouche d'homologation. Pour les formats téléphone, tablette et bureau.
+        li 3 images d'encart d'homologation. Pour les formats téléphone, tablette et bureau.
         li 1 image de tampon d'homologation.
     li
       span Au format&nbsp;
       code .html
       ul
         li
-          span 3 fichiers contenants les cartouches d'homologation au format&nbsp;
+          span 3 fichiers contenant les encarts d'homologation au format&nbsp;
           code base64
           span .
         li
@@ -25,4 +25,4 @@
           code base64
           span .
   .conteneur-actions
-    a.bouton.bouton-avec-icone#lien-archive-tampon-homologation Télécharger le tampon d’homologation
+    a.bouton.bouton-avec-icone#lien-archive-tampon-homologation Télécharger l'encart d'homologation


### PR DESCRIPTION
... suite à une décision du produit.