### PR TITLE
[CORRECTION] Ajoute une `ellipsis` si l'adresse email d'un contributeur est trop longue

### DIFF
--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -1,6 +1,7 @@
 .tiroir {
   height: 100%;
   min-width: 33em;
+  max-width: 33em;
   position: fixed;
   left: 100vw;
   top: 0;

--- a/svelte/lib/gestionContributeurs/invitation/ListeInvitations.svelte
+++ b/svelte/lib/gestionContributeurs/invitation/ListeInvitations.svelte
@@ -36,7 +36,7 @@
           valeur={utilisateur.initiales}
           resumeNiveauDroit={resumeLesDroits(droits)}
         />
-        <span>{@html utilisateur.prenomNom}</span>
+        <span class="prenom-nom">{@html utilisateur.prenomNom}</span>
       </div>
       <div class="conteneur-actions">
         <TagNiveauDroit
@@ -73,5 +73,11 @@
     align-items: center;
     gap: 8px;
     font-weight: 500;
+    overflow: hidden;
+  }
+
+  .prenom-nom {
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 </style>


### PR DESCRIPTION
Pour éviter les débordements de tiroir :

| Avant | Après |
|--------|--------|
| ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/6638b5e7-fece-4afe-9020-5ba1c4e761cd) | ![image](https://github.com/betagouv/mon-service-securise/assets/1643465/017d1085-3084-4b54-91bf-72911f3fd6cd) |