### PR TITLE
[VISITE GUIDEE] Supprime la propriété étape courante

### DIFF
--- a/src/modeles/etatVisiteGuidee.js
+++ b/src/modeles/etatVisiteGuidee.js
@@ -5,7 +5,7 @@ class EtatVisiteGuidee extends Base {
   constructor(donnees = {}, referentiel = Referentiel.creeReferentielVide()) {
     super({
       proprietesAtomiquesRequises: ['dejaTerminee'],
-      proprietesAtomiquesFacultatives: ['etapeCourante', 'etapesVues'],
+      proprietesAtomiquesFacultatives: ['etapesVues'],
     });
     this.renseigneProprietes(donnees);
     this.referentiel = referentiel;
@@ -14,7 +14,6 @@ class EtatVisiteGuidee extends Base {
   termineEtape(idEtape) {
     const etapeSuivante = this.referentiel.etapeSuivanteVisiteGuidee(idEtape);
     if (etapeSuivante) {
-      this.etapeCourante = etapeSuivante;
       this.etapesVues = [...new Set([...(this.etapesVues || []), idEtape])];
     } else {
       this.finalise();
@@ -23,7 +22,6 @@ class EtatVisiteGuidee extends Base {
 
   finalise() {
     this.dejaTerminee = true;
-    this.etapeCourante = undefined;
     this.etapesVues = undefined;
   }
 

--- a/src/routes/privees/routesApiPrivee.js
+++ b/src/routes/privees/routesApiPrivee.js
@@ -419,12 +419,11 @@ const routesApiPrivee = ({
       parcoursUtilisateur.etatVisiteGuidee.termineEtape(idEtape);
       await depotDonnees.sauvegardeParcoursUtilisateur(parcoursUtilisateur);
 
-      reponse.send({
-        urlEtapeSuivante:
-          referentiel.etapeVisiteGuidee(
-            parcoursUtilisateur.etatVisiteGuidee.etapeCourante
-          )?.urlEtape ?? null,
-      });
+      const idEtapeSuivante = referentiel.etapeSuivanteVisiteGuidee(idEtape);
+      const urlEtapeSuivante =
+        referentiel.etapeVisiteGuidee(idEtapeSuivante)?.urlEtape ?? null;
+
+      reponse.send({ urlEtapeSuivante });
     }
   );
 

--- a/test/modeles/etatVisiteGuidee.spec.js
+++ b/test/modeles/etatVisiteGuidee.spec.js
@@ -4,23 +4,6 @@ const EtatVisiteGuidee = require('../../src/modeles/etatVisiteGuidee');
 
 describe('Le modèle état visite guidée', () => {
   describe("sur demande de finalisation d'une étape", () => {
-    it("définit la nouvelle étape courante à l'étape suivante", () => {
-      const referentiel = creeReferentiel({
-        etapesVisiteGuidee: {
-          DECRIRE: { idEtapeSuivante: 'SECURISER' },
-          SECURISER: { idEtapeSuivante: 'HOMOLOGUER' },
-        },
-      });
-      const etatVisiteGuidee = new EtatVisiteGuidee(
-        { etapeCourante: 'DECRIRE' },
-        referentiel
-      );
-
-      etatVisiteGuidee.termineEtape('SECURISER');
-
-      expect(etatVisiteGuidee.etapeCourante).to.be('HOMOLOGUER');
-    });
-
     it("finalise la visite guidée s'il n'y a pas d'étape suivante", () => {
       const referentiel = creeReferentiel({
         etapesVisiteGuidee: {
@@ -28,13 +11,12 @@ describe('Le modèle état visite guidée', () => {
         },
       });
       const etatVisiteGuidee = new EtatVisiteGuidee(
-        { etapeCourante: 'DECRIRE', dejaTerminee: false },
+        { dejaTerminee: false },
         referentiel
       );
 
       etatVisiteGuidee.termineEtape('DECRIRE');
 
-      expect(etatVisiteGuidee.etapeCourante).to.be(undefined);
       expect(etatVisiteGuidee.dejaTerminee).to.be(true);
     });
 
@@ -90,19 +72,10 @@ describe('Le modèle état visite guidée', () => {
 
   describe('sur demande de finalisation de la visite guidée', () => {
     it('finalise la visite guidée', () => {
-      const referentiel = creeReferentiel({
-        etapesVisiteGuidee: {
-          DECRIRE: {},
-        },
+      const etatVisiteGuidee = new EtatVisiteGuidee({
+        dejaTerminee: false,
+        etapesVues: ['UNE_ETAPE'],
       });
-      const etatVisiteGuidee = new EtatVisiteGuidee(
-        {
-          dejaTerminee: false,
-          etapeCourante: 'SECURISER',
-          etapesVues: ['DECRIRE'],
-        },
-        referentiel
-      );
 
       etatVisiteGuidee.finalise();
 
@@ -112,7 +85,7 @@ describe('Le modèle état visite guidée', () => {
     });
   });
 
-  describe("sur demande du nombre d'étapes vues", () => {
+  describe("sur demande du nombre d'étapes restantes", () => {
     it("sait dire combien d'étapes sont restantes", () => {
       const referentiel = creeReferentiel({
         etapesVisiteGuidee: {

--- a/test/modeles/parcoursUtilisateur.spec.js
+++ b/test/modeles/parcoursUtilisateur.spec.js
@@ -9,13 +9,13 @@ describe('Un parcours utilisateur', () => {
     const unParcours = new ParcoursUtilisateur({
       idUtilisateur: '456',
       dateDerniereConnexion: '2023-01-01',
-      etatVisiteGuidee: { dejaTerminee: false, etapeCourante: 'DECRIRE' },
+      etatVisiteGuidee: { dejaTerminee: false },
     });
 
     expect(unParcours.toJSON()).to.eql({
       idUtilisateur: '456',
       dateDerniereConnexion: '2023-01-01',
-      etatVisiteGuidee: { dejaTerminee: false, etapeCourante: 'DECRIRE' },
+      etatVisiteGuidee: { dejaTerminee: false },
     });
   });
 

--- a/test/routes/privees/routesApiPrivee.spec.js
+++ b/test/routes/privees/routesApiPrivee.spec.js
@@ -1254,11 +1254,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       );
     });
 
-    it('sauvegarde la nouvelle étape courante de la visite guidée', async () => {
+    it("sauvegarde l'étape vue de la visite guidée", async () => {
       testeur.depotDonnees().lisParcoursUtilisateur = () =>
         new ParcoursUtilisateur(
           {
-            etatVisiteGuidee: { dejaTerminee: false, etapeCourante: 'DECRIRE' },
+            etatVisiteGuidee: { dejaTerminee: false },
           },
           testeur.referentiel()
         );
@@ -1273,9 +1273,9 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         'http://localhost:1234/api/visiteGuidee/DECRIRE/termine'
       );
 
-      expect(parcoursUtilisateurPasse.etatVisiteGuidee.etapeCourante).to.be(
-        'SECURISER'
-      );
+      expect(parcoursUtilisateurPasse.etatVisiteGuidee.etapesVues).to.eql([
+        'DECRIRE',
+      ]);
     });
 
     it("renvoi l'URL de l'étape suivante", async () => {


### PR DESCRIPTION
... de l'état de la visite guidée, car l'étape courante n'est en fait pas valorisée puisque c'est le front qui déterminera l'étape à afficher en fonction de l'URL.