### PR TITLE
Ajoute le modèle `NotificationExpirationHomologation`

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -1012,24 +1012,28 @@ module.exports = {
       description: '6 mois',
       expiration: expiration('six mois'),
       nbMoisBientotExpire: 2,
+      rappelsExpirationMois: [3, 1],
     },
     unAn: {
       nbMoisDecalage: 12,
       description: '1 an',
       expiration: expiration('un an'),
       nbMoisBientotExpire: 2,
+      rappelsExpirationMois: [6, 3, 1],
     },
     deuxAns: {
       nbMoisDecalage: 24,
       description: '2 ans',
       expiration: expiration('deux ans'),
       nbMoisBientotExpire: 4,
+      rappelsExpirationMois: [12, 6, 3, 1],
     },
     troisAns: {
       nbMoisDecalage: 36,
       description: '3 ans',
       expiration: expiration('trois ans'),
       nbMoisBientotExpire: 6,
+      rappelsExpirationMois: [24, 12, 6, 3, 1],
     },
   },
 

--- a/src/modeles/notificationExpirationHomologation.js
+++ b/src/modeles/notificationExpirationHomologation.js
@@ -1,0 +1,38 @@
+const { ajouteMoisADate } = require('../utilitaires/date');
+
+class NotificationExpirationHomologation {
+  constructor({ idService, dateProchainEnvoi, delaiAvantExpirationMois }) {
+    this.idService = idService;
+    this.dateProchainEnvoi = dateProchainEnvoi;
+    this.delaiAvantExpirationMois = delaiAvantExpirationMois;
+  }
+
+  static pourUnDossier({ idService, dossier, referentiel }) {
+    const idEcheance = dossier.decision.dureeValidite;
+    const nbMoisExpiration = referentiel.nbMoisDecalage(idEcheance);
+
+    const notificationsExpiration = referentiel
+      .nbMoisRappelsExpiration(idEcheance)
+      .map(
+        (delai) =>
+          new NotificationExpirationHomologation({
+            idService,
+            dateProchainEnvoi: ajouteMoisADate(
+              nbMoisExpiration - delai,
+              `${dossier.decision.dateHomologation}T00:00:00Z`
+            ),
+            delaiAvantExpirationMois: delai,
+          })
+      );
+    const notificationDerniereEcheance = new NotificationExpirationHomologation(
+      {
+        idService,
+        dateProchainEnvoi: dossier.dateProchaineHomologation(),
+        delaiAvantExpirationMois: 0,
+      }
+    );
+    return [...notificationsExpiration, notificationDerniereEcheance];
+  }
+}
+
+module.exports = NotificationExpirationHomologation;

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -97,6 +97,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     echeancesRenouvellement()[idEcheance]?.nbMoisDecalage;
   const nbMoisBientotExpire = (idEcheance) =>
     echeancesRenouvellement()[idEcheance]?.nbMoisBientotExpire;
+  const nbMoisRappelsExpiration = (idEcheance) =>
+    echeancesRenouvellement()[idEcheance]?.rappelsExpirationMois;
   const niveauxGravite = () => donnees.niveauxGravite || {};
   const niveauGravite = (idNiveau) => niveauxGravite()[idNiveau] || {};
   const identifiantsNiveauxGravite = () => Object.keys(niveauxGravite() || {});
@@ -331,6 +333,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     mesures,
     nbMoisDecalage,
     nbMoisBientotExpire,
+    nbMoisRappelsExpiration,
     niveauGravite,
     niveauxGravite,
     nombreOrganisationsUtilisatrices,

--- a/test/modeles/notificationExpirationHomologation.spec.js
+++ b/test/modeles/notificationExpirationHomologation.spec.js
@@ -1,0 +1,54 @@
+const expect = require('expect.js');
+
+const NotificationExpirationHomologation = require('../../src/modeles/notificationExpirationHomologation');
+const Referentiel = require('../../src/referentiel');
+const { unDossier } = require('../constructeurs/constructeurDossier');
+
+describe("Une notification d'expiration d'homologation", () => {
+  it("peut s'instancier avec un ID de service, une date de prochain envoi et un délai d'expiration", () => {
+    const uneNotification = new NotificationExpirationHomologation({
+      idService: '123',
+      dateProchainEnvoi: new Date('2024-01-01'),
+      delaiAvantExpirationMois: 6,
+    });
+
+    expect(uneNotification.idService).to.be('123');
+    expect(uneNotification.dateProchainEnvoi).to.eql(new Date('2024-01-01'));
+    expect(uneNotification.delaiAvantExpirationMois).to.be(6);
+  });
+
+  describe("sur demande des notifications pour un dossier d'homologation", () => {
+    it('sait renvoyer une liste des notifications qui seront à envoyer pour un dossier donné', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        echeancesRenouvellement: {
+          unAn: { nbMoisDecalage: 12, rappelsExpirationMois: [1] },
+        },
+        statutsAvisDossierHomologation: { favorable: {} },
+      });
+
+      const debutePremierJanvierEtValideUnAn = unDossier(referentiel)
+        .quiEstComplet()
+        .quiEstActif()
+        .avecDecision('2024-01-01', 'unAn')
+        .construit();
+
+      const notifications = NotificationExpirationHomologation.pourUnDossier({
+        idService: '123',
+        dossier: debutePremierJanvierEtValideUnAn,
+        referentiel,
+      });
+
+      expect(notifications.length).to.be(2);
+      expect(notifications[0]).to.eql({
+        idService: '123',
+        dateProchainEnvoi: new Date('2024-12-01T00:00:00Z'),
+        delaiAvantExpirationMois: 1,
+      });
+      expect(notifications[1]).to.eql({
+        idService: '123',
+        dateProchainEnvoi: new Date('2025-01-01T00:00:00Z'),
+        delaiAvantExpirationMois: 0,
+      });
+    });
+  });
+});


### PR DESCRIPTION
On ajoute ce nouveau modèle, qui a pour but de stocker les notifications de rappels (par email) de l'expiration d'un dossier d'homologation.

> [!IMPORTANT]  
> Pour l'instant, rien n'est stocké en base.
> Cette table sera ensuite exploité par un `cron` qui fera l'envoi d'email.

Les délais d'attente sont disponible dans [ce document](https://lab-anssi-docs.cleverapps.io/doc/emails-rappels-echeance-homologation-r4WUUFeXAD).