### PR TITLE
[CORRECTION] Affichage des mesures en mode "visite guidée"

### DIFF
--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -21,7 +21,8 @@ $(() => {
         statuts,
         idService,
         estLectureSeule,
-        modeVisiteGuidee: etatVisiteGuidee.dejaTerminee === false,
+        modeVisiteGuidee:
+          etatVisiteGuidee.dejaTerminee === false && !etatVisiteGuidee.enPause,
       },
     })
   );


### PR DESCRIPTION
Car on ne vérifiais pas si la visite guidée était en pause. Il était donc possible de :
- Démarrer la visite guidée
- La mettre en pause
- Se rendre sur la page "Sécuriser" d'un service
- Voir apparaître les mesures "factices" de la visite guidée