### PR TITLE
Redirection après connexion

### DIFF
--- a/public/connexion.js
+++ b/public/connexion.js
@@ -4,6 +4,7 @@ $(() => {
   const $inputs = $('input');
   const $erreur = $('.message-erreur');
   const $form = $('#connexion');
+  const { urlRedirection } = JSON.parse($('#url-redirection').text());
 
   const rendsAffichageNeutre = () => {
     $erreur.hide();
@@ -23,7 +24,7 @@ $(() => {
       .post('/api/token', { login, motDePasse })
       .then((reponse) => {
         const { nouvelleFonctionnalite } = reponse.data;
-        let url = '/tableauDeBord';
+        let url = urlRedirection ?? '/tableauDeBord';
         if (nouvelleFonctionnalite)
           url += `?nouvelleFonctionnalite=${nouvelleFonctionnalite}`;
         window.location = url;

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -13,6 +13,7 @@ const {
   ErreurDroitsIncoherents,
   ErreurChainageMiddleware,
 } = require('../erreurs');
+const { ajouteLaRedirectionPostConnexion } = require('./redirection');
 
 const middleware = (configuration = {}) => {
   const {
@@ -78,8 +79,11 @@ const middleware = (configuration = {}) => {
 
   const verificationJWT = (requete, reponse, suite) => {
     const token = adaptateurJWT.decode(requete.session.token);
-    if (!token) reponse.redirect('/connexion');
-    else {
+    if (!token) {
+      const urlDemandee = requete.originalUrl;
+      const urlAvecRedirection = ajouteLaRedirectionPostConnexion(urlDemandee);
+      reponse.redirect(urlAvecRedirection);
+    } else {
       depotDonnees
         .utilisateurExiste(token.idUtilisateur)
         .then((utilisateurExiste) => {

--- a/src/http/redirection.js
+++ b/src/http/redirection.js
@@ -1,0 +1,12 @@
+const ajouteLaRedirectionPostConnexion = (urlDemandee) => {
+  const urlLegalePourRedirection =
+    urlDemandee &&
+    urlDemandee.startsWith('/') &&
+    !urlDemandee.startsWith('/api');
+
+  if (!urlLegalePourRedirection) return '/connexion';
+
+  return `/connexion?urlRedirection=${encodeURIComponent(urlDemandee)}`;
+};
+
+module.exports = { ajouteLaRedirectionPostConnexion };

--- a/src/http/redirection.js
+++ b/src/http/redirection.js
@@ -1,12 +1,18 @@
-const ajouteLaRedirectionPostConnexion = (urlDemandee) => {
-  const urlLegalePourRedirection =
-    urlDemandee &&
-    urlDemandee.startsWith('/') &&
-    !urlDemandee.startsWith('/api');
+const estUrlLegalePourRedirection = (urlDemandee) =>
+  urlDemandee && urlDemandee.startsWith('/') && !urlDemandee.startsWith('/api');
 
-  if (!urlLegalePourRedirection) return '/connexion';
+const ajouteLaRedirectionPostConnexion = (urlDemandee) => {
+  const redirectionValide = estUrlLegalePourRedirection(urlDemandee);
+
+  if (!redirectionValide) return '/connexion';
 
   return `/connexion?urlRedirection=${encodeURIComponent(urlDemandee)}`;
 };
 
-module.exports = { ajouteLaRedirectionPostConnexion };
+const construisUrlAbsolueVersPage = (page) => process.env.URL_BASE_MSS + page;
+
+module.exports = {
+  ajouteLaRedirectionPostConnexion,
+  construisUrlAbsolueVersPage,
+  estUrlLegalePourRedirection,
+};

--- a/src/mss.js
+++ b/src/mss.js
@@ -100,8 +100,15 @@ const creeServeur = (
 
   app.get('/connexion', middleware.suppressionCookie, (requete, reponse) => {
     const { urlRedirection } = requete.query;
-    if (!estUrlLegalePourRedirection(urlRedirection)) {
+
+    if (!urlRedirection) {
       reponse.render('connexion');
+      return;
+    }
+
+    if (!estUrlLegalePourRedirection(urlRedirection)) {
+      // Ici c'est un redirect, pour nettoyer l'URL de la redirection invalide.
+      reponse.redirect('connexion');
       return;
     }
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -14,6 +14,10 @@ const {
   routesBibliotheques,
 } = require('./routes/publiques/routesBibliotheques');
 const routesStyles = require('./routes/publiques/routesStyles');
+const {
+  estUrlLegalePourRedirection,
+  construisUrlAbsolueVersPage,
+} = require('./http/redirection');
 
 require('dotenv').config();
 
@@ -94,8 +98,16 @@ const creeServeur = (
     reponse.render('confidentialite');
   });
 
-  app.get('/connexion', middleware.suppressionCookie, (_requete, reponse) => {
-    reponse.render('connexion');
+  app.get('/connexion', middleware.suppressionCookie, (requete, reponse) => {
+    const { urlRedirection } = requete.query;
+    if (!estUrlLegalePourRedirection(urlRedirection)) {
+      reponse.render('connexion');
+      return;
+    }
+
+    reponse.render('connexion', {
+      urlRedirection: construisUrlAbsolueVersPage(urlRedirection),
+    });
   });
 
   app.get(

--- a/src/vues/connexion.pug
+++ b/src/vues/connexion.pug
@@ -29,3 +29,5 @@ block main
     button.bouton Valider
 
   script(type = 'module', src='/statique/connexion.js')
+  script(id = 'url-redirection', type = 'application/json').
+    !{JSON.stringify({urlRedirection: urlRedirection})}

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -91,6 +91,28 @@ describe('Le middleware MSS', () => {
     middleware.verificationJWT(requete, reponse);
   });
 
+  it("ajoute l'URL originale à la redirection si elle commence par un '/'", (done) => {
+    const adaptateurJWT = { decode: () => null };
+    requete.originalUrl = '/tableauDeBord';
+    prepareVerificationRedirection(
+      reponse,
+      '/connexion?urlRedirection=%2FtableauDeBord',
+      done
+    );
+
+    const middleware = Middleware({ adaptateurJWT });
+    middleware.verificationJWT(requete, reponse);
+  });
+
+  it("n'ajoute pas l'URL originale à la redirection si elle commence par '/api'", (done) => {
+    const adaptateurJWT = { decode: () => null };
+    requete.originalUrl = '/api/service';
+    prepareVerificationRedirection(reponse, '/connexion', done);
+
+    const middleware = Middleware({ adaptateurJWT });
+    middleware.verificationJWT(requete, reponse);
+  });
+
   it('redirige vers mire login si identifiant dans token ne correspond à aucun utilisateur', (done) => {
     const adaptateurJWT = { decode: () => ({ idUtilisateur: '123' }) };
 


### PR DESCRIPTION
On souhaite pouvoir rediriger nos utilisateurs vers la page originalement demandée après connexion.
Aujourd'hui, le middleware `verificationJWT` redirige vers la page `/connexion` si jamais le `token` n'est pas présent ou invalide.
Au moment de cette redirection, on peut récupérer l'URL initialement demandée afin de la faire transiter jusqu'à une redirection après connexion.

On filtre volontairement les routes qui commence par `/api` car la redirection ne devrait pas se faire depuis ces appels.

On suit les bonnes pratiques : 
- On ajoute depuis le backend l'url HOST de notre application
- On s'assure que l'url de redirection commence toujours par un `/`