### PR TITLE
[DÉCRIRE] Séparation du formulaire en deux étapes

### DIFF
--- a/public/assets/images/fleche_gauche_bleue.svg
+++ b/public/assets/images/fleche_gauche_bleue.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.57 5.92969L3.5 11.9997L9.57 18.0697" stroke="#0079D0" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.5 12H3.67004" stroke="#0079D0" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/styles/etapesDossier.css
+++ b/public/assets/styles/etapesDossier.css
@@ -91,3 +91,21 @@ section.autorite {
 .conteneur-page-formulaire section {
   border-bottom: none;
 }
+
+.boutons-etape #suivant {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding: 8px 16px;
+  margin: 0;
+}
+
+.boutons-etape #suivant:after {
+  content: '';
+  background: url(/statique/assets/images/fleche_gauche_bleue.svg);
+  transform: rotate(180deg);
+  filter: brightness(0) invert(100%);
+  display: flex;
+  width: 24px;
+  height: 24px;
+}

--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -94,6 +94,30 @@ form#decrire-etape-2 {
   margin: 0;
 }
 
+.conteneur-actions-etapes :is(#etape-precedente, #etape-suivante) {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+
+.conteneur-actions-etapes #etape-precedente:before {
+  content: '';
+  background: url('/statique/assets/images/fleche_gauche_bleue.svg');
+  display: flex;
+  width: 24px;
+  height: 24px;
+}
+
+.conteneur-actions-etapes #etape-suivante:after {
+  content: '';
+  background: url('/statique/assets/images/fleche_gauche_bleue.svg');
+  transform: rotate(180deg);
+  filter: brightness(0) invert(100%);
+  display: flex;
+  width: 24px;
+  height: 24px;
+}
+
 .conteneur-actions-etapes #etape-precedente {
   display: none;
 }

--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -76,3 +76,28 @@ form.homologation .banniere p {
 section:first-of-type {
   border-top: none;
 }
+
+form#decrire-etape-2 {
+  display: none;
+}
+
+.conteneur-actions-etapes {
+  display: flex;
+  gap: 16px;
+  padding: 24px 0;
+  justify-content: end;
+  border-top: 1px solid var(--liseres-fonce);
+}
+
+.conteneur-actions-etapes button {
+  padding: 8px 16px;
+  margin: 0;
+}
+
+.conteneur-actions-etapes #etape-precedente {
+  display: none;
+}
+
+.conteneur-actions-etapes .conteneur-bouton-finaliser {
+  display: none;
+}

--- a/public/assets/styles/parcoursService.css
+++ b/public/assets/styles/parcoursService.css
@@ -69,7 +69,8 @@ main {
   margin: 12px 62px 16px 100px;
 }
 
