### PR TITLE
[SOIN] Utilise le `busEvenements` pour les consignation dans le journal du `depotDonneesHomologation`

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,6 +58,7 @@ cableTousLesAbonnes(busEvenements, {
   adaptateurTracking,
   adaptateurJournal,
   depotDonnees,
+  referentiel,
 });
 
 const middleware = Middleware({

--- a/server.js
+++ b/server.js
@@ -50,7 +50,6 @@ const moteurRegles = new MoteurRegles(referentiel);
 
 const depotDonnees = DepotDonnees.creeDepot({
   adaptateurChiffrement,
-  adaptateurJournalMSS: adaptateurJournal,
   busEvenements,
 });
 

--- a/src/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.js
+++ b/src/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.js
@@ -1,0 +1,32 @@
+const EvenementNouvelleHomologationCreee = require('../../modeles/journalMSS/evenementNouvelleHomologationCreee');
+
+function consigneNouvelleHomologationCreeeDansJournal({
+  adaptateurJournal,
+  referentiel,
+}) {
+  return async ({ idService, dossier }) => {
+    if (!idService)
+      throw new Error(
+        "Impossible de consigner la finalisation d'un dossier d'homologation sans avoir l'ID du service en paramètre."
+      );
+
+    if (!dossier)
+      throw new Error(
+        "Impossible de consigner la finalisation d'un dossier d'homologation sans avoir le dossier en paramètre."
+      );
+
+    const nouvelleHomologationCreee = new EvenementNouvelleHomologationCreee({
+      idService,
+      dateHomologation: dossier.decision.dateHomologation,
+      dureeHomologationMois: referentiel.nbMoisDecalage(
+        dossier.decision.dureeValidite
+      ),
+    });
+
+    await adaptateurJournal.consigneEvenement(
+      nouvelleHomologationCreee.toJSON()
+    );
+  };
+}
+
+module.exports = { consigneNouvelleHomologationCreeeDansJournal };

--- a/src/bus/abonnements/consigneServiceSupprimeDansJournal.js
+++ b/src/bus/abonnements/consigneServiceSupprimeDansJournal.js
@@ -1,0 +1,18 @@
+const EvenementServiceSupprime = require('../../modeles/journalMSS/evenementServiceSupprime');
+
+function consigneServiceSupprimeDansJournal({ adaptateurJournal }) {
+  return async ({ idService }) => {
+    if (!idService)
+      throw new Error(
+        "Impossible de consigner la suppression d'un service sans avoir l'ID du service en paramètre."
+      );
+
+    const serviceSupprime = new EvenementServiceSupprime({ idService });
+
+    await adaptateurJournal.consigneEvenement(serviceSupprime.toJSON());
+  };
+}
+
+module.exports = {
+  consigneServiceSupprimeDansJournal,
+};

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -32,10 +32,14 @@ const {
   consigneNouvelUtilisateurInscritDansJournal,
 } = require('./abonnements/consigneNouvelUtilisateurInscritDansJournal');
 const EvenementUtilisateurInscrit = require('./evenementUtilisateurInscrit');
+const EvenementDossierHomologationFinalise = require('./evenementDossierHomologationFinalise');
+const {
+  consigneNouvelleHomologationCreeeDansJournal,
+} = require('./abonnements/consigneNouvelleHomologationCreeeDansJournal');
 
 const cableTousLesAbonnes = (
   busEvenements,
-  { adaptateurTracking, adaptateurJournal, depotDonnees }
+  { adaptateurTracking, adaptateurJournal, depotDonnees, referentiel }
 ) => {
   busEvenements.abonnePlusieurs(EvenementNouveauServiceCree, [
     consigneNouveauServiceDansJournal({ adaptateurJournal }),
@@ -69,6 +73,14 @@ const cableTousLesAbonnes = (
     consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal }),
     consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal }),
   ]);
