### PR TITLE
[CORRECTION] Considère qu'un dossier est en cours de validité lorsqu'il est "Bientôt expiré"

### DIFF
--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -39,7 +39,8 @@ class Dossiers extends ElementsConstructibles {
     const dossierActif = this.dossierActif();
 
     if (!dossierActif) return false;
-    return dossierActif.statutHomologation() === Dossiers.ACTIVEE;
+    const statut = dossierActif.statutHomologation();
+    return statut === Dossiers.ACTIVEE || statut === Dossiers.BIENTOT_EXPIREE;
   }
 
   dossierCourant() {

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -20,7 +20,9 @@ describe('Les dossiers liés à un service', () => {
 
   beforeEach(() =>
     referentiel.recharge({
-      echeancesRenouvellement: { unAn: { nbMoisDecalage: 12 } },
+      echeancesRenouvellement: {
+        unAn: { nbMoisDecalage: 12, nbMoisBientotExpire: 1 },
+      },
       statutsAvisDossierHomologation: { favorable: {} },
     })
   );
@@ -239,6 +241,23 @@ describe('Les dossiers liés à un service', () => {
         {
           dossiers: [
             unDossier(referentiel).quiEstComplet().quiEstActif().donnees,
+          ],
+        },
+        referentiel
+      );
+      expect(
+        dossiersAvecDossierActifExpire.aUnDossierEnCoursDeValidite()
+      ).to.be(true);
+    });
+
+    it('retournent `true` si le dossier actif est bientôt expiré', () => {
+      const dossiersAvecDossierActifExpire = new Dossiers(
+        {
+          dossiers: [
+            unDossier(referentiel)
+              .quiEstComplet()
+              .quiEstActif()
+              .quiVaExpirer(1, 'unAn').donnees,
           ],
         },
         referentiel


### PR DESCRIPTION
...sinon le tampon d'homologation n'est plus disponible.