### PR TITLE
Affiche un message d'information sur le tableau de services si la description du service est incomplète

### DIFF
--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -826,3 +826,17 @@ label[for='recherche-service'] {
   position: relative;
   z-index: 2;
 }
+
+.avertissement-completion {
+  font-size: 0.9em;
+  color: var(--texte-fonce);
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+}
+
+.avertissement-completion img {
+  height: 1.1em;
+  width: 1.1em;
+  margin-right: 4px;
+}

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -205,10 +205,23 @@ const tableauDesServices = {
         `<input class='selection-service' type='checkbox' aria-labelledby='nom-${service.id}'>`
       );
       $inputSelection.prop('checked', estSelectionne);
-      const $nomService =
-        $(`<a class='conteneur-noms' href='/service/${service.id}' id='nom-${service.id}'>
-                              <div class='nom-service'>${service.nomService}</div>
-                              <div class='nom-organisation'>${service.organisationResponsable}</div>
+      const $nomService = $(`<a class='conteneur-noms'
+                                href='/service/${service.id}' 
+                                id='nom-${service.id}'>
+                              <div class='nom-service'>
+                                ${service.nomService}
+                              </div>
+                              <div class='nom-organisation'>
+                                ${service.organisationResponsable}
+                              </div>
+                              ${
+                                service.statutSaisieDescription === 'aCompleter'
+                                  ? `<div class="avertissement-completion">
+                                   <img src="/statique/assets/images/icone_danger_bleu.svg" alt="" />
+                                     Informations à mettre à jour
+                                 </div>`
+                                  : ''
+                              }
                             </a>`);
       $celluleNoms.append($inputSelection);
       $celluleNoms.append($nomService);

--- a/src/modeles/descriptionService.js
+++ b/src/modeles/descriptionService.js
@@ -66,6 +66,16 @@ class DescriptionService extends InformationsHomologation {
     return this.pointsAcces.nombre();
   }
 
+  statutSaisie() {
+    const statutSaisieDeBase = super.statutSaisie();
+    if (statutSaisieDeBase !== DescriptionService.COMPLETES) {
+      return statutSaisieDeBase;
+    }
+    return this.organisationResponsable?.statutSaisie() === Entite.COMPLETES
+      ? DescriptionService.COMPLETES
+      : DescriptionService.A_COMPLETER;
+  }
+
   donneesSerialisees() {
     return this.toJSON();
   }

--- a/src/modeles/entite.js
+++ b/src/modeles/entite.js
@@ -1,10 +1,10 @@
-const Base = require('./base');
 const { ErreurDonneesObligatoiresManquantes } = require('../erreurs');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('../adaptateurs/fabriqueAdaptateurGestionErreur');
+const InformationsHomologation = require('./informationsHomologation');
 
-class Entite extends Base {
+class Entite extends InformationsHomologation {
   constructor(donnees = {}) {
     super({
       proprietesAtomiquesRequises: ['siret'],

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -15,6 +15,7 @@ const donnees = (service, autorisation, referentiel) => {
     nomService: service.nomService(),
     organisationResponsable:
       service.descriptionService.organisationResponsable.nom ?? '',
+    statutSaisieDescription: service.descriptionService.statutSaisie(),
     contributeurs: service.contributeurs.map((c) => ({
       id: c.id,
       prenomNom: c.prenomNom(),

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -204,6 +204,29 @@ describe('La description du service', () => {
     );
   });
 
+  elle(
+    "détecte qu'elle est partiellement saisie si tout est rempli sauf le siret",
+    () => {
+      const descriptionService = new DescriptionService(
+        {
+          nomService: 'Super Service',
+          delaiAvantImpactCritique: 'uneJournee',
+          localisationDonnees: 'france',
+          presentation: 'Une présentation',
+          provenanceService: 'uneProvenance',
+          risqueJuridiqueFinancierReputationnel: true,
+          statutDeploiement: 'accessible',
+          nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
+          organisationResponsable: { nom: 'MonOrga' },
+        },
+        referentielAvecStatutValide('accessible')
+      );
+      expect(descriptionService.statutSaisie()).to.equal(
+        InformationsHomologation.A_COMPLETER
+      );
+    }
+  );
+
   elle("détecte qu'elle est complètement saisie", () => {
     const descriptionService = new DescriptionService(
       {
@@ -215,6 +238,7 @@ describe('La description du service', () => {
         risqueJuridiqueFinancierReputationnel: true,
         statutDeploiement: 'accessible',
         nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
+        organisationResponsable: { siret: '12345' },
       },
       referentielAvecStatutValide('accessible')
     );

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -64,6 +64,7 @@ describe("L'objet d'API de `GET /service`", () => {
       id: '123',
       nomService: 'Un service',
       organisationResponsable: 'Une organisation',
+      statutSaisieDescription: 'aCompleter',
       contributeurs: [
         {
           id: 'A',

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -86,6 +86,7 @@ describe("L'objet d'API de `GET /services`", () => {
           id: 'nonRealisee',
           ordre: 1,
         },
+        statutSaisieDescription: 'aCompleter',
         nombreContributeurs: 1 + 1,
         estProprietaire: true,
         documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],

--- a/test/routes/privees/routesApiService.spec.js
+++ b/test/routes/privees/routesApiService.spec.js
@@ -1537,6 +1537,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           enCoursEdition: true,
           etapeCourante: 'autorite',
         },
+        statutSaisieDescription: 'completes',
         nombreContributeurs: 2,
         estProprietaire: false,
         documentsPdfDisponibles: [],


### PR DESCRIPTION
...comme dans le cas du SIRET non renseigné.

Cela permet d'indiquer à l'utilisateur qu'il doit compléter sa saisie. 
Cela fait suite à l'obligation de renseigner le SIRET de l'organisation responsable du service, en l'absence de possibilité de rattrapage automatique des données.

Cette PR corrige par la même occasion le retour de statutSaisie qui avait cassé suite au changement de l'organisation responsable d'une propriété atomique à une Entite. Ce bug faisait que la page décrire avait une check verte alors qu'elle ne devrait pas si le SIRET n'est pas renseigné.