### PR TITLE
[CORRECTION] Droit d'accès aux étapes d'homologation

### DIFF
--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -6,6 +6,10 @@ const { DROITS_VOIR_STATUT_HOMOLOGATION } = Autorisation;
 const donnees = (service, autorisation, referentiel) => {
   const enCoursEdition =
     service.dossiers.statutSaisie() === Dossiers.A_COMPLETER;
+  const etapeCouranteAutorisee = referentiel.etapeDossierAutorisee(
+    service.dossiers.dossierCourant()?.etapeCourante(),
+    autorisation.peutHomologuer()
+  );
   return {
     id: service.id,
     nomService: service.nomService(),
@@ -22,9 +26,7 @@ const donnees = (service, autorisation, referentiel) => {
       statutHomologation: {
         id: service.dossiers.statutHomologation(),
         enCoursEdition,
-        ...(enCoursEdition && {
-          etapeCourante: service.dossiers.dossierCourant()?.etapeCourante(),
-        }),
+        ...(enCoursEdition && { etapeCourante: etapeCouranteAutorisee }),
         ...referentiel.statutHomologation(
           service.dossiers.statutHomologation()
         ),

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -185,11 +185,15 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const premiereEtapeParcours = () =>
     etapesParcoursHomologation().find((e) => e.numero === 1);
 
-  const derniereEtapeParcours = () =>
-    etapesParcoursHomologation().find(
+  const derniereEtapeParcours = (peutHomologuer = true) =>
+    etapesParcoursHomologation(peutHomologuer).find(
       (e) =>
         e.numero ===
-        Math.max(...etapesParcoursHomologation().map(({ numero }) => numero))
+        Math.max(
+          ...etapesParcoursHomologation(peutHomologuer).map(
+            ({ numero }) => numero
+          )
+        )
     );
 
   const etapeExiste = (idEtape) =>

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -223,7 +223,7 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     async (requete, reponse, suite) => {
-      const { homologation } = requete;
+      const { homologation, autorisationService } = requete;
       const { idEtape } = requete.params;
 
       if (!referentiel.etapeExiste(idEtape)) {
@@ -235,7 +235,10 @@ const routesService = ({
         await depotDonnees.ajouteDossierCourantSiNecessaire(homologation.id);
 
         const h = await depotDonnees.homologation(homologation.id);
-        const etapeCourante = h.dossierCourant().etapeCourante();
+        const etapeCourante = referentiel.etapeDossierAutorisee(
+          h.dossierCourant().etapeCourante(),
+          autorisationService.peutHomologuer()
+        );
         const numeroEtapeCourante = referentiel.numeroEtape(etapeCourante);
         const numeroEtapeDemandee = referentiel.numeroEtape(idEtape);
         if (numeroEtapeDemandee > numeroEtapeCourante) {

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -4,7 +4,7 @@ mixin dossier({ statut, dossier, service, indiceCyber, afficheStatutHomologation
   -
     const etapeCourante = referentiel.etapeDossierAutorisee(dossier.etapeCourante(), autorisationsService.peutHomologuer)
     const numeroDerniereEtapeCompletee = referentiel.numeroEtape(etapeCourante)
-    const nombreTotalEtapes = referentiel.derniereEtapeParcours().numero
+    const nombreTotalEtapes = referentiel.derniereEtapeParcours(autorisationsService.peutHomologuer).numero
     const estLectureSeule = autorisationsService.HOMOLOGUER.estLectureSeule
     const texteTronque = (texte, tailleLimite) => {
       const texteDecode = decode(texte);
@@ -35,11 +35,10 @@ mixin dossier({ statut, dossier, service, indiceCyber, afficheStatutHomologation
               div!= `Autorité d'homologation : ${texteTronque(dossier.autorite.nom, 37)} | ${texteTronque(dossier.autorite.fonction, 37)}`
               div= `Date d'échéance : ${dossier.descriptionProchaineDateHomologation()}`
             else
-              if(!estLectureSeule)
-                - const titreEtape = referentiel.etapesParcoursHomologation().find((e) => e.id === etapeCourante)
-                .contenu-etape-courante
-                  .numero-etape!= `Étape ${numeroDerniereEtapeCompletee} sur ${nombreTotalEtapes}`
-                  .titre-etape!= titreEtape.libelle
+              - const titreEtape = referentiel.etapesParcoursHomologation().find((e) => e.id === etapeCourante)
+              .contenu-etape-courante
+                .numero-etape!= `Étape ${numeroDerniereEtapeCompletee} sur ${nombreTotalEtapes}`
+                .titre-etape!= titreEtape.libelle
     if afficheActions
       .conteneur-actions
         if !estLectureSeule

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -106,6 +106,39 @@ describe("L'objet d'API de `GET /service`", () => {
     expect(donnees.statutHomologation).to.be(undefined);
   });
 
+  it("montre la dernière étape disponible si l'utilisateur n'a pas le droit d'homologuer", () => {
+    const referentielDeuxEtapes = Referentiel.creeReferentiel({
+      echeancesRenouvellement: { unAn: {} },
+      statutsAvisDossierHomologation: { favorable: {} },
+      statutsHomologation: {
+        nonRealisee: { libelle: 'Non réalisée', ordre: 1 },
+      },
+      etapesParcoursHomologation: [
+        { numero: 1, libelle: 'Autorité', id: 'autorite' },
+        {
+          numero: 2,
+          libelle: 'Avis',
+          id: 'avis',
+          reserveePeutHomologuer: true,
+        },
+      ],
+    });
+
+    const serviceAvecDossierFinalise = unService(referentielDeuxEtapes)
+      .avecId('123')
+      .avecDossiers([
+        unDossier(referentiel).quiEstComplet().quiEstNonFinalise().donnees,
+      ])
+      .construis();
+
+    const donnees = objetGetService.donnees(
+      serviceAvecDossierFinalise,
+      lectureSurHomologuer,
+      referentielDeuxEtapes
+    );
+    expect(donnees.statutHomologation.etapeCourante).to.be('autorite');
+  });
+
   describe('sur demande des permissions', () => {
     it("autorise la gestion de contributeurs si l'utilisateur est propriétaire", () => {
       const unServiceDontAestCreateur = unService()

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -588,6 +588,32 @@ describe('Le référentiel', () => {
     expect(referentiel.premiereEtapeParcours()).to.equal(premiereEtape);
   });
 
+  describe('sur demande de la derniére étape du parcours Homologation', () => {
+    it('connaît la dernière étape du parcours Homologation', () => {
+      const premiereEtape = { id: 'premiere', numero: 1 };
+      const derniereEtape = { id: 'derniere', numero: 2 };
+      const referentiel = Referentiel.creeReferentiel({
+        etapesParcoursHomologation: [premiereEtape, derniereEtape],
+      });
+
+      expect(referentiel.derniereEtapeParcours()).to.equal(derniereEtape);
+    });
+
+    it("utilise uniquement les étapes autorisées pour l'utilisateur si il n'a pas le droit d'homologuer", () => {
+      const premiereEtape = { id: 'premiere', numero: 1 };
+      const derniereEtape = {
+        id: 'derniere',
+        numero: 2,
+        reserveePeutHomologuer: true,
+      };
+      const referentiel = Referentiel.creeReferentiel({
+        etapesParcoursHomologation: [premiereEtape, derniereEtape],
+      });
+
+      expect(referentiel.derniereEtapeParcours(false)).to.equal(premiereEtape);
+    });
+  });
+
   describe("sur demande du numéro d'une étape du parcours Homologation", () => {
     it("sait retrouver le numéro d'une étape à partir de son ID", () => {
       const referentiel = Referentiel.creeReferentiel({


### PR DESCRIPTION
Lors d'une démo, on a remarqué un bug :
Un utilisateur qui n'a pas le droit d'homologation (donc qui n'est pas propriétaire) peut tout de même accéder aux étapes 5 et 6 du parcours HOMOLOGUER.

On corrige donc dans cette PR :
- Le lien affiché dans le tableau de bord, pointant désormais vers la dernière étape DISPONIBLE par l'utilisateur
- La redirection vers l'URL de la dernière étape DISPONIBLE pour un utilisateur
- L'affichage du nombre d'étapes totales d'un dossier d'homologation