### PR TITLE
[BREVO/ENTREPRISE] Modifie l'entreprise de l'utilisateur dans Brevo lors de la modification de son profil

### DIFF
--- a/src/adaptateurs/adaptateurMailMemoire.js
+++ b/src/adaptateurs/adaptateurMailMemoire.js
@@ -79,11 +79,30 @@ const fabriqueAdaptateurMailMemoire = () => {
       console.log(`Récupération de l'entreprise Brevo pour le SIRET ${siret}`);
   };
 
+  const recupereEntrepriseDuContact = async (idContact) => {
+    if (doitLoguer)
+      // eslint-disable-next-line no-console
+      console.log(
+        `Récupération de l'entreprise Brevo pour le contact ${idContact}`
+      );
+  };
+
   const relieContactAEntreprise = async (idContact, idEntreprise) => {
     if (doitLoguer)
       // eslint-disable-next-line no-console
       console.log(
         `Relie l'utilisateur ${idContact} à l'entreprise Brevo ${idEntreprise}`
+      );
+  };
+
+  const supprimeLienEntreContactEtEntreprise = async (
+    idContact,
+    idEntreprise
+  ) => {
+    if (doitLoguer)
+      // eslint-disable-next-line no-console
+      console.log(
+        `Supprime le lien entre l'utilisateur ${idContact} à l'entreprise Brevo ${idEntreprise}`
       );
   };
 
@@ -112,8 +131,10 @@ const fabriqueAdaptateurMailMemoire = () => {
     envoieNotificationExpirationHomologation,
     envoieNotificationTentativeReinscription,
     recupereEntreprise,
+    recupereEntrepriseDuContact,
     recupereIdentifiantContact,
     relieContactAEntreprise,
+    supprimeLienEntreContactEtEntreprise,
   };
 };
 

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -239,10 +239,34 @@ const recupereEntreprise = async (siret) => {
   return idEntreprise ?? null;
 };
 
+const recupereEntrepriseDuContact = async (idContact) => {
+  const reponse = await axios.get(
+    `${urlBase}/companies?linkedContactsIds=${idContact}`,
+    enteteJSON
+  );
+  if (reponse?.data?.items.length > 1)
+    throw new ErreurApiBrevo(
+      `Plusieurs entreprise pour le contact: ${idContact}`
+    );
+  const idEntreprise = reponse?.data?.items[0]?.id;
+  return idEntreprise ?? null;
+};
+
 const relieContactAEntreprise = async (idContact, idEntreprise) => {
   await axios.patch(
     `${urlBase}/companies/link-unlink/${idEntreprise}`,
     { linkContactIds: [idContact] },
+    enteteJSON
+  );
+};
+
+const supprimeLienEntreContactEtEntreprise = async (
+  idContact,
+  idEntreprise
+) => {
+  await axios.patch(
+    `${urlBase}/companies/link-unlink/${idEntreprise}`,
+    { unlinkContactIds: [idContact] },
     enteteJSON
   );
 };
@@ -286,6 +310,8 @@ module.exports = {
   envoieNotificationExpirationHomologation,
   envoieNotificationTentativeReinscription,
   recupereEntreprise,
+  recupereEntrepriseDuContact,
   recupereIdentifiantContact,
   relieContactAEntreprise,
+  supprimeLienEntreContactEtEntreprise,
 };

--- a/src/bus/abonnements/modifieLienEntrepriseEtContactBrevo.js
+++ b/src/bus/abonnements/modifieLienEntrepriseEtContactBrevo.js
@@ -1,0 +1,8 @@
+function modifieLienEntrepriseEtContactBrevo({ crmBrevo }) {
+  return async ({ utilisateur }) => {
+    await crmBrevo.supprimerLienEntrepriseContact(utilisateur);
+    await crmBrevo.creerLienEntrepriseContact(utilisateur);
+  };
+}
+
+module.exports = { modifieLienEntrepriseEtContactBrevo };

