### PR TITLE
[TAMPON HOMOLOGATION] Ajout d'un lien de redirection vers MSS

### DIFF
--- a/src/adaptateurs/adaptateurPdf.configurationTamponHomologation.js
+++ b/src/adaptateurs/adaptateurPdf.configurationTamponHomologation.js
@@ -2,7 +2,7 @@ const instructionsTamponHomologation = Buffer.from(
   `Instructions d'utilisation
 ------------------------
 
-Vous avez téléchargé une archive .zip sur le site MonServiceSécurisé.
+Vous avez téléchargé une archive .zip sur le site https://www.monservicesecurise.ssi.gouv.fr/.
 Cette archive contient des encarts d'homologation personnalisés pour votre service.
 
 Nous vous proposons ces encarts en divers formats, afin de faciliter leur utilisation

--- a/src/pdf/modeles/tamponHomologation.base64.pug
+++ b/src/pdf/modeles/tamponHomologation.base64.pug
@@ -1,1 +1,2 @@
-img(src=`data:image/png;base64, ${base64}` alt="Tampon d'homologation de MonServiceSécurisé" width=largeur height=hauteur)
+a(href='https://www.monservicesecurise.ssi.gouv.fr/' rel='noopener' target='_blank')
+  img(src=`data:image/png;base64, ${base64}` alt="Tampon d'homologation de MonServiceSécurisé" width=largeur height=hauteur)


### PR DESCRIPTION
On ajoute un lien autour de l'image `html` fournies dans l'archive du tampon d'homologation.

On en profite pour modifier les instructions.