+
+  busEvenements.abonne(
+    EvenementDossierHomologationFinalise,
+    consigneNouvelleHomologationCreeeDansJournal({
+      adaptateurJournal,
+      referentiel,
+    })
+  );
 };
 
 module.exports = { cableTousLesAbonnes };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -36,6 +36,10 @@ const EvenementDossierHomologationFinalise = require('./evenementDossierHomologa
 const {
   consigneNouvelleHomologationCreeeDansJournal,
 } = require('./abonnements/consigneNouvelleHomologationCreeeDansJournal');
+const EvenementServiceSupprime = require('./evenementServiceSupprime');
+const {
+  consigneServiceSupprimeDansJournal,
+} = require('./abonnements/consigneServiceSupprimeDansJournal');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -80,6 +84,11 @@ const cableTousLesAbonnes = (
       adaptateurJournal,
       referentiel,
     })
+  );
+
+  busEvenements.abonne(
+    EvenementServiceSupprime,
+    consigneServiceSupprimeDansJournal({ adaptateurJournal })
   );
 };
 

--- a/src/bus/evenementDossierHomologationFinalise.js
+++ b/src/bus/evenementDossierHomologationFinalise.js
@@ -1,0 +1,14 @@
+class EvenementDossierHomologationFinalise {
+  constructor({ idService, dossier }) {
+    if (!idService)
+      throw Error("Impossible d'instancier l'événement sans ID de service");
+
+    if (!dossier)
+      throw Error("Impossible d'instancier l'événement sans dossier");
+
+    this.idService = idService;
+    this.dossier = dossier;
+  }
+}
+
+module.exports = EvenementDossierHomologationFinalise;

--- a/src/bus/evenementServiceSupprime.js
+++ b/src/bus/evenementServiceSupprime.js
@@ -1,0 +1,10 @@
+class EvenementServiceSupprime {
+  constructor({ idService }) {
+    if (!idService)
+      throw Error("Impossible d'instancier l'événement sans ID de service");
+
+    this.idService = idService;
+  }
+}
+
+module.exports = EvenementServiceSupprime;

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -1,6 +1,5 @@
 const adaptateurJWTParDefaut = require('./adaptateurs/adaptateurJWT');
 const adaptateurUUIDParDefaut = require('./adaptateurs/adaptateurUUID');
-const fabriqueAdaptateurJournalMSS = require('./adaptateurs/fabriqueAdaptateurJournalMSS');
 const fabriqueAdaptateurPersistance = require('./adaptateurs/fabriqueAdaptateurPersistance');
 const Referentiel = require('./referentiel');
 const depotDonneesAutorisations = require('./depots/depotDonneesAutorisations');
