### PR TITLE
[BREVO/ENTREPRISE] Relie un nouvel utilisateur à une entreprise Brevo

### DIFF
--- a/src/adaptateurs/adaptateurMailMemoire.js
+++ b/src/adaptateurs/adaptateurMailMemoire.js
@@ -1,11 +1,11 @@
 const adaptateurEnvironnement = require('./adaptateurEnvironnement');
 
 const fabriqueAdaptateurMailMemoire = () => {
-  const envoyer = (texte, args) => {
-    const doitLoguer = adaptateurEnvironnement
-      .emailMemoire()
-      .logEmailDansConsole();
+  const doitLoguer = adaptateurEnvironnement
+    .emailMemoire()
+    .logEmailDansConsole();
 
+  const envoyer = (texte, args) => {
     // eslint-disable-next-line no-console
     if (doitLoguer) console.log(texte, args);
   };
@@ -64,8 +64,42 @@ const fabriqueAdaptateurMailMemoire = () => {
     envoyer("Envoie de l'email de félicitation d'homologation", args);
   };
 
+  const recupereIdentifiantContact = async (email) => {
+    if (doitLoguer)
+      // eslint-disable-next-line no-console
+      console.log(
+        `Récupération de l'identifiant Brevo pour l'utilisateur ${email}`
+      );
+    return 42;
+  };
+
+  const recupereEntreprise = async (siret) => {
+    if (doitLoguer)
+      // eslint-disable-next-line no-console
+      console.log(`Récupération de l'entreprise Brevo pour le SIRET ${siret}`);
+  };
+
+  const relieContactAEntreprise = async (idContact, idEntreprise) => {
+    if (doitLoguer)
+      // eslint-disable-next-line no-console
+      console.log(
+        `Relie l'utilisateur ${idContact} à l'entreprise Brevo ${idEntreprise}`
+      );
+  };
+
+  const creeEntreprise = async (...args) => {
+    if (doitLoguer)
+      // eslint-disable-next-line no-console
+      console.log(
+        `Création d'une entreprise Brevo avec les paramètres: ${JSON.stringify(
+          args
+        )}`
+      );
+  };
+
   return {
     creeContact,
+    creeEntreprise,
     desinscrisEmailsTransactionnels,
     desinscrisInfolettre,
     inscrisEmailsTransactionnels,
@@ -77,6 +111,9 @@ const fabriqueAdaptateurMailMemoire = () => {
     envoieMessageReinitialisationMotDePasse,
     envoieNotificationExpirationHomologation,
     envoieNotificationTentativeReinscription,
+    recupereEntreprise,
+    recupereIdentifiantContact,
+    relieContactAEntreprise,
   };
 };
 

--- a/src/bus/abonnements/relieEntrepriseEtContactBrevo.js
+++ b/src/bus/abonnements/relieEntrepriseEtContactBrevo.js
@@ -1,0 +1,41 @@
+function relieEntrepriseEtContactBrevo({
+  adaptateurRechercheEntreprise,
+  adaptateurMail,
+}) {
+  return async ({ utilisateur }) => {
+    if (!utilisateur)
+      throw new Error(
+        "Impossible de relier une entreprise et un contact sans avoir l'utilisateur en paramètre."
+      );
+
+    if (!utilisateur.entite.siret) return;
+
+    const idUtilisateurBrevo = await adaptateurMail.recupereIdentifiantContact(
+      utilisateur.email
+    );
+
+    let idEntrepriseBrevo = await adaptateurMail.recupereEntreprise(
+      utilisateur.entite.siret
+    );
+
+    if (!idEntrepriseBrevo) {
+      const { entite } = utilisateur;
+      const entiteResponsable =
+        await adaptateurRechercheEntreprise.recupereDetailsOrganisation(
+          entite.siret
+        );
+      idEntrepriseBrevo = await adaptateurMail.creeEntreprise(
+        entite.siret,
+        entite.nom,
+        entiteResponsable.natureJuridique
+      );
+    }
+
+    await adaptateurMail.relieContactAEntreprise(
+      idUtilisateurBrevo,
+      idEntrepriseBrevo
+    );
+  };
+}
+
+module.exports = { relieEntrepriseEtContactBrevo };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -49,6 +49,9 @@ const {
 const {
   envoieMailFelicitationHomologation,
 } = require('./abonnements/envoieMailFelicitationHomologation');
+const {
+  relieEntrepriseEtContactBrevo,
+} = require('./abonnements/relieEntrepriseEtContactBrevo');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -106,6 +109,10 @@ const cableTousLesAbonnes = (
     consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal }),
     consigneProfilUtilisateurModifieDansJournal({
       adaptateurJournal,
+      adaptateurRechercheEntreprise,
+    }),
+    relieEntrepriseEtContactBrevo({
+      adaptateurMail,
       adaptateurRechercheEntreprise,
     }),
   ]);

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -1,5 +1,6 @@
 class EchecAutorisation extends Error {}
 class EchecEnvoiMessage extends Error {}
