### PR TITLE
[CORRECTION] Autorise la mise à jour partielle de profil utilisateur

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -103,10 +103,11 @@ const creeDepot = (config = {}) => {
 
   const metsAJourUtilisateur = async (id, donnees) => {
     delete donnees.motDePasse;
-    donnees.entite = await Entite.completeDonnees(
-      donnees.entite,
-      adaptateurRechercheEntite
-    );
+    if (donnees.entite)
+      donnees.entite = await Entite.completeDonnees(
+        donnees.entite,
+        adaptateurRechercheEntite
+      );
 
     await adaptateurPersistance.metsAJourUtilisateur(id, donnees);
 

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -177,6 +177,20 @@ describe('Le dépôt de données des utilisateurs', () => {
       expect(u.id).to.equal('123');
     });
 
+    it("permet la mise à jour d'informations partielles du profil (ne plante pas si l'entité n'est pas fournie)", async () => {
+      const sansEntite = unUtilisateur()
+        .avecId('123')
+        .quiSAppelle('Jérôme Dubois').donnees;
+      delete sansEntite.entite;
+
+      await depot.metsAJourUtilisateur('123', sansEntite);
+
+      const u = await depot.utilisateur('123');
+      expect(u.prenom).to.equal('Jérôme');
+      expect(u.nom).to.equal('Dubois');
+      // Le test passe si aucune exception n'est levée
+    });
+
     it("publie sur le bus d'événements l'utilisateur modifié", async () => {
       await depot.metsAJourUtilisateur(
         '123',


### PR DESCRIPTION
Bug rencontré en PROD :
 - un utilisateur arrive sur la page d'initialisation de mot de passe après son inscription
 - il valide la page

Attendu : ça fonctionne
Observé : le dépôt crash car le code de l'API l'appelle avec des données partielles :

```
await depotDonnees.metsAJourUtilisateur(u.id, { infolettreAcceptee: true });
```

On avait prévu ce cas dans `depotDonneesUtilisateur.nouvelUtilisateur()` mais on avait oublié `metsAJourUtilisateur()`.

Ce commit rajoute le test et la correction.