-.conteneur-etapier a.etape {
+.conteneur-etapier a.etape,
+.conteneur-etapier .etape.active {
   opacity: 1;
 }
 
@@ -79,6 +80,10 @@ main {
   opacity: 0.5;
   text-decoration: none;
   flex: 1;
+}
+
+.conteneur-etapier .etape.active {
+  cursor: pointer;
 }
 
 nav.marges-fixes {

--- a/public/modules/interactions/brancheValidationCasesACocher.mjs
+++ b/public/modules/interactions/brancheValidationCasesACocher.mjs
@@ -1,15 +1,17 @@
-const declencheValidationCasesACocher = () => {
-  $('fieldset.casesACocher[required]').each((_, $groupeCasesACocher) => {
-    const $toutesCasesACocher = $('input:checkbox', $groupeCasesACocher);
-    const messageErreur =
-      $toutesCasesACocher.filter(':checked').length === 0
-        ? 'Erreur de saisie'
-        : '';
-    $toutesCasesACocher.each((__, caseACocher) => {
-      caseACocher.setCustomValidity(messageErreur);
-      caseACocher.reportValidity();
-    });
-  });
+const declencheValidationCasesACocher = (selecteurFormulaire) => {
+  $('fieldset.casesACocher[required]', selecteurFormulaire).each(
+    (_, $groupeCasesACocher) => {
+      const $toutesCasesACocher = $('input:checkbox', $groupeCasesACocher);
+      const messageErreur =
+        $toutesCasesACocher.filter(':checked').length === 0
+          ? 'Erreur de saisie'
+          : '';
+      $toutesCasesACocher.each((__, caseACocher) => {
+        caseACocher.setCustomValidity(messageErreur);
+        caseACocher.reportValidity();
+      });
+    }
+  );
 };
 
 const brancheValidationGroupeCasesACocher = ($groupeCasesACocher) => {

--- a/public/modules/interactions/validation.mjs
+++ b/public/modules/interactions/validation.mjs
@@ -45,8 +45,8 @@ const marqueTousChampsCommeTouches = (selecteurFormulaire) => {
 };
 
 const declencheValidation = (selecteurFormulaire) => {
-  marqueTousChampsCommeTouches();
-  declencheValidationCasesACocher();
+  marqueTousChampsCommeTouches(selecteurFormulaire);
+  declencheValidationCasesACocher(selecteurFormulaire);
   declencheScrollSurErreur(selecteurFormulaire);
 };
 

--- a/public/modules/interactions/validation.mjs
+++ b/public/modules/interactions/validation.mjs
@@ -3,6 +3,9 @@ import {
   declencheValidationCasesACocher,
 } from './brancheValidationCasesACocher.mjs';
 
+const EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE =
+  'EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE';
+
 // Tous les champs de formulaires reçoivent la classe "touche" au moment d'un changement (input, change)
 // Cette classe permet d'afficher les messages d'erreurs sur tous les `input.touche:invalid`
 // Au moment de la validation du formulaire, on ajoute la classe `.touche` sur tous les champs,
@@ -50,4 +53,22 @@ const declencheValidation = (selecteurFormulaire) => {
   declencheScrollSurErreur(selecteurFormulaire);
 };
 
-export { brancheConteneur, brancheValidation, declencheValidation };
+const declencheValidationFormulairesMultiple = (
+  selecteurConteneurFormulaires
+) => {
+  let tousFormulaireValides = true;
+  $('form', selecteurConteneurFormulaires).each((_i, element) => {
+    if (!element.checkValidity()) tousFormulaireValides = false;
+  });
+
+  if (tousFormulaireValides)
+    selecteurConteneurFormulaires.trigger(EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE);
+};
+
+export {
+  brancheConteneur,
+  brancheValidation,
+  declencheValidation,
+  declencheValidationFormulairesMultiple,
+  EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE,
+};

--- a/public/modules/parametresDescriptionService.mjs
+++ b/public/modules/parametresDescriptionService.mjs
@@ -5,7 +5,17 @@ import parametres, {
 import convertisReponseOuiNon from './convertisReponseOuiNon.mjs';
 
 const extraisParametresDescriptionService = (selecteurFormulaire) => {
-  const params = parametres(selecteurFormulaire);
+  const idFormulaires = $.map(
+    $('form', selecteurFormulaire),
+    (formulaire) => formulaire.id
+  );
+  const params = idFormulaires.reduce(
+    (acc, idFormulaire) => ({
+      ...acc,
+      ...parametres(`#${idFormulaire}`),
+    }),
+    {}
+  );
 
   params.risqueJuridiqueFinancierReputationnel = convertisReponseOuiNon(
     params.risqueJuridiqueFinancierReputationnel

--- a/public/modules/soumetsHomologation.mjs
+++ b/public/modules/soumetsHomologation.mjs
@@ -1,7 +1,8 @@
 import adaptateurAjaxAxios from './adaptateurAjaxAxios.mjs';
 import {
-  brancheValidation,
   declencheValidation,
+  declencheValidationFormulairesMultiple,
+  EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE,
 } from './interactions/validation.mjs';
 import basculeEnCoursChargement from './enregistreRubrique.mjs';
 
@@ -19,10 +20,7 @@ const initialiseComportementFormulaire = (
     : { method: 'post', url: '/api/service' };
   const $form = $(selecteurFormulaire);
 
-  brancheValidation(selecteurFormulaire);
-
-  $form.on('submit', async (evenement) => {
-    evenement.preventDefault();
+  $form.on(EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE, async () => {
     basculeEnCoursChargement($bouton, true);
     requete.data = fonctionExtractionParametres(selecteurFormulaire);
 
@@ -45,6 +43,7 @@ const initialiseComportementFormulaire = (
 
   $bouton.on('click', () => {
     declencheValidation(selecteurFormulaire);
+    declencheValidationFormulairesMultiple($form);
   });
 };
 

--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -50,11 +50,25 @@ const estNomServiceDejaUtilise = (reponseErreur) =>
   reponseErreur.data?.erreur?.code === 'NOM_SERVICE_DEJA_EXISTANT';
 
 const brancheComportementNavigationEtapes = () => {
+  const donneesEtapes = {
+    1: {
+      titre: 'Présentation du service',
+      description:
+        "Complétez les informations permettant d'évaluer les besoins de sécurité du service et de proposer <b>des mesures de sécurité adaptées</b>.",
+    },
+    2: {
+      titre: 'Données et fonctionnalités',
+      description:
+        'Pour mieux comprendre votre service et ses enjeux de protection des données, veuillez répondre aux questions suivantes sur ses <b>fonctionnalités et les données collectées.</b>',
+    },
+  };
+
   const etapeMin = 1;
   const etapeMax = 2;
   const $boutonPrecedent = $('#etape-precedente');
   const $boutonSuivant = $('#etape-suivante');
   const $conteneurBoutonFinaliser = $('.conteneur-bouton-finaliser');
+  const $entete = $('.conteneur-entete');
   let etapeCourante = 1;
 
   brancheValidation($('#decrire-etape-1'));
@@ -67,11 +81,19 @@ const brancheComportementNavigationEtapes = () => {
     $('.etape-decrire').hide();
     $(`#decrire-etape-${etapeCourante}`).show();
 
-    const $entete = $('.marges-fixes');
+    const $hautDePage = $('.marges-fixes');
+    const { titre, description } = donneesEtapes[etapeCourante];
 
     $('.avancement-etape p', $entete).text(
       `Étape ${etapeCourante} sur ${etapeMax}`
     );
+    $('.titre.titre-page h1', $entete).text(titre);
+    $('.sous-titre h2', $entete).html(description);
+    $('.etape', $entete).removeClass('active');
+    for (let i = 1; i <= etapeCourante; i += 1) {
+      $(`.etape:nth-child(${i})`, $entete).addClass('active');
+    }
+
     if (etapeCourante === etapeMin) cacheBouton($boutonPrecedent);
     else afficheBouton($boutonPrecedent);
 
@@ -83,7 +105,7 @@ const brancheComportementNavigationEtapes = () => {
       cacheBouton($conteneurBoutonFinaliser);
     }
 
-    $entete[0].scrollIntoView({
+    $hautDePage[0].scrollIntoView({
       behavior: 'smooth',
       block: 'start',
     });
@@ -99,6 +121,14 @@ const brancheComportementNavigationEtapes = () => {
     declencheValidation($formulaireEtape);
     if ($formulaireEtape[0].checkValidity()) {
       etapeCourante = Math.min(etapeCourante + 1, etapeMax);
+      afficheEtape();
+    }
+  });
+
+  $('.etape', $entete).on('click', (e) => {
+    const $etape = $(e.target);
+    if ($etape.hasClass('active')) {
+      etapeCourante = $etape.data('numero-etape');
       afficheEtape();
     }
   });

--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -69,6 +69,9 @@ const brancheComportementNavigationEtapes = () => {
 
     const $entete = $('.marges-fixes');
 
+    $('.avancement-etape p', $entete).text(
+      `Étape ${etapeCourante} sur ${etapeMax}`
+    );
     if (etapeCourante === etapeMin) cacheBouton($boutonPrecedent);
     else afficheBouton($boutonPrecedent);
 

--- a/src/vues/fragments/avancementEtape.pug
+++ b/src/vues/fragments/avancementEtape.pug
@@ -1,0 +1,2 @@
+mixin avancementEtape(courante, max)
+  p!= `Étape ${courante} sur ${max}`

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -16,226 +16,232 @@ mixin formulaireDescriptionService(idHomologation)
   - const estEnCreation = !idHomologation;
   - const estLectureSeule  = estEnCreation ? false : autorisationsService.DECRIRE.estLectureSeule;
   - const entite = service?.descriptionService?.organisationResponsable || {};
-  form.homologation#homologation
-    section
-      .mention champ obligatoire
-      .requis
-        label Nom du service numérique à homologuer
-          br
-          input(
-            id = 'nom-service',
-            name = 'nomService',
-            type = 'text',
-            data-form-type="other",
-            value != service.nomService(),
-            required
-            readonly = estLectureSeule
-          )
-          .message-erreur Le nom est obligatoire. Veuillez le renseigner.
-          .message-erreur-specifique#nom-deja-utilise Ce nom est déjà utilisé pour un autre service. Veuillez en saisir un autre.
-
-      if estLectureSeule
+  .homologation#homologation
+    form.etape-decrire#decrire-etape-1
+      section
+        .mention champ obligatoire
         .requis
-          label Organisation responsable du service numérique
+          label Nom du service numérique à homologuer
             br
             input(
-              id = 'entite-readonly',
-              name = 'entite-readonly',
+              id = 'nom-service',
+              name = 'nomService',
               type = 'text',
-              value != entite.nom,
+              data-form-type="other",
+              value != service.nomService(),
               required
-              readonly = true
-            )
-
-      unless estLectureSeule
-        .requis
-          label(for = 'departementEntite-selectize') Département de l'organisation responsable du service numérique
-            select(
-              id = 'departementEntite-selectize',
-              name = 'departementEntite-selectize',
-              placeHolder = 'ex : 33, Morbihan',
-              required,
               readonly = estLectureSeule
             )
-            .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.
-            input(type='hidden' name='departementEntite' id='departementEntite' value != entite.departement)
+            .message-erreur Le nom est obligatoire. Veuillez le renseigner.
+            .message-erreur-specifique#nom-deja-utilise Ce nom est déjà utilisé pour un autre service. Veuillez en saisir un autre.
+
+        if estLectureSeule
+          .requis
+            label Organisation responsable du service numérique
+              br
+              input(
+                id = 'entite-readonly',
+                name = 'entite-readonly',
+                type = 'text',
+                value != entite.nom,
+                required
+                readonly = true
+              )
+
+        unless estLectureSeule
+          .requis
+            label(for = 'departementEntite-selectize') Département de l'organisation responsable du service numérique
+              select(
+                id = 'departementEntite-selectize',
+                name = 'departementEntite-selectize',
+                placeHolder = 'ex : 33, Morbihan',
+                required,
+                readonly = estLectureSeule
+              )
+              .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.
+              input(type='hidden' name='departementEntite' id='departementEntite' value != entite.departement)
+
+          .requis
+            label(for = 'siretEntite-selectize') Nom ou SIRET de l'organisation responsable du service numérique
+              select(
+                id = 'siretEntite-selectize',
+                name = 'siretEntite-selectize',
+                placeHolder = 'ex : 13261762000010, Agglomération de Mansart, Société Y',
+                required,
+                readonly = estLectureSeule
+              )
+              .icone-chargement
+              .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.
+              input(type='hidden' name='nomEntite' id='nomEntite' value != entite.nom)
+              input(type='hidden' name='siretEntite' id='siretEntite' value != entite.siret)
+
+            .banniere.banniere-avertissement.invisible
+              img(src='/statique/assets/images/icone_danger.svg' alt='')
+              .contenu-texte-avertissement
+                strong Information à mettre à jour
+                p Vous pouvez directement rechercher le nom ou le numéro de SIRET de votre organisation.
+
+        - const { borneBasse, borneHaute } = service.descriptionService.nombreOrganisationsUtilisatrices
+        - const valeurService = `${borneBasse}-${borneHaute}`
+        - const valeurVide = '0-0'
+        .conteneur-nombre-organisations-utilisatrices(class = `${valeurService === valeurVide && !estLectureSeule && !estEnCreation ? 'vide' : ''}`)
+          .requis
+            label À combien d'organisations publiques est destiné le service ?
+              p.description Si le service est mutualisé au profit de plusieurs organisations publiques, merci de préciser combien en bénéficieront.
+              p.description Si le service n’est pas mutualisé, merci de choisir « Mon organisation uniquement ».
+              select(
+                id = 'nombre-organisations-utilisatrices'
+                name = 'nombreOrganisationsUtilisatrices'
+                required
+                disabled = estLectureSeule
+              )
+                option(value='' disabled label='-' selected=(valeurService===valeurVide))
+                each tranche in referentiel.nombreOrganisationsUtilisatrices()
+                  - const valeurOption = `${tranche.borneBasse}-${tranche.borneHaute}`
+                  option(value=valeurOption label=tranche.label selected=(valeurService===valeurOption))
+              .message-erreur Ce champ est obligatoire. Veuillez sélectionner une option.
 
         .requis
-          label(for = 'siretEntite-selectize') Nom ou SIRET de l'organisation responsable du service numérique
-            select(
-              id = 'siretEntite-selectize',
-              name = 'siretEntite-selectize',
-              placeHolder = 'ex : 13261762000010, Agglomération de Mansart, Société Y',
-              required,
-              readonly = estLectureSeule
-            )
-            .icone-chargement
-            .message-erreur Ce champ est obligatoire. Veuillez sélectionner une entrée.
-            input(type='hidden' name='nomEntite' id='nomEntite' value != entite.nom)
-            input(type='hidden' name='siretEntite' id='siretEntite' value != entite.siret)
+          +inputChoix({
+            type: 'checkbox',
+            nom: 'typeService',
+            titre: 'Type(s)',
+            items: referentiel.typesService(),
+            objetDonnees: service.descriptionService,
+            messageErreur: 'Ce champ est obligatoire. Veuillez sélectionner une ou plusieurs options.',
+            requis: true,
+            lectureSeule: estLectureSeule
+          })
 
-          .banniere.banniere-avertissement.invisible
-            img(src='/statique/assets/images/icone_danger.svg' alt='')
-            .contenu-texte-avertissement
-              strong Information à mettre à jour
-              p Vous pouvez directement rechercher le nom ou le numéro de SIRET de votre organisation.
-
-      - const { borneBasse, borneHaute } = service.descriptionService.nombreOrganisationsUtilisatrices
-      - const valeurService = `${borneBasse}-${borneHaute}`
-      - const valeurVide = '0-0'
-      .conteneur-nombre-organisations-utilisatrices(class = `${valeurService === valeurVide && !estLectureSeule && !estEnCreation ? 'vide' : ''}`)
         .requis
-          label À combien d'organisations publiques est destiné le service ?
-            p.description Si le service est mutualisé au profit de plusieurs organisations publiques, merci de préciser combien en bénéficieront.
-            p.description Si le service n’est pas mutualisé, merci de choisir « Mon organisation uniquement ».
-            select(
-              id = 'nombre-organisations-utilisatrices'
-              name = 'nombreOrganisationsUtilisatrices'
-              required
-              disabled = estLectureSeule
-            )
-              option(value='' disabled label='-' selected=(valeurService===valeurVide))
-              each tranche in referentiel.nombreOrganisationsUtilisatrices()
-                - const valeurOption = `${tranche.borneBasse}-${tranche.borneHaute}`
-                option(value=valeurOption label=tranche.label selected=(valeurService===valeurOption))
-            .message-erreur Ce champ est obligatoire. Veuillez sélectionner une option.
+          +inputChoix({
+            type: 'radio',
+            nom: 'provenanceService',
+            titre: 'Provenance',
+            items: referentiel.provenancesService(),
+            objetDonnees: service.descriptionService,
+            messageErreur: 'La provenance est obligatoire. Veuillez cocher une option.',
+            requis: true,
+            lectureSeule: estLectureSeule
+          })
 
-      .requis
+        .requis
+          +inputChoix({
+            type: 'radio',
+            nom: 'statutDeploiement',
+            titre: 'Statut',
+            items: referentiel.statutsDeploiement(),
+            objetDonnees: service.descriptionService,
+            messageErreur: 'Le statut est obligatoire. Veuillez cocher une option.',
+            requis: true,
+            lectureSeule: estLectureSeule
+          })
+
+        label Présentation
+          textarea(
+            id = 'presentation',
+            name = 'presentation',
+            placeholder = 'ex : site internet de la médiathèque permettant de créer un compte utilisateur, de réserver, prolonger leur réservation de contenus multimédia.',
+            readonly = estLectureSeule
+          )= service.descriptionService.presentation
+
+        label(id='label-acces') Accès
+          br
+          +elementsAjoutablesDescription({
+            identifiantConteneur: 'points-acces',
+            nom: 'point-acces',
+            valeurExemple: 'exemple : https://www.adresse.fr, adresse IP',
+            donnees: service.descriptionService.pointsAcces.toJSON(),
+            texteLienAjouter: 'Ajouter un accès',
+            zoneSaisieVideVisible: true,
+            lectureSeule: estLectureSeule,
+            identifiantChampTitre: 'label-acces'
+          })
+
+    form.etape-decrire#decrire-etape-2
+      section
         +inputChoix({
           type: 'checkbox',
-          nom: 'typeService',
-          titre: 'Type(s)',
-          items: referentiel.typesService(),
+          nom: 'fonctionnalites',
+          titre: 'Fonctionnalité(s) offerte(s)',
+          description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
+          items: referentiel.fonctionnalites(),
           objetDonnees: service.descriptionService,
-          messageErreur: 'Ce champ est obligatoire. Veuillez sélectionner une ou plusieurs options.',
-          requis: true,
           lectureSeule: estLectureSeule
         })
 
-      .requis
-        +inputChoix({
-          type: 'radio',
-          nom: 'provenanceService',
-          titre: 'Provenance',
-          items: referentiel.provenancesService(),
-          objetDonnees: service.descriptionService,
-          messageErreur: 'La provenance est obligatoire. Veuillez cocher une option.',
-          requis: true,
-          lectureSeule: estLectureSeule
-        })
-
-      .requis
-        +inputChoix({
-          type: 'radio',
-          nom: 'statutDeploiement',
-          titre: 'Statut',
-          items: referentiel.statutsDeploiement(),
-          objetDonnees: service.descriptionService,
-          messageErreur: 'Le statut est obligatoire. Veuillez cocher une option.',
-          requis: true,
-          lectureSeule: estLectureSeule
-        })
-
-      label Présentation
-        textarea(
-          id = 'presentation',
-          name = 'presentation',
-          placeholder = 'ex : site internet de la médiathèque permettant de créer un compte utilisateur, de réserver, prolonger leur réservation de contenus multimédia.',
-          readonly = estLectureSeule
-        )= service.descriptionService.presentation
-
-      label(id='label-acces') Accès
-        br
         +elementsAjoutablesDescription({
-          identifiantConteneur: 'points-acces',
-          nom: 'point-acces',
-          valeurExemple: 'exemple : https://www.adresse.fr, adresse IP',
-          donnees: service.descriptionService.pointsAcces.toJSON(),
-          texteLienAjouter: 'Ajouter un accès',
-          zoneSaisieVideVisible: true,
+          identifiantConteneur: 'fonctionnalites-specifiques',
+          nom: 'fonctionnalite',
+          donnees: service.descriptionService.fonctionnalitesSpecifiques.toJSON(),
+          texteLienAjouter: 'Ajouter une fonctionnalité',
           lectureSeule: estLectureSeule,
-          identifiantChampTitre: 'label-acces'
+          identifiantChampTitre: 'fonctionnalites-label'
         })
 
-    section
-      +inputChoix({
-        type: 'checkbox',
-        nom: 'fonctionnalites',
-        titre: 'Fonctionnalité(s) offerte(s)',
-        description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
-        items: referentiel.fonctionnalites(),
-        objetDonnees: service.descriptionService,
-        lectureSeule: estLectureSeule
-      })
-
-      +elementsAjoutablesDescription({
-        identifiantConteneur: 'fonctionnalites-specifiques',
-        nom: 'fonctionnalite',
-        donnees: service.descriptionService.fonctionnalitesSpecifiques.toJSON(),
-        texteLienAjouter: 'Ajouter une fonctionnalité',
-        lectureSeule: estLectureSeule,
-        identifiantChampTitre: 'fonctionnalites-label'
-      })
-
-    section
-      +inputChoix({
-        type: 'checkbox',
-        nom: 'donneesCaracterePersonnel',
-        titre: 'Données à caractère personnel et autres données sensibles stockées par le service',
-        description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
-        items: referentiel.donneesCaracterePersonnel(),
-        objetDonnees: service.descriptionService,
-        lectureSeule: estLectureSeule
-      })
-
-      +elementsAjoutablesDescription({
-        identifiantConteneur: 'donnees-sensibles-specifiques',
-        nom: 'donnees-sensibles',
-        donnees: service.descriptionService.donneesSensiblesSpecifiques.toJSON(),
-        texteLienAjouter: 'Ajouter des données',
-        lectureSeule: estLectureSeule,
-        identifiantChampTitre: 'donneesCaracterePersonnel-label'
-      })
-
-    section
-      .requis
+      section
         +inputChoix({
-          type: 'radio',
-          nom: 'localisationDonnees',
-          titre: 'Localisation des données',
-          items: referentiel.localisationsDonnees(),
+          type: 'checkbox',
+          nom: 'donneesCaracterePersonnel',
+          titre: 'Données à caractère personnel et autres données sensibles stockées par le service',
+          description: "Cette question permet d'obtenir la liste personnalisée des mesures de sécurité à appliquer.",
+          items: referentiel.donneesCaracterePersonnel(),
           objetDonnees: service.descriptionService,
-          messageErreur: 'La localisation des données est obligatoire. Veuillez cocher une option.',
-          requis: true,
           lectureSeule: estLectureSeule
         })
 
-      .requis
-        +inputChoix({
-          type: 'radio',
-          nom: 'delaiAvantImpactCritique',
-          titre: 'Estimation de la durée maximale acceptable de dysfonctionnement grave du service',
-          items: referentiel.delaisAvantImpactCritique(),
-          objetDonnees: service.descriptionService,
-          messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
-          requis: true,
-          lectureSeule: estLectureSeule
-        })
-      .requis
-        +inputOuiNon({
-          nom: 'risqueJuridiqueFinancierReputationnel',
-          titre: 'Une atteinte à la sécurité ou au bon fonctionnement du service pourrait entraîner un impact critique sur les plans juridique, financier ou réputationnel',
-          objetDonnees: service.descriptionService,
-          exempleOui: "Les mesures de sécurité à mettre en œuvre, proposées dans l'étape suivante « Sécuriser », seront renforcées (ex : réaliser un audit de sécurité approfondi, une analyse de risque Ebios Risk Manager, …).",
-          messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
-          requis: true,
-          lectureSeule: estLectureSeule
+        +elementsAjoutablesDescription({
+          identifiantConteneur: 'donnees-sensibles-specifiques',
+          nom: 'donnees-sensibles',
+          donnees: service.descriptionService.donneesSensiblesSpecifiques.toJSON(),
+          texteLienAjouter: 'Ajouter des données',
+          lectureSeule: estLectureSeule,
+          identifiantChampTitre: 'donneesCaracterePersonnel-label'
         })
 
-    if !estLectureSeule
-      if !estEnCreation
-        button.bouton#diagnostic(idHomologation = idHomologation) Enregistrer
-      else
-        button.bouton#diagnostic Valider
+      section
+        .requis
+          +inputChoix({
+            type: 'radio',
+            nom: 'localisationDonnees',
+            titre: 'Localisation des données',
+            items: referentiel.localisationsDonnees(),
+            objetDonnees: service.descriptionService,
+            messageErreur: 'La localisation des données est obligatoire. Veuillez cocher une option.',
+            requis: true,
+            lectureSeule: estLectureSeule
+          })
+
+        .requis
+          +inputChoix({
+            type: 'radio',
+            nom: 'delaiAvantImpactCritique',
+            titre: 'Estimation de la durée maximale acceptable de dysfonctionnement grave du service',
+            items: referentiel.delaisAvantImpactCritique(),
+            objetDonnees: service.descriptionService,
+            messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
+            requis: true,
+            lectureSeule: estLectureSeule
+          })
+        .requis
+          +inputOuiNon({
+            nom: 'risqueJuridiqueFinancierReputationnel',
+            titre: 'Une atteinte à la sécurité ou au bon fonctionnement du service pourrait entraîner un impact critique sur les plans juridique, financier ou réputationnel',
+            objetDonnees: service.descriptionService,
+            exempleOui: "Les mesures de sécurité à mettre en œuvre, proposées dans l'étape suivante « Sécuriser », seront renforcées (ex : réaliser un audit de sécurité approfondi, une analyse de risque Ebios Risk Manager, …).",
+            messageErreur: 'Ce champ est obligatoire. Veuillez cocher une option.',
+            requis: true,
+            lectureSeule: estLectureSeule
+          })
+
+    .conteneur-actions-etapes
+      button.bouton.bouton-secondaire#etape-precedente Précédent
+      button.bouton#etape-suivante Suivant
+      .conteneur-bouton-finaliser
+        if !estLectureSeule
+          if !estEnCreation
+            button.bouton#diagnostic(idHomologation = idHomologation) Enregistrer les modifications
+          else
+            button.bouton#diagnostic Commencer à sécuriser le service
 
   script(type = 'module', src = '/statique/service/descriptionService.js')

--- a/src/vues/service/creation.pug
+++ b/src/vues/service/creation.pug
@@ -1,11 +1,23 @@
 extends ./decrire
 include ../fragments/formulaireDescriptionService
+include ../fragments/avancementEtape
 
 block titre
-  h1 Décrire
+  h1 Présentation du service
 
 block sous-titre
-  h2 Fournir les informations permettant d'évaluer les besoins de sécurité du service et de proposer des mesures de sécurité adaptées
+  h2
+    | Complétez les informations permettant d'évaluer les besoins de sécurité du service et de proposer&nbsp;
+    b des mesures de sécurité adaptées
+    | .
+
+block avancement-etape
+  +avancementEtape(1, 2)
+
+block etapier
+  .conteneur-etapier
+    .etape.active(data-numero-etape="1")
+    .etape(data-numero-etape="2")
 
 block formulaire
   script(id = 'infos-siret-manquant', type = 'application/json').

--- a/src/vues/service/descriptionService.pug
+++ b/src/vues/service/descriptionService.pug
@@ -8,13 +8,21 @@ block header-titre-page
     +texteTronque({texte: service.nomService() || ''})
 
 block titre
-  h1 Décrire
+  h1 Présentation du service
 
 block sous-titre
-  h2 Fournir les informations permettant d'évaluer les besoins de sécurité du service et de proposer des mesures de sécurité adaptées
+  h2
+    | Complétez les informations permettant d'évaluer les besoins de sécurité du service et de proposer&nbsp;
+    b des mesures de sécurité adaptées
+    | .
 
 block avancement-etape
   +avancementEtape(1, 2)
+
+block etapier
+  .conteneur-etapier
+    .etape.active(data-numero-etape="1")
+    .etape(data-numero-etape="2")
 
 block formulaire
   script(id = 'infos-siret-manquant', type = 'application/json').

--- a/src/vues/service/descriptionService.pug
+++ b/src/vues/service/descriptionService.pug
@@ -1,6 +1,7 @@
 extends ./decrire
 include ../fragments/texteTronque
 include ../fragments/formulaireDescriptionService
+include ../fragments/avancementEtape
 
 block header-titre-page
   h3
@@ -11,6 +12,9 @@ block titre
 
 block sous-titre
   h2 Fournir les informations permettant d'évaluer les besoins de sécurité du service et de proposer des mesures de sécurité adaptées
+
+block avancement-etape
+  +avancementEtape(1, 2)
 
 block formulaire
   script(id = 'infos-siret-manquant', type = 'application/json').

--- a/src/vues/service/formulaireEtapier.pug
+++ b/src/vues/service/formulaireEtapier.pug
@@ -1,5 +1,6 @@
 extends ../parcoursService
 include ../fragments/texteTronque
+include ../fragments/avancementEtape
 
 block append styles
   link(href='/statique/assets/styles/etapesDossier.css', rel='stylesheet')
@@ -21,8 +22,7 @@ block titre
 
 block avancement-etape
   if idEtape
-    p!= `Étape ${referentiel.numeroEtape(idEtape)} sur ${referentiel.derniereEtapeParcours(autorisationsService.peutHomologuer).numero}`
-
+    +avancementEtape(referentiel.numeroEtape(idEtape), referentiel.derniereEtapeParcours(autorisationsService.peutHomologuer).numero)
 
 block etapier
   if idEtape


### PR DESCRIPTION
On modifie le formulaire de la description de service, pour le découper en plusieurs sous-étapes.

On choisit d'utiliser plusieurs `form` qui sont validés séparemment, avant de les valider tous avant l'envoi de la `payload`.
HTML ne permet pas d'avoir un `form` dans un autre.

On doit donc modifier légérement la logique de validation et de récupération des données.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/947f0eeb-3b48-4812-a68a-be991c42e515)