@@ -11,7 +10,6 @@ const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 const creeDepot = (config = {}) => {
   const {
     adaptateurChiffrement,
-    adaptateurJournalMSS = fabriqueAdaptateurJournalMSS(),
     adaptateurJWT = adaptateurJWTParDefaut,
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
     adaptateurUUID = adaptateurUUIDParDefaut,
@@ -21,7 +19,6 @@ const creeDepot = (config = {}) => {
 
   const depotHomologations = depotDonneesHomologations.creeDepot({
     adaptateurChiffrement,
-    adaptateurJournalMSS,
     adaptateurPersistance,
     adaptateurUUID,
     busEvenements,

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -6,7 +6,6 @@ const {
 const DescriptionService = require('../modeles/descriptionService');
 const Dossier = require('../modeles/dossier');
 const Homologation = require('../modeles/homologation');
-const EvenementServiceSupprime = require('../modeles/journalMSS/evenementServiceSupprime');
 const Autorisation = require('../modeles/autorisations/autorisation');
 const EvenementMesuresServiceModifiees = require('../bus/evenementMesuresServiceModifiees');
 const EvenementNouveauServiceCree = require('../bus/evenementNouveauServiceCree');
@@ -14,6 +13,7 @@ const {
   EvenementDescriptionServiceModifiee,
 } = require('../bus/evenementDescriptionServiceModifiee');
 const EvenementDossierHomologationFinalise = require('../bus/evenementDossierHomologationFinalise');
+const EvenementServiceSupprime = require('../bus/evenementServiceSupprime');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = async (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -91,7 +91,6 @@ const fabriquePersistance = (
 const creeDepot = (config = {}) => {
   const {
     adaptateurChiffrement,
-    adaptateurJournalMSS,
     adaptateurPersistance,
     adaptateurUUID,
     busEvenements,
@@ -319,9 +318,7 @@ const creeDepot = (config = {}) => {
   const supprimeHomologation = async (idService) => {
     await adaptateurPersistance.supprimeAutorisationsHomologation(idService);
     await p.supprime(idService);
-    await adaptateurJournalMSS.consigneEvenement(
-      new EvenementServiceSupprime({ idService }).toJSON()
-    );
+    await busEvenements.publie(new EvenementServiceSupprime({ idService }));
   };
 
   const trouveIndexDisponible = async (idProprietaire, nomService) => {

--- a/src/depots/depotDonneesHomologations.js
+++ b/src/depots/depotDonneesHomologations.js
@@ -316,15 +316,13 @@ const creeDepot = (config = {}) => {
   const remplaceRisquesSpecifiquesDuService = (...params) =>
     remplaceProprieteService('risquesSpecifiques', ...params);
 
-  const supprimeHomologation = (idHomologation) =>
-    adaptateurPersistance
-      .supprimeAutorisationsHomologation(idHomologation)
-      .then(() => p.supprime(idHomologation))
-      .then(() =>
-        adaptateurJournalMSS.consigneEvenement(
-          new EvenementServiceSupprime({ idService: idHomologation }).toJSON()
-        )
-      );
+  const supprimeHomologation = async (idService) => {
+    await adaptateurPersistance.supprimeAutorisationsHomologation(idService);
+    await p.supprime(idService);
+    await adaptateurJournalMSS.consigneEvenement(
+      new EvenementServiceSupprime({ idService }).toJSON()
+    );
+  };
 
   const trouveIndexDisponible = async (idProprietaire, nomService) => {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping

--- a/test/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.spec.js
+++ b/test/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.spec.js
@@ -1,0 +1,61 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const {
+  consigneNouvelleHomologationCreeeDansJournal,
+} = require('../../../src/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal');
+const { unDossier } = require('../../constructeurs/constructeurDossier');
+const Referentiel = require('../../../src/referentiel');
+
+describe("L'abonnement qui consigne (dans le journal MSS) la finalisation d'un dossier d'homologation", () => {
+  let adaptateurJournal;
+  let referentiel;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+    referentiel = Referentiel.creeReferentiel({
+      echeancesRenouvellement: { unAn: { nbMoisDecalage: 12 } },
+      statutsAvisDossierHomologation: { favorable: {} },
+    });
+  });
+
+  it('consigne un événement de "nouvelle homologation créée"', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneNouvelleHomologationCreeeDansJournal({
+      adaptateurJournal,
+      referentiel,
+    })({
+      idService: '123',
+      dossier: unDossier(referentiel).quiEstComplet().quiEstActif().construit(),
+    });
+
+    expect(evenementRecu.type).to.be('NOUVELLE_HOMOLOGATION_CREEE');
+  });
+
+  [
+    { propriete: 'idService', nom: "l'ID du service" },
+    { propriete: 'dossier', nom: 'le dossier' },
+  ].forEach(({ propriete, nom }) => {
+    const donnees = {
+      idService: '123',
+      dossier: {},
+    };
+    it(`lève une exception s'il ne reçoit pas ${nom}`, async () => {
+      try {
+        delete donnees[propriete];
+        await consigneNouvelleHomologationCreeeDansJournal({
+          adaptateurJournal,
+          referentiel,
+        })(donnees);
+        expect().fail("L'instanciation aurait dû lever une exception.");
+      } catch (e) {
+        expect(e.message).to.be(
+          `Impossible de consigner la finalisation d'un dossier d'homologation sans avoir ${nom} en paramètre.`
+        );
+      }
+    });
+  });
+});

--- a/test/bus/abonnements/consigneServiceSupprimeDansJournal.spec.js
+++ b/test/bus/abonnements/consigneServiceSupprimeDansJournal.spec.js
@@ -1,0 +1,39 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const {
+  consigneServiceSupprimeDansJournal,
+} = require('../../../src/bus/abonnements/consigneServiceSupprimeDansJournal');
+
+describe("L'abonnement qui consigne (dans le journal MSS) la finalisation d'un dossier d'homologation", () => {
+  let adaptateurJournal;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+  });
+
+  it('consigne un événement de "service supprimé"', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneServiceSupprimeDansJournal({ adaptateurJournal })({
+      idService: '123',
+    });
+
+    expect(evenementRecu.type).to.be('SERVICE_SUPPRIME');
+  });
+
+  it("lève une exception s'il ne reçoit pas l'ID du service", async () => {
+    try {
+      await consigneServiceSupprimeDansJournal({ adaptateurJournal })({
+        idService: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de consigner la suppression d'un service sans avoir l'ID du service en paramètre."
+      );
+    }
+  });
+});

--- a/test/bus/evenementDossierHomologationFinalise.spec.js
+++ b/test/bus/evenementDossierHomologationFinalise.spec.js
@@ -1,0 +1,23 @@
+const expect = require('expect.js');
+const EvenementDossierHomologationFinalise = require('../../src/bus/evenementDossierHomologationFinalise');
+
+describe("L'événement 'DossierHomologationFinalise'", () => {
+  it("lève une exception s'il est instancié sans ID de service", () => {
+    expect(
+      () =>
+        new EvenementDossierHomologationFinalise({
+          dossier: {},
+          idService: null,
+        })
+    ).to.throwError();
+  });
+
+  it("lève une exception s'il est instancié sans dossier", () => {
+    expect(
+      () =>
+        new EvenementDossierHomologationFinalise({
+          dossier: null,
+        })
+    ).to.throwError();
+  });
+});

--- a/test/bus/evenementServiceSupprime.spec.js
+++ b/test/bus/evenementServiceSupprime.spec.js
@@ -1,0 +1,13 @@
+const expect = require('expect.js');
+const EvenementServiceSupprime = require('../../src/bus/evenementServiceSupprime');
+
+describe("L'événement 'ServiceSupprimé'", () => {
+  it("lève une exception s'il est instancié sans ID de service", () => {
+    expect(
+      () =>
+        new EvenementServiceSupprime({
+          idService: null,
+        })
+    ).to.throwError();
+  });
+});

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -2,14 +2,12 @@ const {
   unePersistanceMemoire,
 } = require('./constructeurAdaptateurPersistanceMemoire');
 const DepotDonneesHomologations = require('../../src/depots/depotDonneesHomologations');
-const AdaptateurJournalMSSMemoire = require('../../src/adaptateurs/adaptateurJournalMSSMemoire');
 const Referentiel = require('../../src/referentiel');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 class ConstructeurDepotDonneesServices {
   constructor() {
     this.constructeurAdaptateurPersistance = unePersistanceMemoire();
-    this.adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
     this.adaptateurUUID = { genereUUID: () => 'unUUID' };
     this.busEvenements = { publie: () => {}, abonne: () => {} };
     this.referentiel = Referentiel.creeReferentielVide();
@@ -17,11 +15,6 @@ class ConstructeurDepotDonneesServices {
 
   avecAdaptateurPersistance(constructeurAdaptateurPersistance) {
     this.constructeurAdaptateurPersistance = constructeurAdaptateurPersistance;
-    return this;
-  }
-
-  avecJournalMSS(adaptateurJournalMSS) {
-    this.adaptateurJournalMSS = adaptateurJournalMSS;
     return this;
   }
 
@@ -38,7 +31,6 @@ class ConstructeurDepotDonneesServices {
   construis() {
     return DepotDonneesHomologations.creeDepot({
       adaptateurChiffrement: fauxAdaptateurChiffrement(),
-      adaptateurJournalMSS: this.adaptateurJournalMSS,
       adaptateurPersistance: this.constructeurAdaptateurPersistance.construis(),
       adaptateurUUID: this.adaptateurUUID,
       busEvenements: this.busEvenements,

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -842,6 +842,7 @@ describe('Le dépôt de données des homologations', () => {
   describe("sur demande de suppression d'une homologation", () => {
     let adaptateurPersistance;
     let adaptateurJournalMSS;
+    let depot;
 
     beforeEach(() => {
       const donneesHomologation = {
@@ -858,14 +859,13 @@ describe('Le dépôt de données des homologations', () => {
       });
 
       adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
-    });
-
-    it("supprime l'homologation", (done) => {
-      const depot = DepotDonneesHomologations.creeDepot({
+      depot = DepotDonneesHomologations.creeDepot({
         adaptateurPersistance,
         adaptateurJournalMSS,
       });
+    });
 
+    it("supprime l'homologation", (done) => {
       adaptateurPersistance
         .homologation('123')
         .then((h) => expect(h).to.be.an(Object))
@@ -879,11 +879,6 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     it('supprime le service', (done) => {
-      const depot = DepotDonneesHomologations.creeDepot({
-        adaptateurPersistance,
-        adaptateurJournalMSS,
-      });
-
       adaptateurPersistance
         .service('123')
         .then((s) => expect(s).to.be.an(Object))
@@ -912,10 +907,11 @@ describe('Le dépôt de données des homologations', () => {
           uneAutorisation().avecId('789').deContributeur('000', '222').donnees,
         ],
       });
-      const depot = DepotDonneesHomologations.creeDepot({
+      depot = DepotDonneesHomologations.creeDepot({
         adaptateurPersistance,
         adaptateurJournalMSS,
       });
+
       const depotAutorisations = DepotDonneesAutorisations.creeDepot({
         adaptateurPersistance,
       });
@@ -938,7 +934,7 @@ describe('Le dépôt de données des homologations', () => {
         done();
       };
 
-      const depot = DepotDonneesHomologations.creeDepot({
+      depot = DepotDonneesHomologations.creeDepot({
         adaptateurPersistance,
         adaptateurJournalMSS,
       });

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -9,7 +9,6 @@ const {
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 
-const AdaptateurJournalMSSMemoire = require('../../src/adaptateurs/adaptateurJournalMSSMemoire');
 const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
 const AdaptateurUUID = require('../../src/adaptateurs/adaptateurUUID');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
@@ -374,7 +373,6 @@ describe('Le dépôt de données des homologations', () => {
 
   describe("sur demande de mise à jour de la description d'un service", () => {
     let adaptateurPersistance;
-    let adaptateurJournalMSS;
     let bus;
     let depot;
     let referentiel;
@@ -391,12 +389,10 @@ describe('Le dépôt de données des homologations', () => {
         .ajouteUneAutorisation(
           uneAutorisation().deProprietaire('U1', 'S1').donnees
         );
-      adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
       bus = fabriqueBusPourLesTests();
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
         .avecAdaptateurPersistance(adaptateurPersistance)
-        .avecJournalMSS(adaptateurJournalMSS)
         .avecBusEvenements(bus)
         .construis();
     });
@@ -582,7 +578,6 @@ describe('Le dépôt de données des homologations', () => {
 
   describe("quand il reçoit une demande d'enregistrement d'un nouveau service", () => {
     let adaptateurChiffrement;
-    let adaptateurJournalMSS;
     let adaptateurPersistance;
     let adaptateurTracking;
     let adaptateurUUID;
@@ -591,7 +586,6 @@ describe('Le dépôt de données des homologations', () => {
 
     beforeEach(() => {
       adaptateurChiffrement = fauxAdaptateurChiffrement();
-      adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
       adaptateurPersistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(
           unUtilisateur().avecId('123').avecEmail('jean.dupont@mail.fr').donnees
@@ -603,7 +597,6 @@ describe('Le dépôt de données des homologations', () => {
 
       depot = DepotDonneesHomologations.creeDepot({
         adaptateurChiffrement,
-        adaptateurJournalMSS,
         adaptateurPersistance,
         adaptateurTracking,
         adaptateurUUID,
@@ -842,7 +835,6 @@ describe('Le dépôt de données des homologations', () => {
 
   describe("sur demande de suppression d'une homologation", () => {
     let adaptateurPersistance;
-    let adaptateurJournalMSS;
     let depot;
 
     beforeEach(() => {
@@ -859,10 +851,8 @@ describe('Le dépôt de données des homologations', () => {
         ],
       });
 
-      adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
       depot = DepotDonneesHomologations.creeDepot({
         adaptateurPersistance,
-        adaptateurJournalMSS,
         busEvenements,
       });
     });
@@ -911,7 +901,6 @@ describe('Le dépôt de données des homologations', () => {
       });
       depot = DepotDonneesHomologations.creeDepot({
         adaptateurPersistance,
-        adaptateurJournalMSS,
         busEvenements,
       });
 
@@ -1173,7 +1162,6 @@ describe('Le dépôt de données des homologations', () => {
   });
 
   describe('sur demande de finalisation du dossier courant', () => {
-    let adaptateurJournalMSS;
     let adaptateurPersistance;
     let depot;
     const referentiel = Referentiel.creeReferentiel({
@@ -1186,11 +1174,9 @@ describe('Le dépôt de données des homologations', () => {
     });
 
     beforeEach(() => {
-      adaptateurJournalMSS = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
       adaptateurPersistance = unePersistanceMemoire().construis();
       depot = DepotDonneesHomologations.creeDepot({
         adaptateurChiffrement: fauxAdaptateurChiffrement(),
-        adaptateurJournalMSS,
         adaptateurPersistance,
         referentiel,
         busEvenements,
@@ -1306,7 +1292,6 @@ describe('Le dépôt de données des homologations', () => {
 
       depot = DepotDonneesHomologations.creeDepot({
         adaptateurChiffrement: fauxAdaptateurChiffrement(),
-        adaptateurJournalMSS: AdaptateurJournalMSSMemoire.nouvelAdaptateur(),
         adaptateurPersistance,
         adaptateurTracking: unAdaptateurTracking().construis(),
         adaptateurUUID: AdaptateurUUID,

--- a/test/depots/depotVide.js
+++ b/test/depots/depotVide.js
@@ -1,4 +1,3 @@
-const adaptateurJournalMSSMemoire = require('../../src/adaptateurs/adaptateurJournalMSSMemoire');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 const fabriqueAdaptateurPersistance = require('../../src/adaptateurs/fabriqueAdaptateurPersistance');
@@ -7,7 +6,6 @@ const DepotDonnees = require('../../src/depotDonnees');
 const depotVide = (
   config = {
     adaptateurChiffrement: fauxAdaptateurChiffrement(),
-    adaptateurJournalMSS: adaptateurJournalMSSMemoire.nouvelAdaptateur(),
     adaptateurPersistance: fabriqueAdaptateurPersistance(),
   }
 ) => {


### PR DESCRIPTION
On supprime la dépendance du `depotDonneesHomologation` à l'`adaptateurJournalMSS`.
Désormais, les événements sont envoyés vers le `busEvenements`, qui re-dispatch vers des `listeners` de `consignationDansJournalMSS`.

> [!IMPORTANT]  
> Cette PR marque la fin de l'utilisation d'un `adaptateurJournalMSS` dans les `depotDonnees`. C'est un gros ménage qui est étalé sur de nombreuses PR précédente, et qui nous permet de fonctionner uniquement avec le `busEvenements` désormais