### PR TITLE
[SOIN] Extrait la consignation d'évènements associés à l'utilisateur vers le bus d'évènements

### DIFF
--- a/src/bus/abonnements/consigneNouvelUtilisateurInscritDansJournal.js
+++ b/src/bus/abonnements/consigneNouvelUtilisateurInscritDansJournal.js
@@ -1,0 +1,20 @@
+const EvenementNouvelUtilisateurInscrit = require('../../modeles/journalMSS/evenementNouvelUtilisateurInscrit');
+
+function consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal }) {
+  return async ({ utilisateur }) => {
+    if (!utilisateur)
+      throw new Error(
+        "Impossible de consigner l'inscription d'un utilisateur sans avoir l'utilisateur en paramètre."
+      );
+
+    const profilUtilisateurModifie = new EvenementNouvelUtilisateurInscrit({
+      idUtilisateur: utilisateur.id,
+    });
+
+    await adaptateurJournal.consigneEvenement(
+      profilUtilisateurModifie.toJSON()
+    );
+  };
+}
+
+module.exports = { consigneNouvelUtilisateurInscritDansJournal };

--- a/src/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.js
+++ b/src/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.js
@@ -1,0 +1,20 @@
+const EvenementProfilUtilisateurModifie = require('../../modeles/journalMSS/evenementProfilUtilisateurModifie');
+
+function consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal }) {
+  return async ({ utilisateur }) => {
+    if (!utilisateur)
+      throw new Error(
+        `Impossible de consigner les mises à jour de profil utilisateur sans avoir l'utilisateur en paramètre.`
+      );
+
+    const profilUtilisateurModifie = new EvenementProfilUtilisateurModifie(
+      utilisateur
+    );
+
+    await adaptateurJournal.consigneEvenement(
+      profilUtilisateurModifie.toJSON()
+    );
+  };
+}
+
+module.exports = { consigneProfilUtilisateurModifieDansJournal };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -65,10 +65,10 @@ const cableTousLesAbonnes = (
     consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal })
   );
 
-  busEvenements.abonne(
-    EvenementUtilisateurInscrit,
-    consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal })
-  );
+  busEvenements.abonnePlusieurs(EvenementUtilisateurInscrit, [
+    consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal }),
+    consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal }),
+  ]);
 };
 
 module.exports = { cableTousLesAbonnes };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -28,6 +28,10 @@ const EvenementUtilisateurModifie = require('./evenementUtilisateurModifie');
 const {
   consigneProfilUtilisateurModifieDansJournal,
 } = require('./abonnements/consigneProfilUtilisateurModifieDansJournal');
+const {
+  consigneNouvelUtilisateurInscritDansJournal,
+} = require('./abonnements/consigneNouvelUtilisateurInscritDansJournal');
+const EvenementUtilisateurInscrit = require('./evenementUtilisateurInscrit');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -59,6 +63,11 @@ const cableTousLesAbonnes = (
   busEvenements.abonne(
     EvenementUtilisateurModifie,
     consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal })
+  );
+
+  busEvenements.abonne(
+    EvenementUtilisateurInscrit,
+    consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal })
   );
 };
 

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -24,6 +24,10 @@ const {
 const {
   EvenementDescriptionServiceModifiee,
 } = require('./evenementDescriptionServiceModifiee');
+const EvenementUtilisateurModifie = require('./evenementUtilisateurModifie');
+const {
+  consigneProfilUtilisateurModifieDansJournal,
+} = require('./abonnements/consigneProfilUtilisateurModifieDansJournal');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -50,6 +54,11 @@ const cableTousLesAbonnes = (
   busEvenements.abonne(
     EvenementAutorisationsServiceModifiees,
     consigneAutorisationsModifieesDansJournal({ adaptateurJournal })
+  );
+
+  busEvenements.abonne(
+    EvenementUtilisateurModifie,
+    consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal })
   );
 };
 

--- a/src/bus/evenementUtilisateurInscrit.js
+++ b/src/bus/evenementUtilisateurInscrit.js
@@ -1,0 +1,10 @@
+class EvenementUtilisateurInscrit {
+  constructor({ utilisateur }) {
+    if (!utilisateur)
+      throw Error("Impossible d'instancier l'événement sans utilisateur");
+
+    this.utilisateur = utilisateur;
+  }
+}
+
+module.exports = EvenementUtilisateurInscrit;

