### PR TITLE
[SEO] Ajoute les balises `meta` de description

### DIFF
--- a/src/vues/aPropos.pug
+++ b/src/vues/aPropos.pug
@@ -1,4 +1,6 @@
 extends mssDeconnecte
+block variables
+  - const meta_description = 'Découvrez qui nous sommes, notre mission et notre expertise. Ensemble, protégeons vos services numériques.'
 
 block title
   title À propos | MonServiceSécurisé

--- a/src/vues/accessibilite.pug
+++ b/src/vues/accessibilite.pug
@@ -1,4 +1,6 @@
 extends mssDeconnecte
+block variables
+  - const meta_description = "Découvrez notre engagement envers l'accessibilité sur MonServiceSécurisé. Consultez nos efforts pour rendre nos services numériques accessibles à tous."
 
 block title
   title Accessibilité | MonServiceSécurisé

--- a/src/vues/base.pug
+++ b/src/vues/base.pug
@@ -1,3 +1,5 @@
+block variables
+    - const meta_description = ''
 doctype html
 html(lang = 'fr', xml:lang = 'fr', xmlns = 'http://www.w3.org/1999/xhtml')
     head
@@ -6,6 +8,7 @@ html(lang = 'fr', xml:lang = 'fr', xmlns = 'http://www.w3.org/1999/xhtml')
         if (process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
             meta(name = 'google-site-verification', content = process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
         meta(property = 'og:site_name', content = 'MonServiceSécurisé')
+        meta(name = 'description' content=meta_description)
         link(rel='icon', href='/statique/assets/images/favicons/favicon.ico')
 
     block title

--- a/src/vues/cgu.pug
+++ b/src/vues/cgu.pug
@@ -1,4 +1,7 @@
 extends mssDeconnecte
+block variables
+  - const meta_description = "Découvrez nos conditions générales d'utilisation sur MonServiceSécurisé. Protégez vos services numériques en toute conformité. Consultez nos engagements pour une sécurité renforcée."
+
 
 block title
   title Conditions générales d'utilisation | MonServiceSécurisé

--- a/src/vues/connexion.pug
+++ b/src/vues/connexion.pug
@@ -1,4 +1,6 @@
 extends mssConnexionEnCours
+block variables
+  - const meta_description = 'Connectez-vous à MonServiceSécurisé pour accéder à votre tableau de bord et continuer à sécuriser vos services numériques en équipe !'
 
 block title
   title Connexion | MonServiceSécurisé

--- a/src/vues/home.pug
+++ b/src/vues/home.pug
@@ -1,4 +1,6 @@
 extends mssDeconnecte
+block variables
+  - const meta_description = 'Pilotez la sécurité de vos services numériques en équipe et homologuez les rapidement avec MonServiceSécurisé. Découvrez maintenant !'
 
 mixin contenuAvantage(titre, description)
   .contenu-avantage

--- a/src/vues/inscription.pug
+++ b/src/vues/inscription.pug
@@ -1,5 +1,8 @@
 extends ./mssInscription
 include ./fragments/utilisateur/questionCgu
+block variables
+  - const meta_description = 'Inscrivez-vous sur MonServiceSécurisé et accédez à une plateforme pour sécuriser tous vos services numériques.'
+
 
 block title
   title Inscription | MonServiceSécurisé

--- a/src/vues/mentionsLegales.pug
+++ b/src/vues/mentionsLegales.pug
@@ -1,4 +1,6 @@
 extends mssDeconnecte
+block variables
+  - const meta_description = "Découvrez les mentions légales de MonServiceSécurisé. Consultez nos conditions d'utilisation, notre politique de confidentialité et nos engagements en matière de sécurité numérique. Protégez-vous en toute transparence."
 
 block title
   title Mentions légales | MonServiceSécurisé

--- a/src/vues/securite.pug
+++ b/src/vues/securite.pug
@@ -1,4 +1,6 @@
 extends mssDeconnecte
+block variables
+  - const meta_description = 'Découvrez les mesures que MonServiceSécurisé met en place pour assurer la sécurité de vos données.'
 
 block title
   title Sécurité | MonServiceSécurisé

--- a/src/vues/statistiques.pug
+++ b/src/vues/statistiques.pug
@@ -1,4 +1,6 @@
 extends mssDeconnecte
+block variables
+  - const meta_description = "Découvrez les statistiques d’utilisation de MonServiceSécurisé et l'impact généré sur les services numériques qui utilisent le produit."
 
 block title
   title Statistiques | MonServiceSécurisé


### PR DESCRIPTION
... afin de renforcer notre SEO.

On utilise une nouvelle méthode pour déclarer la balise `meta` dans le template de `base.pug`, et modifier cette variable dans les fichiers `enfant`.
Cette même mêthode pourrait être utilisée pour les `title` de page.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/a1ebf3cb-7137-4716-826b-03268d144b8a)
