### PR TITLE
[CORRECTION] Hotfix sur l'étape SÉCURISER

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -320,11 +320,7 @@ const creeServeur = (
         });
       } else if (idEtape === 'securiser') {
         const mesures = moteurRegles.mesures(service.descriptionService);
-        const completude = service.completudeMesures();
-        const pourcentageProgression = Math.round(
-          (completude.nombreMesuresCompletes / completude.nombreTotalMesures) *
-            100
-        );
+        const pourcentageProgression = 80;
 
         reponse.render('service/mesures', {
           InformationsHomologation,

--- a/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
+++ b/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
@@ -15,7 +15,10 @@
     sousEtapes={[
       {
         cible: cibleNomService,
-        callbackInitialeCible: (cible) => (cible.style.width = '50%'),
+        callbackInitialeCible: (cible) => {
+          cible.style.width = '50%';
+          window.scrollTo(0, 0); // Ici on force le scroll pour ne pas être dérangé par "Erreur de saisie"
+        },
         callbackFinaleCible: (cible) => (cible.style.width = '100%'),
         positionnementModale: 'MilieuDroite',
         titre: 'Décrivez votre service',

--- a/svelte/lib/visiteGuidee/etapes/securiser/EtapeSecuriser.svelte
+++ b/svelte/lib/visiteGuidee/etapes/securiser/EtapeSecuriser.svelte
@@ -23,6 +23,9 @@
           document.querySelector(
             '#conteneur-mesure .conteneur-actions button'
           ).disabled = true;
+          document.getElementsByClassName(
+            'fermeture-tiroir'
+          )[0].disabled = true;
         },
         delaiAvantAffichage: 200,
         avecTrouRideauColle: true,


### PR DESCRIPTION
On corrige quelque bugs :
- Il était possible de fermer le tiroir des mesures
- Le pourcentage de mesures complétées affichait `null`
- L'erreur de saisie des checkbox déclenchait un scroll sur la page Décrire
    - Pour l'instant, on force le scroll en haut de page. On pourra enlever cela lorsque le bug sera résolu