### PR TITLE
Sauvegarde des notifications d'expiration d'homologation

### DIFF
--- a/server.js
+++ b/server.js
@@ -54,6 +54,7 @@ const depotDonnees = DepotDonnees.creeDepot({
 });
 
 cableTousLesAbonnes(busEvenements, {
+  adaptateurHorloge,
   adaptateurTracking,
   adaptateurJournal,
   depotDonnees,

--- a/src/bus/abonnements/sauvegardeNotificationsExpirationHomologation.js
+++ b/src/bus/abonnements/sauvegardeNotificationsExpirationHomologation.js
@@ -1,0 +1,32 @@
+const NotificationExpirationHomologation = require('../../modeles/notificationExpirationHomologation');
+
+function sauvegardeNotificationsExpirationHomologation({
+  adaptateurHorloge,
+  depotDonnees,
+  referentiel,
+}) {
+  return async ({ idService, dossier }) => {
+    if (!idService)
+      throw new Error(
+        "Impossible de sauvegarder les notifications d'expiration d'un dossier d'homologation sans avoir l'ID du service en paramètre."
+      );
+    if (!dossier)
+      throw new Error(
+        "Impossible de sauvegarder les notifications d'expiration d'un dossier d'homologation sans avoir le dossier en paramètre."
+      );
+
+    const notifications = NotificationExpirationHomologation.pourUnDossier({
+      idService,
+      dossier,
+      referentiel,
+    }).filter((n) => n.dateProchainEnvoi > adaptateurHorloge.maintenant());
+    await depotDonnees.supprimeNotificationsExpirationHomologationPourService(
+      idService
+    );
+    await depotDonnees.sauvegardeNotificationsExpirationHomologation(
+      notifications
+    );
+  };
+}
+
+module.exports = { sauvegardeNotificationsExpirationHomologation };

--- a/src/bus/abonnements/supprimeNotificationsExpirationHomologation.js
+++ b/src/bus/abonnements/supprimeNotificationsExpirationHomologation.js
@@ -1,0 +1,14 @@
+function supprimeNotificationsExpirationHomologation({ depotDonnees }) {
+  return async ({ idService }) => {
+    if (!idService)
+      throw new Error(
+        "Impossible de supprimer les notifications d'expiration d'un dossier d'homologation sans avoir l'ID du service en paramètre."
+      );
+
+    await depotDonnees.supprimeNotificationsExpirationHomologationPourService(
+      idService
+    );
+  };
+}
+
+module.exports = { supprimeNotificationsExpirationHomologation };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -43,6 +43,9 @@ const {
 const {
   sauvegardeNotificationsExpirationHomologation,
 } = require('./abonnements/sauvegardeNotificationsExpirationHomologation');
+const {
+  supprimeNotificationsExpirationHomologation,
+} = require('./abonnements/supprimeNotificationsExpirationHomologation');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -99,10 +102,10 @@ const cableTousLesAbonnes = (
     }),
   ]);
 
-  busEvenements.abonne(
-    EvenementServiceSupprime,
-    consigneServiceSupprimeDansJournal({ adaptateurJournal })
-  );
+  busEvenements.abonnePlusieurs(EvenementServiceSupprime, [
+    consigneServiceSupprimeDansJournal({ adaptateurJournal }),
+    supprimeNotificationsExpirationHomologation({ depotDonnees }),
+  ]);
 };
 
 module.exports = { cableTousLesAbonnes };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -40,10 +40,19 @@ const EvenementServiceSupprime = require('./evenementServiceSupprime');
 const {
   consigneServiceSupprimeDansJournal,
 } = require('./abonnements/consigneServiceSupprimeDansJournal');
