### PR TITLE
Ajout de la tâche d'envoi de mail de notification d'expiration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -16,6 +16,8 @@ SENDINBLUE_TEMPLATE_INVITATION_CONTRIBUTION= # id de template
 SENDINBLUE_TEMPLATE_INVITATION_INSCRIPTION= # id de template
 SENDINBLUE_TEMPLATE_REINITIALISATION_MOT_DE_PASSE= # id de template
 SENDINBLUE_TEMPLATE_TENTATIVE_REINSCRIPTION= # id de template
+SENDINBLUE_TEMPLATE_NOTIFICATION_EXPIRATION_HOMOLOGATION= # id de template
+SENDINBLUE_TEMPLATE_NOTIFICATION_HOMOLOGATION_EXPIREE= # id de template
 SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE= # l'ID de la liste de contacts utilisée pour les mails transactionnels de relance
 
 ADRESSES_IP_AUTORISEES= # Seules ces IP seront autorisées. Les autres ne seront pas servies. Séparées par des ',' s'il y en a plusieurs. Supprimer la variable d'env pour désactiver le filtrage.

--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "command": "0 10,13,15 * * * node scripts/taches/tacheEnvoieMailsNotificationExpiration.js"
+    }
+  ]
+}

--- a/scripts/taches/tacheEnvoieMailsNotificationExpiration.js
+++ b/scripts/taches/tacheEnvoieMailsNotificationExpiration.js
@@ -1,0 +1,29 @@
+const Sentry = require('@sentry/node');
+const DepotDonnees = require('../../src/depotDonnees');
+const adaptateurEnvironnement = require('../../src/adaptateurs/adaptateurEnvironnement');
+const adaptateurHorloge = require('../../src/adaptateurs/adaptateurHorloge');
+const adaptateurMail = require('../../src/adaptateurs/adaptateurMailSendinblue');
+const {
+  envoieMailsNotificationExpirationHomologation,
+} = require('../../src/taches/envoieMailsNotificationExpirationHomologation');
+
+const main = async () => {
+  const depotDonnees = DepotDonnees.creeDepot();
+  return envoieMailsNotificationExpirationHomologation({
+    depotDonnees,
+    adaptateurHorloge,
+    adaptateurMail,
+  });
+};
+
+const config = adaptateurEnvironnement.sentry();
+Sentry.init({
+  dsn: config.dsn(),
+  environment: config.environnement(),
+});
+
+main().then((rapport) => {
+  Sentry.captureMessage(
+    `[TACHE][ENVOI NOTIFICATIONS HOMOLOGATION] ${rapport.nbNotificationsEnvoyees} envoyées / ${rapport.nbEchecs} erreurs`
+  );
+});

--- a/scripts/taches/tacheEnvoieMailsNotificationExpiration.js
+++ b/scripts/taches/tacheEnvoieMailsNotificationExpiration.js
@@ -23,7 +23,10 @@ Sentry.init({
 });
 
 main().then((rapport) => {
-  Sentry.captureMessage(
-    `[TACHE][ENVOI NOTIFICATIONS HOMOLOGATION] ${rapport.nbNotificationsEnvoyees} envoyées / ${rapport.nbEchecs} erreurs`
-  );
+  Sentry.captureMessage(`[TACHE][ENVOI NOTIFICATIONS HOMOLOGATION]`, {
+    extra: {
+      'Notifications envoyees': rapport.nbNotificationsEnvoyees,
+      'Notifications en echec': rapport.nbEchecs,
+    },
+  });
 });

--- a/src/adaptateurs/adaptateurMailMemoire.js
+++ b/src/adaptateurs/adaptateurMailMemoire.js
@@ -53,6 +53,13 @@ const fabriqueAdaptateurMailMemoire = () => {
     );
   };
 
