### PR TITLE
[BALEEN] Invalidation du cache après déploiement

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -59,3 +59,7 @@ NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes auto
 CHIFFREMENT_URL_BASE_DU_SERVICE= # URL de base du service de chiffrement. Tout jusqu'à `/v1` exclu.
 CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT= # Nom de la clé Transit à utiliser.
 CHIFFREMENT_TOKEN_VAULT= # Token à utiliser pour le chiffrement.
+
+# API Baleen
+BALEEN_TOKEN= # Le Personal Access Token (PAT) permettant d'utiliser l'API Baleen
+BALEEN_NAMESPACE = # L'identifiant de l'application Baleen

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bash scripts/start-scalingo.sh
+postdeploy: bash scripts/baleen/invalidation-cache.sh

--- a/scripts/baleen/invalidation-cache.sh
+++ b/scripts/baleen/invalidation-cache.sh
@@ -1,0 +1,17 @@
+#! /bin/sh
+
+if [ -z "$BALEEN_TOKEN" ] || [ -z "$BALEEN_NAMESPACE" ]
+then
+    echo -e "\x1b[31m❌ Le Token et le Namespace Baleen sont nécessaires pour l'invalidation du cache\x1b[0m"
+    exit 1
+fi
+
+NAMESPACE_ID=$(curl https://console.baleen.cloud/api/account -s -H "X-Api-Key: $BALEEN_TOKEN" | jq '.namespaces | to_entries | .[] | select(.value == "'$BALEEN_NAMESPACE'") .key')
+
+curl -X POST https://console.baleen.cloud/api/cache/invalidations \
+  -H "X-Api-Key: $BALEEN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --cookie "baleen-namespace=$NAMESPACE_ID" \
+  --data-raw '{"patterns": ["."]}'
+
+echo -e "\x1b[92m✅ Le cache a été invalidé\x1b[0m"

--- a/src/adaptateurs/adaptateurPdf.configurationTamponHomologation.js
+++ b/src/adaptateurs/adaptateurPdf.configurationTamponHomologation.js
@@ -2,7 +2,7 @@ const instructionsTamponHomologation = Buffer.from(
   `Instructions d'utilisation
 ------------------------
 
-Vous avez téléchargé une archive .zip sur le site MonServiceSécurisé.
+Vous avez téléchargé une archive .zip sur le site https://www.monservicesecurise.ssi.gouv.fr/.
 Cette archive contient des encarts d'homologation personnalisés pour votre service.
 
 Nous vous proposons ces encarts en divers formats, afin de faciliter leur utilisation

--- a/src/pdf/modeles/tamponHomologation.base64.pug
+++ b/src/pdf/modeles/tamponHomologation.base64.pug
@@ -1,1 +1,2 @@
-img(src=`data:image/png;base64, ${base64}` alt="Tampon d'homologation de MonServiceSécurisé" width=largeur height=hauteur)
+a(href='https://www.monservicesecurise.ssi.gouv.fr/' rel='noopener' target='_blank')
+  img(src=`data:image/png;base64, ${base64}` alt="Tampon d'homologation de MonServiceSécurisé" width=largeur height=hauteur)


### PR DESCRIPTION
On utilise l'API de Baleen afin d'invalider le cache après chaque déploiement.

> [!CAUTION]
> Deux variables d'environnement sont à ajouter :  `BALEEN_TOKEN` et `BALEEN_NAMESPACE`