+const {
+  sauvegardeNotificationsExpirationHomologation,
+} = require('./abonnements/sauvegardeNotificationsExpirationHomologation');
 
 const cableTousLesAbonnes = (
   busEvenements,
-  { adaptateurTracking, adaptateurJournal, depotDonnees, referentiel }
+  {
+    adaptateurHorloge,
+    adaptateurTracking,
+    adaptateurJournal,
+    depotDonnees,
+    referentiel,
+  }
 ) => {
   busEvenements.abonnePlusieurs(EvenementNouveauServiceCree, [
     consigneNouveauServiceDansJournal({ adaptateurJournal }),
@@ -78,13 +87,17 @@ const cableTousLesAbonnes = (
     consigneProfilUtilisateurModifieDansJournal({ adaptateurJournal }),
   ]);
 
-  busEvenements.abonne(
-    EvenementDossierHomologationFinalise,
+  busEvenements.abonnePlusieurs(EvenementDossierHomologationFinalise, [
     consigneNouvelleHomologationCreeeDansJournal({
       adaptateurJournal,
       referentiel,
-    })
-  );
+    }),
+    sauvegardeNotificationsExpirationHomologation({
+      adaptateurHorloge,
+      depotDonnees,
+      referentiel,
+    }),
+  ]);
 
   busEvenements.abonne(
     EvenementServiceSupprime,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -98,6 +98,26 @@ const creeDepot = (config = {}) => {
   const { lisParcoursUtilisateur, sauvegardeParcoursUtilisateur } =
     depotParcoursUtilisateurs;
 
+  const supprimeNotificationsExpirationHomologationPourService = async (
+    idService
+  ) => {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Notifications d'expiration d'homologation supprimées pour le service ${idService}`
+    );
+  };
+
+  const sauvegardeNotificationsExpirationHomologation = async (
+    notifications
+  ) => {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Notifications d'expiration d'homologation sauvegardées: ${JSON.stringify(
+        notifications
+      )}`
+    );
+  };
+
   return {
     accesAutorise,
     ajouteContributeurAuService,
@@ -127,9 +147,11 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesDuService,
     sauvegardeAutorisation,
     sauvegardeParcoursUtilisateur,
+    sauvegardeNotificationsExpirationHomologation,
     supprimeContributeur,
     supprimeHomologation,
     supprimeIdResetMotDePassePourUtilisateur,
+    supprimeNotificationsExpirationHomologationPourService,
     supprimeUtilisateur,
     tousUtilisateurs,
     tousLesServices,

--- a/test/bus/abonnements/sauvegardeNotificationsExpirationHomologation.spec.js
+++ b/test/bus/abonnements/sauvegardeNotificationsExpirationHomologation.spec.js
@@ -1,0 +1,119 @@
+const expect = require('expect.js');
+const {
+  sauvegardeNotificationsExpirationHomologation,
+} = require('../../../src/bus/abonnements/sauvegardeNotificationsExpirationHomologation');
+const Referentiel = require('../../../src/referentiel');
+const { unDossier } = require('../../constructeurs/constructeurDossier');
+
+describe("L'abonnement qui sauvegarde (en base de données) les notifications d'expiration d'une homologation", () => {
+  let depotDonnees;
+  let referentiel;
+  let adaptateurHorloge;
+
+  beforeEach(() => {
+    adaptateurHorloge = {
+      maintenant: () => new Date('2024-01-01'),
+    };
+    depotDonnees = {
+      sauvegardeNotificationsExpirationHomologation: async () => {},
+      supprimeNotificationsExpirationHomologationPourService: async () => {},
+    };
+    referentiel = Referentiel.creeReferentiel({
+      echeancesRenouvellement: {
+        unAn: { nbMoisDecalage: 12, rappelsExpirationMois: [1] },
+      },
+      statutsAvisDossierHomologation: { favorable: {} },
+    });
+  });
+
+  [
+    { propriete: 'idService', nom: "l'ID du service" },
+    { propriete: 'dossier', nom: 'le dossier' },
+  ].forEach(({ propriete, nom }) => {
+    const donnees = {
+      idService: '123',
+      dossier: {},
+    };
+    it(`lève une exception s'il ne reçoit pas ${nom}`, async () => {
+      try {
+        delete donnees[propriete];
+        await sauvegardeNotificationsExpirationHomologation({
+          adaptateurHorloge,
+          depotDonnees,
+          referentiel,
+        })(donnees);
+        expect().fail("L'instanciation aurait dû lever une exception.");
+      } catch (e) {
+        expect(e.message).to.be(
+          `Impossible de sauvegarder les notifications d'expiration d'un dossier d'homologation sans avoir ${nom} en paramètre.`
+        );
+      }
+    });
+  });
+
+  it('demande au dépôt de supprimer les notifications existantes pour ce service', async () => {
+    let depotAppele = false;
+    depotDonnees.supprimeNotificationsExpirationHomologationPourService =
+      async () => {
+        depotAppele = true;
+      };
+
+    await sauvegardeNotificationsExpirationHomologation({
+      adaptateurHorloge,
+      depotDonnees,
+      referentiel,
+    })({
+      idService: '123',
+      dossier: unDossier(referentiel).quiEstComplet().construit(),
+    });
+
+    expect(depotAppele).to.be(true);
+  });
+
+  it('passe des NotificationsExpirationHomologation au dépôt de données', async () => {
+    let notificationsRecus = [];
+    depotDonnees.sauvegardeNotificationsExpirationHomologation = async (
+      notifications
+    ) => {
+      notificationsRecus = notifications;
+    };
+
+    await sauvegardeNotificationsExpirationHomologation({
+      adaptateurHorloge,
+      depotDonnees,
+      referentiel,
+    })({
+      idService: '123',
+      dossier: unDossier(referentiel)
+        .quiEstComplet()
+        .avecDecision('2024-01-01', 'unAn')
+        .construit(),
+    });
+
+    expect(notificationsRecus.length).to.be(2);
+    expect(notificationsRecus[0].idService).to.be('123');
+  });
+
+  it('filtre les notifications qui sont dans le passé', async () => {
+    let notificationsRecus = [];
+    depotDonnees.sauvegardeNotificationsExpirationHomologation = async (
+      notifications
+    ) => {
+      notificationsRecus = notifications;
+    };
+
+    await sauvegardeNotificationsExpirationHomologation({
+      adaptateurHorloge,
+      depotDonnees,
+      referentiel,
+    })({
+      idService: '123',
+      dossier: unDossier(referentiel)
+        .quiEstComplet()
+        .avecDecision('2023-01-02', 'unAn')
+        .construit(),
+    });
+
+    expect(notificationsRecus.length).to.be(1);
+  });
+});

--- a/test/bus/abonnements/supprimeNotificationsExpirationHomologation.spec.js
+++ b/test/bus/abonnements/supprimeNotificationsExpirationHomologation.spec.js
@@ -1,0 +1,41 @@
+const expect = require('expect.js');
+const {
+  supprimeNotificationsExpirationHomologation,
+} = require('../../../src/bus/abonnements/supprimeNotificationsExpirationHomologation');
+
+describe("L'abonnement qui supprime (en base de données) les notifications d'expiration d'une homologation", () => {
+  let depotDonnees;
+
+  beforeEach(() => {
+    depotDonnees = {
+      supprimeNotificationsExpirationHomologationPourService: async () => {},
+    };
+  });
+
+  it("lève une exception s'il ne reçoit pas l'ID du service", async () => {
+    try {
+      await supprimeNotificationsExpirationHomologation({ depotDonnees })({
+        idService: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de supprimer les notifications d'expiration d'un dossier d'homologation sans avoir l'ID du service en paramètre."
+      );
+    }
+  });
+
+  it('demande au dépôt de supprimer les notifications existantes pour ce service', async () => {
+    let depotAppele = false;
+    depotDonnees.supprimeNotificationsExpirationHomologationPourService =
+      async () => {
+        depotAppele = true;
+      };
+
+    await supprimeNotificationsExpirationHomologation({ depotDonnees })({
+      idService: '123',
+    });
+
+    expect(depotAppele).to.be(true);
+  });
+});


### PR DESCRIPTION
On utilise le `busEvenements` pour sauvegarder les notifications d'expiration d'homologation.
On en profite aussi pour supprimer les notifications existantes pour un service au moment de la sauvegarde, et aussi les supprimer au moment de la suppression d'un service.

> [!WARNING]  
> Pour l'instant, le dépôt données a un "bouchon" qui loggue les actions de `sauvegarde` et `suppression` 