### PR TITLE
[VISITE GUIDÉE] Ajoute un middleware qui charge l'état de la visite guidée

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -66,3 +66,6 @@ CHIFFREMENT_TOKEN_VAULT= # Token à utiliser pour le chiffrement.
 # API Baleen
 BALEEN_TOKEN= # Le Personal Access Token (PAT) permettant d'utiliser l'API Baleen
 BALEEN_NAMESPACE = # L'identifiant de l'application Baleen
+
+# Feature Flags
+FEATURE_FLAG_ETAT_VISITE_GUIDEE= # Un JSON.stringify de l'objet chargé par le middleware pour la visite guidée. Supprimer la variable d'env pour désactiver la feature.

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -48,9 +48,15 @@ const chiffrement = () => ({
   tokenVault: () => process.env.CHIFFREMENT_TOKEN_VAULT,
 });
 
+const featureFlag = () => ({
+  etatVisiteGuidee: () =>
+    JSON.parse(process.env.FEATURE_FLAG_ETAT_VISITE_GUIDEE) ?? null,
+});
+
 module.exports = {
   chiffrement,
   emailMemoire,
+  featureFlag,
   filtrageIp,
   journalMSS,
   matomo,

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -198,6 +198,14 @@ const middleware = (configuration = {}) => {
   const aseptiseListe = (nomListe, proprietesParametre) =>
     aseptiseListes([{ nom: nomListe, proprietes: proprietesParametre }]);
 
+  const chargeEtatVisiteGuidee = (_requete, reponse, suite) => {
+    const etatVisiteGuidee = adaptateurEnvironnement
+      .featureFlag()
+      .etatVisiteGuidee();
+    if (etatVisiteGuidee) reponse.locals.etatVisiteGuidee = etatVisiteGuidee;
+    suite();
+  };
+
   const chargePreferencesUtilisateur = (requete, reponse, suite) => {
     reponse.locals.preferencesUtilisateur = {
       etatMenuNavigation: requete.cookies['etat-menu-navigation'],
@@ -289,6 +297,7 @@ const middleware = (configuration = {}) => {
     aseptiseListe,
     aseptiseListes,
     chargeAutorisationsService,
+    chargeEtatVisiteGuidee,
     chargePreferencesUtilisateur,
     positionneHeaders,
     positionneHeadersAvecNonce,

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -815,4 +815,38 @@ describe('Le middleware MSS', () => {
       });
     });
   });
+
+  describe("sur demande de chargement de l'état de la visite guidée", () => {
+    it("ajoute un objet d'état de visite guidée à `reponse.locals` si la variable d'environnement est définie", (done) => {
+      const adaptateurEnvironnement = {
+        featureFlag: () => ({
+          etatVisiteGuidee: () => ({ dejaTerminee: false }),
+        }),
+      };
+      const middleware = Middleware({
+        adaptateurEnvironnement,
+      });
+
+      middleware.chargeEtatVisiteGuidee(requete, reponse, () => {
+        expect(reponse.locals.etatVisiteGuidee).to.eql({
+          dejaTerminee: false,
+        });
+        done();
+      });
+    });
+
+    it("n'ajoute pas un objet d'état de visite guidée à `reponse.locals` si la variable d'environnement n'est pas définie", (done) => {
+      const adaptateurEnvironnement = {
+        featureFlag: () => ({ etatVisiteGuidee: () => null }),
+      };
+      const middleware = Middleware({
+        adaptateurEnvironnement,
+      });
+
+      middleware.chargeEtatVisiteGuidee(requete, reponse, () => {
+        expect(reponse.locals.etatVisiteGuidee).to.be(undefined);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
... afin de pouvoir l'utiliser dans nos `.pug`.

Pour l'instant, il ne s'agit que d'une variable d'environnement, afin de pouvoir le tester en environnement de PR.
Par la suite, on ira directement lire cette valeur depuis la persistance, pour l'utilisateur courant.