--- a/src/bus/abonnements/relieEntrepriseEtContactBrevo.js
+++ b/src/bus/abonnements/relieEntrepriseEtContactBrevo.js
@@ -1,40 +1,6 @@
-function relieEntrepriseEtContactBrevo({
-  adaptateurRechercheEntreprise,
-  adaptateurMail,
-}) {
+function relieEntrepriseEtContactBrevo({ crmBrevo }) {
   return async ({ utilisateur }) => {
-    if (!utilisateur)
-      throw new Error(
-        "Impossible de relier une entreprise et un contact sans avoir l'utilisateur en paramètre."
-      );
-
-    if (!utilisateur.entite.siret) return;
-
-    const idUtilisateurBrevo = await adaptateurMail.recupereIdentifiantContact(
-      utilisateur.email
-    );
-
-    let idEntrepriseBrevo = await adaptateurMail.recupereEntreprise(
-      utilisateur.entite.siret
-    );
-
-    if (!idEntrepriseBrevo) {
-      const { entite } = utilisateur;
-      const entiteResponsable =
-        await adaptateurRechercheEntreprise.recupereDetailsOrganisation(
-          entite.siret
-        );
-      idEntrepriseBrevo = await adaptateurMail.creeEntreprise(
-        entite.siret,
-        entite.nom,
-        entiteResponsable.natureJuridique
-      );
-    }
-
-    await adaptateurMail.relieContactAEntreprise(
-      idUtilisateurBrevo,
-      idEntrepriseBrevo
-    );
+    await crmBrevo.creerLienEntrepriseContact(utilisateur);
   };
 }
 

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -52,6 +52,7 @@ const {
 const {
   relieEntrepriseEtContactBrevo,
 } = require('./abonnements/relieEntrepriseEtContactBrevo');
+const CrmBrevo = require('../crm/crmBrevo');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -65,6 +66,11 @@ const cableTousLesAbonnes = (
     referentiel,
   }
 ) => {
+  const crmBrevo = new CrmBrevo({
+    adaptateurRechercheEntreprise,
+    adaptateurMail,
+  });
+
   busEvenements.abonnePlusieurs(EvenementNouveauServiceCree, [
     consigneNouveauServiceDansJournal({ adaptateurJournal }),
     consigneProprietaireCreeUnServiceDansJournal({ adaptateurJournal }),
@@ -111,10 +117,7 @@ const cableTousLesAbonnes = (
       adaptateurJournal,
       adaptateurRechercheEntreprise,
     }),
-    relieEntrepriseEtContactBrevo({
-      adaptateurMail,
-      adaptateurRechercheEntreprise,
-    }),
+    relieEntrepriseEtContactBrevo({ crmBrevo }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementDossierHomologationFinalise, [

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -53,6 +53,9 @@ const {
   relieEntrepriseEtContactBrevo,
 } = require('./abonnements/relieEntrepriseEtContactBrevo');
 const CrmBrevo = require('../crm/crmBrevo');
+const {
+  modifieLienEntrepriseEtContactBrevo,
+} = require('./abonnements/modifieLienEntrepriseEtContactBrevo');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -103,13 +106,13 @@ const cableTousLesAbonnes = (
     consigneAutorisationsModifieesDansJournal({ adaptateurJournal })
   );
 
-  busEvenements.abonne(
-    EvenementUtilisateurModifie,
+  busEvenements.abonnePlusieurs(EvenementUtilisateurModifie, [
     consigneProfilUtilisateurModifieDansJournal({
       adaptateurJournal,
       adaptateurRechercheEntreprise,
-    })
-  );
+    }),
+    modifieLienEntrepriseEtContactBrevo({ crmBrevo }),
+  ]);
 
   busEvenements.abonnePlusieurs(EvenementUtilisateurInscrit, [
     consigneNouvelUtilisateurInscritDansJournal({ adaptateurJournal }),

--- a/src/crm/crmBrevo.js
+++ b/src/crm/crmBrevo.js
@@ -7,6 +7,25 @@ class CrmBrevo {
     this.adaptateurMail = adaptateurMail;
   }
 
+  async supprimerLienEntrepriseContact(utilisateur) {
+    if (!utilisateur)
+      throw new Error(
+        "Impossible de relier une entreprise et un contact sans avoir l'utilisateur en paramètre."
+      );
+    const idUtilisateurBrevo =
+      await this.adaptateurMail.recupereIdentifiantContact(utilisateur.email);
+
+    const idEntreprise =
+      await this.adaptateurMail.recupereEntrepriseDuContact(idUtilisateurBrevo);
+
+    if (idEntreprise) {
+      await this.adaptateurMail.supprimeLienEntreContactEtEntreprise(
+        idUtilisateurBrevo,
+        idEntreprise
+      );
+    }
+  }
+
   async creerLienEntrepriseContact(utilisateur) {
     if (!utilisateur)
       throw new Error(

--- a/src/crm/crmBrevo.js
+++ b/src/crm/crmBrevo.js
@@ -1,0 +1,45 @@
+class CrmBrevo {
+  constructor({ adaptateurRechercheEntreprise, adaptateurMail }) {
+    if (!adaptateurRechercheEntreprise || !adaptateurMail) {
+      throw new Error("Impossible d'instancier le CRM sans adaptateurs");
+    }
+    this.adaptateurRechercheEntreprise = adaptateurRechercheEntreprise;
+    this.adaptateurMail = adaptateurMail;
+  }
+
+  async creerLienEntrepriseContact(utilisateur) {
+    if (!utilisateur)
+      throw new Error(
+        "Impossible de relier une entreprise et un contact sans avoir l'utilisateur en paramètre."
+      );
+
+    if (!utilisateur.entite.siret) return;
+
+    const idUtilisateurBrevo =
+      await this.adaptateurMail.recupereIdentifiantContact(utilisateur.email);
+
+    let idEntrepriseBrevo = await this.adaptateurMail.recupereEntreprise(
+      utilisateur.entite.siret
+    );
+
+    if (!idEntrepriseBrevo) {
+      const { entite } = utilisateur;
+      const entiteResponsable =
+        await this.adaptateurRechercheEntreprise.recupereDetailsOrganisation(
+          entite.siret
+        );
+      idEntrepriseBrevo = await this.adaptateurMail.creeEntreprise(
+        entite.siret,
+        entite.nom,
+        entiteResponsable.natureJuridique
+      );
+    }
+
+    await this.adaptateurMail.relieContactAEntreprise(
+      idUtilisateurBrevo,
+      idEntrepriseBrevo
+    );
+  }
+}
+
+module.exports = CrmBrevo;

--- a/test/bus/abonnements/modifieLienEntrepriseEtContactBrevo.spec.js
+++ b/test/bus/abonnements/modifieLienEntrepriseEtContactBrevo.spec.js
@@ -1,0 +1,38 @@
+const expect = require('expect.js');
+const {
+  modifieLienEntrepriseEtContactBrevo,
+} = require('../../../src/bus/abonnements/modifieLienEntrepriseEtContactBrevo');
+
+describe("L'abonnement aui modifie le lien entre une entreprise et un contact dans Brevo", () => {
+  let crmBrevo;
+  beforeEach(() => {
+    crmBrevo = {
+      creerLienEntrepriseContact: async () => ({}),
+      supprimerLienEntrepriseContact: async () => ({}),
+    };
+  });
+
+  it('délègue au CRM Brevo la suppression du lien existant entre utilisateur et entreprise', async () => {
+    let utilisateurRecu;
+    crmBrevo.supprimerLienEntrepriseContact = async (utilisateur) => {
+      utilisateurRecu = utilisateur;
+    };
+    const utilisateur = { id: '123' };
+
+    await modifieLienEntrepriseEtContactBrevo({ crmBrevo })({ utilisateur });
+
+    expect(utilisateurRecu.id).to.eql('123');
+  });
+
+  it('délègue au CRM Brevo la création du lien entre utilisateur et entreprise', async () => {
+    let utilisateurRecu;
+    crmBrevo.creerLienEntrepriseContact = async (utilisateur) => {
+      utilisateurRecu = utilisateur;
+    };
+    const utilisateur = { id: '123' };
+
+    await modifieLienEntrepriseEtContactBrevo({ crmBrevo })({ utilisateur });
+
+    expect(utilisateurRecu.id).to.eql('123');
+  });
+});

--- a/test/bus/abonnements/relieEntrepriseEtContactBrevo.spec.js
+++ b/test/bus/abonnements/relieEntrepriseEtContactBrevo.spec.js
@@ -2,147 +2,19 @@ const expect = require('expect.js');
 const {
   relieEntrepriseEtContactBrevo,
 } = require('../../../src/bus/abonnements/relieEntrepriseEtContactBrevo');
-const {
-  fabriqueAdaptateurMailMemoire,
-} = require('../../../src/adaptateurs/adaptateurMailMemoire');
-const {
-  unUtilisateur,
-} = require('../../constructeurs/constructeurUtilisateur');
-const fauxAdaptateurRechercheEntreprise = require('../../mocks/adaptateurRechercheEntreprise');
 
 describe("L'abonnement relie une entreprise et un contact dans Brevo", () => {
-  let adaptateurMail;
-  let adaptateurRechercheEntreprise;
-
-  beforeEach(() => {
-    adaptateurMail = fabriqueAdaptateurMailMemoire();
-    adaptateurRechercheEntreprise = fauxAdaptateurRechercheEntreprise();
-  });
-
-  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
-    try {
-      await relieEntrepriseEtContactBrevo({
-        adaptateurMail,
-        adaptateurRechercheEntreprise,
-      })({
-        utilisateur: null,
-      });
-      expect().fail("L'instanciation aurait dû lever une exception.");
-    } catch (e) {
-      expect(e.message).to.be(
-        "Impossible de relier une entreprise et un contact sans avoir l'utilisateur en paramètre."
-      );
-    }
-  });
-
-  it("ne fait rien si l'utilisateur n'a pas de SIRET", async () => {
-    let adaptateurAppele = false;
-
-    adaptateurMail.recupereIdentifiantContact = async () => {
-      adaptateurAppele = true;
+  it('délègue au CRM Brevo la création du lien entre utilisateur et entreprise', async () => {
+    let utilisateurRecu;
+    const crmBrevo = {
+      creerLienEntrepriseContact: async (utilisateur) => {
+        utilisateurRecu = utilisateur;
+      },
     };
+    const utilisateur = { id: '123' };
 
-    const utilisateur = unUtilisateur()
-      .quiTravaillePourUneEntiteAvecSiret('')
-      .construis();
+    await relieEntrepriseEtContactBrevo({ crmBrevo })({ utilisateur });
 
-    await relieEntrepriseEtContactBrevo({
-      adaptateurMail,
-      adaptateurRechercheEntreprise,
-    })({
-      utilisateur,
-    });
-    expect(adaptateurAppele).to.be(false);
-  });
-
-  describe("si l'utilisateur a un SIRET", () => {
-    let utilisateur;
-
-    beforeEach(() => {
-      utilisateur = unUtilisateur()
-        .avecEmail('jean.dujardin@beta.gouv.com')
-        .quiTravaillePourUneEntiteAvecSiret('1234')
-        .avecNomEntite('MonServiceSécurisé')
-        .construis();
-      adaptateurMail.recupereIdentifiantContact = async () => 'C1';
-    });
-
-    it("recupère l'identifiant Brevo de l'utilisateur via son email", async () => {
-      let emailRecu;
-
-      adaptateurMail.recupereIdentifiantContact = async (email) => {
-        emailRecu = email;
-      };
-
-      await relieEntrepriseEtContactBrevo({
-        adaptateurMail,
-        adaptateurRechercheEntreprise,
-      })({
-        utilisateur,
-      });
-      expect(emailRecu).to.be('jean.dujardin@beta.gouv.com');
-    });
-
-    it("vérifie si l'entreprise existe déjà sur Brevo via son SIRET", async () => {
-      let siretRecu;
-
-      adaptateurMail.recupereEntreprise = async (siret) => {
-        siretRecu = siret;
-      };
-
-      await relieEntrepriseEtContactBrevo({
-        adaptateurMail,
-        adaptateurRechercheEntreprise,
-      })({
-        utilisateur,
-      });
-      expect(siretRecu).to.be('1234');
-    });
-
-    describe("si l'entreprise n'existe pas", () => {
-      it("créé l'entreprise", async () => {
-        let donneesRecuesCreationEntreprise;
-
-        adaptateurRechercheEntreprise.recupereDetailsOrganisation =
-          async () => ({
-            natureJuridique: 'NatureJuridique',
-          });
-        adaptateurMail.recupereEntreprise = async () => null;
-        adaptateurMail.creeEntreprise = async (siret, nom, natureJuridique) => {
-          donneesRecuesCreationEntreprise = { siret, nom, natureJuridique };
-          return 'E1';
-        };
-
-        await relieEntrepriseEtContactBrevo({
-          adaptateurMail,
-          adaptateurRechercheEntreprise,
-        })({
-          utilisateur,
-        });
-        expect(donneesRecuesCreationEntreprise).to.eql({
-          siret: '1234',
-          nom: 'MonServiceSécurisé',
-          natureJuridique: 'NatureJuridique',
-        });
-      });
-    });
-
-    it("relie l'utilisateur à l'entreprise", async () => {
-      let donneesRecues;
-
-      adaptateurMail.recupereEntreprise = async () => 'E1';
-      adaptateurMail.relieContactAEntreprise = async (
-        idContact,
-        idEntreprise
-      ) => {
-        donneesRecues = { idContact, idEntreprise };
-      };
-
-      await relieEntrepriseEtContactBrevo({ adaptateurMail })({
-        utilisateur,
-      });
-      expect(donneesRecues.idContact).to.be('C1');
-      expect(donneesRecues.idEntreprise).to.be('E1');
-    });
+    expect(utilisateurRecu.id).to.eql('123');
   });
 });

--- a/test/crm/crmBrevo.spec.js
+++ b/test/crm/crmBrevo.spec.js
@@ -1,0 +1,141 @@
+const expect = require('expect.js');
+const CrmBrevo = require('../../src/crm/crmBrevo');
+const {
+  fabriqueAdaptateurMailMemoire,
+} = require('../../src/adaptateurs/adaptateurMailMemoire');
+const fauxAdaptateurRechercheEntreprise = require('../mocks/adaptateurRechercheEntreprise');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+
+describe('Le CRM Brevo', () => {
+  it("jette une erreur s'il n'est pas instancié avec les bons adaptateurs", () => {
+    expect(() => new CrmBrevo({})).to.throwError((e) => {
+      expect(e.message).to.be(
+        "Impossible d'instancier le CRM sans adaptateurs"
+      );
+    });
+  });
+  describe('sur demande de création du lien entre un utilisateur et son entreprise', () => {
+    let adaptateurMail;
+    let adaptateurRechercheEntreprise;
+    let crmBrevo;
+
+    beforeEach(() => {
+      adaptateurMail = fabriqueAdaptateurMailMemoire();
+      adaptateurRechercheEntreprise = fauxAdaptateurRechercheEntreprise();
+      crmBrevo = new CrmBrevo({
+        adaptateurRechercheEntreprise,
+        adaptateurMail,
+      });
+    });
+
+    it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+      try {
+        await crmBrevo.creerLienEntrepriseContact(null);
+
+        expect().fail("L'instanciation aurait dû lever une exception.");
+      } catch (e) {
+        expect(e.message).to.be(
+          "Impossible de relier une entreprise et un contact sans avoir l'utilisateur en paramètre."
+        );
+      }
+    });
+
+    it("ne fait rien si l'utilisateur n'a pas de SIRET", async () => {
+      let adaptateurAppele = false;
+
+      adaptateurMail.recupereIdentifiantContact = async () => {
+        adaptateurAppele = true;
+      };
+
+      const utilisateur = unUtilisateur()
+        .quiTravaillePourUneEntiteAvecSiret('')
+        .construis();
+
+      await crmBrevo.creerLienEntrepriseContact(utilisateur);
+
+      expect(adaptateurAppele).to.be(false);
+    });
+
+    describe("si l'utilisateur a un SIRET", () => {
+      let utilisateur;
+
+      beforeEach(() => {
+        utilisateur = unUtilisateur()
+          .avecEmail('jean.dujardin@beta.gouv.com')
+          .quiTravaillePourUneEntiteAvecSiret('1234')
+          .avecNomEntite('MonServiceSécurisé')
+          .construis();
+        adaptateurMail.recupereIdentifiantContact = async () => 'C1';
+      });
+
+      it("recupère l'identifiant Brevo de l'utilisateur via son email", async () => {
+        let emailRecu;
+
+        adaptateurMail.recupereIdentifiantContact = async (email) => {
+          emailRecu = email;
+        };
+
+        await crmBrevo.creerLienEntrepriseContact(utilisateur);
+
+        expect(emailRecu).to.be('jean.dujardin@beta.gouv.com');
+      });
+
+      it("vérifie si l'entreprise existe déjà sur Brevo via son SIRET", async () => {
+        let siretRecu;
+
+        adaptateurMail.recupereEntreprise = async (siret) => {
+          siretRecu = siret;
+        };
+
+        await crmBrevo.creerLienEntrepriseContact(utilisateur);
+
+        expect(siretRecu).to.be('1234');
+      });
+
+      describe("si l'entreprise n'existe pas", () => {
+        it("créé l'entreprise", async () => {
+          let donneesRecuesCreationEntreprise;
+
+          adaptateurRechercheEntreprise.recupereDetailsOrganisation =
+            async () => ({
+              natureJuridique: 'NatureJuridique',
+            });
+          adaptateurMail.recupereEntreprise = async () => null;
+          adaptateurMail.creeEntreprise = async (
+            siret,
+            nom,
+            natureJuridique
+          ) => {
+            donneesRecuesCreationEntreprise = { siret, nom, natureJuridique };
+            return 'E1';
+          };
+
+          await crmBrevo.creerLienEntrepriseContact(utilisateur);
+
+          expect(donneesRecuesCreationEntreprise).to.eql({
+            siret: '1234',
+            nom: 'MonServiceSécurisé',
+            natureJuridique: 'NatureJuridique',
+          });
+        });
+      });
+
+      it("relie l'utilisateur à l'entreprise", async () => {
+        let donneesRecues;
+
+        adaptateurMail.recupereEntreprise = async () => 'E1';
+        adaptateurMail.relieContactAEntreprise = async (
+          idContact,
+          idEntreprise
+        ) => {
+          donneesRecues = { idContact, idEntreprise };
+        };
+
+        await crmBrevo.creerLienEntrepriseContact(utilisateur);
+
+        expect(donneesRecues.idContact).to.be('C1');
+        expect(donneesRecues.idEntreprise).to.be('E1');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Pour cela, on vérifie d'abord si l'utilisateur a une entreprise dans Brevo, et si oui, on "délie" l'utilisateur de l'entreprise.

On exécute ensuite le même code que pour la liaison faite au moment de l'inscription. 
Pour mutualisé le code, on créé une classe `CrmBrevo` qui contient les méthodes utiles. 