--- a/src/bus/evenementUtilisateurModifie.js
+++ b/src/bus/evenementUtilisateurModifie.js
@@ -1,0 +1,10 @@
+class EvenementUtilisateurModifie {
+  constructor({ utilisateur }) {
+    if (!utilisateur)
+      throw Error("Impossible d'instancier l'événement sans utilisateur");
+
+    this.utilisateur = utilisateur;
+  }
+}
+
+module.exports = EvenementUtilisateurModifie;

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -30,7 +30,6 @@ const creeDepot = (config = {}) => {
 
   const depotUtilisateurs = depotDonneesUtilisateurs.creeDepot({
     adaptateurChiffrement,
-    adaptateurJournalMSS,
     adaptateurJWT,
     adaptateurPersistance,
     adaptateurUUID,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -35,6 +35,7 @@ const creeDepot = (config = {}) => {
     adaptateurPersistance,
     adaptateurUUID,
     depotHomologations,
+    busEvenements,
   });
 
   const depotAutorisations = depotDonneesAutorisations.creeDepot({

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -9,8 +9,8 @@ const {
   ErreurMotDePasseIncorrect,
 } = require('../erreurs');
 const EvenementNouvelUtilisateurInscrit = require('../modeles/journalMSS/evenementNouvelUtilisateurInscrit');
-const EvenementProfilUtilisateurModifie = require('../modeles/journalMSS/evenementProfilUtilisateurModifie');
 const Utilisateur = require('../modeles/utilisateur');
+const EvenementUtilisateurModifie = require('../bus/evenementUtilisateurModifie');
 
 const creeDepot = (config = {}) => {
   const {
@@ -19,6 +19,7 @@ const creeDepot = (config = {}) => {
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
     adaptateurUUID = adaptateurUUIDParDefaut,
+    busEvenements,
   } = config;
 
   const utilisateur = async (identifiant) => {
@@ -54,8 +55,8 @@ const creeDepot = (config = {}) => {
       }).toJSON()
     );
 
-    await adaptateurJournalMSS.consigneEvenement(
-      new EvenementProfilUtilisateurModifie(u).toJSON()
+    await busEvenements.publie(
+      new EvenementUtilisateurModifie({ utilisateur: u })
     );
 
     return u;
@@ -103,8 +104,8 @@ const creeDepot = (config = {}) => {
     delete donnees.motDePasse;
     await adaptateurPersistance.metsAJourUtilisateur(id, donnees);
     const u = await utilisateur(id);
-    await adaptateurJournalMSS.consigneEvenement(
-      new EvenementProfilUtilisateurModifie(u).toJSON()
+    await busEvenements.publie(
+      new EvenementUtilisateurModifie({ utilisateur: u })
     );
     return u;
   };

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -8,14 +8,13 @@ const {
   ErreurUtilisateurInexistant,
   ErreurMotDePasseIncorrect,
 } = require('../erreurs');
-const EvenementNouvelUtilisateurInscrit = require('../modeles/journalMSS/evenementNouvelUtilisateurInscrit');
 const Utilisateur = require('../modeles/utilisateur');
 const EvenementUtilisateurModifie = require('../bus/evenementUtilisateurModifie');
+const EvenementUtilisateurInscrit = require('../bus/evenementUtilisateurInscrit');
 
 const creeDepot = (config = {}) => {
   const {
     adaptateurChiffrement,
-    adaptateurJournalMSS,
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
     adaptateurUUID = adaptateurUUIDParDefaut,
@@ -49,10 +48,8 @@ const creeDepot = (config = {}) => {
     await adaptateurPersistance.ajouteUtilisateur(id, donneesUtilisateur);
     u = await utilisateur(id);
 
-    await adaptateurJournalMSS.consigneEvenement(
-      new EvenementNouvelUtilisateurInscrit({
-        idUtilisateur: id,
-      }).toJSON()
+    await busEvenements.publie(
+      new EvenementUtilisateurInscrit({ utilisateur: u })
     );
 
     await busEvenements.publie(

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -52,10 +52,6 @@ const creeDepot = (config = {}) => {
       new EvenementUtilisateurInscrit({ utilisateur: u })
     );
 
-    await busEvenements.publie(
-      new EvenementUtilisateurModifie({ utilisateur: u })
-    );
-
     return u;
   };
 

--- a/test/bus/abonnements/consigneNouvelUtilisateurInscritDansJournal.spec.js
+++ b/test/bus/abonnements/consigneNouvelUtilisateurInscritDansJournal.spec.js
@@ -1,0 +1,42 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+const {
+  consigneNouvelUtilisateurInscritDansJournal,
+} = require('../../../src/bus/abonnements/consigneNouvelUtilisateurInscritDansJournal');
+
+describe("L'abonnement qui consigne (dans le journal MSS) l'inscription d'un utilisateur", () => {
+  let adaptateurJournal;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+  });
+
+  it('consigne un événement de "nouvel utilisateur inscrit"', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal })({
+      utilisateur: unUtilisateur().construis(),
+    });
+
+    expect(evenementRecu.type).to.be('NOUVEL_UTILISATEUR_INSCRIT');
+  });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal })({
+        utilisateur: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de consigner l'inscription d'un utilisateur sans avoir l'utilisateur en paramètre."
+      );
+    }
+  });
+});

--- a/test/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.spec.js
+++ b/test/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.spec.js
@@ -1,0 +1,42 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+const {
+  consigneProfilUtilisateurModifieDansJournal,
+} = require('../../../src/bus/abonnements/consigneProfilUtilisateurModifieDansJournal');
+
+describe("L'abonnement qui consigne (dans le journal MSS) la mise à jour du profil d'un utilisateur", () => {
+  let adaptateurJournal;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+  });
+
+  it('consigne un événement de "profil utilisateur modifié"', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal })({
+      utilisateur: unUtilisateur().construis(),
+    });
+
+    expect(evenementRecu.type).to.be('PROFIL_UTILISATEUR_MODIFIE');
+  });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal })({
+        utilisateur: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de consigner les mises à jour de profil utilisateur sans avoir l'utilisateur en paramètre."
+      );
+    }
+  });
+});

