### PR TITLE
[VISITE GUIDEE] Désactive le bouton suivant du formulaire homologation

### DIFF
--- a/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
+++ b/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
@@ -15,6 +15,9 @@
     sousEtapes={[
       {
         cible: cibleNouvelleHomologation,
+        callbackInitialeCible: () => {
+          document.getElementById('suivant').inert = true;
+        },
         positionnementModale: 'HautDroite',
         titre: 'Mettez-vous en conformité',
         description:


### PR DESCRIPTION
... pour que le bouton "Nouvelle homologation" qui est mis en valeur ne soit pas cliquable, le service affiché dans la visite guidée n'existant pas réellement.
