### PR TITLE
[WORDING] N'affiche pas de durée d'homologation conseillée avec un indice cyber inférieur à 2

### DIFF
--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -60,6 +60,7 @@ block zone-principale
       .conteneur-duree-recommandee
         if(trancheIndiceCyber.conseilHomologation)
           p= trancheIndiceCyber.conseilHomologation
+        if(!trancheIndiceCyber.deconseillee)
           .separateur
-        p= `Durée d'homologation conseillée ${trancheIndiceCyber.deconseillee ? "en cas de décision d'homologation" : ""}`
-        p#duree-recommandee= trancheIndiceCyber.dureeHomologationConseillee
+          p Durée d'homologation conseillée
+          p#duree-recommandee= trancheIndiceCyber.dureeHomologationConseillee


### PR DESCRIPTION
Pour montrer que l'ANSSI ne recommande pas l'homologation