+  const envoieNotificationExpirationHomologation = async (...args) => {
+    envoyer(
+      "Envoie de l'email de notification d'expiration d'homologation",
+      args
+    );
+  };
+
   return {
     creeContact,
     desinscrisEmailsTransactionnels,
@@ -63,6 +70,7 @@ const fabriqueAdaptateurMailMemoire = () => {
     envoieMessageInvitationContribution,
     envoieMessageInvitationInscription,
     envoieMessageReinitialisationMotDePasse,
+    envoieNotificationExpirationHomologation,
     envoieNotificationTentativeReinscription,
   };
 };

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -192,6 +192,21 @@ const envoieNotificationTentativeReinscription = (destinataire) =>
     }
   );
 
+const envoieNotificationExpirationHomologation = (
+  destinataire,
+  idService,
+  delaiAvantExpirationMois
+) => {
+  const idTemplate =
+    delaiAvantExpirationMois === 0
+      ? process.env.SENDINBLUE_TEMPLATE_NOTIFICATION_HOMOLOGATION_EXPIREE
+      : process.env.SENDINBLUE_TEMPLATE_NOTIFICATION_EXPIRATION_HOMOLOGATION;
+  return envoieEmail(destinataire, parseInt(idTemplate, 10), {
+    id_service: idService,
+    delai_expiration: delaiAvantExpirationMois,
+  });
+};
+
 module.exports = {
   creeContact,
   desinscrisEmailsTransactionnels,
@@ -202,5 +217,6 @@ module.exports = {
   envoieMessageInvitationContribution,
   envoieMessageInvitationInscription,
   envoieMessageReinitialisationMotDePasse,
+  envoieNotificationExpirationHomologation,
   envoieNotificationTentativeReinscription,
 };

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -266,6 +266,13 @@ const nouvelAdaptateur = (
     ];
   };
 
