### PR TITLE
[MENU] Toujours garder le bouton de gestion des contributeurs ouvert

### DIFF
--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -302,7 +302,9 @@
   overflow: hidden;
   border: none;
 }
-
+.menu-navigation #gerer-contributeurs:hover {
+  filter: contrast(1.15) brightness(1.05);
+}
 .menu-navigation #gerer-contributeurs:active {
   background: #08416a;
 }

--- a/public/assets/styles/menuNavigation.css
+++ b/public/assets/styles/menuNavigation.css
@@ -322,20 +322,8 @@
 
 .menu-navigation:not(.ferme)
   :is(#gerer-contributeurs:hover, #gerer-contributeurs.ouvert)
-  .nombre-contributeurs {
-  display: none;
-}
-
-.menu-navigation:not(.ferme)
-  :is(#gerer-contributeurs:hover, #gerer-contributeurs.ouvert)
   .inviter-contributeurs {
   display: block;
-}
-
-.menu-navigation #gerer-contributeurs .nombre-contributeurs {
-  color: #fff;
-  transform: translateY(-2px);
-  padding-right: 8px;
 }
 
 .menu-navigation #gerer-contributeurs .inviter-contributeurs {

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -93,16 +93,8 @@ const repliMenu = () => {
     ouvrir: () => cookie().supprimer(),
   };
 
-  const fermeApresDelai = () => {
-    setTimeout(() => {
-      $gererContributeurs.removeClass('ouvert');
-    }, 3000);
-  };
-
   return {
     brancheComportement: () => {
-      fermeApresDelai();
-
       $repliMenu.on('click', () => {
         const menuOuvert = !$menu.hasClass('ferme');
         if (menuOuvert) {
@@ -113,7 +105,6 @@ const repliMenu = () => {
           $menu.removeClass('ferme');
           persistance.ouvrir();
           $gererContributeurs.addClass('ouvert');
-          fermeApresDelai();
         }
       });
     },

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -20,8 +20,8 @@ const tiroirContributeur = (idService, modeVisiteGuidee = false) => {
   };
 
   return {
-    brancheComportement: () => {
-      if (idService) rechargeNbContributeurs();
+    brancheComportement: async () => {
+      if (idService) await rechargeNbContributeurs();
 
       $(document.body).on('jquery-recharge-services', async () => {
         await rechargeNbContributeurs();
@@ -111,7 +111,7 @@ const repliMenu = () => {
   };
 };
 
-$(() => {
+$(async () => {
   const idService = $('.page-service').data('id-service');
   const etatVisiteGuidee = JSON.parse($('#etat-visite-guidee').text());
   const modeVisiteGuidee = etatVisiteGuidee.dejaTerminee === false;
@@ -119,6 +119,6 @@ $(() => {
   repliMenu().brancheComportement();
 
   gestionnaireTiroir.brancheComportement();
-  tiroirContributeur(idService, modeVisiteGuidee).brancheComportement();
+  await tiroirContributeur(idService, modeVisiteGuidee).brancheComportement();
   tiroirTelechargement(idService).brancheComportement();
 });

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -5,11 +5,9 @@ import ActionTelechargement from '../modules/tableauDeBord/actions/ActionTelecha
 const tiroirContributeur = (idService, modeVisiteGuidee = false) => {
   const contributeurs = new ActionContributeurs();
   let donneesService;
-  const rechargeNbContributeurs = async () => {
+  const chargeDonneesDuService = async () => {
     if (modeVisiteGuidee) {
-      donneesService = {
-        nombreContributeurs: 3,
-      };
+      donneesService = { nombreContributeurs: 3 };
     } else {
       const reponse = await axios.get(`/api/service/${idService}`);
       donneesService = reponse.data;
@@ -18,10 +16,10 @@ const tiroirContributeur = (idService, modeVisiteGuidee = false) => {
 
   return {
     brancheComportement: async () => {
-      if (idService) await rechargeNbContributeurs();
+      if (idService) await chargeDonneesDuService();
 
       $(document.body).on('jquery-recharge-services', async () => {
-        await rechargeNbContributeurs();
+        await chargeDonneesDuService();
       });
 
       $(document.body).on(

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -14,9 +14,6 @@ const tiroirContributeur = (idService, modeVisiteGuidee = false) => {
       const reponse = await axios.get(`/api/service/${idService}`);
       donneesService = reponse.data;
     }
-    $('.nombre-contributeurs', '#gerer-contributeurs').text(
-      donneesService.nombreContributeurs
-    );
   };
 
   return {

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -2,16 +2,13 @@ import { gestionnaireTiroir } from '../modules/tableauDeBord/gestionnaireTiroir.
 import ActionContributeurs from '../modules/tableauDeBord/actions/ActionContributeurs.mjs';
 import ActionTelechargement from '../modules/tableauDeBord/actions/ActionTelechargement.mjs';
 
-const tiroirContributeur = (idService, modeVisiteGuidee = false) => {
+const tiroirContributeur = (idService) => {
   const contributeurs = new ActionContributeurs();
   let donneesService;
+
   const chargeDonneesDuService = async () => {
-    if (modeVisiteGuidee) {
-      donneesService = { nombreContributeurs: 3 };
-    } else {
-      const reponse = await axios.get(`/api/service/${idService}`);
-      donneesService = reponse.data;
-    }
+    const reponse = await axios.get(`/api/service/${idService}`);
+    donneesService = reponse.data;
   };
 
   return {
@@ -108,12 +105,10 @@ const repliMenu = () => {
 
 $(async () => {
   const idService = $('.page-service').data('id-service');
-  const etatVisiteGuidee = JSON.parse($('#etat-visite-guidee').text());
-  const modeVisiteGuidee = etatVisiteGuidee.dejaTerminee === false;
 
   repliMenu().brancheComportement();
 
   gestionnaireTiroir.brancheComportement();
-  await tiroirContributeur(idService, modeVisiteGuidee).brancheComportement();
+  await tiroirContributeur(idService).brancheComportement();
   tiroirTelechargement(idService).brancheComportement();
 });

--- a/src/vues/fragments/menuNavigation.pug
+++ b/src/vues/fragments/menuNavigation.pug
@@ -29,7 +29,6 @@ mixin etapeParcours({ id, url, nom, sousTitre, estVisible, statut })
     if !estSurCreationDeService
       button#gerer-contributeurs(class = preferencesUtilisateur.etatMenuNavigation === 'ferme' ? '' : 'ouvert')
         img(src = '/statique/assets/images/bouton_inviter_collaborateur_persona.svg' alt='Inviter des collaborateur à contribuer')
-        span.none-si-ferme.nombre-contributeurs= service.contributeurs.length
         span.inviter-contributeurs Gérer les contributeurs
     button.repli-menu
       img(src = '/statique/assets/images/forme_chevron_blanc.svg' alt='Chevron vers la gauche')

--- a/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
+++ b/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
@@ -33,9 +33,6 @@
           document.getElementsByClassName(
             'inviter-contributeurs'
           )[0].style.display = 'flex';
-          document.getElementsByClassName(
-            'nombre-contributeurs'
-          )[0].style.display = 'none';
           document.body.dispatchEvent(
             new CustomEvent('jquery-affiche-tiroir-contributeurs-visite-guidee')
           );


### PR DESCRIPTION
## Contexte
On ne veut plus que le bouton se mette en mode « replié » 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/405193b7-a564-4228-892e-7b0a8ebb8a22)

Il doit toujours resté en mode « déplié » 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/f6a265b2-9e93-4841-8bb6-dd2eb0a5ecd6)

## PR
Cette PR supprime le repli.
Cette suppression rend inutile le chargement de « nombre de contributeurs » puisque celui-ci n'est plus jamais affiché. 
Donc la PR enlève tout le code qui alimentait ce nombre de contributeurs.