### PR TITLE
[CORRECTION] Corrige les erreurs du menu de navigation pendant la visite guidée

### DIFF
--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -2,13 +2,15 @@ import { gestionnaireTiroir } from '../modules/tableauDeBord/gestionnaireTiroir.
 import ActionContributeurs from '../modules/tableauDeBord/actions/ActionContributeurs.mjs';
 import ActionTelechargement from '../modules/tableauDeBord/actions/ActionTelechargement.mjs';
 
-const tiroirContributeur = (idService) => {
+const tiroirContributeur = (idService, modeVisiteGuidee = false) => {
   const contributeurs = new ActionContributeurs();
   let donneesService;
 
   const chargeDonneesDuService = async () => {
-    const reponse = await axios.get(`/api/service/${idService}`);
-    donneesService = reponse.data;
+    if (!modeVisiteGuidee) {
+      const reponse = await axios.get(`/api/service/${idService}`);
+      donneesService = reponse.data;
+    }
   };
 
   return {
@@ -113,10 +115,12 @@ const repliMenu = () => {
 
 $(async () => {
   const idService = $('.page-service').data('id-service');
+  const etatVisiteGuidee = JSON.parse($('#etat-visite-guidee').text());
+  const modeVisiteGuidee = etatVisiteGuidee.dejaTerminee === false;
 
   repliMenu().brancheComportement();
 
   gestionnaireTiroir.brancheComportement();
-  await tiroirContributeur(idService).brancheComportement();
+  await tiroirContributeur(idService, modeVisiteGuidee).brancheComportement();
   tiroirTelechargement(idService).brancheComportement();
 });

--- a/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
+++ b/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrire.svelte
@@ -29,7 +29,7 @@
       {
         cible: cibleGererContributeurs,
         callbackInitialeCible: (cible) => {
-          cible.style.minWidth = '204px';
+          cible.inert = true;
           document.getElementsByClassName(
             'inviter-contributeurs'
           )[0].style.display = 'flex';

--- a/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
+++ b/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
@@ -26,7 +26,7 @@
       },
       {
         cible: cibleTelechargement,
-        callbackInitialeCible: () => {
+        callbackInitialeCible: (cible) => {
           document.body.dispatchEvent(
             new CustomEvent(
               'jquery-affiche-tiroir-telechargement-visite-guidee'
@@ -36,6 +36,7 @@
           document.getElementsByClassName(
             'fermeture-tiroir'
           )[0].disabled = true;
+          cible.inert = true;
         },
         callbackFinaleCible: () => {
           document


### PR DESCRIPTION
On corrige :
- L'appel API inutile pour le tiroir des contributeurs, en mode visite guidée
- La possibilité de "cliquer à nouveau" sur la gestion des contributeurs
- La possibilité de "cliquer à nouveau" sur les téléchargements de documents