### PR TITLE
[SOIN] Remplace le middleware `trouveService`

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -128,7 +128,7 @@ const middleware = (configuration = {}) => {
                 if (!accesAutorise)
                   reponse.status(403).render('erreurAccesRefuse');
                 else {
-                  requete.homologation = service;
+                  requete.service = service;
                   suite();
                 }
               });
@@ -141,14 +141,14 @@ const middleware = (configuration = {}) => {
   };
 
   const trouveDossierCourant = (requete, reponse, suite) => {
-    if (!requete.homologation)
+    if (!requete.service)
       throw new ErreurChainageMiddleware(
-        'Une homologation doit être présente dans la requête. Manque-t-il un appel à `trouveService` ?'
+        'Un service doit être présent dans la requête. Manque-t-il un appel à `trouveService` ?'
       );
 
-    const dossierCourant = requete.homologation.dossierCourant();
+    const dossierCourant = requete.service.dossierCourant();
     if (!dossierCourant) {
-      reponse.status(404).send('Homologation sans dossier courant');
+      reponse.status(404).send('Service sans dossier courant');
     } else {
       requete.dossierCourant = dossierCourant;
       suite();
@@ -206,12 +206,12 @@ const middleware = (configuration = {}) => {
   };
 
   const chargeAutorisationsService = (requete, reponse, suite) => {
-    if (!requete.idUtilisateurCourant || !requete.homologation)
+    if (!requete.idUtilisateurCourant || !requete.service)
       throw new ErreurChainageMiddleware(
         'Un utilisateur courant et un service doivent être présent dans la requête. Manque-t-il un appel à `verificationJWT` et `trouveService` ?'
       );
     depotDonnees
-      .autorisationPour(requete.idUtilisateurCourant, requete.homologation.id)
+      .autorisationPour(requete.idUtilisateurCourant, requete.service.id)
       .then((autorisation) => {
         const droitsRubriques = Object.entries(autorisation.droits).reduce(
           (droits, [rubrique, niveau]) => ({

--- a/src/routes/privees/routesApiService.js
+++ b/src/routes/privees/routesApiService.js
@@ -140,7 +140,7 @@ const routesApiService = ({
           descriptionService
         );
 
-        reponse.send({ idService: requete.homologation.id });
+        reponse.send({ idService: requete.service.id });
       } catch (e) {
         if (e instanceof ErreurModele) reponse.status(422).send(e.message);
         else suite(e);
@@ -155,7 +155,7 @@ const routesApiService = ({
     middleware.chargeAutorisationsService,
     async (requete, reponse) => {
       const donnees = objetGetService.donnees(
-        requete.homologation,
+        requete.service,
         requete.autorisationService,
         referentiel
       );
@@ -167,7 +167,7 @@ const routesApiService = ({
     '/:id/mesures',
     middleware.trouveService({ [SECURISER]: LECTURE }),
     (requete, reponse) => {
-      const { homologation: service } = requete;
+      const { service } = requete;
 
       reponse.json(objetGetMesures.donnees(service));
     }
@@ -186,7 +186,7 @@ const routesApiService = ({
     ),
     (requete, reponse, suite) => {
       const { mesuresSpecifiques = [], mesuresGenerales = {} } = requete.body;
-      const idService = requete.homologation.id;
+      const idService = requete.service.id;
       const idUtilisateur = requete.idUtilisateurCourant;
 
       try {
@@ -236,7 +236,7 @@ const routesApiService = ({
     ]),
     (requete, reponse) => {
       const rolesResponsabilites = new RolesResponsabilites(requete.body);
-      const idService = requete.homologation.id;
+      const idService = requete.service.id;
       depotDonnees
         .ajouteRolesResponsabilitesAService(idService, rolesResponsabilites)
         .then(() => reponse.send({ idService }));
@@ -255,7 +255,7 @@ const routesApiService = ({
     (requete, reponse, suite) => {
       const { risquesSpecifiques = [], ...params } = requete.body;
       const prefixeAttributRisque = /^(commentaire|niveauGravite)-/;
-      const idService = requete.homologation.id;
+      const idService = requete.service.id;
 
       try {
         const donneesRisques = Object.keys(params)
@@ -309,14 +309,14 @@ const routesApiService = ({
     middleware.trouveDossierCourant,
     middleware.aseptise('nom', 'fonction'),
     (requete, reponse, suite) => {
-      const { homologation, dossierCourant } = requete;
+      const { service, dossierCourant } = requete;
 
       const {
         body: { nom, fonction },
       } = requete;
       dossierCourant.enregistreAutoriteHomologation(nom, fonction);
       depotDonnees
-        .enregistreDossier(homologation.id, dossierCourant)
+        .enregistreDossier(service.id, dossierCourant)
         .then(() => reponse.sendStatus(204))
         .catch(suite);
     }
@@ -341,11 +341,11 @@ const routesApiService = ({
         return;
       }
 
-      const { homologation, dossierCourant } = requete;
+      const { service, dossierCourant } = requete;
 
       dossierCourant.enregistreDecision(dateHomologation, dureeValidite);
       depotDonnees
-        .enregistreDossier(homologation.id, dossierCourant)
+        .enregistreDossier(service.id, dossierCourant)
         .then(() => reponse.sendStatus(204))
         .catch(suite);
     }
@@ -356,12 +356,12 @@ const routesApiService = ({
     middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     middleware.trouveDossierCourant,
     (requete, reponse, suite) => {
-      const { homologation, dossierCourant } = requete;
+      const { service, dossierCourant } = requete;
 
       const dateTelechargement = adaptateurHorloge.maintenant();
       dossierCourant.enregistreDateTelechargement(dateTelechargement);
       depotDonnees
-        .enregistreDossier(homologation.id, dossierCourant)
+        .enregistreDossier(service.id, dossierCourant)
         .then(() => reponse.sendStatus(204))
         .catch(suite);
     }
@@ -390,14 +390,14 @@ const routesApiService = ({
         return;
       }
 
-      const { homologation, dossierCourant } = requete;
+      const { service, dossierCourant } = requete;
       const avecAvis = valeurBooleenne(requete.body.avecAvis);
 
       if (avecAvis) dossierCourant.enregistreAvis(avis);
       else dossierCourant.declareSansAvis();
 
       depotDonnees
-        .enregistreDossier(homologation.id, dossierCourant)
+        .enregistreDossier(service.id, dossierCourant)
         .then(() => reponse.sendStatus(204))
         .catch(suite);
     }
@@ -417,14 +417,14 @@ const routesApiService = ({
         return;
       }
 
-      const { homologation, dossierCourant } = requete;
+      const { service, dossierCourant } = requete;
       const avecDocuments = valeurBooleenne(requete.body.avecDocuments);
 
       if (avecDocuments) dossierCourant.enregistreDocuments(documents);
       else dossierCourant.declareSansDocument();
 
       depotDonnees
-        .enregistreDossier(homologation.id, dossierCourant)
+        .enregistreDossier(service.id, dossierCourant)
         .then(() => reponse.sendStatus(204))
         .catch(suite);
     }
@@ -434,10 +434,10 @@ const routesApiService = ({
     '/:id/homologation/finalise',
     middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     (requete, reponse, suite) => {
-      const { homologation } = requete;
+      const { service } = requete;
 
       depotDonnees
-        .finaliseDossierCourant(homologation)
+        .finaliseDossierCourant(service)
         .then(() => reponse.sendStatus(204))
         .catch(suite);
     }
@@ -448,7 +448,7 @@ const routesApiService = ({
     middleware.trouveService({ [HOMOLOGUER]: ECRITURE }),
     middleware.challengeMotDePasse,
     async (requete, reponse, suite) => {
-      const { homologation: service } = requete;
+      const { service } = requete;
       try {
         service.supprimeDossierCourant();
         await depotDonnees.metsAJourService(service);
@@ -532,7 +532,7 @@ const routesApiService = ({
     middleware.trouveService({}),
     middleware.aseptise('id'),
     async (requete, reponse) => {
-      const { id: idService } = requete.homologation;
+      const { id: idService } = requete.service;
       let autorisations = await depotDonnees.autorisationsDuService(idService);
 
       const autorisationUtilisateurCourant = autorisations.find(
@@ -577,8 +577,8 @@ const routesApiService = ({
         return;
       }
 
-      const { homologation } = requete;
-      const cibleUnServiceDifferent = ciblee.idService !== homologation.id;
+      const { service } = requete;
+      const cibleUnServiceDifferent = ciblee.idService !== service.id;
       if (cibleUnServiceDifferent) {
         reponse.status(422).json({ code: 'LIEN_INCOHERENT' });
         return;
@@ -596,7 +596,7 @@ const routesApiService = ({
     middleware.trouveService({ [SECURISER]: LECTURE }),
     middleware.aseptise('id'),
     (requete, reponse) => {
-      const { homologation: service } = requete;
+      const { service } = requete;
       const completude = service.completudeMesures();
       const pourcentageProgression = Math.round(
         (completude.nombreMesuresCompletes / completude.nombreTotalMesures) *
@@ -611,8 +611,8 @@ const routesApiService = ({
     middleware.trouveService({ [SECURISER]: LECTURE }),
     middleware.aseptise('id'),
     (requete, reponse) => {
-      const { homologation } = requete;
-      reponse.json(homologation.indiceCyber());
+      const { service } = requete;
+      reponse.json(service.indiceCyber());
     }
   );
 
@@ -621,7 +621,7 @@ const routesApiService = ({
     middleware.trouveService({ [SECURISER]: ECRITURE }),
     middleware.aseptise('id', 'idMesure', 'idRetour', 'commentaire'),
     async (requete, reponse) => {
-      const { homologation: service, idUtilisateurCourant } = requete;
+      const { service, idUtilisateurCourant } = requete;
       const { idRetour, idMesure, commentaire } = requete.body;
       const retourUtilisateur =
         referentiel.retourUtilisateurMesureAvecId(idRetour);

--- a/src/routes/privees/routesApiServicePdf.js
+++ b/src/routes/privees/routesApiServicePdf.js
@@ -65,9 +65,9 @@ const routesApiServicePdf = ({
     '/:id/pdf/annexes.pdf',
     middleware.trouveService(Autorisation.DROITS_ANNEXES_PDF),
     (requete, reponse, suite) => {
-      const { homologation } = requete;
+      const { service } = requete;
 
-      generePdfAnnexes(homologation)
+      generePdfAnnexes(service)
         .then((pdf) => reponse.contentType('application/pdf').send(pdf))
         .catch(suite);
     }
@@ -78,9 +78,9 @@ const routesApiServicePdf = ({
     middleware.trouveService(Autorisation.DROITS_DOSSIER_DECISION_PDF),
     middleware.trouveDossierCourant,
     (requete, reponse, suite) => {
-      const { homologation, dossierCourant } = requete;
+      const { service, dossierCourant } = requete;
 
-      generePdfDossierDecision(homologation, dossierCourant)
+      generePdfDossierDecision(service, dossierCourant)
         .then((pdf) => reponse.contentType('application/pdf').send(pdf))
         .catch(suite);
     }
@@ -90,9 +90,9 @@ const routesApiServicePdf = ({
     '/:id/pdf/syntheseSecurite.pdf',
     middleware.trouveService(Autorisation.DROIT_SYNTHESE_SECURITE_PDF),
     (requete, reponse, suite) => {
-      const { homologation } = requete;
+      const { service } = requete;
 
-      generePdfSyntheseSecurite(homologation)
+      generePdfSyntheseSecurite(service)
         .then((pdf) => reponse.contentType('application/pdf').send(pdf))
         .catch(suite);
     }
@@ -103,24 +103,21 @@ const routesApiServicePdf = ({
     middleware.trouveService({}),
     middleware.chargeAutorisationsService,
     async (requete, reponse, suite) => {
-      const { homologation, autorisationService } = requete;
+      const { service, autorisationService } = requete;
 
       const genereUnDocument = (idDocument) => {
         const references = {
           annexes: {
-            pdf: () => generePdfAnnexes(homologation),
+            pdf: () => generePdfAnnexes(service),
             nom: () => 'Annexes.pdf',
           },
           dossierDecision: {
             pdf: () =>
-              generePdfDossierDecision(
-                homologation,
-                homologation.dossierCourant()
-              ),
+              generePdfDossierDecision(service, service.dossierCourant()),
             nom: () => 'DossierDecision.pdf',
           },
           syntheseSecurite: {
-            pdf: () => generePdfSyntheseSecurite(homologation),
+            pdf: () => generePdfSyntheseSecurite(service),
             nom: () => 'SyntheseSecurite.pdf',
           },
         };
@@ -131,7 +128,7 @@ const routesApiServicePdf = ({
       };
 
       Promise.all(
-        homologation
+        service
           .documentsPdfDisponibles(autorisationService)
           .map((d) => genereUnDocument(d))
       )
@@ -157,7 +154,7 @@ const routesApiServicePdf = ({
     middleware.trouveService(Autorisation.DROIT_TAMPON_HOMOLOGATION_ZIP),
     async (requete, reponse, suite) => {
       try {
-        const { homologation: service } = requete;
+        const { service } = requete;
         if (!service.dossiers.dossierActif()) {
           reponse.status(422).send("Le service n'a pas d'homologation active");
           return;

--- a/src/routes/privees/routesService.js
+++ b/src/routes/privees/routesService.js
@@ -68,11 +68,11 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
-      const { homologation } = requete;
+      const { service } = requete;
       reponse.render('service/descriptionService', {
         InformationsHomologation,
         referentiel,
-        service: homologation,
+        service,
         etapeActive: 'descriptionService',
       });
     }
@@ -84,10 +84,10 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     async (requete, reponse) => {
-      const { homologation } = requete;
+      const { service } = requete;
 
-      const mesures = moteurRegles.mesures(homologation.descriptionService);
-      const completude = homologation.completudeMesures();
+      const mesures = moteurRegles.mesures(service.descriptionService);
+      const completude = service.completudeMesures();
       const pourcentageProgression = Math.round(
         (completude.nombreMesuresCompletes / completude.nombreTotalMesures) *
           100
@@ -96,7 +96,7 @@ const routesService = ({
       reponse.render('service/mesures', {
         InformationsHomologation,
         referentiel,
-        service: homologation,
+        service,
         etapeActive: 'mesures',
         pourcentageProgression,
         mesures,
@@ -109,7 +109,7 @@ const routesService = ({
     middleware.aseptise('id', 'avecDonneesAdditionnelles'),
     middleware.trouveService({ [SECURISER]: LECTURE }),
     async (requete, reponse) => {
-      const { homologation: service } = requete;
+      const { service } = requete;
       const { avecDonneesAdditionnelles } = requete.query;
 
       try {
@@ -144,7 +144,7 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     async (requete, reponse) => {
-      const { homologation: service } = requete;
+      const { service } = requete;
       const referentiels = Object.entries(
         service.mesures.enrichiesAvecDonneesPersonnalisees().mesuresGenerales
       ).map(([_, mesure]) => mesure.referentiel);
@@ -166,10 +166,10 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
-      const { homologation } = requete;
+      const { service } = requete;
       reponse.render('service/rolesResponsabilites', {
         InformationsHomologation,
-        service: homologation,
+        service,
         etapeActive: 'contactsUtiles',
         referentiel,
       });
@@ -182,11 +182,11 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
-      const { homologation } = requete;
+      const { service } = requete;
       reponse.render('service/risques', {
         InformationsHomologation,
         referentiel,
-        service: homologation,
+        service,
         etapeActive: 'risques',
       });
     }
@@ -198,7 +198,7 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse) => {
-      const { homologation: service, autorisationService } = requete;
+      const { service, autorisationService } = requete;
 
       const peutVoirTamponHomologation =
         autorisationService.aLesPermissions(
@@ -223,7 +223,7 @@ const routesService = ({
     middleware.chargeAutorisationsService,
     middleware.chargePreferencesUtilisateur,
     async (requete, reponse, suite) => {
-      const { homologation, autorisationService } = requete;
+      const { service, autorisationService } = requete;
       const { idEtape } = requete.params;
 
       if (!referentiel.etapeExiste(idEtape)) {
@@ -232,11 +232,11 @@ const routesService = ({
       }
 
       try {
-        await depotDonnees.ajouteDossierCourantSiNecessaire(homologation.id);
+        await depotDonnees.ajouteDossierCourantSiNecessaire(service.id);
 
-        const h = await depotDonnees.homologation(homologation.id);
+        const s = await depotDonnees.homologation(service.id);
         const etapeCourante = referentiel.etapeDossierAutorisee(
-          h.dossierCourant().etapeCourante(),
+          s.dossierCourant().etapeCourante(),
           autorisationService.peutHomologuer()
         );
         const numeroEtapeCourante = referentiel.numeroEtape(etapeCourante);
@@ -249,7 +249,7 @@ const routesService = ({
         reponse.render(`service/etapeDossier/${idEtape}`, {
           InformationsHomologation,
           referentiel,
-          service: h,
+          service: s,
           etapeActive: 'dossiers',
           idEtape,
         });

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -244,14 +244,14 @@ describe('Le middleware MSS', () => {
     });
 
     it('retourne le service trouvé et appelle le middleware suivant', (done) => {
-      const homologation = {};
-      depotDonnees.homologation = () => Promise.resolve(homologation);
+      const service = {};
+      depotDonnees.homologation = () => Promise.resolve(service);
       depotDonnees.accesAutorise = () => Promise.resolve(true);
       const middleware = Middleware({ adaptateurJWT, depotDonnees });
 
       middleware.trouveService({})(requete, reponse, () => {
         try {
-          expect(requete.homologation).to.equal(homologation);
+          expect(requete.service).to.equal(service);
           done();
         } catch (e) {
           done(e);
@@ -261,17 +261,17 @@ describe('Le middleware MSS', () => {
   });
 
   describe("sur recherche du dossier courant d'une homologation existante", () => {
-    it("renvoie une erreur HTTP 404 si l'homologation n'a pas de dossier courant'", (done) => {
-      const homologation = {
+    it("renvoie une erreur HTTP 404 si le service n'a pas de dossier courant'", (done) => {
+      const service = {
         dossierCourant: () => null,
       };
-      requete.homologation = homologation;
+      requete.service = service;
       const middleware = Middleware();
 
       prepareVerificationReponse(
         reponse,
         404,
-        'Homologation sans dossier courant',
+        'Service sans dossier courant',
         done
       );
 
@@ -280,8 +280,8 @@ describe('Le middleware MSS', () => {
       middleware.trouveDossierCourant(requete, reponse, suite);
     });
 
-    it("jette une erreur technique si l'homologation n'est pas présente dans la requête", (done) => {
-      requete.homologation = null;
+    it("jette une erreur technique si le service n'est pas présent dans la requête", (done) => {
+      requete.service = null;
       const middleware = Middleware();
 
       expect(() =>
@@ -289,7 +289,7 @@ describe('Le middleware MSS', () => {
       ).to.throwError((e) => {
         expect(e).to.be.an(ErreurChainageMiddleware);
         expect(e.message).to.equal(
-          'Une homologation doit être présente dans la requête. Manque-t-il un appel à `trouveService` ?'
+          'Un service doit être présent dans la requête. Manque-t-il un appel à `trouveService` ?'
         );
         done();
       });
@@ -297,11 +297,11 @@ describe('Le middleware MSS', () => {
 
     it('retourne le dossier courant trouvé et appelle le middleware suivant', (done) => {
       const dossierCourant = {};
-      const homologation = {
+      const service = {
         dossierCourant: () => dossierCourant,
       };
 
-      requete.homologation = homologation;
+      requete.service = service;
       const middleware = Middleware();
 
       middleware.trouveDossierCourant(requete, reponse, () => {
@@ -730,13 +730,13 @@ describe('Le middleware MSS', () => {
   describe('sur demande de chargement des autorisations pour un service', () => {
     beforeEach(() => {
       requete.idUtilisateurCourant = '999';
-      requete.homologation = { id: '123' };
+      requete.service = { id: '123' };
       depotDonnees.autorisationPour = async () =>
         uneAutorisation().avecDroits({}).construis();
     });
 
     it("jette une erreur technique si le service ou l'utilisateur ne sont pas présents dans la requête", (done) => {
-      requete.homologation = null;
+      requete.service = null;
       const middleware = Middleware({ depotDonnees });
 
       expect(() =>

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -48,7 +48,7 @@ let droitVerifie = null;
 let expirationCookieRepoussee = false;
 let headersAvecNoncePositionnes = false;
 let headersPositionnes = false;
-let homologationTrouvee;
+let serviceTrouve;
 let idUtilisateurCourant;
 let listesAseptisees = [];
 let listeAdressesIPsAutorisee = [];
@@ -77,7 +77,7 @@ const middlewareFantaisie = {
     expirationCookieRepoussee = false;
     headersAvecNoncePositionnes = false;
     headersPositionnes = false;
-    homologationTrouvee = homologationARenvoyer;
+    serviceTrouve = homologationARenvoyer;
     idUtilisateurCourant = idUtilisateur;
     autorisationChargee = autorisationACharger;
     listesAseptisees = [];
@@ -171,12 +171,12 @@ const middlewareFantaisie = {
     }));
     requete.idUtilisateurCourant = idUtilisateurCourant;
     requete.cguAcceptees = cguAcceptees;
-    requete.homologation = homologationTrouvee;
+    requete.service = serviceTrouve;
     suite();
   },
 
   trouveDossierCourant: (requete, _reponse, suite) => {
-    requete.dossierCourant = requete.homologation.dossierCourant();
+    requete.dossierCourant = requete.service.dossierCourant();
     rechercheDossierCourantEffectuee = true;
     suite();
   },

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -65,7 +65,7 @@ const middlewareFantaisie = {
   reinitialise: ({
     idUtilisateur,
     acceptationCGU = true,
-    homologationARenvoyer = unService()
+    serviceARenvoyer = unService()
       .avecId('456')
       .avecNomService('un service')
       .construis(),
@@ -77,7 +77,7 @@ const middlewareFantaisie = {
     expirationCookieRepoussee = false;
     headersAvecNoncePositionnes = false;
     headersPositionnes = false;
-    serviceTrouve = homologationARenvoyer;
+    serviceTrouve = serviceARenvoyer;
     idUtilisateurCourant = idUtilisateur;
     autorisationChargee = autorisationACharger;
     listesAseptisees = [];

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -315,7 +315,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
 
       testeur.middleware().reinitialise({
-        homologationARenvoyer: unService(avecMesureA)
+        serviceARenvoyer: unService(avecMesureA)
           .avecMesures(mesures)
           .construis(),
       });
@@ -709,7 +709,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: homologationAvecDossier });
+        .reinitialise({ serviceARenvoyer: homologationAvecDossier });
       testeur.depotDonnees().enregistreDossier = async () => {};
     });
 
@@ -776,7 +776,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: homologationAvecDossier });
+        .reinitialise({ serviceARenvoyer: homologationAvecDossier });
       testeur.depotDonnees().enregistreDossier = async () => {};
       testeur.referentiel().recharge({ echeancesRenouvellement: { unAn: {} } });
     });
@@ -874,7 +874,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: homologationAvecDossier });
+        .reinitialise({ serviceARenvoyer: homologationAvecDossier });
       testeur.depotDonnees().enregistreDossier = () => Promise.resolve();
       testeur
         .referentiel()
@@ -937,7 +937,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: homologationAvecDossier });
+        .reinitialise({ serviceARenvoyer: homologationAvecDossier });
       testeur.depotDonnees().enregistreDossier = () => Promise.resolve();
       testeur.referentiel().recharge({
         echeancesRenouvellement: { unAn: {} },
@@ -1082,7 +1082,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: homologationAvecDossier });
+        .reinitialise({ serviceARenvoyer: homologationAvecDossier });
       testeur.depotDonnees().enregistreDossier = () => Promise.resolve();
     });
 
@@ -1195,7 +1195,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: homologationAvecDossier });
+        .reinitialise({ serviceARenvoyer: homologationAvecDossier });
       testeur.depotDonnees().finaliseDossierCourant = () => Promise.resolve();
     });
 
@@ -1473,7 +1473,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .avecDossiers([donneesDossier])
         .construis();
       testeur.middleware().reinitialise({
-        homologationARenvoyer: serviceARenvoyer,
+        serviceARenvoyer,
         idUtilisateur: '123',
         autorisationACharger: uneAutorisation()
           .avecDroits({ [HOMOLOGUER]: LECTURE })
@@ -1627,7 +1627,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
       testeur.middleware().reinitialise({
         idUtilisateur: 'LEROY',
-        homologationARenvoyer: serviceABC,
+        serviceARenvoyer: serviceABC,
         autorisationACharger: leroyProprietaireDeABC,
       });
 
@@ -1761,7 +1761,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .avecId('456')
         .construis();
       testeur.middleware().reinitialise({
-        homologationARenvoyer: serviceARenvoyer,
+        serviceARenvoyer,
         idUtilisateur: 'AAA',
       });
       testeur.depotDonnees().autorisationsDuService = async (idService) => [
@@ -1803,7 +1803,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .avecNContributeurs(1)
         .construis();
       testeur.middleware().reinitialise({
-        homologationARenvoyer: serviceARenvoyer,
+        serviceARenvoyer,
         idUtilisateur: 'AAA',
       });
 
@@ -1840,7 +1840,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .avecNContributeurs(3, ['ABC', 'DEF', 'GHI'])
         .construis();
       testeur.middleware().reinitialise({
-        homologationARenvoyer: serviceARenvoyer,
+        serviceARenvoyer,
         idUtilisateur: 'AAA',
       });
       testeur.depotDonnees().autorisationsDuService = async () => [
@@ -1863,7 +1863,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .avecNContributeurs(3, ['ABC', 'DEF', 'GHI'])
         .construis();
       testeur.middleware().reinitialise({
-        homologationARenvoyer: serviceARenvoyer,
+        serviceARenvoyer,
         idUtilisateur: 'DEF',
       });
       testeur.depotDonnees().autorisationsDuService = async () => [
@@ -1910,7 +1910,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       const serviceARenvoyer = unService().construis();
       serviceARenvoyer.indiceCyber = () => ({ total: 1.5 });
       testeur.middleware().reinitialise({
-        homologationARenvoyer: serviceARenvoyer,
+        serviceARenvoyer,
       });
 
       const { data } = await axios.get(
@@ -1951,7 +1951,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         nombreTotalMesures: 10,
       });
       testeur.middleware().reinitialise({
-        homologationARenvoyer: serviceARenvoyer,
+        serviceARenvoyer,
       });
 
       const { data } = await axios.get(
@@ -2074,7 +2074,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("retourne une erreur HTTP 422 si le service n'a pas de dossier courant", (done) => {
       const service = unService().construis();
-      testeur.middleware().reinitialise({ homologationARenvoyer: service });
+      testeur.middleware().reinitialise({ serviceARenvoyer: service });
 
       testeur.verifieRequeteGenereErreurHTTP(
         422,
@@ -2100,7 +2100,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .construis();
       let serviceMisAJour;
 
-      testeur.middleware().reinitialise({ homologationARenvoyer: service });
+      testeur.middleware().reinitialise({ serviceARenvoyer: service });
       testeur.depotDonnees().metsAJourService = async (s) => {
         serviceMisAJour = s;
       };

--- a/test/routes/privees/routesApiServicePdf.spec.js
+++ b/test/routes/privees/routesApiServicePdf.spec.js
@@ -66,7 +66,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
     });
 
     beforeEach(() => {
-      const homologationARenvoyer = new Homologation(
+      const serviceARenvoyer = new Homologation(
         {
           id: '456',
           descriptionService: { nomService: 'un service' },
@@ -86,8 +86,8 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         },
         referentiel
       );
-      homologationARenvoyer.mesures.indiceCyber = () => 3.5;
-      testeur.middleware().reinitialise({ homologationARenvoyer });
+      serviceARenvoyer.mesures.indiceCyber = () => 3.5;
+      testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
     it('recherche le service correspondant', (done) => {
@@ -155,10 +155,10 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       mesures: { uneMesure: { categorie: 'uneCategorie' } },
       reglesPersonnalisation: { mesuresBase: ['uneMesure'] },
     });
-    const homologationARenvoyer = new Homologation({ id: '456' }, referentiel);
+    const serviceARenvoyer = unService(referentiel).avecId('456').construis();
 
     beforeEach(() => {
-      testeur.middleware().reinitialise({ homologationARenvoyer });
+      testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
     it('recherche le service correspondant', (done) => {
@@ -191,14 +191,14 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         'http://localhost:1234/api/service/456/pdf/syntheseSecurite.pdf'
       );
 
-      expect(donneesSynthese.service).to.eql(homologationARenvoyer);
+      expect(donneesSynthese.service).to.eql(serviceARenvoyer);
       expect(donneesSynthese.referentiel).to.eql(testeur.referentiel());
     });
   });
 
   describe('quand requête GET sur `/api/service/:id/pdf/documentsHomologation.zip`', () => {
     const referentiel = Referentiel.creeReferentielVide();
-    const homologationARenvoyer = new Homologation(
+    const serviceARenvoyer = new Homologation(
       {
         id: '456',
         descriptionService: { nomService: 'un service' },
@@ -206,15 +206,15 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       },
       referentiel
     );
-    homologationARenvoyer.mesures.indiceCyber = () => 3.5;
-    homologationARenvoyer.documentsPdfDisponibles = () => [
+    serviceARenvoyer.mesures.indiceCyber = () => 3.5;
+    serviceARenvoyer.documentsPdfDisponibles = () => [
       'annexes',
       'syntheseSecurite',
       'dossierDecision',
     ];
 
     beforeEach(() => {
-      testeur.middleware().reinitialise({ homologationARenvoyer });
+      testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
     it('recherche le service correspondant', (done) => {
@@ -259,7 +259,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
 
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: serviceUnSeulDocument });
+        .reinitialise({ serviceARenvoyer: serviceUnSeulDocument });
 
       let fichiersZipes;
       testeur.adaptateurPdf().genereAnnexes = async () => 'PDF A';
@@ -309,9 +309,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       .construis();
 
     beforeEach(() => {
-      testeur
-        .middleware()
-        .reinitialise({ homologationARenvoyer: serviceARenvoyer });
+      testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
     it('recherche le service correspondant', (done) => {
@@ -350,7 +348,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         .construis();
       testeur
         .middleware()
-        .reinitialise({ homologationARenvoyer: serviceSansDossierActif });
+        .reinitialise({ serviceARenvoyer: serviceSansDossierActif });
 
       testeur.verifieRequeteGenereErreurHTTP(
         422,

--- a/test/routes/privees/routesService.spec.js
+++ b/test/routes/privees/routesService.spec.js
@@ -2,7 +2,6 @@ const axios = require('axios');
 const expect = require('expect.js');
 
 const testeurMSS = require('../testeurMSS');
-const Homologation = require('../../../src/modeles/homologation');
 const {
   Permissions: { LECTURE },
   Rubriques: { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES },
@@ -221,7 +220,7 @@ describe('Le serveur MSS des routes /service/*', () => {
       const requete = {};
 
       testeur.middleware().trouveService(requete, undefined, () => {
-        const { nomService } = requete.homologation.descriptionService;
+        const { nomService } = requete.service.descriptionService;
         expect(nomService).to.equal('un service'); // sanity check
       });
 


### PR DESCRIPTION
... afin de placer un `service` dans la requête, et non plus une `homologation`.

Cette PR fait partie de la tâche de fond qui consiste à remplacer les `homologations` par des `services`.

> [!NOTE]  
> Il reste aujourd'hui **_882 occurences_** du mot "homologation" dans le projet, contre _**994 avant cette PR**_.
> 
> ![](https://geps.dev/progress/11?dangerColor=1f6feb)