### PR TITLE
[INSCRIPTION/PROFIL] Ajout de la question sur l'estimation du nombre de services

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -52,6 +52,14 @@ module.exports = {
     { label: 'plus de 5 000', borneBasse: 5001, borneHaute: 5001 },
   ],
 
+  estimationNombreServices: [
+    { label: '1 à 10', borneBasse: 1, borneHaute: 10 },
+    { label: '10 à 49', borneBasse: 10, borneHaute: 49 },
+    { label: '50 à 99', borneBasse: 50, borneHaute: 99 },
+    { label: '+ de 100', borneBasse: 100, borneHaute: 100 },
+    { label: 'Je ne sais pas', borneBasse: -1, borneHaute: -1 },
+  ],
+
   tranchesIndicesCybers: [
     {
       borneInferieure: 0,

--- a/migrations/20240528090117_ajoutEstimationNombreServicesVideUtilisateur.js
+++ b/migrations/20240528090117_ajoutEstimationNombreServicesVideUtilisateur.js
@@ -1,0 +1,17 @@
+exports.up = async (knex) => {
+  const utilisateurs = await knex('utilisateurs');
+  const misesAJour = utilisateurs.map(({ id, donnees }) => {
+    donnees.estimationNombreServices = { borneBasse: '0', borneHaute: '0' };
+    return knex('utilisateurs').where({ id }).update({ donnees });
+  });
+  await Promise.all(misesAJour);
+};
+
+exports.down = async (knex) => {
+  const utilisateurs = await knex('utilisateurs');
+  const misesAJour = utilisateurs.map(({ id, donnees }) => {
+    delete donnees.estimationNombreServices;
+    return knex('utilisateurs').where({ id }).update({ donnees });
+  });
+  await Promise.all(misesAJour);
+};

--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -416,13 +416,21 @@ button.bouton.en-cours-chargement::before {
   cursor: pointer;
 }
 
-form.homologation label p.description:first-of-type {
+.requis label p.description:first-of-type {
   margin-top: 8px;
 }
 
-form.homologation label p.description {
+.requis label p.description:last-of-type {
+  margin-bottom: 16px;
+}
+
+.requis label p.description {
   font-weight: normal;
   font-size: 0.9em;
   margin: 0;
   color: var(--texte-fonce);
+}
+
+select#estimation-nombre-services {
+  appearance: auto;
 }

--- a/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
+++ b/public/modules/interactions/brancheSoumissionFormulaireUtilisateur.js
@@ -44,6 +44,12 @@ const brancheSoumissionFormulaireUtilisateur = (
     email: () => $('#email').val(),
     telephone: () => $('#telephone').val(),
     siretEntite: () => $('#siretEntite').val(),
+    estimationNombreServices: () => {
+      const [borneBasse, borneHaute] = $('#estimation-nombre-services')
+        .val()
+        .split('_');
+      return { borneBasse, borneHaute };
+    },
     motDePasse: () => $('#mot-de-passe').val(),
     cguAcceptees: () => reponseAcceptee('cguAcceptees'),
     infolettreAcceptee: () => $('#infolettreAcceptee').is(':checked'),

--- a/public/tableauDeBord.js
+++ b/public/tableauDeBord.js
@@ -11,10 +11,26 @@ const afficheBandeauMajProfil = () =>
       if (completudeProfil.estComplet) {
         return;
       }
-      if (completudeProfil.champsNonRenseignes.includes('nom')) {
-        $('#bandeau-profil').removeClass('invisible');
-      } else if (completudeProfil.champsNonRenseignes.includes('siret')) {
+      if (completudeProfil.champsNonRenseignes.includes('siret')) {
         $('#bandeau-siret').removeClass('invisible');
+        return;
+      }
+
+      const autresChamps = {
+        nom: { ancre: 'nom' },
+        estimationNombreServices: { ancre: 'estimation-nombre-services' },
+      };
+      const premierChampManquant = completudeProfil.champsNonRenseignes.find(
+        (c) => Object.keys(autresChamps).includes(c)
+      );
+      if (premierChampManquant) {
+        const $bandeau = $('#bandeau-profil');
+        const lien = $bandeau.attr('href');
+        $bandeau.attr(
+          'href',
+          `${lien}#${autresChamps[premierChampManquant].ancre}`
+        );
+        $bandeau.removeClass('invisible');
       }
     });
 

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -27,6 +27,7 @@ class Utilisateur extends Base {
         'postes',
         'infolettreAcceptee',
         'transactionnelAccepte',
+        'estimationNombreServices',
       ],
     });
     valide(donnees);
@@ -81,7 +82,7 @@ class Utilisateur extends Base {
       validePresenceProprietes(['email']);
     }
     validePresenceProprietes(['prenom', 'nom']);
-    validePresenceProprietesObjet(['entite']);
+    validePresenceProprietesObjet(['entite', 'estimationNombreServices']);
     Entite.valideDonnees(donnees.entite);
     validePresenceProprietesBooleenes([
       'infolettreAcceptee',

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -101,6 +101,7 @@ class Utilisateur extends Base {
       'infolettreAcceptee',
       'transactionnelAccepte',
       'postes.*',
+      'estimationNombreServices.*',
     ];
   }
 

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -143,13 +143,22 @@ class Utilisateur extends Base {
   completudeProfil() {
     const nomEstRenseigne = (this.nom?.trim() ?? '') !== '';
     const siretEstRenseigne = (this.entite?.siret ?? '') !== '';
-    const estComplet = nomEstRenseigne && siretEstRenseigne;
+    const estimationNombreServicesEstRenseigne =
+      (this.estimationNombreServices?.borneBasse ?? '0') !== '0' &&
+      (this.estimationNombreServices?.borneHaute ?? '0') !== '0';
+    const estComplet =
+      nomEstRenseigne &&
+      siretEstRenseigne &&
+      estimationNombreServicesEstRenseigne;
     const champsNonRenseignes = [];
     if (!nomEstRenseigne) {
       champsNonRenseignes.push('nom');
     }
     if (!siretEstRenseigne) {
       champsNonRenseignes.push('siret');
+    }
+    if (!estimationNombreServicesEstRenseigne) {
+      champsNonRenseignes.push('estimationNombreServices');
     }
     return { estComplet, champsNonRenseignes };
   }

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -25,6 +25,7 @@ const donneesReferentielVide = {
   statutsMesures: {},
   tranchesIndicesCybers: [],
   nombreOrganisationsUtilisatrices: [],
+  estimationNombreServices: [],
   etapesVisiteGuidee: [],
 };
 
@@ -131,6 +132,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     );
   const nombreOrganisationsUtilisatrices = () =>
     donnees.nombreOrganisationsUtilisatrices || [];
+  const estimationNombreServices = () => donnees.estimationNombreServices || [];
 
   const coefficientIndiceCyberMesuresIndispensables = () =>
     donnees.indiceCyber?.coefficientIndispensables || 0.5;
@@ -322,6 +324,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     estIdentifiantEcheanceRenouvellementConnu,
     estIdentifiantMesureConnu,
     estIdentifiantStatutAvisDossierHomologationConnu,
+    estimationNombreServices,
     etapeDossierAutorisee,
     etapeExiste,
     etapesParcoursHomologation,

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -51,11 +51,13 @@ const routesConnectePage = ({
     (requete, reponse) => {
       const departements = referentiel.departements();
       const idUtilisateur = requete.idUtilisateurCourant;
-      depotDonnees
-        .utilisateur(idUtilisateur)
-        .then((utilisateur) =>
-          reponse.render('utilisateur/edition', { utilisateur, departements })
-        );
+      depotDonnees.utilisateur(idUtilisateur).then((utilisateur) =>
+        reponse.render('utilisateur/edition', {
+          utilisateur,
+          departements,
+          referentiel,
+        })
+      );
     }
   );
 

--- a/src/routes/mappeur/utilisateur.js
+++ b/src/routes/mappeur/utilisateur.js
@@ -8,6 +8,7 @@ const obtentionDonneesDeBaseUtilisateur = (corps) => ({
   entite: {
     siret: corps.siretEntite,
   },
+  estimationNombreServices: corps.estimationNombreServices,
   infolettreAcceptee: valeurBooleenne(corps.infolettreAcceptee),
   transactionnelAccepte: valeurBooleenne(corps.transactionnelAccepte),
   postes: corps.postes,

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -42,7 +42,7 @@ const routesNonConnectePage = ({ depotDonnees, middleware, referentiel }) => {
 
   routes.get('/inscription', (_requete, reponse) => {
     const departements = referentiel.departements();
-    reponse.render('inscription', { departements });
+    reponse.render('inscription', { departements, referentiel });
   });
 
   routes.get('/activation', (_requete, reponse) => {

--- a/src/vues/fragments/formulaireUtilisateur.pug
+++ b/src/vues/fragments/formulaireUtilisateur.pug
@@ -166,4 +166,21 @@ mixin formulaireUtilisateur({ donnees = {}, emailLectureSeule, forceEmailsTransa
             )
             .message-erreur Ce champ est obligatoire. Veuillez sélectionner une ou plusieurs options.
 
+      .requis
+        - const { borneBasse, borneHaute } = donnees.estimationNombreServices ?? {borneBasse: 0, borneHaute: 0}
+        - const valeurUtilisateur = `${borneBasse}_${borneHaute}`
+        - const valeurVide = '0_0'
+        label Combien de services publics numériques avez-vous à sécuriser ?
+          p.description (ex : Systèmes d’information, site web, application mobile, API, téléservices)
+          select(
+            id = 'estimation-nombre-services'
+            name = 'estimationNombreServices'
+            required
+          )
+            option(value='' disabled label='-' selected=(valeurUtilisateur === valeurVide))
+            each tranche in referentiel.estimationNombreServices()
+              - const valeurOption = `${tranche.borneBasse}_${tranche.borneHaute}`
+              option(value=valeurOption label=tranche.label selected=(valeurUtilisateur === valeurOption))
+          .message-erreur Ce champ est obligatoire. Veuillez sélectionner une option.
+
       +preferencesCommunication(donnees, forceEmailsTransactionnels)

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -17,6 +17,10 @@ class ConstructeurUtilisateur {
         departement: '',
         siret: '',
       },
+      estimationNombreServices: {
+        borneBasse: '1',
+        borneHaute: '10',
+      },
       infolettreAcceptee: '',
       transactionnelAccepte: '',
     };

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -17,17 +17,19 @@ describe('Un utilisateur', () => {
         nom: 'Dupont',
         email: 'jean.dupont@mail.fr',
         entite: { siret: '12345' },
+        estimationNombreServices: { borneBasse: '1', borneHaute: '10' },
       });
       expect(utilisateur.completudeProfil().estComplet).to.be(true);
       expect(utilisateur.completudeProfil().champsNonRenseignes).to.eql([]);
     });
 
-    it('considère le profil « incomplet » à cause du nom et du SIRET manquants si le nom et le SIRET ne sont pas renseignés', () => {
+    it("considère le profil « incomplet » à cause du nom, du SIRET et de l'estimation du nombre de services manquants s'ils ne sont pas renseignés", () => {
       const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
       expect(utilisateur.completudeProfil().estComplet).to.be(false);
       expect(utilisateur.completudeProfil().champsNonRenseignes).to.eql([
         'nom',
         'siret',
+        'estimationNombreServices',
       ]);
     });
 
@@ -35,10 +37,24 @@ describe('Un utilisateur', () => {
       const utilisateur = new Utilisateur({
         nom: 'Dupont',
         email: 'jean.dupont@mail.fr',
+        estimationNombreServices: { borneBasse: '1', borneHaute: '10' },
       });
       expect(utilisateur.completudeProfil().estComplet).to.be(false);
       expect(utilisateur.completudeProfil().champsNonRenseignes).to.eql([
         'siret',
+      ]);
+    });
+
+    it("considère le profil « incomplet » à cause de l'estimation du nombre de services manquante si les bornes sont égales à zéro", () => {
+      const utilisateur = new Utilisateur({
+        nom: 'Dupont',
+        email: 'jean.dupont@mail.fr',
+        entite: { siret: '12345' },
+        estimationNombreServices: { borneBasse: '0', borneHaute: '0' },
+      });
+      expect(utilisateur.completudeProfil().estComplet).to.be(false);
+      expect(utilisateur.completudeProfil().champsNonRenseignes).to.eql([
+        'estimationNombreServices',
       ]);
     });
   });

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -188,6 +188,7 @@ describe('Un utilisateur', () => {
       'infolettreAcceptee',
       'transactionnelAccepte',
       'postes.*',
+      'estimationNombreServices.*',
     ];
     expect(Utilisateur.nomsProprietesBase()).to.eql(nomsProprietes);
   });

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -223,6 +223,10 @@ describe('Un utilisateur', () => {
         entite: {
           siret: '7524242424',
         },
+        estimationNombreServices: {
+          borneBasse: 1,
+          borneHaute: 10,
+        },
         infolettreAcceptee: true,
         transactionnelAccepte: true,
       };
@@ -257,6 +261,14 @@ describe('Un utilisateur', () => {
 
     it("exige que le SIRET de l'entité soit renseigné", (done) => {
       verifiePresencePropriete('entite.siret', "SIRET de l'entité", done);
+    });
+
+    it("exige que l'estimation du nombre de services soit renseignée", (done) => {
+      verifiePresencePropriete(
+        'estimationNombreServices',
+        'Estimation du nombre de services',
+        done
+      );
     });
 
     it('exige que les postes soient renseignés', (done) => {

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -638,6 +638,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         telephone: '0100000000',
         postes: ['RSSI', "Chargé des systèmes d'informations"],
         siretEntite: '13000766900018',
+        estimationNombreServices: {
+          borneBasse: 1,
+          borneHaute: 10,
+        },
         infolettreAcceptee: 'true',
         transactionnelAccepte: 'true',
       };

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -662,6 +662,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           'infolettreAcceptee',
           'transactionnelAccepte',
           'postes.*',
+          'estimationNombreServices.*',
           'siretEntite',
         ],
         {

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -70,6 +70,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
           'infolettreAcceptee',
           'transactionnelAccepte',
           'postes.*',
+          'estimationNombreServices.*',
           'siretEntite',
         ],
         {

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -29,6 +29,10 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         telephone: '0100000000',
         postes: ['RSSI', "Chargé des systèmes d'informations"],
         siretEntite: '13000766900018',
+        estimationNombreServices: {
+          borneBasse: 1,
+          borneHaute: 10,
+        },
         cguAcceptees: 'true',
         infolettreAcceptee: 'true',
         transactionnelAccepte: 'true',
@@ -142,6 +146,10 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
           telephone: '0100000000',
           entite: {
             siret: '13000766900018',
+          },
+          estimationNombreServices: {
+            borneBasse: 1,
+            borneHaute: 10,
           },
           infolettreAcceptee: true,
           transactionnelAccepte: true,


### PR DESCRIPTION
On souhaite ajouter une nouvelle question à l'inscription et dans le profil utilisateur : 
> Combien de services publics numériques avez-vous à sécuriser ?

___

Cette information se retrouve dans le modèle `Utilisateur` sous la forme d'un objet 
```js
estimationNombreServices : {
    borneBasse: 1,
    borneHaute: 10
}
```
Des valeurs spécifiques existent :
- `{ borneBasse: 0, borneHaute: 0 }` par défaut, pour un utilisateur qui n'a pas mis à jour son champ (via la migration)
- `{ borneBasse: -1, borneHaute: -1 }` pour le choix "Je ne sais pas"

Petite particularité du front, on construit les `value` du `select` de la forme `borneBasse_borneHaute` pour éviter l'utilisation du "-" qui cause des problèmes avec les nombres négatifs.