### PR TITLE
[SOIN] Réorganisation des routeurs et harmonisation des middlewares

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -101,11 +101,6 @@ const creeServeur = (
     }
   );
 
-  // Pour que les utilisateurs ayant cette page en favoris ne soient pas perdus.
-  app.get('/questionsFrequentes', (_requete, reponse) => {
-    reponse.redirect('https://aide.monservicesecurise.ssi.gouv.fr');
-  });
-
   app.get(
     '/espacePersonnel',
     middleware.verificationAcceptationCGU,

--- a/src/mss.js
+++ b/src/mss.js
@@ -22,6 +22,7 @@ const {
 const InformationsHomologation = require('./modeles/informationsHomologation');
 const Service = require('./modeles/service');
 const Utilisateur = require('./modeles/utilisateur');
+const routesNonConnectePage = require('./routes/nonConnecte/routesNonConnectePage');
 
 require('dotenv').config();
 
@@ -77,10 +78,6 @@ const creeServeur = (
   app.set('trust proxy', 1);
   app.set('view engine', 'pug');
   app.set('views', './src/vues');
-
-  app.get('/', (_requete, reponse) => {
-    reponse.render('home');
-  });
 
   app.get('/aPropos', (_requete, reponse) => {
     reponse.render('aPropos');
@@ -227,6 +224,8 @@ const creeServeur = (
       reponse.render('historiqueProduit');
     }
   );
+
+  app.use('', routesNonConnectePage());
 
   app.use(
     '/api',

--- a/src/mss.js
+++ b/src/mss.js
@@ -93,7 +93,7 @@ const creeServeur = (
   );
 
   app.use('', routesNonConnectePage({ depotDonnees, middleware, referentiel }));
-  app.use('', middleware.verificationJWT, routesConnectePage({ depotDonnees }));
+  app.use('', routesConnectePage({ depotDonnees, middleware, referentiel }));
 
   app.use(
     '/api',
@@ -139,20 +139,6 @@ const creeServeur = (
       adaptateurGestionErreur,
       adaptateurHorloge,
     })
-  );
-
-  app.get(
-    '/utilisateur/edition',
-    middleware.verificationJWT,
-    (requete, reponse) => {
-      const departements = referentiel.departements();
-      const idUtilisateur = requete.idUtilisateurCourant;
-      depotDonnees
-        .utilisateur(idUtilisateur)
-        .then((utilisateur) =>
-          reponse.render('utilisateur/edition', { utilisateur, departements })
-        );
-    }
   );
 
   app.get(

--- a/src/mss.js
+++ b/src/mss.js
@@ -76,15 +76,6 @@ const creeServeur = (
   app.set('views', './src/vues');
 
   app.get(
-    '/tableauDeBord',
-    middleware.verificationAcceptationCGU,
-    middleware.chargeEtatVisiteGuidee,
-    (_requete, reponse) => {
-      reponse.render('tableauDeBord');
-    }
-  );
-
-  app.get(
     '/historiqueProduit',
     middleware.verificationAcceptationCGU,
     (_requete, reponse) => {

--- a/src/mss.js
+++ b/src/mss.js
@@ -76,19 +76,6 @@ const creeServeur = (
   app.set('views', './src/vues');
 
   app.get(
-    '/motDePasse/initialisation',
-    middleware.verificationJWT,
-    (requete, reponse) => {
-      const idUtilisateur = requete.idUtilisateurCourant;
-      depotDonnees
-        .utilisateur(idUtilisateur)
-        .then((utilisateur) =>
-          reponse.render('motDePasse/edition', { utilisateur })
-        );
-    }
-  );
-
-  app.get(
     '/espacePersonnel',
     middleware.verificationAcceptationCGU,
     (_requete, reponse) => {

--- a/src/mss.js
+++ b/src/mss.js
@@ -1,4 +1,3 @@
-const uuid = require('uuid');
 const cookieSession = require('cookie-session');
 const cookieParser = require('cookie-parser');
 const express = require('express');
@@ -108,31 +107,6 @@ const creeServeur = (
   });
 
   app.get(
-    '/initialisationMotDePasse/:idReset',
-    middleware.aseptise('idReset'),
-    async (requete, reponse) => {
-      const { idReset } = requete.params;
-
-      const pasUnUUID = !uuid.validate(idReset);
-      if (pasUnUUID) {
-        reponse.status(400).send(`UUID requis`);
-        return;
-      }
-
-      const utilisateur = await depotDonnees.utilisateurAFinaliser(idReset);
-      if (!utilisateur) {
-        reponse
-          .status(404)
-          .send(`Identifiant d'initialisation de mot de passe inconnu`);
-        return;
-      }
-
-      requete.session.token = utilisateur.genereToken();
-      reponse.render('motDePasse/edition', { utilisateur });
-    }
-  );
-
-  app.get(
     '/espacePersonnel',
     middleware.verificationAcceptationCGU,
     (_requete, reponse) => {
@@ -157,7 +131,7 @@ const creeServeur = (
     }
   );
 
-  app.use('', routesNonConnectePage({ middleware, referentiel }));
+  app.use('', routesNonConnectePage({ depotDonnees, middleware, referentiel }));
 
   app.use(
     '/api',

--- a/src/mss.js
+++ b/src/mss.js
@@ -76,14 +76,6 @@ const creeServeur = (
   app.set('views', './src/vues');
 
   app.get(
-    '/espacePersonnel',
-    middleware.verificationAcceptationCGU,
-    (_requete, reponse) => {
-      reponse.redirect('tableauDeBord');
-    }
-  );
-
-  app.get(
     '/tableauDeBord',
     middleware.verificationAcceptationCGU,
     middleware.chargeEtatVisiteGuidee,

--- a/src/mss.js
+++ b/src/mss.js
@@ -79,10 +79,6 @@ const creeServeur = (
   app.set('view engine', 'pug');
   app.set('views', './src/vues');
 
-  app.get('/aPropos', (_requete, reponse) => {
-    reponse.render('aPropos');
-  });
-
   app.get('/securite', (_requete, reponse) => {
     reponse.render('securite');
   });

--- a/src/mss.js
+++ b/src/mss.js
@@ -108,14 +108,6 @@ const creeServeur = (
   });
 
   app.get(
-    '/reinitialisationMotDePasse',
-    middleware.suppressionCookie,
-    (_requete, reponse) => {
-      reponse.render('reinitialisationMotDePasse');
-    }
-  );
-
-  app.get(
     '/initialisationMotDePasse/:idReset',
     middleware.aseptise('idReset'),
     async (requete, reponse) => {

--- a/src/mss.js
+++ b/src/mss.js
@@ -75,14 +75,6 @@ const creeServeur = (
   app.set('view engine', 'pug');
   app.set('views', './src/vues');
 
-  app.get(
-    '/historiqueProduit',
-    middleware.verificationAcceptationCGU,
-    (_requete, reponse) => {
-      reponse.render('historiqueProduit');
-    }
-  );
-
   app.use('', routesNonConnectePage({ depotDonnees, middleware, referentiel }));
   app.use('', routesConnectePage({ depotDonnees, middleware, referentiel }));
 

--- a/src/mss.js
+++ b/src/mss.js
@@ -18,6 +18,7 @@ const InformationsHomologation = require('./modeles/informationsHomologation');
 const Service = require('./modeles/service');
 const Utilisateur = require('./modeles/utilisateur');
 const routesNonConnectePage = require('./routes/nonConnecte/routesNonConnectePage');
+const routesConnectePage = require('./routes/connecte/routesConnectePage');
 
 require('dotenv').config();
 
@@ -75,20 +76,6 @@ const creeServeur = (
   app.set('views', './src/vues');
 
   app.get(
-    '/motDePasse/edition',
-    middleware.verificationJWT,
-    (requete, reponse) => {
-      const idUtilisateur = requete.idUtilisateurCourant;
-      depotDonnees.utilisateur(idUtilisateur).then((utilisateur) =>
-        reponse.render('motDePasse/edition', {
-          utilisateur,
-          afficheChallengeMotDePasse: true,
-        })
-      );
-    }
-  );
-
-  app.get(
     '/motDePasse/initialisation',
     middleware.verificationJWT,
     (requete, reponse) => {
@@ -127,6 +114,7 @@ const creeServeur = (
   );
 
   app.use('', routesNonConnectePage({ depotDonnees, middleware, referentiel }));
+  app.use('', middleware.verificationJWT, routesConnectePage({ depotDonnees }));
 
   app.use(
     '/api',

--- a/src/mss.js
+++ b/src/mss.js
@@ -1,7 +1,6 @@
 const cookieSession = require('cookie-session');
 const cookieParser = require('cookie-parser');
 const express = require('express');
-const { decode } = require('html-entities');
 const {
   CACHE_CONTROL_FICHIERS_STATIQUES,
   DUREE_SESSION,
@@ -14,9 +13,6 @@ const {
   routesNonConnecteApiBibliotheques,
 } = require('./routes/nonConnecte/routesNonConnecteApiBibliotheques');
 const routesNonConnecteApiStyles = require('./routes/nonConnecte/routesNonConnecteApiStyles');
-const InformationsHomologation = require('./modeles/informationsHomologation');
-const Service = require('./modeles/service');
-const Utilisateur = require('./modeles/utilisateur');
 const routesNonConnectePage = require('./routes/nonConnecte/routesNonConnectePage');
 const routesConnectePage = require('./routes/connecte/routesConnectePage');
 
@@ -76,7 +72,15 @@ const creeServeur = (
   app.set('views', './src/vues');
 
   app.use('', routesNonConnectePage({ depotDonnees, middleware, referentiel }));
-  app.use('', routesConnectePage({ depotDonnees, middleware, referentiel }));
+  app.use(
+    '',
+    routesConnectePage({
+      depotDonnees,
+      middleware,
+      moteurRegles,
+      referentiel,
+    })
+  );
 
   app.use(
     '/api',
@@ -122,69 +126,6 @@ const creeServeur = (
       adaptateurGestionErreur,
       adaptateurHorloge,
     })
-  );
-
-  app.get(
-    '/visiteGuidee/:idEtape',
-    middleware.verificationJWT,
-    middleware.chargePreferencesUtilisateur,
-    middleware.chargeEtatVisiteGuidee,
-    (requete, reponse) => {
-      const utilisateurVisiteGuidee = new Utilisateur({
-        email: 'visite-guidee@cyber.gouv.fr',
-      });
-      const service = Service.creePourUnUtilisateur(utilisateurVisiteGuidee);
-      service.id = 'ID-SERVICE-VISITE-GUIDEE';
-
-      const { idEtape } = requete.params;
-      reponse.locals.etatVisiteGuidee = {
-        ...reponse.locals.etatVisiteGuidee,
-        etapeCourante: idEtape.toUpperCase(),
-      };
-      reponse.locals.autorisationsService = {
-        DECRIRE: { estMasque: false },
-        SECURISER: { estMasque: false, estLectureSeule: false },
-        HOMOLOGUER: { estMasque: false },
-        RISQUES: { estMasque: false },
-        CONTACTS: { estMasque: false },
-        peutHomologuer: false,
-      };
-
-      if (idEtape === 'decrire') {
-        reponse.render('service/creation', {
-          InformationsHomologation,
-          referentiel,
-          service,
-          etapeActive: 'descriptionService',
-          departements: referentiel.departements(),
-        });
-      } else if (idEtape === 'securiser') {
-        const mesures = moteurRegles.mesures(service.descriptionService);
-        const pourcentageProgression = 80;
-
-        service.indiceCyber = () => ({ total: 4.3 });
-        reponse.render('service/mesures', {
-          InformationsHomologation,
-          referentiel,
-          service,
-          etapeActive: 'mesures',
-          pourcentageProgression,
-          mesures,
-        });
-      } else if (idEtape === 'homologuer') {
-        reponse.render('service/dossiers', {
-          InformationsHomologation,
-          decode,
-          service,
-          etapeActive: 'dossiers',
-          premiereEtapeParcours: referentiel.premiereEtapeParcours(),
-          peutVoirTamponHomologation: true,
-          referentiel,
-        });
-      } else if (idEtape === 'piloter') {
-        reponse.render('tableauDeBord');
-      }
-    }
   );
 
   app.use(

--- a/src/mss.js
+++ b/src/mss.js
@@ -79,22 +79,6 @@ const creeServeur = (
   app.set('view engine', 'pug');
   app.set('views', './src/vues');
 
-  app.get('/securite', (_requete, reponse) => {
-    reponse.render('securite');
-  });
-
-  app.get('/accessibilite', (_requete, reponse) => {
-    reponse.render('accessibilite');
-  });
-
-  app.get('/cgu', (_requete, reponse) => {
-    reponse.render('cgu');
-  });
-
-  app.get('/confidentialite', (_requete, reponse) => {
-    reponse.render('confidentialite');
-  });
-
   app.get('/connexion', middleware.suppressionCookie, (requete, reponse) => {
     const { urlRedirection } = requete.query;
 
@@ -146,14 +130,6 @@ const creeServeur = (
     reponse.redirect('https://aide.monservicesecurise.ssi.gouv.fr');
   });
 
-  app.get('/mentionsLegales', (_requete, reponse) => {
-    reponse.render('mentionsLegales');
-  });
-
-  app.get('/statistiques', (_requete, reponse) => {
-    reponse.render('statistiques');
-  });
-
   app.get(
     '/reinitialisationMotDePasse',
     middleware.suppressionCookie,
@@ -161,15 +137,6 @@ const creeServeur = (
       reponse.render('reinitialisationMotDePasse');
     }
   );
-
-  app.get('/inscription', (_requete, reponse) => {
-    const departements = referentiel.departements();
-    reponse.render('inscription', { departements });
-  });
-
-  app.get('/activation', (_requete, reponse) => {
-    reponse.render('activation');
-  });
 
   app.get(
     '/initialisationMotDePasse/:idReset',
@@ -221,7 +188,7 @@ const creeServeur = (
     }
   );
 
-  app.use('', routesNonConnectePage());
+  app.use('', routesNonConnectePage({ referentiel }));
 
   app.use(
     '/api',

--- a/src/mss.js
+++ b/src/mss.js
@@ -15,10 +15,6 @@ const {
   routesNonConnecteApiBibliotheques,
 } = require('./routes/nonConnecte/routesNonConnecteApiBibliotheques');
 const routesNonConnecteApiStyles = require('./routes/nonConnecte/routesNonConnecteApiStyles');
-const {
-  estUrlLegalePourRedirection,
-  construisUrlAbsolueVersPage,
-} = require('./http/redirection');
 const InformationsHomologation = require('./modeles/informationsHomologation');
 const Service = require('./modeles/service');
 const Utilisateur = require('./modeles/utilisateur');
@@ -78,25 +74,6 @@ const creeServeur = (
   app.set('trust proxy', 1);
   app.set('view engine', 'pug');
   app.set('views', './src/vues');
-
-  app.get('/connexion', middleware.suppressionCookie, (requete, reponse) => {
-    const { urlRedirection } = requete.query;
-
-    if (!urlRedirection) {
-      reponse.render('connexion');
-      return;
-    }
-
-    if (!estUrlLegalePourRedirection(urlRedirection)) {
-      // Ici c'est un redirect, pour nettoyer l'URL de la redirection invalide.
-      reponse.redirect('connexion');
-      return;
-    }
-
-    reponse.render('connexion', {
-      urlRedirection: construisUrlAbsolueVersPage(urlRedirection),
-    });
-  });
 
   app.get(
     '/motDePasse/edition',
@@ -188,7 +165,7 @@ const creeServeur = (
     }
   );
 
-  app.use('', routesNonConnectePage({ referentiel }));
+  app.use('', routesNonConnectePage({ middleware, referentiel }));
 
   app.use(
     '/api',

--- a/src/mss.js
+++ b/src/mss.js
@@ -7,7 +7,6 @@ const {
   ENDPOINTS_SANS_CSRF,
 } = require('./http/configurationServeur');
 const routesConnecteApi = require('./routes/connecte/routesConnecteApi');
-const routesConnectePageService = require('./routes/connecte/routesConnectePageService');
 const routesNonConnecteApi = require('./routes/nonConnecte/routesNonConnecteApi');
 const {
   routesNonConnecteApiBibliotheques,
@@ -79,9 +78,11 @@ const creeServeur = (
       middleware,
       moteurRegles,
       referentiel,
+      adaptateurCsv,
+      adaptateurGestionErreur,
+      adaptateurHorloge,
     })
   );
-
   app.use(
     '/api',
     routesNonConnecteApi({
@@ -93,9 +94,6 @@ const creeServeur = (
       adaptateurMail,
     })
   );
-  app.use('/bibliotheques', routesNonConnecteApiBibliotheques());
-  app.use('/styles', routesNonConnecteApiStyles());
-
   app.use(
     '/api',
     middleware.verificationJWT,
@@ -113,20 +111,8 @@ const creeServeur = (
       serviceAnnuaire,
     })
   );
-
-  app.use(
-    '/service',
-    middleware.verificationJWT,
-    routesConnectePageService({
-      middleware,
-      referentiel,
-      depotDonnees,
-      moteurRegles,
-      adaptateurCsv,
-      adaptateurGestionErreur,
-      adaptateurHorloge,
-    })
-  );
+  app.use('/bibliotheques', routesNonConnecteApiBibliotheques());
+  app.use('/styles', routesNonConnecteApiStyles());
 
   app.use(
     '/statique',

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -13,6 +13,15 @@ const routesConnectePage = ({ depotDonnees }) => {
     );
   });
 
+  routes.get('/motDePasse/initialisation', (requete, reponse) => {
+    const idUtilisateur = requete.idUtilisateurCourant;
+    depotDonnees
+      .utilisateur(idUtilisateur)
+      .then((utilisateur) =>
+        reponse.render('motDePasse/edition', { utilisateur })
+      );
+  });
+
   return routes;
 };
 

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -1,6 +1,15 @@
 const express = require('express');
+const { decode } = require('html-entities');
+const Utilisateur = require('../../modeles/utilisateur');
+const Service = require('../../modeles/service');
+const InformationsHomologation = require('../../modeles/informationsHomologation');
 
-const routesConnectePage = ({ middleware, depotDonnees, referentiel }) => {
+const routesConnectePage = ({
+  middleware,
+  moteurRegles,
+  depotDonnees,
+  referentiel,
+}) => {
   const routes = express.Router();
 
   routes.get(
@@ -59,6 +68,69 @@ const routesConnectePage = ({ middleware, depotDonnees, referentiel }) => {
     middleware.chargeEtatVisiteGuidee,
     (_requete, reponse) => {
       reponse.render('historiqueProduit');
+    }
+  );
+
+  routes.get(
+    '/visiteGuidee/:idEtape',
+    middleware.verificationAcceptationCGU,
+    middleware.chargePreferencesUtilisateur,
+    middleware.chargeEtatVisiteGuidee,
+    (requete, reponse) => {
+      const utilisateurVisiteGuidee = new Utilisateur({
+        email: 'visite-guidee@cyber.gouv.fr',
+      });
+      const service = Service.creePourUnUtilisateur(utilisateurVisiteGuidee);
+      service.id = 'ID-SERVICE-VISITE-GUIDEE';
+
+      const { idEtape } = requete.params;
+      reponse.locals.etatVisiteGuidee = {
+        ...reponse.locals.etatVisiteGuidee,
+        etapeCourante: idEtape.toUpperCase(),
+      };
+      reponse.locals.autorisationsService = {
+        DECRIRE: { estMasque: false },
+        SECURISER: { estMasque: false, estLectureSeule: false },
+        HOMOLOGUER: { estMasque: false },
+        RISQUES: { estMasque: false },
+        CONTACTS: { estMasque: false },
+        peutHomologuer: false,
+      };
+
+      if (idEtape === 'decrire') {
+        reponse.render('service/creation', {
+          InformationsHomologation,
+          referentiel,
+          service,
+          etapeActive: 'descriptionService',
+          departements: referentiel.departements(),
+        });
+      } else if (idEtape === 'securiser') {
+        const mesures = moteurRegles.mesures(service.descriptionService);
+        const pourcentageProgression = 80;
+
+        service.indiceCyber = () => ({ total: 4.3 });
+        reponse.render('service/mesures', {
+          InformationsHomologation,
+          referentiel,
+          service,
+          etapeActive: 'mesures',
+          pourcentageProgression,
+          mesures,
+        });
+      } else if (idEtape === 'homologuer') {
+        reponse.render('service/dossiers', {
+          InformationsHomologation,
+          decode,
+          service,
+          etapeActive: 'dossiers',
+          premiereEtapeParcours: referentiel.premiereEtapeParcours(),
+          peutVoirTamponHomologation: true,
+          referentiel,
+        });
+      } else if (idEtape === 'piloter') {
+        reponse.render('tableauDeBord');
+      }
     }
   );
 

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -42,7 +42,8 @@ const routesConnectePage = ({
 
   routes.get(
     '/utilisateur/edition',
-    middleware.verificationJWT,
+    middleware.verificationAcceptationCGU,
+    middleware.chargeEtatVisiteGuidee,
     (requete, reponse) => {
       const departements = referentiel.departements();
       const idUtilisateur = requete.idUtilisateurCourant;

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -143,6 +143,7 @@ const routesConnectePage = ({
   routes.use(
     '/service',
     middleware.verificationAcceptationCGU,
+    middleware.chargeEtatVisiteGuidee,
     routesConnectePageService({
       middleware,
       referentiel,

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -3,12 +3,16 @@ const { decode } = require('html-entities');
 const Utilisateur = require('../../modeles/utilisateur');
 const Service = require('../../modeles/service');
 const InformationsHomologation = require('../../modeles/informationsHomologation');
+const routesConnectePageService = require('./routesConnectePageService');
 
 const routesConnectePage = ({
   middleware,
   moteurRegles,
   depotDonnees,
   referentiel,
+  adaptateurCsv,
+  adaptateurGestionErreur,
+  adaptateurHorloge,
 }) => {
   const routes = express.Router();
 
@@ -134,6 +138,20 @@ const routesConnectePage = ({
         reponse.render('tableauDeBord');
       }
     }
+  );
+
+  routes.use(
+    '/service',
+    middleware.verificationAcceptationCGU,
+    routesConnectePageService({
+      middleware,
+      referentiel,
+      depotDonnees,
+      moteurRegles,
+      adaptateurCsv,
+      adaptateurGestionErreur,
+      adaptateurHorloge,
+    })
   );
 
   return routes;

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -53,6 +53,15 @@ const routesConnectePage = ({ middleware, depotDonnees, referentiel }) => {
     }
   );
 
+  routes.get(
+    '/historiqueProduit',
+    middleware.verificationAcceptationCGU,
+    middleware.chargeEtatVisiteGuidee,
+    (_requete, reponse) => {
+      reponse.render('historiqueProduit');
+    }
+  );
+
   return routes;
 };
 

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -1,0 +1,19 @@
+const express = require('express');
+
+const routesConnectePage = ({ depotDonnees }) => {
+  const routes = express.Router();
+
+  routes.get('/motDePasse/edition', (requete, reponse) => {
+    const idUtilisateur = requete.idUtilisateurCourant;
+    depotDonnees.utilisateur(idUtilisateur).then((utilisateur) =>
+      reponse.render('motDePasse/edition', {
+        utilisateur,
+        afficheChallengeMotDePasse: true,
+      })
+    );
+  });
+
+  return routes;
+};
+
+module.exports = routesConnectePage;

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -1,26 +1,48 @@
 const express = require('express');
 
-const routesConnectePage = ({ depotDonnees }) => {
+const routesConnectePage = ({ middleware, depotDonnees, referentiel }) => {
   const routes = express.Router();
 
-  routes.get('/motDePasse/edition', (requete, reponse) => {
-    const idUtilisateur = requete.idUtilisateurCourant;
-    depotDonnees.utilisateur(idUtilisateur).then((utilisateur) =>
-      reponse.render('motDePasse/edition', {
-        utilisateur,
-        afficheChallengeMotDePasse: true,
-      })
-    );
-  });
-
-  routes.get('/motDePasse/initialisation', (requete, reponse) => {
-    const idUtilisateur = requete.idUtilisateurCourant;
-    depotDonnees
-      .utilisateur(idUtilisateur)
-      .then((utilisateur) =>
-        reponse.render('motDePasse/edition', { utilisateur })
+  routes.get(
+    '/motDePasse/edition',
+    middleware.verificationJWT,
+    (requete, reponse) => {
+      const idUtilisateur = requete.idUtilisateurCourant;
+      depotDonnees.utilisateur(idUtilisateur).then((utilisateur) =>
+        reponse.render('motDePasse/edition', {
+          utilisateur,
+          afficheChallengeMotDePasse: true,
+        })
       );
-  });
+    }
+  );
+
+  routes.get(
+    '/motDePasse/initialisation',
+    middleware.verificationJWT,
+    (requete, reponse) => {
+      const idUtilisateur = requete.idUtilisateurCourant;
+      depotDonnees
+        .utilisateur(idUtilisateur)
+        .then((utilisateur) =>
+          reponse.render('motDePasse/edition', { utilisateur })
+        );
+    }
+  );
+
+  routes.get(
+    '/utilisateur/edition',
+    middleware.verificationJWT,
+    (requete, reponse) => {
+      const departements = referentiel.departements();
+      const idUtilisateur = requete.idUtilisateurCourant;
+      depotDonnees
+        .utilisateur(idUtilisateur)
+        .then((utilisateur) =>
+          reponse.render('utilisateur/edition', { utilisateur, departements })
+        );
+    }
+  );
 
   return routes;
 };

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -14,7 +14,8 @@ const routesConnectePage = ({
 
   routes.get(
     '/motDePasse/edition',
-    middleware.verificationJWT,
+    middleware.verificationAcceptationCGU,
+    middleware.chargeEtatVisiteGuidee,
     (requete, reponse) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       depotDonnees.utilisateur(idUtilisateur).then((utilisateur) =>

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -44,6 +44,15 @@ const routesConnectePage = ({ middleware, depotDonnees, referentiel }) => {
     }
   );
 
+  routes.get(
+    '/tableauDeBord',
+    middleware.verificationAcceptationCGU,
+    middleware.chargeEtatVisiteGuidee,
+    (_requete, reponse) => {
+      reponse.render('tableauDeBord');
+    }
+  );
+
   return routes;
 };
 

--- a/src/routes/connecte/routesConnectePageService.js
+++ b/src/routes/connecte/routesConnectePageService.js
@@ -29,7 +29,6 @@ const routesConnectePageService = ({
 
   routes.get(
     '/creation',
-    middleware.verificationAcceptationCGU,
     middleware.chargePreferencesUtilisateur,
     (requete, reponse, suite) => {
       const { idUtilisateurCourant } = requete;

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -1,6 +1,10 @@
 const express = require('express');
+const {
+  estUrlLegalePourRedirection,
+  construisUrlAbsolueVersPage,
+} = require('../../http/redirection');
 
-const routesNonConnectePage = ({ referentiel }) => {
+const routesNonConnectePage = ({ middleware, referentiel }) => {
   const routes = express.Router();
 
   routes.get('/', (_requete, reponse) => {
@@ -42,6 +46,25 @@ const routesNonConnectePage = ({ referentiel }) => {
 
   routes.get('/activation', (_requete, reponse) => {
     reponse.render('activation');
+  });
+
+  routes.get('/connexion', middleware.suppressionCookie, (requete, reponse) => {
+    const { urlRedirection } = requete.query;
+
+    if (!urlRedirection) {
+      reponse.render('connexion');
+      return;
+    }
+
+    if (!estUrlLegalePourRedirection(urlRedirection)) {
+      // Ici c'est un redirect, pour nettoyer l'URL de la redirection invalide.
+      reponse.redirect('connexion');
+      return;
+    }
+
+    reponse.render('connexion', {
+      urlRedirection: construisUrlAbsolueVersPage(urlRedirection),
+    });
   });
 
   return routes;

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -7,6 +7,10 @@ const routesNonConnectePage = () => {
     reponse.render('home');
   });
 
+  routes.get('/aPropos', (_requete, reponse) => {
+    reponse.render('aPropos');
+  });
+
   return routes;
 };
 

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const routesNonConnectePage = () => {
+const routesNonConnectePage = ({ referentiel }) => {
   const routes = express.Router();
 
   routes.get('/', (_requete, reponse) => {
@@ -9,6 +9,39 @@ const routesNonConnectePage = () => {
 
   routes.get('/aPropos', (_requete, reponse) => {
     reponse.render('aPropos');
+  });
+
+  routes.get('/securite', (_requete, reponse) => {
+    reponse.render('securite');
+  });
+
+  routes.get('/accessibilite', (_requete, reponse) => {
+    reponse.render('accessibilite');
+  });
+
+  routes.get('/cgu', (_requete, reponse) => {
+    reponse.render('cgu');
+  });
+
+  routes.get('/confidentialite', (_requete, reponse) => {
+    reponse.render('confidentialite');
+  });
+
+  routes.get('/mentionsLegales', (_requete, reponse) => {
+    reponse.render('mentionsLegales');
+  });
+
+  routes.get('/statistiques', (_requete, reponse) => {
+    reponse.render('statistiques');
+  });
+
+  routes.get('/inscription', (_requete, reponse) => {
+    const departements = referentiel.departements();
+    reponse.render('inscription', { departements });
+  });
+
+  routes.get('/activation', (_requete, reponse) => {
+    reponse.render('activation');
   });
 
   return routes;

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -67,6 +67,14 @@ const routesNonConnectePage = ({ middleware, referentiel }) => {
     });
   });
 
+  routes.get(
+    '/reinitialisationMotDePasse',
+    middleware.suppressionCookie,
+    (_requete, reponse) => {
+      reponse.render('reinitialisationMotDePasse');
+    }
+  );
+
   return routes;
 };
 

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -1,0 +1,13 @@
+const express = require('express');
+
+const routesNonConnectePage = () => {
+  const routes = express.Router();
+
+  routes.get('/', (_requete, reponse) => {
+    reponse.render('home');
+  });
+
+  return routes;
+};
+
+module.exports = routesNonConnectePage;

--- a/src/vues/statistiques.pug
+++ b/src/vues/statistiques.pug
@@ -12,10 +12,11 @@ block main
   .marges-fixes
     h1 Statistiques
 
-    iframe(
-      src=`${new URL(
-              `/public/dashboard/${process.env.STATISTIQUES_ID_DASHBOARD_METABASE}#titled=false&bordered=false&theme=transparent`,
-              process.env.STATISTIQUES_DOMAINE_METABASE_MSS
-            ).toString()}`
-      sandbox="allow-scripts allow-same-origin"
-    )
+    if process.env.STATISTIQUES_ID_DASHBOARD_METABASE
+      iframe(
+        src=`${new URL(
+                `/public/dashboard/${process.env.STATISTIQUES_ID_DASHBOARD_METABASE}#titled=false&bordered=false&theme=transparent`,
+                process.env.STATISTIQUES_DOMAINE_METABASE_MSS
+              ).toString()}`
+        sandbox="allow-scripts allow-same-origin"
+      )

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -39,20 +39,6 @@ describe('Le serveur MSS', () => {
     });
   });
 
-  describe('quand GET sur /motDePasse/initialisation', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      const utilisateur = { accepteCGU: () => true };
-      testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
-
-      testeur
-        .middleware()
-        .verifieRequeteExigeJWT(
-          'http://localhost:1234/motDePasse/initialisation',
-          done
-        );
-    });
-  });
-
   describe('quand requête GET sur `/espacePersonnel`', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       testeur

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -39,17 +39,6 @@ describe('Le serveur MSS', () => {
     });
   });
 
-  describe('quand requête GET sur `/connexion`', () => {
-    it("déconnecte l'utilisateur courant", (done) => {
-      testeur
-        .middleware()
-        .verifieRequeteExigeSuppressionCookie(
-          'http://localhost:1234/connexion',
-          done
-        );
-    });
-  });
-
   describe('quand GET sur /motDePasse/edition', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       const utilisateur = { accepteCGU: () => true };

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -67,17 +67,6 @@ describe('Le serveur MSS', () => {
     });
   });
 
-  describe('quand requête GET sur `/reinitialisationMotDePasse`', () => {
-    it("déconnecte l'utilisateur courant", (done) => {
-      testeur
-        .middleware()
-        .verifieRequeteExigeSuppressionCookie(
-          'http://localhost:1234/reinitialisationMotDePasse',
-          done
-        );
-    });
-  });
-
   describe('quand requête GET sur `/initialisationMotDePasse/:idReset`', () => {
     const uuid = '109156be-c4fb-41ea-b1b4-efe1671c5836';
 

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -11,16 +11,6 @@ describe('Le serveur MSS', () => {
 
   afterEach(testeur.arrete);
 
-  it('sert des pages HTML', (done) => {
-    axios
-      .get('http://localhost:1234/')
-      .then((reponse) => {
-        expect(reponse.status).to.equal(200);
-        done();
-      })
-      .catch(done);
-  });
-
   it('utilise un filtrage IP pour ne servir que les IP autorisées', (done) => {
     testeur.middleware().verifieFiltrageIp('http://localhost:1234', done);
   });

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -48,19 +48,6 @@ describe('Le serveur MSS', () => {
       );
   });
 
-  describe('quand requête GET sur `/utilisateur/edition`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      const utilisateur = unUtilisateur().quiAccepteCGU().construis();
-      testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
-      testeur
-        .middleware()
-        .verifieRequeteExigeJWT(
-          'http://localhost:1234/utilisateur/edition',
-          done
-        );
-    });
-  });
-
   describe('quand requête GET sur `/visiteGuidee/:idEtape`', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       const utilisateur = unUtilisateur().quiAccepteCGU().construis();

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -67,68 +67,6 @@ describe('Le serveur MSS', () => {
     });
   });
 
-  describe('quand requête GET sur `/initialisationMotDePasse/:idReset`', () => {
-    const uuid = '109156be-c4fb-41ea-b1b4-efe1671c5836';
-
-    describe('avec idReset valide', () => {
-      const utilisateur = {
-        id: '123',
-        genereToken: () => 'un token',
-        accepteCGU: () => false,
-      };
-
-      beforeEach(() => {
-        testeur.depotDonnees().utilisateurAFinaliser = async () => utilisateur;
-        testeur.depotDonnees().utilisateur = async () => utilisateur;
-      });
-
-      it('dépose le jeton dans un cookie', async () => {
-        let idRecu;
-        testeur.depotDonnees().utilisateurAFinaliser = async (idReset) => {
-          idRecu = idReset;
-          return utilisateur;
-        };
-
-        const reponse = await axios.get(
-          `http://localhost:1234/initialisationMotDePasse/${uuid}`
-        );
-
-        expect(idRecu).to.be(uuid);
-        await testeur.verifieJetonDepose(reponse, () => {});
-      });
-    });
-
-    it("aseptise l'identifiant reçu", (done) => {
-      testeur
-        .middleware()
-        .verifieAseptisationParametres(
-          ['idReset'],
-          `http://localhost:1234/initialisationMotDePasse/${uuid}`,
-          done
-        );
-    });
-
-    it("retourne une erreur HTTP 400 sur idReset n'est pas un UUID valide", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
-        400,
-        'UUID requis',
-        'http://localhost:1234/initialisationMotDePasse/999',
-        done
-      );
-    });
-
-    it('retourne une erreur HTTP 404 si idReset inconnu', (done) => {
-      testeur.depotDonnees().utilisateurAFinaliser = async () => {};
-
-      testeur.verifieRequeteGenereErreurHTTP(
-        404,
-        `Identifiant d'initialisation de mot de passe inconnu`,
-        `http://localhost:1234/initialisationMotDePasse/${uuid}`,
-        done
-      );
-    });
-  });
-
   describe('quand requête GET sur `/espacePersonnel`', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       testeur

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -1,8 +1,6 @@
 const axios = require('axios');
 const expect = require('expect.js');
-
 const testeurMSS = require('./routes/testeurMSS');
-const { unUtilisateur } = require('./constructeurs/constructeurUtilisateur');
 
 describe('Le serveur MSS', () => {
   const testeur = testeurMSS();
@@ -36,49 +34,6 @@ describe('Le serveur MSS', () => {
       testeur
         .middleware()
         .verifieRequeteRepousseExpirationCookie('http://localhost:1234/', done);
-    });
-  });
-
-  describe('quand requête GET sur `/visiteGuidee/:idEtape`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      const utilisateur = unUtilisateur().quiAccepteCGU().construis();
-      testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
-      testeur
-        .middleware()
-        .verifieRequeteExigeJWT(
-          'http://localhost:1234/visiteGuidee/decrire',
-          done
-        );
-    });
-
-    it("charge les préférences de l'utilisateur", (done) => {
-      testeur
-        .middleware()
-        .verifieChargementDesPreferences(
-          'http://localhost:1234/visiteGuidee/decrire',
-          done
-        );
-    });
-
-    it("charge l'état de la visite guidée", (done) => {
-      testeur
-        .middleware()
-        .verifieRequeteChargeEtatVisiteGuidee(
-          'http://localhost:1234/visiteGuidee/decrire',
-          done
-        );
-    });
-
-    ['decrire', 'securiser', 'homologuer', 'piloter'].forEach((idEtape) => {
-      it(`rend une vue '.pug' correspondant à l'étape '${idEtape}'`, async () => {
-        testeur.referentiel().recharge({
-          etapesParcoursHomologation: [{ numero: 1 }],
-        });
-        const reponse = await axios.get(
-          `http://localhost:1234/visiteGuidee/${idEtape}`
-        );
-        expect(reponse.status).to.be(200);
-      });
     });
   });
 });

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -39,20 +39,6 @@ describe('Le serveur MSS', () => {
     });
   });
 
-  describe('quand GET sur /motDePasse/edition', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      const utilisateur = { accepteCGU: () => true };
-      testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
-
-      testeur
-        .middleware()
-        .verifieRequeteExigeJWT(
-          'http://localhost:1234/motDePasse/edition',
-          done
-        );
-    });
-  });
-
   describe('quand GET sur /motDePasse/initialisation', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       const utilisateur = { accepteCGU: () => true };

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -39,15 +39,6 @@ describe('Le serveur MSS', () => {
     });
   });
 
-  it("vérifie que l'état de la visite guidée est chargé sur le tableau de bord", (done) => {
-    testeur
-      .middleware()
-      .verifieRequeteChargeEtatVisiteGuidee(
-        'http://localhost:1234/tableauDeBord',
-        done
-      );
-  });
-
   describe('quand requête GET sur `/visiteGuidee/:idEtape`', () => {
     it("vérifie que l'utilisateur est authentifié", (done) => {
       const utilisateur = unUtilisateur().quiAccepteCGU().construis();

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -39,27 +39,6 @@ describe('Le serveur MSS', () => {
     });
   });
 
-  describe('quand requête GET sur `/espacePersonnel`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
-        .middleware()
-        .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/espacePersonnel',
-          done
-        );
-    });
-
-    it('redirige vers le tableau de bord', (done) => {
-      axios
-        .get('http://localhost:1234/espacePersonnel')
-        .then((reponse) => {
-          expect(reponse.request.res.responseUrl).to.contain('tableauDeBord');
-          done();
-        })
-        .catch(done);
-    });
-  });
-
   it("vérifie que l'état de la visite guidée est chargé sur le tableau de bord", (done) => {
     testeur
       .middleware()

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -40,7 +40,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
     });
   });
 
-  ['/tableauDeBord'].forEach((route) => {
+  ['/tableauDeBord', '/historiqueProduit'].forEach((route) => {
     describe(`quand GET sur ${route}`, () => {
       it("vérifie que l'utilisateur est authentifié", (done) => {
         testeur

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -39,4 +39,37 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
       });
     });
   });
+
+  ['/tableauDeBord'].forEach((route) => {
+    describe(`quand GET sur ${route}`, () => {
+      it("vérifie que l'utilisateur est authentifié", (done) => {
+        testeur
+          .middleware()
+          .verifieRequeteExigeAcceptationCGU(
+            `http://localhost:1234${route}`,
+            done
+          );
+      });
+
+      it("vérifie que l'état de la visite guidée est chargé sur la route", (done) => {
+        testeur
+          .middleware()
+          .verifieRequeteChargeEtatVisiteGuidee(
+            `http://localhost:1234${route}`,
+            done
+          );
+      });
+
+      it('sert le contenu HTML de la page', (done) => {
+        axios
+          .get(`http://localhost:1234${route}`)
+          .then((reponse) => {
+            expect(reponse.status).to.equal(200);
+            expect(reponse.headers['content-type']).to.contain('text/html');
+            done();
+          })
+          .catch(done);
+      });
+    });
+  });
 });

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -10,34 +10,36 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
   beforeEach(testeur.initialise);
   afterEach(testeur.arrete);
 
-  ['/motDePasse/initialisation', '/utilisateur/edition'].forEach((route) => {
-    describe(`quand GET sur ${route}`, () => {
-      beforeEach(() => {
-        const utilisateur = unUtilisateur().construis();
-        testeur.depotDonnees().utilisateur = async () => utilisateur;
-      });
+  describe(`quand GET sur /motDePasse/initialisation`, () => {
+    beforeEach(() => {
+      const utilisateur = unUtilisateur().construis();
+      testeur.depotDonnees().utilisateur = async () => utilisateur;
+    });
 
-      it("vérifie que l'utilisateur est authentifié", (done) => {
-        testeur
-          .middleware()
-          .verifieRequeteExigeJWT(`http://localhost:1234${route}`, done);
-      });
+    it("vérifie que l'utilisateur est authentifié", (done) => {
+      testeur
+        .middleware()
+        .verifieRequeteExigeJWT(
+          'http://localhost:1234/motDePasse/initialisation',
+          done
+        );
+    });
 
-      it('sert le contenu HTML de la page', (done) => {
-        axios
-          .get(`http://localhost:1234${route}`)
-          .then((reponse) => {
-            expect(reponse.status).to.equal(200);
-            expect(reponse.headers['content-type']).to.contain('text/html');
-            done();
-          })
-          .catch(done);
-      });
+    it('sert le contenu HTML de la page ', (done) => {
+      axios
+        .get('http://localhost:1234/motDePasse/initialisation')
+        .then((reponse) => {
+          expect(reponse.status).to.equal(200);
+          expect(reponse.headers['content-type']).to.contain('text/html');
+          done();
+        })
+        .catch(done);
     });
   });
 
   [
     '/motDePasse/edition',
+    '/utilisateur/edition',
     '/tableauDeBord',
     '/historiqueProduit',
     '/visiteGuidee/decrire',

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -7,7 +7,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
   beforeEach(testeur.initialise);
   afterEach(testeur.arrete);
 
-  ['/motDePasse/edition'].forEach((route) => {
+  ['/motDePasse/edition', '/motDePasse/initialisation'].forEach((route) => {
     describe(`quand GET sur ${route}`, () => {
       beforeEach(() => {
         const utilisateur = { accepteCGU: () => true };

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -10,11 +10,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
   beforeEach(testeur.initialise);
   afterEach(testeur.arrete);
 
-  [
-    '/motDePasse/edition',
-    '/motDePasse/initialisation',
-    '/utilisateur/edition',
-  ].forEach((route) => {
+  ['/motDePasse/initialisation', '/utilisateur/edition'].forEach((route) => {
     describe(`quand GET sur ${route}`, () => {
       beforeEach(() => {
         const utilisateur = unUtilisateur().construis();
@@ -41,6 +37,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
   });
 
   [
+    '/motDePasse/edition',
     '/tableauDeBord',
     '/historiqueProduit',
     '/visiteGuidee/decrire',
@@ -50,6 +47,8 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
   ].forEach((route) => {
     describe(`quand GET sur ${route}`, () => {
       beforeEach(() => {
+        const utilisateur = unUtilisateur().construis();
+        testeur.depotDonnees().utilisateur = async () => utilisateur;
         testeur.referentiel().recharge({
           etapesParcoursHomologation: [{ numero: 1 }],
         });

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -40,9 +40,22 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
     });
   });
 
-  ['/tableauDeBord', '/historiqueProduit'].forEach((route) => {
+  [
+    '/tableauDeBord',
+    '/historiqueProduit',
+    '/visiteGuidee/decrire',
+    '/visiteGuidee/securiser',
+    '/visiteGuidee/homologuer',
+    '/visiteGuidee/piloter',
+  ].forEach((route) => {
     describe(`quand GET sur ${route}`, () => {
-      it("vérifie que l'utilisateur est authentifié", (done) => {
+      beforeEach(() => {
+        testeur.referentiel().recharge({
+          etapesParcoursHomologation: [{ numero: 1 }],
+        });
+      });
+
+      it("vérifie que l'utilisateur a accepté les CGU", (done) => {
         testeur
           .middleware()
           .verifieRequeteExigeAcceptationCGU(
@@ -70,6 +83,17 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
           })
           .catch(done);
       });
+    });
+  });
+
+  describe('quand requête GET sur `/visiteGuidee/:idEtape`', () => {
+    it("charge les préférences de l'utilisateur", (done) => {
+      testeur
+        .middleware()
+        .verifieChargementDesPreferences(
+          'http://localhost:1234/visiteGuidee/decrire',
+          done
+        );
     });
   });
 });

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -1,0 +1,35 @@
+const axios = require('axios');
+const expect = require('expect.js');
+const testeurMSS = require('../testeurMSS');
+
+describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
+  const testeur = testeurMSS();
+  beforeEach(testeur.initialise);
+  afterEach(testeur.arrete);
+
+  ['/motDePasse/edition'].forEach((route) => {
+    describe(`quand GET sur ${route}`, () => {
+      beforeEach(() => {
+        const utilisateur = { accepteCGU: () => true };
+        testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
+      });
+
+      it("vérifie que l'utilisateur est authentifié", (done) => {
+        testeur
+          .middleware()
+          .verifieRequeteExigeJWT(`http://localhost:1234${route}`, done);
+      });
+
+      it('sert le contenu HTML de la page', (done) => {
+        axios
+          .get(`http://localhost:1234${route}`)
+          .then((reponse) => {
+            expect(reponse.status).to.equal(200);
+            expect(reponse.headers['content-type']).to.contain('text/html');
+            done();
+          })
+          .catch(done);
+      });
+    });
+  });
+});

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -1,17 +1,24 @@
 const axios = require('axios');
 const expect = require('expect.js');
 const testeurMSS = require('../testeurMSS');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
 
 describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
   const testeur = testeurMSS();
   beforeEach(testeur.initialise);
   afterEach(testeur.arrete);
 
-  ['/motDePasse/edition', '/motDePasse/initialisation'].forEach((route) => {
+  [
+    '/motDePasse/edition',
+    '/motDePasse/initialisation',
+    '/utilisateur/edition',
+  ].forEach((route) => {
     describe(`quand GET sur ${route}`, () => {
       beforeEach(() => {
-        const utilisateur = { accepteCGU: () => true };
-        testeur.depotDonnees().utilisateur = () => Promise.resolve(utilisateur);
+        const utilisateur = unUtilisateur().construis();
+        testeur.depotDonnees().utilisateur = async () => utilisateur;
       });
 
       it("vérifie que l'utilisateur est authentifié", (done) => {

--- a/test/routes/connecte/routesConnectePageService.spec.js
+++ b/test/routes/connecte/routesConnectePageService.spec.js
@@ -56,6 +56,15 @@ describe('Le serveur MSS des routes /service/*', () => {
           );
       });
 
+      it("vérifie que l'état de la visite guidée est chargé sur la route", (done) => {
+        testeur
+          .middleware()
+          .verifieRequeteChargeEtatVisiteGuidee(
+            `http://localhost:1234/service${route}`,
+            done
+          );
+      });
+
       it('sert le contenu HTML de la page', (done) => {
         axios
           .get(`http://localhost:1234/service${route}`)

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -1,0 +1,20 @@
+const axios = require('axios');
+const expect = require('expect.js');
+const testeurMSS = require('../testeurMSS');
+
+describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
+  const testeur = testeurMSS();
+  beforeEach(testeur.initialise);
+  afterEach(testeur.arrete);
+
+  it("sert la page d'accueil", (done) => {
+    axios
+      .get('http://localhost:1234/')
+      .then((reponse) => {
+        expect(reponse.status).to.equal(200);
+        expect(reponse.headers['content-type']).to.contain('text/html');
+        done();
+      })
+      .catch(done);
+  });
+});

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -54,4 +54,77 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
         );
     });
   });
+
+  describe('quand requête GET sur `/initialisationMotDePasse/:idReset`', () => {
+    const uuid = '109156be-c4fb-41ea-b1b4-efe1671c5836';
+
+    describe('avec idReset valide', () => {
+      const utilisateur = {
+        id: '123',
+        genereToken: () => 'un token',
+        accepteCGU: () => false,
+      };
+
+      beforeEach(() => {
+        testeur.depotDonnees().utilisateurAFinaliser = async () => utilisateur;
+        testeur.depotDonnees().utilisateur = async () => utilisateur;
+      });
+
+      it('dépose le jeton dans un cookie', async () => {
+        let idRecu;
+        testeur.depotDonnees().utilisateurAFinaliser = async (idReset) => {
+          idRecu = idReset;
+          return utilisateur;
+        };
+
+        const reponse = await axios.get(
+          `http://localhost:1234/initialisationMotDePasse/${uuid}`
+        );
+
+        expect(idRecu).to.be(uuid);
+        await testeur.verifieJetonDepose(reponse, () => {});
+      });
+
+      it('sert le contenu HTML de la page', (done) => {
+        axios
+          .get(`http://localhost:1234/initialisationMotDePasse/${uuid}`)
+          .then((reponse) => {
+            expect(reponse.status).to.equal(200);
+            expect(reponse.headers['content-type']).to.contain('text/html');
+            done();
+          })
+          .catch(done);
+      });
+    });
+
+    it("aseptise l'identifiant reçu", (done) => {
+      testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['idReset'],
+          `http://localhost:1234/initialisationMotDePasse/${uuid}`,
+          done
+        );
+    });
+
+    it("retourne une erreur HTTP 400 sur idReset n'est pas un UUID valide", (done) => {
+      testeur.verifieRequeteGenereErreurHTTP(
+        400,
+        'UUID requis',
+        'http://localhost:1234/initialisationMotDePasse/999',
+        done
+      );
+    });
+
+    it('retourne une erreur HTTP 404 si idReset inconnu', (done) => {
+      testeur.depotDonnees().utilisateurAFinaliser = async () => {};
+
+      testeur.verifieRequeteGenereErreurHTTP(
+        404,
+        `Identifiant d'initialisation de mot de passe inconnu`,
+        `http://localhost:1234/initialisationMotDePasse/${uuid}`,
+        done
+      );
+    });
+  });
 });

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -19,6 +19,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
     '/inscription',
     '/activation',
     '/connexion',
+    '/reinitialisationMotDePasse',
   ].forEach((route) => {
     it(`sert le contenu HTML de la page ${route}`, (done) => {
       axios
@@ -38,6 +39,17 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
         .middleware()
         .verifieRequeteExigeSuppressionCookie(
           'http://localhost:1234/connexion',
+          done
+        );
+    });
+  });
+
+  describe('quand requête GET sur `/reinitialisationMotDePasse`', () => {
+    it("déconnecte l'utilisateur courant", (done) => {
+      testeur
+        .middleware()
+        .verifieRequeteExigeSuppressionCookie(
+          'http://localhost:1234/reinitialisationMotDePasse',
           done
         );
     });

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -7,14 +7,16 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
   beforeEach(testeur.initialise);
   afterEach(testeur.arrete);
 
-  it("sert la page d'accueil", (done) => {
-    axios
-      .get('http://localhost:1234/')
-      .then((reponse) => {
-        expect(reponse.status).to.equal(200);
-        expect(reponse.headers['content-type']).to.contain('text/html');
-        done();
-      })
-      .catch(done);
+  ['/', '/aPropos'].forEach((route) => {
+    it(`sert le contenu HTML de la page ${route}`, (done) => {
+      axios
+        .get(`http://localhost:1234${route}`)
+        .then((reponse) => {
+          expect(reponse.status).to.equal(200);
+          expect(reponse.headers['content-type']).to.contain('text/html');
+          done();
+        })
+        .catch(done);
+    });
   });
 });

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -7,7 +7,18 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
   beforeEach(testeur.initialise);
   afterEach(testeur.arrete);
 
-  ['/', '/aPropos'].forEach((route) => {
+  [
+    '/',
+    '/aPropos',
+    '/securite',
+    '/accessibilite',
+    '/cgu',
+    '/confidentialite',
+    '/mentionsLegales',
+    '/statistiques',
+    '/inscription',
+    '/activation',
+  ].forEach((route) => {
     it(`sert le contenu HTML de la page ${route}`, (done) => {
       axios
         .get(`http://localhost:1234${route}`)

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -18,6 +18,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
     '/statistiques',
     '/inscription',
     '/activation',
+    '/connexion',
   ].forEach((route) => {
     it(`sert le contenu HTML de la page ${route}`, (done) => {
       axios
@@ -28,6 +29,17 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
           done();
         })
         .catch(done);
+    });
+  });
+
+  describe('quand requête GET sur `/connexion`', () => {
+    it("déconnecte l'utilisateur courant", (done) => {
+      testeur
+        .middleware()
+        .verifieRequeteExigeSuppressionCookie(
+          'http://localhost:1234/connexion',
+          done
+        );
     });
   });
 });


### PR DESCRIPTION
On déplace toutes les routes "orphelines" vers les routeurs pertinents.

Au passage, on modifie l'utilisation du middleware `verificationJWT` au profit de `verificationCGUAcceptees` pour toutes les pages sauf `/motDePasse/initialisation`.

On en profite aussi pour charger l'état de la visite guidée sur toutes les pages "connectées"