### PR TITLE
[CORRECTION] N'appelle pas la recherche entreprise pour les évènements du journal ProfilUtilisateurModifié pour une invitation

### DIFF
--- a/src/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.js
+++ b/src/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.js
@@ -10,10 +10,13 @@ function consigneProfilUtilisateurModifieDansJournal({
         `Impossible de consigner les mises à jour de profil utilisateur sans avoir l'utilisateur en paramètre.`
       );
 
-    const entite =
-      await adaptateurRechercheEntreprise.recupereDetailsOrganisation(
+    let entite = {};
+    const estUnInvite = !utilisateur.entite.siret;
+    if (!estUnInvite) {
+      entite = await adaptateurRechercheEntreprise.recupereDetailsOrganisation(
         utilisateur.entite.siret
       );
+    }
 
     const profilUtilisateurModifie = new EvenementProfilUtilisateurModifie(
       utilisateur,

--- a/test/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.spec.js
+++ b/test/bus/abonnements/consigneProfilUtilisateurModifieDansJournal.spec.js
@@ -65,6 +65,7 @@ describe("L'abonnement qui consigne (dans le journal MSS) la mise à jour du pro
       utilisateur: unUtilisateur()
         .avecId('123')
         .avecPostes(['AB', 'CD'])
+        .quiTravaillePourUneEntiteAvecSiret('12345')
         .construis(),
     });
 
@@ -87,5 +88,22 @@ describe("L'abonnement qui consigne (dans le journal MSS) la mise à jour du pro
         "Impossible de consigner les mises à jour de profil utilisateur sans avoir l'utilisateur en paramètre."
       );
     }
+  });
+
+  it("ne complète pas les détails de l'entité si l'utilisateur n'a pas d'entité, comme dans le cas d'une invitation", async () => {
+    const utilisateurInvite = unUtilisateur()
+      .avecEmail('invite@mail.com')
+      .quiTravaillePour({})
+      .construis();
+
+    adaptateurRechercheEntreprise.recupereDetailsOrganisation = async () =>
+      expect().fail("L'adaptateur ne devrait pas être appelé pour un invité");
+
+    await consigneProfilUtilisateurModifieDansJournal({
+      adaptateurJournal,
+      adaptateurRechercheEntreprise,
+    })({
+      utilisateur: utilisateurInvite,
+    });
   });
 });

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -52,6 +52,11 @@ class ConstructeurUtilisateur {
     return this;
   }
 
+  quiTravaillePour(entite) {
+    this.donnees.entite = entite;
+    return this;
+  }
+
   quiSAppelle(prenomNom) {
     const [prenom, nom] = prenomNom.split(' ');
     this.donnees.prenom = prenom;


### PR DESCRIPTION
Car dans le cas d'une invitation, le SIRET de l'entité de l'utilisateur n'est pas encore renseigné