+class ErreurApiBrevo extends Error {}
 class ErreurDroitsIncoherents extends Error {}
 class ErreurChainageMiddleware extends Error {}
 class ErreurModele extends Error {}
@@ -53,6 +54,7 @@ class ErreurUtilisateurExistant extends ErreurModele {
 module.exports = {
   EchecAutorisation,
   EchecEnvoiMessage,
+  ErreurApiBrevo,
   ErreurAutorisationExisteDeja,
   ErreurAutorisationInexistante,
   ErreurAvisInvalide,

--- a/test/bus/abonnements/relieEntrepriseEtContactBrevo.spec.js
+++ b/test/bus/abonnements/relieEntrepriseEtContactBrevo.spec.js
@@ -1,0 +1,148 @@
+const expect = require('expect.js');
+const {
+  relieEntrepriseEtContactBrevo,
+} = require('../../../src/bus/abonnements/relieEntrepriseEtContactBrevo');
+const {
+  fabriqueAdaptateurMailMemoire,
+} = require('../../../src/adaptateurs/adaptateurMailMemoire');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+const fauxAdaptateurRechercheEntreprise = require('../../mocks/adaptateurRechercheEntreprise');
+
+describe("L'abonnement relie une entreprise et un contact dans Brevo", () => {
+  let adaptateurMail;
+  let adaptateurRechercheEntreprise;
+
+  beforeEach(() => {
+    adaptateurMail = fabriqueAdaptateurMailMemoire();
+    adaptateurRechercheEntreprise = fauxAdaptateurRechercheEntreprise();
+  });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await relieEntrepriseEtContactBrevo({
+        adaptateurMail,
+        adaptateurRechercheEntreprise,
+      })({
+        utilisateur: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de relier une entreprise et un contact sans avoir l'utilisateur en paramètre."
+      );
+    }
+  });
+
+  it("ne fait rien si l'utilisateur n'a pas de SIRET", async () => {
+    let adaptateurAppele = false;
+
+    adaptateurMail.recupereIdentifiantContact = async () => {
+      adaptateurAppele = true;
+    };
+
+    const utilisateur = unUtilisateur()
+      .quiTravaillePourUneEntiteAvecSiret('')
+      .construis();
+
+    await relieEntrepriseEtContactBrevo({
+      adaptateurMail,
+      adaptateurRechercheEntreprise,
+    })({
+      utilisateur,
+    });
+    expect(adaptateurAppele).to.be(false);
+  });
+
+  describe("si l'utilisateur a un SIRET", () => {
+    let utilisateur;
+
+    beforeEach(() => {
+      utilisateur = unUtilisateur()
+        .avecEmail('jean.dujardin@beta.gouv.com')
+        .quiTravaillePourUneEntiteAvecSiret('1234')
+        .avecNomEntite('MonServiceSécurisé')
+        .construis();
+      adaptateurMail.recupereIdentifiantContact = async () => 'C1';
+    });
+
+    it("recupère l'identifiant Brevo de l'utilisateur via son email", async () => {
+      let emailRecu;
+
+      adaptateurMail.recupereIdentifiantContact = async (email) => {
+        emailRecu = email;
+      };
+
+      await relieEntrepriseEtContactBrevo({
+        adaptateurMail,
+        adaptateurRechercheEntreprise,
+      })({
+        utilisateur,
+      });
+      expect(emailRecu).to.be('jean.dujardin@beta.gouv.com');
+    });
+
+    it("vérifie si l'entreprise existe déjà sur Brevo via son SIRET", async () => {
+      let siretRecu;
+
+      adaptateurMail.recupereEntreprise = async (siret) => {
+        siretRecu = siret;
+      };
+
+      await relieEntrepriseEtContactBrevo({
+        adaptateurMail,
+        adaptateurRechercheEntreprise,
+      })({
+        utilisateur,
+      });
+      expect(siretRecu).to.be('1234');
+    });
+
+    describe("si l'entreprise n'existe pas", () => {
+      it("créé l'entreprise", async () => {
+        let donneesRecuesCreationEntreprise;
+
+        adaptateurRechercheEntreprise.recupereDetailsOrganisation =
+          async () => ({
+            natureJuridique: 'NatureJuridique',
+          });
+        adaptateurMail.recupereEntreprise = async () => null;
+        adaptateurMail.creeEntreprise = async (siret, nom, natureJuridique) => {
+          donneesRecuesCreationEntreprise = { siret, nom, natureJuridique };
+          return 'E1';
+        };
+
+        await relieEntrepriseEtContactBrevo({
+          adaptateurMail,
+          adaptateurRechercheEntreprise,
+        })({
+          utilisateur,
+        });
+        expect(donneesRecuesCreationEntreprise).to.eql({
+          siret: '1234',
+          nom: 'MonServiceSécurisé',
+          natureJuridique: 'NatureJuridique',
+        });
+      });
+    });
+
+    it("relie l'utilisateur à l'entreprise", async () => {
+      let donneesRecues;
+
+      adaptateurMail.recupereEntreprise = async () => 'E1';
+      adaptateurMail.relieContactAEntreprise = async (
+        idContact,
+        idEntreprise
+      ) => {
+        donneesRecues = { idContact, idEntreprise };
+      };
+
+      await relieEntrepriseEtContactBrevo({ adaptateurMail })({
+        utilisateur,
+      });
+      expect(donneesRecues.idContact).to.be('C1');
+      expect(donneesRecues.idEntreprise).to.be('E1');
+    });
+  });
+});


