### PR TITLE
[CORRECTION] Applique le "décodage" HTML avant de couper la chaine de caractère

### DIFF
--- a/src/routes/connecte/routesConnectePageService.js
+++ b/src/routes/connecte/routesConnectePageService.js
@@ -121,7 +121,7 @@ const routesConnectePageService = ({
           referentiel
         );
 
-        const s = decode(service.nomService().substring(0, 30));
+        const s = decode(service.nomService()).substring(0, 30);
         const date = dateYYYYMMDD(adaptateurHorloge.maintenant());
         const perimetre = avecDonneesAdditionnelles ? 'avec' : 'sans';
         const fichier = `${s} Liste mesures ${perimetre} données additionnelles ${date}.csv`;


### PR DESCRIPTION
... pour éviter de couper la chaine au milieu d'un caractère spéciale (exemple: `&#x27;`), ce qui entraine une erreur du formattage du nom de fichier.

Cette erreur a été remontée par Sentry.