### PR TITLE
[VISITE GUIDÉE] Permet l'ouverture du composant 'Contributeurs' en mode 'visite guidée'

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionContributeurs.mjs
+++ b/public/modules/tableauDeBord/actions/ActionContributeurs.mjs
@@ -12,11 +12,11 @@ class ActionContributeurs extends ActionAbstraite {
     });
   }
 
-  initialise({ donneesServices }) {
+  initialise({ donneesServices, modeVisiteGuidee }) {
     super.initialise();
     document.body.dispatchEvent(
       new CustomEvent('svelte-recharge-contributeurs', {
-        detail: { services: donneesServices },
+        detail: { services: donneesServices, modeVisiteGuidee },
       })
     );
   }

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -21,6 +21,15 @@ const tiroirContributeur = (idService) => {
         await rechargeNbContributeurs();
       });
 
+      $(document.body).on(
+        'jquery-affiche-tiroir-contributeurs-visite-guidee',
+        () =>
+          gestionnaireTiroir.afficheContenuAction(
+            { action: contributeurs, estSelectionMulitple: false },
+            { modeVisiteGuidee: true }
+          )
+      );
+
       $('#gerer-contributeurs').on('click', () => {
         gestionnaireTiroir.afficheContenuAction(
           { action: contributeurs, estSelectionMulitple: false },

--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -5,13 +5,17 @@
   import SuppressionContributeur from './suppression/SuppressionContributeur.svelte';
   import { onMount } from 'svelte';
   import PersonnalisationContributeur from './personnalisation/PersonnalisationContributeur.svelte';
+  import { autorisationsVisiteGuidee } from './modeVisiteGuidee/donneesVisiteGuidee';
+
+  export let modeVisiteGuidee: boolean;
 
   $: surServiceUnique = $store.services.length === 1;
   $: serviceUnique = $store.services[0];
   $: contributeurs = serviceUnique.contributeurs;
 
   onMount(async () => {
-    if (surServiceUnique) {
+    if (modeVisiteGuidee) store.autorisations.charge(autorisationsVisiteGuidee);
+    else if (surServiceUnique) {
       const reponse = await axios.get(
         `/api/service/${serviceUnique.id}/autorisations`
       );
@@ -26,7 +30,7 @@
   <PersonnalisationContributeur />
 {:else}
   {#if $store.services.every((s) => s.estProprietaire)}
-    <InvitationContributeur />
+    <InvitationContributeur {modeVisiteGuidee} />
   {/if}
   {#if $store.etapeCourante !== 'InvitationContributeurs' && surServiceUnique}
     <h3 class="titre-liste">Liste des contributeurs au service</h3>

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -2,10 +2,14 @@
 // On veut utiliser Axios ici car il est configuré pour utiliser le token CSRF
 declare global {
   const axios: any;
+  interface HTMLElementEventMap {
+    'svelte-recharge-contributeurs': CustomEvent;
+  }
 }
 
 export type GestionContributeursProps = {
   services: Service[];
+  modeVisiteGuidee: boolean;
 };
 
 export type Service = {

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.ts
@@ -4,6 +4,7 @@ import type {
   Service,
 } from './gestionContributeurs.d';
 import { store } from './gestionContributeurs.store';
+import { donneesServiceVisiteGuidee } from './modeVisiteGuidee/donneesVisiteGuidee';
 
 document.body.addEventListener(
   'svelte-recharge-contributeurs',
@@ -18,10 +19,12 @@ const reinitialiseStore = (services: Service[]) => {
 
 const rechargeApp = (props: GestionContributeursProps) => {
   app?.$destroy();
-  reinitialiseStore(props.services);
+  const { modeVisiteGuidee, services } = props;
+  reinitialiseStore(modeVisiteGuidee ? [donneesServiceVisiteGuidee] : services);
   app = new GestionContributeurs({
     target: document.getElementById('conteneur-gestion-contributeurs')!,
+    props: { modeVisiteGuidee },
   });
 };
 
-export default app;
+export default app!;

--- a/svelte/lib/gestionContributeurs/invitation/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/invitation/InvitationContributeur.svelte
@@ -14,6 +14,9 @@
   import BoutonsActions from './BoutonsActions.svelte';
   import EnvoiEnCours from './EnvoiEnCours.svelte';
   import Rapport from './Rapport.svelte';
+  import { contributeursRechercheVisiteGuidee } from '../modeVisiteGuidee/donneesVisiteGuidee';
+
+  export let modeVisiteGuidee: boolean;
 
   type Etape = 'Ajout' | 'Personnalisation' | 'EnvoiEnCours' | 'Rapport';
   type Email = string;
@@ -74,11 +77,20 @@
   <form class="conteneur-formulaire" on:submit|preventDefault>
     <label for="email-invitation-collaboration">
       Ajouter un ou plusieurs contributeurs
-      <ChampAvecSuggestions
-        id="email-invitation-collaboration"
-        callbackDeRecherche={api.rechercheContributeurs}
-        on:contributeurChoisi={ajouteInvitation}
-      />
+      {#if modeVisiteGuidee}
+        <ChampAvecSuggestions
+          id="email-invitation-collaboration"
+          callbackDeRecherche={async () => contributeursRechercheVisiteGuidee}
+          valeurInitiale="Fréd"
+          modeVisiteGuidee={true}
+        />
+      {:else}
+        <ChampAvecSuggestions
+          id="email-invitation-collaboration"
+          callbackDeRecherche={api.rechercheContributeurs}
+          on:contributeurChoisi={ajouteInvitation}
+        />
+      {/if}
     </label>
     <ListeInvitations
       invitations={Object.values(invitations)}

--- a/svelte/lib/gestionContributeurs/kit/ChampAvecSuggestions.svelte
+++ b/svelte/lib/gestionContributeurs/kit/ChampAvecSuggestions.svelte
@@ -7,8 +7,10 @@
   export let id: string;
   export let callbackDeRecherche: (recherche: string) => Promise<Utilisateur[]>;
   export let dureeDebounceEnMs = 300;
+  export let valeurInitiale: string = '';
+  export let modeVisiteGuidee: boolean = false;
 
-  let saisie = '';
+  let saisie = valeurInitiale;
   let minuteur: NodeJS.Timeout;
   let suggestions: Utilisateur[] = [];
 
@@ -35,6 +37,10 @@
     saisie = '';
     envoiEvenement('contributeurChoisi', donnees);
   };
+
+  if (modeVisiteGuidee) {
+    rechercheSuggestions();
+  }
 </script>
 
 <div class="conteneur-suggestions">
@@ -65,7 +71,10 @@
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <div
         class="option suggestion-contributeur"
-        on:click={() => choisisContributeur(suggestion)}
+        on:click={() => {
+          if (modeVisiteGuidee) return;
+          choisisContributeur(suggestion);
+        }}
       >
         <Initiales valeur={suggestion.initiales} resumeNiveauDroit="ECRITURE" />
         <div>{@html suggestion.prenomNom}</div>

--- a/svelte/lib/gestionContributeurs/modeVisiteGuidee/donneesVisiteGuidee.ts
+++ b/svelte/lib/gestionContributeurs/modeVisiteGuidee/donneesVisiteGuidee.ts
@@ -1,0 +1,98 @@
+import type {
+  Autorisation,
+  Service,
+  Utilisateur,
+} from '../gestionContributeurs.d';
+
+const contributeurs: Utilisateur[] = [
+  {
+    id: 'ID-UTILISATEUR-VISITE-GUIDEE-1',
+    prenomNom: 'Émilie Leroy',
+    initiales: 'EL',
+    poste: 'RSSI',
+    email: 'emilie.leroy@beta.gouv.fr',
+    estUtilisateurCourant: false,
+  },
+  {
+    id: 'ID-UTILISATEUR-VISITE-GUIDEE-2',
+    prenomNom: 'Dominique Beauvais',
+    initiales: 'DB',
+    poste: "Ingénieur d'affaires",
+    email: 'dominique.beauvais@beta.gouv.fr',
+    estUtilisateurCourant: false,
+  },
+  {
+    id: 'ID-UTILISATEUR-VISITE-GUIDEE-3',
+    prenomNom: 'Claude Lefevre',
+    initiales: 'CL',
+    poste: 'Responsable du développement',
+    email: 'claude.lefevre@beta.gouv.fr',
+    estUtilisateurCourant: false,
+  },
+];
+
+export const contributeursRechercheVisiteGuidee: Utilisateur[] = [
+  {
+    id: 'ID-UTILISATEUR-VISITE-GUIDEE-4',
+    prenomNom: 'Frédérique Morin',
+    initiales: 'FM',
+    poste: 'RSSI',
+    email: 'frederique.morin@beta.gouv.fr',
+    estUtilisateurCourant: false,
+  },
+  {
+    id: 'ID-UTILISATEUR-VISITE-GUIDEE-5',
+    prenomNom: 'Frédérique Dupont',
+    initiales: 'FD',
+    poste: 'RSSI',
+    email: 'frederique.dupont@beta.gouv.fr',
+    estUtilisateurCourant: false,
+  },
+];
+
+export const autorisationsVisiteGuidee: Autorisation[] = [
+  {
+    idUtilisateur: 'ID-UTILISATEUR-VISITE-GUIDEE-1',
+    idAutorisation: 'ID-AUTORISATION-VISITE-GUIDEE-1',
+    resumeNiveauDroit: 'PROPRIETAIRE',
+    droits: {
+      DECRIRE: 2,
+      SECURISER: 2,
+      HOMOLOGUER: 2,
+      RISQUES: 2,
+      CONTACTS: 2,
+    },
+  },
+  {
+    idUtilisateur: 'ID-UTILISATEUR-VISITE-GUIDEE-2',
+    idAutorisation: 'ID-AUTORISATION-VISITE-GUIDEE-2',
+    resumeNiveauDroit: 'ECRITURE',
+    droits: {
+      DECRIRE: 2,
+      SECURISER: 2,
+      HOMOLOGUER: 2,
+      RISQUES: 2,
+      CONTACTS: 2,
+    },
+  },
+  {
+    idUtilisateur: 'ID-UTILISATEUR-VISITE-GUIDEE-3',
+    idAutorisation: 'ID-AUTORISATION-VISITE-GUIDEE-3',
+    resumeNiveauDroit: 'LECTURE',
+    droits: {
+      DECRIRE: 1,
+      SECURISER: 1,
+      HOMOLOGUER: 1,
+      RISQUES: 1,
+      CONTACTS: 1,
+    },
+  },
+];
+
+export const donneesServiceVisiteGuidee: Service = {
+  id: 'ID-SERVICE-VISITE-GUIDEE',
+  estProprietaire: true,
+  contributeurs: contributeurs,
+  permissions: { gestionContributeurs: false },
+  nomService: 'Nom de mon service',
+};


### PR DESCRIPTION
On ajoute le mode `visiteGuidee` au composant `Svelte` de `GestionContributeurs`.

De plus, on permet de pouvoir instancier et ouvrir le tiroir via un `event` du DOM.
Cela servira ensuite au composant `VisiteGuidee` pour déclencher l'ouverture du tiroir de manière simple.