### PR TITLE
[SOIN] Suppression du `rollback` lors d'un echec Brevo à l'inscription

### DIFF
--- a/src/routes/nonConnecte/routesNonConnecteApi.js
+++ b/src/routes/nonConnecte/routesNonConnecteApi.js
@@ -26,14 +26,10 @@ const routesNonConnecteApi = ({
     middleware.protegeTrafic(),
     middleware.aseptise(...Utilisateur.nomsProprietesBase(), 'siretEntite'),
     async (requete, reponse, suite) => {
-      const verifieSuccesEnvoiMessage = async (
-        promesseEnvoiMessage,
-        utilisateur
-      ) => {
+      const verifieSuccesEnvoiMessage = async (promesseEnvoiMessage) => {
         try {
           await promesseEnvoiMessage;
         } catch {
-          await depotDonnees.supprimeUtilisateur(utilisateur.id);
           throw new EchecEnvoiMessage();
         }
       };
@@ -46,8 +42,7 @@ const routesNonConnecteApi = ({
             utilisateur.nom ?? '',
             !utilisateur.infolettreAcceptee,
             false
-          ),
-          utilisateur
+          )
         );
       };
 
@@ -57,8 +52,7 @@ const routesNonConnecteApi = ({
             utilisateur.email,
             utilisateur.idResetMotDePasse,
             utilisateur.prenom
-          ),
-          utilisateur
+          )
         );
       };
 

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -251,24 +251,6 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
           done
         );
       });
-
-      it("supprime l'utilisateur créé", (done) => {
-        let utilisateurSupprime = false;
-        testeur.depotDonnees().supprimeUtilisateur = (id) => {
-          expect(id).to.equal('123');
-
-          utilisateurSupprime = true;
-          return Promise.resolve();
-        };
-
-        axios
-          .post('http://localhost:1234/api/utilisateur', donneesRequete)
-          .catch(() => {
-            expect(utilisateurSupprime).to.be(true);
-            done();
-          })
-          .catch(done);
-      });
     });
 
     it('envoie un email de notification de tentative de réinscription', (done) => {


### PR DESCRIPTION
On souhaite harmoniser l'inscription et l'invitation.

Dans une prochaine PR, on inversera l'ordre, afin que l'appel "fail" tout simplement si Brevo ne réponds pas.