### PR TITLE
[CORRECTION] Ajoute une balise `head`

### DIFF
--- a/src/vues/base.pug
+++ b/src/vues/base.pug
@@ -1,11 +1,12 @@
 doctype html
 html(lang = 'fr', xml:lang = 'fr', xmlns = 'http://www.w3.org/1999/xhtml')
-    meta(charset='utf-8')
-    meta(name = 'viewport', content = 'width=device-width')
-    if (process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
-        meta(name = 'google-site-verification', content = process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
-    meta(property = 'og:site_name', content = 'MonServiceSécurisé')
-    link(rel='icon', href='/statique/assets/images/favicons/favicon.ico')
+    head
+        meta(charset='utf-8')
+        meta(name = 'viewport', content = 'width=device-width')
+        if (process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
+            meta(name = 'google-site-verification', content = process.env.GOOGLE_SEARCH_CONSOLE_VERIFICATION)
+        meta(property = 'og:site_name', content = 'MonServiceSécurisé')
+        link(rel='icon', href='/statique/assets/images/favicons/favicon.ico')
 
     block title
         title MonServiceSécurisé


### PR DESCRIPTION
... afin de suivre le format standard d'une page HTML.
Sans ça, la vérification de la Google Search console ne peut pas être effectuée