### PR TITLE
[VISITE GUIDEE] Sauvegarde l'état de la visite guidée de l'utilisateur

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -68,4 +68,4 @@ BALEEN_TOKEN= # Le Personal Access Token (PAT) permettant d'utiliser l'API Balee
 BALEEN_NAMESPACE = # L'identifiant de l'application Baleen
 
 # Feature Flags
-FEATURE_FLAG_ETAT_VISITE_GUIDEE= # Un JSON.stringify de l'objet chargé par le middleware pour la visite guidée. Supprimer la variable d'env pour désactiver la feature.
+FEATURE_FLAG_VISITE_GUIDEE= # Pour activer la visite guidée. Supprimer la variable d'env pour désactiver la feature.

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -49,8 +49,7 @@ const chiffrement = () => ({
 });
 
 const featureFlag = () => ({
-  etatVisiteGuidee: () =>
-    JSON.parse(process.env.FEATURE_FLAG_ETAT_VISITE_GUIDEE ?? 'null'),
+  visiteGuideeActive: () => process.env.FEATURE_FLAG_VISITE_GUIDEE === 'true',
 });
 
 module.exports = {

--- a/src/depots/depotDonneesParcoursUtilisateur.js
+++ b/src/depots/depotDonneesParcoursUtilisateur.js
@@ -6,10 +6,9 @@ const creeDepot = (config = {}) => {
   const lisParcoursUtilisateur = async (idUtilisateur) => {
     const parcoursConnu =
       await adaptateurPersistance.lisParcoursUtilisateur(idUtilisateur);
-    return new ParcoursUtilisateur(
-      parcoursConnu ?? { idUtilisateur },
-      referentiel
-    );
+    return parcoursConnu
+      ? new ParcoursUtilisateur(parcoursConnu, referentiel)
+      : ParcoursUtilisateur.pourUtilisateur(idUtilisateur, referentiel);
   };
 
   const sauvegardeParcoursUtilisateur = async (parcoursUtilisateur) => {

--- a/src/modeles/etatVisiteGuidee.js
+++ b/src/modeles/etatVisiteGuidee.js
@@ -1,0 +1,12 @@
+const Base = require('./base');
+
+class EtatVisiteGuidee extends Base {
+  constructor(donnees = {}) {
+    super({
+      proprietesAtomiquesRequises: ['dejaTerminee', 'etapeCourante'],
+    });
+    this.renseigneProprietes(donnees);
+  }
+}
+
+module.exports = EtatVisiteGuidee;

--- a/src/modeles/parcoursUtilisateur.js
+++ b/src/modeles/parcoursUtilisateur.js
@@ -44,6 +44,16 @@ class ParcoursUtilisateur extends Base {
     return undefined;
   }
 
+  static pourUtilisateur(idUtilisateur, referentiel) {
+    return new ParcoursUtilisateur(
+      {
+        idUtilisateur,
+        etatVisiteGuidee: { dejaTerminee: false },
+      },
+      referentiel
+    );
+  }
+
   toJSON() {
     return {
       ...super.toJSON(),

--- a/src/modeles/parcoursUtilisateur.js
+++ b/src/modeles/parcoursUtilisateur.js
@@ -1,6 +1,7 @@
 const adaptateurHorlogeParDefaut = require('../adaptateurs/adaptateurHorloge');
 const Base = require('./base');
 const Referentiel = require('../referentiel');
+const EtatVisiteGuidee = require('./etatVisiteGuidee');
 
 class ParcoursUtilisateur extends Base {
   constructor(
@@ -12,6 +13,7 @@ class ParcoursUtilisateur extends Base {
       proprietesAtomiquesRequises: ['idUtilisateur', 'dateDerniereConnexion'],
     });
     this.renseigneProprietes(donnees);
+    this.etatVisiteGuidee = new EtatVisiteGuidee(donnees.etatVisiteGuidee);
     this.adaptateurHorloge = adaptateurHorloge;
     this.referentiel = referentiel;
   }
@@ -40,6 +42,13 @@ class ParcoursUtilisateur extends Base {
     )
       return derniereFonctionnalite.id;
     return undefined;
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      etatVisiteGuidee: this.etatVisiteGuidee.toJSON(),
+    };
   }
 }
 

--- a/test/depots/depotDonneesParcoursUtilisateur.spec.js
+++ b/test/depots/depotDonneesParcoursUtilisateur.spec.js
@@ -3,6 +3,7 @@ const expect = require('expect.js');
 const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
 const DepotDonneesParcoursUtilisateur = require('../../src/depots/depotDonneesParcoursUtilisateur');
 const ParcoursUtilisateur = require('../../src/modeles/parcoursUtilisateur');
+const EtatVisiteGuidee = require('../../src/modeles/etatVisiteGuidee');
 
 describe('Le dépôt de données Parcours utilisateur', () => {
   let adaptateurPersistance;
@@ -49,5 +50,10 @@ describe('Le dépôt de données Parcours utilisateur', () => {
 
     expect(parcours).to.be.a(ParcoursUtilisateur);
     expect(parcours.idUtilisateur).to.equal('nouvel utilisateur');
+    expect(parcours.etatVisiteGuidee).to.eql(
+      new EtatVisiteGuidee({
+        dejaTerminee: false,
+      })
+    );
   });
 });

--- a/test/modeles/parcoursUtilisateur.spec.js
+++ b/test/modeles/parcoursUtilisateur.spec.js
@@ -8,11 +8,13 @@ describe('Un parcours utilisateur', () => {
     const unParcours = new ParcoursUtilisateur({
       idUtilisateur: '456',
       dateDerniereConnexion: '2023-01-01',
+      etatVisiteGuidee: { dejaTerminee: false, etapeCourante: 'DECRIRE' },
     });
 
     expect(unParcours.toJSON()).to.eql({
       idUtilisateur: '456',
       dateDerniereConnexion: '2023-01-01',
+      etatVisiteGuidee: { dejaTerminee: false, etapeCourante: 'DECRIRE' },
     });
   });
 

--- a/test/modeles/parcoursUtilisateur.spec.js
+++ b/test/modeles/parcoursUtilisateur.spec.js
@@ -2,6 +2,7 @@ const expect = require('expect.js');
 
 const ParcoursUtilisateur = require('../../src/modeles/parcoursUtilisateur');
 const Referentiel = require('../../src/referentiel');
+const EtatVisiteGuidee = require('../../src/modeles/etatVisiteGuidee');
 
 describe('Un parcours utilisateur', () => {
   it('sait se convertir en JSON', () => {
@@ -16,6 +17,16 @@ describe('Un parcours utilisateur', () => {
       dateDerniereConnexion: '2023-01-01',
       etatVisiteGuidee: { dejaTerminee: false, etapeCourante: 'DECRIRE' },
     });
+  });
+
+  it('sait se créer pour un utilisateur avec des valeurs par défaut', () => {
+    const etatInitial = ParcoursUtilisateur.pourUtilisateur('456');
+
+    expect(etatInitial.dateDerniereConnexion).to.be(undefined);
+    expect(etatInitial.idUtilisateur).to.equal('456');
+    expect(etatInitial.etatVisiteGuidee).to.eql(
+      new EtatVisiteGuidee({ dejaTerminee: false })
+    );
   });
 
   it("sait enregistrer une date de dernière connexion en utilisant l'adaptateur horloge", () => {


### PR DESCRIPTION
On enrichit le modèle `parcoursUtilisateur` avec un nouveau modèle `EtatVisiteGuidee`.

Ce modèle va permettre de suivre l'utilisateur au cours de la visite guidée, et d'afficher les modales en conséquences.
Dans cette PR, on se contente de créer une valeur par défaut, et de modifier le middleware pour qu'il la prenne en compte.