### PR TITLE
[VISITE GUIDEE] Force l'ouverture du menu navigation

### DIFF
--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -116,6 +116,14 @@ const repliMenu = () => {
           fermeApresDelai();
         }
       });
+
+      $(document.body).on('jquery-deplie-menu-navigation-visite-guidee', () => {
+        const menuFerme = $menu.hasClass('ferme');
+        if (menuFerme) {
+          $menu.removeClass('ferme');
+          $gererContributeurs.addClass('ouvert');
+        }
+      });
     },
   };
 };

--- a/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
+++ b/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
@@ -37,6 +37,9 @@
             'nombre-contributeurs'
           )[0].style.display = 'none';
           document.body.dispatchEvent(
+            new CustomEvent('jquery-deplie-menu-navigation-visite-guidee')
+          );
+          document.body.dispatchEvent(
             new CustomEvent('jquery-affiche-tiroir-contributeurs-visite-guidee')
           );
           document.getElementsByClassName('tiroir')[0].style.zIndex = '10001';


### PR DESCRIPTION
... sur l'étape DECRIRE de la visite, pour que le pointeur soit au bon endroit si le menu était fermé.

Si le menu était fermé avant cette étape, il retrouve cet état par la suite car cette fermeture n'est pas sauvegardée.

Pour corriger cet affichage : 
<img width="909" alt="Capture d’écran 2024-04-26 à 10 07 51" src="https://github.com/betagouv/mon-service-securise/assets/308609/422a811c-8afe-427b-af3e-44af8d935b82">
