### PR TITLE
[VISITE GUIDEE] Affiche le menu de visite guidée sur toutes les pages connectées

### DIFF
--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -116,7 +116,9 @@ const repliMenu = () => {
 $(async () => {
   const idService = $('.page-service').data('id-service');
   const etatVisiteGuidee = JSON.parse($('#etat-visite-guidee').text());
-  const modeVisiteGuidee = etatVisiteGuidee.dejaTerminee === false;
+  const modeVisiteGuidee =
+    etatVisiteGuidee.dejaTerminee === false &&
+    etatVisiteGuidee.enPause === false;
 
   repliMenu().brancheComportement();
 

--- a/src/vues/mssConnecte.pug
+++ b/src/vues/mssConnecte.pug
@@ -3,6 +3,7 @@ extends mss
 block append styles
   link(href = '/statique/assets/styles/headerLarge.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modale.css', rel = 'stylesheet')
+  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
 
 block navigation
   block bandeau-nouveautes

--- a/src/vues/parcoursService.pug
+++ b/src/vues/parcoursService.pug
@@ -5,7 +5,6 @@ block append styles
   link(href = '/statique/assets/styles/parcoursService.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/menuNavigation.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/tiroir.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/selectize.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/homologation/formulaire.css', rel = 'stylesheet')

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -6,7 +6,6 @@ block title
 
 block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
 
 block append scripts
   script(type = 'module', src = '/statique/composants-svelte/mesure.js')

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -25,7 +25,6 @@ block append styles
   link(href = '/statique/assets/styles/modules/selectize.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/tableauDeBord.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/tiroir.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
 
 block append scripts
   script(src = "/statique/bibliotheques/selectize-0.15.2.min.js")

--- a/svelte/lib/visiteGuidee/kit/MenuNavigation.svelte
+++ b/svelte/lib/visiteGuidee/kit/MenuNavigation.svelte
@@ -22,8 +22,12 @@
   };
 
   const fermeMenu = async () => {
-    await metsEnPause();
-    window.location.href = '/tableauDeBord';
+    if (enPause) {
+      menuOuvert = false;
+    } else {
+      await metsEnPause();
+      window.location.href = '/tableauDeBord';
+    }
   };
 
   const configuration: ConfigurationIndicateurEtape = {


### PR DESCRIPTION
...lorsque la visite est en pause et pas définitivement terminée.

En dehors de la visite guidée, refermer le menu ne force pas le retour sur le tableau de bord pour ne pas dérouter l'utilisateur.