### PR TITLE
[CORRECTION] Interdit la duplication de service sans SIRET

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -36,7 +36,6 @@ class ErreurMesureInconnue extends ErreurModele {}
 class ErreurMotDePasseIncorrect extends ErreurModele {}
 class ErreurNiveauGraviteInconnu extends ErreurModele {}
 class ErreurNomServiceDejaExistant extends ErreurModele {}
-class ErreurProprieteManquante extends ErreurModele {}
 class ErreurRisqueInconnu extends ErreurModele {}
 class ErreurStatutDeploiementInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
@@ -79,7 +78,6 @@ module.exports = {
   ErreurModele,
   ErreurNiveauGraviteInconnu,
   ErreurNomServiceDejaExistant,
-  ErreurProprieteManquante,
   ErreurRisqueInconnu,
   ErreurServiceInexistant,
   ErreurStatutDeploiementInvalide,

--- a/src/modeles/entite.js
+++ b/src/modeles/entite.js
@@ -1,5 +1,5 @@
 const Base = require('./base');
-const { ErreurProprieteManquante } = require('../erreurs');
+const { ErreurDonneesObligatoiresManquantes } = require('../erreurs');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('../adaptateurs/fabriqueAdaptateurGestionErreur');
@@ -15,7 +15,7 @@ class Entite extends Base {
 
   static valideDonnees(donnees = {}) {
     if (typeof donnees.siret !== 'string' || donnees.siret === '') {
-      throw new ErreurProprieteManquante(
+      throw new ErreurDonneesObligatoiresManquantes(
         'La propriété "entite.siret" est requise'
       );
     }

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -1,5 +1,8 @@
 const Base = require('./base');
-const { ErreurEmailManquant, ErreurProprieteManquante } = require('../erreurs');
+const {
+  ErreurEmailManquant,
+  ErreurDonneesObligatoiresManquantes,
+} = require('../erreurs');
 const { formatteListeFr } = require('../utilitaires/liste');
 const Entite = require('./entite');
 
@@ -33,8 +36,8 @@ class Utilisateur extends Base {
   }
 
   static valideDonnees(donnees = {}, utilisateurExistant = false) {
-    const envoieErreurProprieteManquante = (propriete) => {
-      throw new ErreurProprieteManquante(
+    const envoieErreurDonneeManquante = (propriete) => {
+      throw new ErreurDonneesObligatoiresManquantes(
         `La propriété "${propriete}" est requise`
       );
     };
@@ -45,7 +48,7 @@ class Utilisateur extends Base {
           typeof donnees[propriete] !== 'string' ||
           donnees[propriete] === ''
         ) {
-          envoieErreurProprieteManquante(propriete);
+          envoieErreurDonneeManquante(propriete);
         }
       });
     };
@@ -53,7 +56,7 @@ class Utilisateur extends Base {
     const validePresenceProprietesObjet = (proprietes) => {
       proprietes.forEach((propriete) => {
         if (typeof donnees[propriete] !== 'object') {
-          envoieErreurProprieteManquante(propriete);
+          envoieErreurDonneeManquante(propriete);
         }
       });
     };
@@ -61,7 +64,7 @@ class Utilisateur extends Base {
     const validePresenceProprietesBooleenes = (proprietes) => {
       proprietes.forEach((propriete) => {
         if (typeof donnees[propriete] !== 'boolean') {
-          envoieErreurProprieteManquante(propriete);
+          envoieErreurDonneeManquante(propriete);
         }
       });
     };
@@ -69,7 +72,7 @@ class Utilisateur extends Base {
     const validePresenceProprieteListes = (proprietes) => {
       proprietes.forEach((propriete) => {
         if (!Array.isArray(donnees[propriete])) {
-          envoieErreurProprieteManquante(propriete);
+          envoieErreurDonneeManquante(propriete);
         }
       });
     };

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -6,7 +6,6 @@ const {
   ErreurDonneesObligatoiresManquantes,
   ErreurServiceInexistant,
   ErreurNomServiceDejaExistant,
-  ErreurProprieteManquante,
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 
@@ -464,7 +463,7 @@ describe('Le dépôt de données des homologations', () => {
           'La mise à jour de la description du service aurait dû lever une exception'
         );
       } catch (e) {
-        expect(e).to.be.an(ErreurProprieteManquante);
+        expect(e).to.be.an(ErreurDonneesObligatoiresManquantes);
         expect(e.message).to.equal('La propriété "entite.siret" est requise');
       }
     });
@@ -839,7 +838,7 @@ describe('Le dépôt de données des homologations', () => {
           'La mise à jour de la description du service aurait dû lever une exception'
         );
       } catch (e) {
-        expect(e).to.be.an(ErreurProprieteManquante);
+        expect(e).to.be.an(ErreurDonneesObligatoiresManquantes);
         expect(e.message).to.equal('La propriété "entite.siret" est requise');
       }
     });

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -2,7 +2,7 @@ const expect = require('expect.js');
 
 const {
   ErreurEmailManquant,
-  ErreurProprieteManquante,
+  ErreurDonneesObligatoiresManquantes,
 } = require('../../src/erreurs');
 const Utilisateur = require('../../src/modeles/utilisateur');
 const {
@@ -205,10 +205,10 @@ describe('Un utilisateur', () => {
       try {
         Utilisateur.valideDonnees(donnees);
         done(
-          `La validation des données d'un utilisateur sans ${nom} aurait du lever une erreur de propriété manquante`
+          `La validation des données d'un utilisateur sans ${nom} aurait du lever une erreur de donnée manquante`
         );
       } catch (error) {
-        expect(error).to.be.a(ErreurProprieteManquante);
+        expect(error).to.be.a(ErreurDonneesObligatoiresManquantes);
         expect(error.message).to.equal(`La propriété "${clef}" est requise`);
         done();
       }
@@ -247,7 +247,7 @@ describe('Un utilisateur', () => {
         done();
       } catch (erreur) {
         let messageEchec = `La validation des données d'un utilisateur existant sans email n'aurait pas du lever d'erreur : ${erreur.message}`;
-        if (erreur instanceof ErreurProprieteManquante) {
+        if (erreur instanceof ErreurDonneesObligatoiresManquantes) {
           messageEchec =
             "La validation des données d'un utilisateur existant sans email n'aurait pas du lever d'erreur de propriété manquante";
         }


### PR DESCRIPTION
...Reproduction du bug : essayer de dupliquer un service qui n'a pas encore de SIRET.
Attendu : la duplication n'est pas possible car la donnée est obligatoire.
Observé : MSS crash.

Ce commit change le type d'exception levé par la vérification de présence de SIRET pour rentrer dans le flow d'affichage du tiroir avec le message incitant à compléter la page décrire