--- a/test/bus/evenementUtilisateurInscrit.spec.js
+++ b/test/bus/evenementUtilisateurInscrit.spec.js
@@ -1,0 +1,13 @@
+const expect = require('expect.js');
+const EvenementUtilisateurInscrit = require('../../src/bus/evenementUtilisateurInscrit');
+
+describe("L'événement `utilisateurInscrit", () => {
+  it("lève une exception s'il est instancié sans utilisateur", () => {
+    expect(
+      () =>
+        new EvenementUtilisateurInscrit({
+          utilisateur: null,
+        })
+    ).to.throwError();
+  });
+});

--- a/test/bus/evenementUtilisateurModifie.spec.js
+++ b/test/bus/evenementUtilisateurModifie.spec.js
@@ -1,0 +1,13 @@
+const expect = require('expect.js');
+const EvenementUtilisateurModifie = require('../../src/bus/evenementUtilisateurModifie');
+
+describe("L'événement `utilisateurModifie", () => {
+  it("lève une exception s'il est instancié sans utilisateur", () => {
+    expect(
+      () =>
+        new EvenementUtilisateurModifie({
+          utilisateur: null,
+        })
+    ).to.throwError();
+  });
+});

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -448,21 +448,6 @@ describe('Le dépôt de données des utilisateurs', () => {
         const recu = bus.recupereEvenement(EvenementUtilisateurInscrit);
         expect(recu.utilisateur.id).not.to.be(undefined);
       });
-
-      it("publie sur le bus d'événements l'utilisateur modifié", async () => {
-        await depot.nouvelUtilisateur({
-          prenom: 'Jean',
-          nom: 'Dupont',
-          email: 'jean.dupont@mail.fr',
-        });
-
-        expect(bus.aRecuUnEvenement(EvenementUtilisateurModifie)).to.be(true);
-        const recu = bus.recupereEvenement(EvenementUtilisateurModifie);
-        expect(recu.utilisateur.id).not.to.be(undefined);
-        expect(recu.utilisateur.prenom).to.be('Jean');
-        expect(recu.utilisateur.nom).to.be('Dupont');
-        expect(recu.utilisateur.email).to.be('jean.dupont@mail.fr');
-      });
     });
 
     describe("quand l'utilisateur existe déjà", () => {


### PR DESCRIPTION
Actuellement, le `depotDonneesUtilisateur` consigne lui même des évènements dans le journal, via l'`adaptateurJournal`.

On souhaite déplacer cette reponsabilité, grâce au `busEvenements` mit en place.

Les deux évènements concernés sont `ProfilUtilisateurModifie` et `NouvelUtilisateurInscrit`.