### PR TITLE
[SOIN] Inversion de l'ordre des appels Brevo/MSS lors de la création d'un utilisateur

### DIFF
--- a/src/modeles/autorisations/ajoutContributeurSurServices.js
+++ b/src/modeles/autorisations/ajoutContributeurSurServices.js
@@ -36,11 +36,11 @@ const ajoutContributeurSurServices = ({
   };
 
   const creeUtilisateur = async (email) => {
+    await adaptateurMail.creeContact(email, '', '', true, true);
     const utilisateur = await depotDonnees.nouvelUtilisateur({
       email,
       infolettreAcceptee: false,
     });
-    await adaptateurMail.creeContact(email, '', '', true, true);
     return utilisateur;
   };
 

--- a/src/routes/nonConnecte/routesNonConnecteApi.js
+++ b/src/routes/nonConnecte/routesNonConnecteApi.js
@@ -70,8 +70,8 @@ const routesNonConnecteApi = ({
           );
       } else {
         try {
+          await creeContactEmail(donnees);
           const utilisateur = await depotDonnees.nouvelUtilisateur(donnees);
-          await creeContactEmail(utilisateur);
           await envoieMessageFinalisationInscription(utilisateur);
 
           await adaptateurTracking.envoieTrackingInscription(utilisateur.email);

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -187,11 +187,6 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
 
     it('crée un contact email', (done) => {
-      utilisateur.email = 'jean.dupont@mail.fr';
-      utilisateur.prenom = 'Jean';
-      utilisateur.nom = 'Dupont';
-      utilisateur.infolettreAcceptee = false;
-
       testeur.adaptateurMail().creeContact = (
         destinataire,
         prenom,
@@ -202,7 +197,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         expect(destinataire).to.equal('jean.dupont@mail.fr');
         expect(prenom).to.equal('Jean');
         expect(nom).to.equal('Dupont');
-        expect(bloqueEmails).to.equal(true);
+        expect(bloqueEmails).to.equal(false);
         expect(bloqueMarketing).to.be(false);
         return Promise.resolve();
       };


### PR DESCRIPTION
... à l'inscription, et lors de l'invitation d'un contributeur.

Cela permettra de "crasher" avant le création coté MSS si Brevo ne réponds pas, et donc ne pas avoir à faire un rollback.