+  const supprimeNotificationsExpirationHomologation = async (ids) => {
+    donnees.notificationsExpirationHomologation =
+      donnees.notificationsExpirationHomologation.filter(
+        (n) => !ids.includes(n.id)
+      );
+  };
+
   const supprimeNotificationsExpirationHomologationPourService = async (
     idService
   ) => {
@@ -302,6 +309,7 @@ const nouvelAdaptateur = (
     supprimeAutorisationsHomologation,
     supprimeHomologation,
     supprimeHomologations,
+    supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
     supprimeService,
     supprimeUtilisateur,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -246,6 +246,17 @@ const nouvelAdaptateur = (
     );
   };
 
+  const lisNotificationsExpirationHomologationDansIntervalle = async (
+    debut,
+    fin
+  ) => {
+    const dateDebut = new Date(debut);
+    const dateFin = new Date(fin);
+    return donnees.notificationsExpirationHomologation.filter(
+      (n) => dateDebut <= n.dateProchainEnvoi && n.dateProchainEnvoi < dateFin
+    );
+  };
+
   const sauvegardeNotificationsExpirationHomologation = async (
     notifications
   ) => {
@@ -274,6 +285,7 @@ const nouvelAdaptateur = (
     homologation,
     homologationAvecNomService,
     homologations,
+    lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -311,6 +311,21 @@ const nouvelAdaptateur = (env) => {
       );
   };
 
+  const lisNotificationsExpirationHomologationDansIntervalle = async (
+    debut,
+    fin
+  ) =>
+    (
+      await knex('notifications_expiration_homologation')
+        .where('date_prochain_envoi', '>=', debut)
+        .where('date_prochain_envoi', '<', fin)
+    ).map((n) => ({
+      id: n.id,
+      idService: n.id_service,
+      dateProchainEnvoi: n.date_prochain_envoi,
+      delaiAvantExpirationMois: n.delai_avant_expiration_mois,
+    }));
+
   const sauvegardeNotificationsExpirationHomologation = async (notifications) =>
     knex.batchInsert(
       'notifications_expiration_homologation',
@@ -340,6 +355,7 @@ const nouvelAdaptateur = (env) => {
     homologation,
     homologationAvecNomService,
     homologations,
+    lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -337,6 +337,9 @@ const nouvelAdaptateur = (env) => {
       }))
     );
 
+  const supprimeNotificationsExpirationHomologation = async (ids) =>
+    knex('notifications_expiration_homologation').whereIn('id', ids).del();
+
   const supprimeNotificationsExpirationHomologationPourService = async (
     idService
   ) =>
@@ -371,6 +374,7 @@ const nouvelAdaptateur = (env) => {
     supprimeAutorisationsContribution,
     supprimeAutorisationsHomologation,
     supprimeHomologation,
+    supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
     supprimeService,
     supprimeHomologations,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -108,6 +108,7 @@ const creeDepot = (config = {}) => {
     depotParcoursUtilisateurs;
 
   const {
+    lisNotificationsExpirationHomologationEnDate,
     sauvegardeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
   } = depotNotificationsExpirationHomologation;
@@ -131,6 +132,7 @@ const creeDepot = (config = {}) => {
     homologations,
     enregistreDossier,
     finaliseDossierCourant,
+    lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
     metsAJourMotDePasse,
     metsAJourUtilisateur,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -110,6 +110,7 @@ const creeDepot = (config = {}) => {
   const {
     lisNotificationsExpirationHomologationEnDate,
     sauvegardeNotificationsExpirationHomologation,
+    supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
   } = depotNotificationsExpirationHomologation;
 
@@ -147,6 +148,7 @@ const creeDepot = (config = {}) => {
     supprimeContributeur,
     supprimeHomologation,
     supprimeIdResetMotDePassePourUtilisateur,
+    supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
     supprimeUtilisateur,
     tousUtilisateurs,

--- a/src/depots/depotDonneesNotificationsExpirationHomologation.js
+++ b/src/depots/depotDonneesNotificationsExpirationHomologation.js
@@ -22,13 +22,15 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  const supprimeNotificationsExpirationHomologation = async (ids) =>
+    adaptateurPersistance.supprimeNotificationsExpirationHomologation(ids);
+
   const supprimeNotificationsExpirationHomologationPourService = async (
     idService
-  ) => {
-    await adaptateurPersistance.supprimeNotificationsExpirationHomologationPourService(
+  ) =>
+    adaptateurPersistance.supprimeNotificationsExpirationHomologationPourService(
       idService
     );
-  };
 
   const sauvegardeNotificationsExpirationHomologation = async (
     notifications
@@ -46,6 +48,7 @@ const creeDepot = (config = {}) => {
   return {
     lisNotificationsExpirationHomologationEnDate,
     sauvegardeNotificationsExpirationHomologation,
+    supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
   };
 };

--- a/src/depots/depotDonneesNotificationsExpirationHomologation.js
+++ b/src/depots/depotDonneesNotificationsExpirationHomologation.js
@@ -1,5 +1,26 @@
+const NotificationExpirationHomologation = require('../modeles/notificationExpirationHomologation');
+
 const creeDepot = (config = {}) => {
   const { adaptateurPersistance, adaptateurUUID } = config;
+
+  const lisNotificationsExpirationHomologationEnDate = async (date) => {
+    const debutMinuitUTC = new Date(
+      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0)
+    );
+
+    const demainMinuitUTC = new Date(debutMinuitUTC);
+    demainMinuitUTC.setDate(demainMinuitUTC.getDate() + 1);
+
+    const resultats =
+      await adaptateurPersistance.lisNotificationsExpirationHomologationDansIntervalle(
+        debutMinuitUTC.toISOString(),
+        demainMinuitUTC.toISOString()
+      );
+
+    return resultats.map(
+      (donnees) => new NotificationExpirationHomologation(donnees)
+    );
+  };
 
   const supprimeNotificationsExpirationHomologationPourService = async (
     idService
@@ -23,6 +44,7 @@ const creeDepot = (config = {}) => {
   };
 
   return {
+    lisNotificationsExpirationHomologationEnDate,
     sauvegardeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
   };

--- a/src/modeles/notificationExpirationHomologation.js
+++ b/src/modeles/notificationExpirationHomologation.js
@@ -1,7 +1,8 @@
 const { ajouteMoisADate } = require('../utilitaires/date');
 
 class NotificationExpirationHomologation {
-  constructor({ idService, dateProchainEnvoi, delaiAvantExpirationMois }) {
+  constructor({ id, idService, dateProchainEnvoi, delaiAvantExpirationMois }) {
+    if (id) this.id = id;
     this.idService = idService;
     this.dateProchainEnvoi = dateProchainEnvoi;
     this.delaiAvantExpirationMois = delaiAvantExpirationMois;

--- a/src/taches/envoieMailsNotificationExpirationHomologation.js
+++ b/src/taches/envoieMailsNotificationExpirationHomologation.js
@@ -1,0 +1,35 @@
+const envoieMailsNotificationExpirationHomologation = async (config = {}) => {
+  const { depotDonnees, adaptateurHorloge, adaptateurMail } = config;
+
+  const notifications =
+    await depotDonnees.lisNotificationsExpirationHomologationEnDate(
+      adaptateurHorloge.maintenant()
+    );
+
+  const resultats = await Promise.allSettled(
+    notifications.map(async (notification) => {
+      const autorisationProprietaire = (
+        await depotDonnees.autorisationsDuService(notification.idService)
+      ).find((a) => a.estProprietaire);
+      const destinataire = (
+        await depotDonnees.utilisateur(autorisationProprietaire.idUtilisateur)
+      ).email;
+      await adaptateurMail.envoieNotificationExpirationHomologation(
+        destinataire,
+        notification.idService,
+        notification.delaiAvantExpirationMois
+      );
+      await depotDonnees.supprimeNotificationsExpirationHomologation([
+        notification.id,
+      ]);
+    })
+  );
+
+  return {
+    nbNotificationsEnvoyees: resultats.filter((r) => r.status === 'fulfilled')
+      .length,
+    nbEchecs: resultats.filter((r) => r.status === 'rejected').length,
+  };
+};
+
+module.exports = { envoieMailsNotificationExpirationHomologation };

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -5,6 +5,7 @@ class ConstructeurAdaptateurPersistanceMemoire {
     this.autorisations = [];
     this.services = [];
     this.utilisateurs = [];
+    this.notificationsExpirationHomologation = [];
   }
 
   ajouteUneAutorisation(autorisation) {
@@ -22,12 +23,19 @@ class ConstructeurAdaptateurPersistanceMemoire {
     return this;
   }
 
+  ajouteUneNotificationExpirationHomologation(notification) {
+    this.notificationsExpirationHomologation.push(notification);
+    return this;
+  }
+
   construis() {
     return AdaptateurPersistanceMemoire.nouvelAdaptateur({
       autorisations: this.autorisations,
       homologations: this.services,
       services: this.services,
       utilisateurs: this.utilisateurs,
+      notificationsExpirationHomologation:
+        this.notificationsExpirationHomologation,
     });
   }
 }

--- a/test/depots/depotDonneesNotificationsExpirationHomologation.spec.js
+++ b/test/depots/depotDonneesNotificationsExpirationHomologation.spec.js
@@ -78,4 +78,43 @@ describe("Le dépôt de données des notifications d'expiration d'homologation",
       expect(adaptateurAppele).to.be(false);
     });
   });
+
+  describe('sur demande de lecture des notifications en date', () => {
+    it("passe à l'adaptateur de persistance les dates du jour et du lendemain en tant que bornes", async () => {
+      let donneesRecues;
+      adaptateurPersistance.lisNotificationsExpirationHomologationDansIntervalle =
+        async (debut, fin) => {
+          donneesRecues = { debut, fin };
+          return [];
+        };
+
+      await depot.lisNotificationsExpirationHomologationEnDate(
+        new Date('2024-01-25T00:00:00Z')
+      );
+
+      expect(donneesRecues).to.eql({
+        debut: '2024-01-25T00:00:00.000Z',
+        fin: '2024-01-26T00:00:00.000Z',
+      });
+    });
+
+    it('retourne les notifications', async () => {
+      adaptateurPersistance.lisNotificationsExpirationHomologationDansIntervalle =
+        async () => [
+          {
+            id: 'un ID',
+            idService: 'un ID de service',
+          },
+        ];
+
+      const notifications =
+        await depot.lisNotificationsExpirationHomologationEnDate(
+          new Date('2024-01-01T00:00:00Z')
+        );
+
+      expect(notifications[0]).to.be.an(NotificationExpirationHomologation);
+      expect(notifications[0].id).to.be('un ID');
+      expect(notifications[0].idService).to.be('un ID de service');
+    });
+  });
 });

--- a/test/depots/depotDonneesNotificationsExpirationHomologation.spec.js
+++ b/test/depots/depotDonneesNotificationsExpirationHomologation.spec.js
@@ -31,6 +31,19 @@ describe("Le dépôt de données des notifications d'expiration d'homologation",
     expect(idServiceAppele).to.be('123');
   });
 
+  it("délègue à l'adaptateur de persistance la suppression des notifications par identifiants", async () => {
+    let idsPasses;
+    adaptateurPersistance.supprimeNotificationsExpirationHomologation = async (
+      ids
+    ) => {
+      idsPasses = ids;
+    };
+
+    await depot.supprimeNotificationsExpirationHomologation([1, 2]);
+
+    expect(idsPasses).to.eql([1, 2]);
+  });
+
   describe('sur demande de sauvegarde de notifications', () => {
     it('utilise un adaptateur de chiffrement pour générer des UUID', async () => {
       let donneesPassees;

--- a/test/taches/envoieMailsNotificationExpirationHomologation.spec.js
+++ b/test/taches/envoieMailsNotificationExpirationHomologation.spec.js
@@ -1,0 +1,148 @@
+const expect = require('expect.js');
+const {
+  envoieMailsNotificationExpirationHomologation,
+} = require('../../src/taches/envoieMailsNotificationExpirationHomologation');
+const { depotVide } = require('../depots/depotVide');
+const AdaptateurHorloge = require('../../src/adaptateurs/adaptateurHorloge');
+const { creeDepot } = require('../../src/depotDonnees');
+const {
+  unePersistanceMemoire,
+} = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
+const {
+  uneAutorisation,
+} = require('../constructeurs/constructeurAutorisation');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+
+describe("La tâche d'envoie des emails de notifications d'expiration d'homologation", () => {
+  let depotDonnees;
+  let adaptateurHorloge;
+  let adaptateurMail;
+
+  beforeEach(async () => {
+    adaptateurHorloge = AdaptateurHorloge;
+    adaptateurMail = {
+      envoieNotificationExpirationHomologation: () => {},
+    };
+    depotDonnees = await depotVide();
+  });
+
+  it("lit les notifications du jour via le dépôt de données, en utilisant l'adaptateur Horloge pour obtenir la date du jour", async () => {
+    let dateRecue;
+    depotDonnees.lisNotificationsExpirationHomologationEnDate = async (
+      date
+    ) => {
+      dateRecue = date;
+      return [];
+    };
+    adaptateurHorloge.maintenant = () => new Date('2024-01-01');
+
+    await envoieMailsNotificationExpirationHomologation({
+      depotDonnees,
+      adaptateurHorloge,
+      adaptateurMail,
+    });
+
+    expect(dateRecue).to.eql(new Date('2024-01-01'));
+  });
+
+  it("utilise l'adaptateur de mail pour envoyer la notification", async () => {
+    let notificationEnvoyee;
+    adaptateurMail.envoieNotificationExpirationHomologation = (
+      destinataire,
+      idService,
+      delai
+    ) => {
+      notificationEnvoyee = { destinataire, idService, delai };
+    };
+    const adaptateurPersistance = unePersistanceMemoire()
+      .ajouteUneAutorisation(
+        uneAutorisation().deProprietaire('U1', 'S1').donnees
+      )
+      .ajouteUnUtilisateur(
+        unUtilisateur().avecId('U1').avecEmail('jean.dujardin@beta.gouv.fr')
+          .donnees
+      )
+      .ajouteUneNotificationExpirationHomologation({
+        id: 'N1',
+        idService: 'S1',
+        delaiAvantExpirationMois: 6,
+        dateProchainEnvoi: new Date('2024-01-01T00:00:00.000Z'),
+      })
+      .construis();
+    depotDonnees = creeDepot({ adaptateurPersistance });
+    adaptateurHorloge = {
+      maintenant: () => new Date('2024-01-01'),
+    };
+
+    await envoieMailsNotificationExpirationHomologation({
+      depotDonnees,
+      adaptateurHorloge,
+      adaptateurMail,
+    });
+
+    expect(notificationEnvoyee).to.eql({
+      destinataire: 'jean.dujardin@beta.gouv.fr',
+      idService: 'S1',
+      delai: 6,
+    });
+  });
+
+  it('utilise le dépôt de données pour supprimer les notifications après envoi', async () => {
+    const adaptateurPersistance = unePersistanceMemoire()
+      .ajouteUneAutorisation(
+        uneAutorisation().deProprietaire('U1', 'S1').donnees
+      )
+      .ajouteUnUtilisateur(
+        unUtilisateur().avecId('U1').avecEmail('jean.dujardin@beta.gouv.fr')
+          .donnees
+      )
+      .construis();
+    depotDonnees = creeDepot({ adaptateurPersistance });
+
+    const idsPasses = [];
+    depotDonnees.supprimeNotificationsExpirationHomologation = async (ids) => {
+      idsPasses.push(...ids);
+    };
+    depotDonnees.lisNotificationsExpirationHomologationEnDate = async () => [
+      { id: 1, idService: 'S1' },
+      { id: 2, idService: 'S1' },
+    ];
+
+    await envoieMailsNotificationExpirationHomologation({
+      depotDonnees,
+      adaptateurHorloge,
+      adaptateurMail,
+    });
+
+    expect(idsPasses).to.eql([1, 2]);
+  });
+
+  it("retourne un rapport d'exécution", async () => {
+    const adaptateurPersistance = unePersistanceMemoire()
+      .ajouteUneAutorisation(
+        uneAutorisation().deProprietaire('U1', 'S1').donnees
+      )
+      .ajouteUnUtilisateur(
+        unUtilisateur().avecId('U1').avecEmail('jean.dujardin@beta.gouv.fr')
+          .donnees
+      )
+      .construis();
+    depotDonnees = creeDepot({ adaptateurPersistance });
+
+    depotDonnees.lisNotificationsExpirationHomologationEnDate = async () => [
+      { id: 1, idService: 'S1' },
+      { id: 2, idService: 'ServiceQuiNexistePas' },
+    ];
+
+    const resultat = await envoieMailsNotificationExpirationHomologation({
+      depotDonnees,
+      adaptateurHorloge,
+      adaptateurMail,
+    });
+
+    expect(resultat).to.eql({
+      nbNotificationsEnvoyees: 1,
+      nbEchecs: 1,
+    });
+  });
+});


### PR DESCRIPTION
On ajoute une tâche qui a pour but, chaque jour, d'envoyer les emails de notification d'expiration d'homologation.
Cette tâche :
- Lis les notifications du jour
- Envoi un email pour chaque notification
- Supprime la notification

> [!CAUTION]
> Deux variables d'environnement sont à ajouter :
> `SENDINBLUE_TEMPLATE_NOTIFICATION_EXPIRATION_HOMOLOGATION` et `SENDINBLUE_TEMPLATE_NOTIFICATION_HOMOLOGATION_EXPIREE`
> Les IDs de template sont disponible dans Outline
