### PR TITLE
[CORRECTION] Ajoute le return qui casse la chaîne de middleware

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -205,6 +205,7 @@ const middleware = (configuration = {}) => {
     reponse.locals.visiteGuideeActive = visiteGuideeActive;
     if (!visiteGuideeActive) {
       suite();
+      return;
     }
     if (!requete.idUtilisateurCourant)
       throw new ErreurChainageMiddleware(


### PR DESCRIPTION
 … dans le cas où la visite guidée n'est pas activée.
 Sinon, en cas de visite guidée désactivée, toutes les routes connectées deviennent inaccessibles.