### PR DESCRIPTION
Lors de l'inscription d'un nouvel utilisateur, on veut le relier à une `Entreprise` coté Brevo.

Le scenario est le suivant :

```mermaid
graph TB
A[Nouvel Utilisateur Inscrit] --> B{Possède une entité ?}
B -. Oui (Inscription volontaire) .-> C[Recupère ID Contact Brevo]
C --> D["Recupère ID Entreprise Brevo via SIRET (via SIRET)"]
D --> E{Entreprise existe ?}
E -. Oui .-> F[Relie contact à entreprise]
E -. Non .-> G["Créé entreprise Brevo (SIRET, nom, nature juridique)"]
G --> F
B -. Non (Invitation) .-> Z["🛑 Ne fait rien"]

classDef mss fill:#0079d0,stroke:#0079d0,stroke-width:2px;
classDef brevo fill:#0c996e,stroke:#d3fec9,stroke-width:2px;
classDef stop stroke:#ff6584,stroke-width:2px;
class A mss
class C,D,G,F brevo
class Z stop
```

On ajoute donc un nouvel abonné `relieEntrepriseEtContactBrevo`.

Cet abonné pourra évoluer pour la partie "Mise à jour" d'un utilisateur, en s'assurant qu'on supprime le lien actuel entre l'utilisateur et l'entreprise, avant de recréer un lien.

> [!WARNING]  
> Bien que cette PR ne dépendent pas directement des PRs #1466 et #1467, il faudra la merger **APRÈS** pour s'assurer que l'appel de création de contact vers Brevo est bien fait **AVANT** la création de l'entreprise