### PR TITLE
Ajoute une balise <meta> de vérification

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,6 +39,8 @@ SECRET_JWT= # chaîne utilisée pour chiffrer le JWT
 ID_MATOMO=# ID du site déclaré dans Matomo. Laisser vide ou commenter la ligne pour ne pas utiliser Matomo
 MATOMO_URL_TAG_MANAGER=# URL du `.js` du tag manager Matomo, ex. https://stats.data.gouv.fr/js/container_XXXX.js
 
+GOOGLE_SEARCH_CONSOLE_VERIFICATION=# Code de vérification de la Google Search Console. Laisser vide pour ne pas inclure la balise <meta> de vérification.
+
 # Journal MSS
 URL_SERVEUR_BASE_DONNEES_JOURNAL= # URL de la base de données du Journal MSS. ex. postgres://user@mss-journal-db:5432/mss-journal
 

--- a/src/vues/base.pug
+++ b/src/vues/base.pug
@@ -2,6 +2,8 @@ doctype html
 html(lang = 'fr', xml:lang = 'fr', xmlns = 'http://www.w3.org/1999/xhtml')
     meta(charset='utf-8')
     meta(name = 'viewport', content = 'width=device-width')
+    if (process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
+        meta(name = 'google-site-verification', content = process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
     meta(property = 'og:site_name', content = 'MonServiceSécurisé')
     link(rel='icon', href='/statique/assets/images/favicons/favicon.ico')
 


### PR DESCRIPTION
… pour la Google Search Console.

On va se servir de la console pour améliorer notre référencement.

> [!IMPORTANT]
> Il faut créer `GOOGLE_SEARCH_CONSOLE_VERIFICATION` en variable d'env.