### PR TITLE
[Brevo] Transmettre le numéro de téléphone du contact

### DIFF
--- a/src/adaptateurs/adaptateurMailMemoire.js
+++ b/src/adaptateurs/adaptateurMailMemoire.js
@@ -14,6 +14,10 @@ const fabriqueAdaptateurMailMemoire = () => {
     envoyer("Création d'un contact email", args);
   };
 
+  const metAJourContact = async (...args) => {
+    envoyer('Mise à jour du contact email', args);
+  };
+
   const metAJourDonneesContact = async (...args) => {
     envoyer("Mise à jour des données d'un contact email", args);
   };
@@ -122,6 +126,7 @@ const fabriqueAdaptateurMailMemoire = () => {
 
   return {
     creeContact,
+    metAJourContact,
     metAJourDonneesContact,
     creeEntreprise,
     desinscrisEmailsTransactionnels,

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -52,10 +52,14 @@ const desinscrisInfolettre = (destinataire) =>
 const inscrisInfolettre = (destinataire) =>
   basculeInfolettre(destinataire, false);
 
+const numeroTelephoneAvecIndicatif = (numero) =>
+  numero ? `+33${numero.substring(1)}` : '';
+
 const creeContact = (
   destinataire,
   prenom,
   nom,
+  telephone,
   bloqueNewsletter,
   bloqueMarketing
 ) =>
@@ -65,7 +69,11 @@ const creeContact = (
       {
         email: destinataire,
         emailBlacklisted: bloqueNewsletter,
-        attributes: { PRENOM: decode(prenom), NOM: decode(nom) },
+        attributes: {
+          PRENOM: decode(prenom),
+          NOM: decode(nom),
+          sync_mss_numero_telephone: numeroTelephoneAvecIndicatif(telephone),
+        },
         ...(!bloqueMarketing && { listIds: [idListeEmailsMarketing] }),
       },
       enteteJSON

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -16,7 +16,6 @@ const urlBase = process.env.SENDINBLUE_EMAIL_API_URL_BASE;
 const idListeEmailsMarketing = Number(
   process.env.SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE
 );
-
 const basculeInfolettre = (destinataire, etat) =>
   axios
     .put(
@@ -31,24 +30,9 @@ const basculeInfolettre = (destinataire, etat) =>
       return Promise.reject(e);
     });
 
-const metAJourDonneesContact = (destinataire, donnees) =>
-  axios
-    .put(
-      `${urlBase}/contacts/${encodeURIComponent(destinataire)}`,
-      {
-        attributes: donnees,
-      },
-      enteteJSON
-    )
-    .catch((e) => {
-      fabriqueAdaptateurGestionErreur().logueErreur(e, {
-        'Erreur renvoyée par API Brevo': e.response.data,
-      });
-      return Promise.reject(e);
-    });
-
 const desinscrisInfolettre = (destinataire) =>
   basculeInfolettre(destinataire, true);
+
 const inscrisInfolettre = (destinataire) =>
   basculeInfolettre(destinataire, false);
 
@@ -87,6 +71,29 @@ const creeContact = (
       });
       return Promise.reject(e);
     });
+
+const metAJourDonneesContact = (destinataire, donnees) =>
+  axios
+    .put(
+      `${urlBase}/contacts/${encodeURIComponent(destinataire)}`,
+      {
+        attributes: donnees,
+      },
+      enteteJSON
+    )
+    .catch((e) => {
+      fabriqueAdaptateurGestionErreur().logueErreur(e, {
+        'Erreur renvoyée par API Brevo': e.response.data,
+      });
+      return Promise.reject(e);
+    });
+
+const metAJourContact = (destinataire, prenom, nom, telephone) =>
+  metAJourDonneesContact(destinataire, {
+    PRENOM: decode(prenom),
+    NOM: decode(nom),
+    sync_mss_numero_telephone: numeroTelephoneAvecIndicatif(telephone),
+  });
 
 const inscrisEmailsTransactionnels = async (destinataire) => {
   // https://developers.brevo.com/reference/addcontacttolist-1
@@ -321,6 +328,7 @@ const creeEntreprise = async (siret, nom, natureJuridique) => {
 
 module.exports = {
   creeContact,
+  metAJourContact,
   metAJourDonneesContact,
   creeEntreprise,
   desinscrisEmailsTransactionnels,

--- a/src/bus/abonnements/metAJourContactBrevoDeLUtilisateur.js
+++ b/src/bus/abonnements/metAJourContactBrevoDeLUtilisateur.js
@@ -1,0 +1,13 @@
+function metAJourContactBrevoDeLUtilisateur({ crmBrevo }) {
+  return async ({ utilisateur }) => {
+    if (!utilisateur) {
+      throw new Error(
+        "Impossible d'envoyer à Brevo le profil utilisateur sans avoir l'utilisateur en paramètre."
+      );
+    }
+
+    await crmBrevo.metAJourProfilContact(utilisateur);
+  };
+}
+
+module.exports = { metAJourContactBrevoDeLUtilisateur };

--- a/src/bus/abonnements/metAJourContactBrevoDuContributeur.js
+++ b/src/bus/abonnements/metAJourContactBrevoDuContributeur.js
@@ -1,4 +1,4 @@
-function metAJourContactBrevo({ crmBrevo, depotDonnees }) {
+function metAJourContactBrevoDuContributeur({ crmBrevo, depotDonnees }) {
   return async ({ utilisateur }) => {
     if (!utilisateur) {
       throw new Error(
@@ -17,4 +17,4 @@ function metAJourContactBrevo({ crmBrevo, depotDonnees }) {
   };
 }
 
-module.exports = { metAJourContactBrevo };
+module.exports = { metAJourContactBrevoDuContributeur };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -56,7 +56,9 @@ const CrmBrevo = require('../crm/crmBrevo');
 const {
   modifieLienEntrepriseEtContactBrevo,
 } = require('./abonnements/modifieLienEntrepriseEtContactBrevo');
-const { metAJourContactBrevo } = require('./abonnements/metAJourContactBrevo');
+const {
+  metAJourContactBrevoDuContributeur,
+} = require('./abonnements/metAJourContactBrevoDuContributeur');
 const {
   metAJourContactsBrevoDesContributeurs,
 } = require('./abonnements/metAJourContactsBrevoDesContributeurs');
@@ -90,7 +92,7 @@ const cableTousLesAbonnes = (
       adaptateurRechercheEntreprise,
     }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
-    metAJourContactBrevo({
+    metAJourContactBrevoDuContributeur({
       crmBrevo,
       depotDonnees,
     }),

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -65,6 +65,9 @@ const {
 const {
   metAJourEstimationNombreServicesContactBrevo,
 } = require('./abonnements/metAJourEstimationNombreServicesContactBrevo');
+const {
+  metAJourContactBrevoDeLUtilisateur,
+} = require('./abonnements/metAJourContactBrevoDeLUtilisateur');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -126,6 +129,7 @@ const cableTousLesAbonnes = (
     }),
     modifieLienEntrepriseEtContactBrevo({ crmBrevo }),
     metAJourEstimationNombreServicesContactBrevo({ crmBrevo }),
+    metAJourContactBrevoDeLUtilisateur({ crmBrevo }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementUtilisateurInscrit, [

--- a/src/crm/crmBrevo.js
+++ b/src/crm/crmBrevo.js
@@ -60,6 +60,20 @@ class CrmBrevo {
     );
   }
 
+  metAJourProfilContact(utilisateur) {
+    if (!utilisateur)
+      throw new Error(
+        "Impossible de mettre à jour le contact sans l'utilisateur en paramètre."
+      );
+
+    return this.adaptateurMail.metAJourContact(
+      utilisateur.email,
+      utilisateur.prenom,
+      utilisateur.nom,
+      utilisateur.telephone
+    );
+  }
+
   metAJourNombresContributionsContact(utilisateur, autorisations) {
     if (!utilisateur) {
       throw new Error(

--- a/src/routes/nonConnecte/routesNonConnecteApi.js
+++ b/src/routes/nonConnecte/routesNonConnecteApi.js
@@ -40,6 +40,7 @@ const routesNonConnecteApi = ({
             utilisateur.email,
             utilisateur.prenom ?? '',
             utilisateur.nom ?? '',
+            utilisateur.telephone ?? '',
             !utilisateur.infolettreAcceptee,
             false
           )

--- a/test/bus/abonnements/metAJourContactBrevoDeLUtilisateur.spec.js
+++ b/test/bus/abonnements/metAJourContactBrevoDeLUtilisateur.spec.js
@@ -1,0 +1,52 @@
+const expect = require('expect.js');
+const {
+  metAJourContactBrevoDeLUtilisateur,
+} = require('../../../src/bus/abonnements/metAJourContactBrevoDeLUtilisateur');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+
+describe("L'abonnement qui met à jour le contact Brevo de l'utilisateur", () => {
+  let crmBrevo;
+  let utilisateur;
+
+  beforeEach(() => {
+    utilisateur = unUtilisateur()
+      .avecEmail('jean.dujardin@beta.gouv.com')
+      .construis();
+    crmBrevo = {
+      metAJourContact: async () => {},
+    };
+  });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await metAJourContactBrevoDeLUtilisateur({
+        crmBrevo,
+      })({
+        utilisateur: null,
+      });
+
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible d'envoyer à Brevo le profil utilisateur sans avoir l'utilisateur en paramètre."
+      );
+    }
+  });
+
+  it('délègue au CRM Brevo la mise à jour du contact', async () => {
+    let utilisateurRecu;
+    crmBrevo.metAJourProfilContact = async (u) => {
+      utilisateurRecu = u;
+    };
+
+    await metAJourContactBrevoDeLUtilisateur({
+      crmBrevo,
+    })({
+      utilisateur,
+    });
+
+    expect(utilisateurRecu).to.eql(utilisateur);
+  });
+});

--- a/test/bus/abonnements/metAJourContactBrevoDuContributeur.spec.js
+++ b/test/bus/abonnements/metAJourContactBrevoDuContributeur.spec.js
@@ -1,7 +1,7 @@
 const expect = require('expect.js');
 const {
-  metAJourContactBrevo,
-} = require('../../../src/bus/abonnements/metAJourContactBrevo');
+  metAJourContactBrevoDuContributeur,
+} = require('../../../src/bus/abonnements/metAJourContactBrevoDuContributeur');
 const {
   unUtilisateur,
 } = require('../../constructeurs/constructeurUtilisateur');
@@ -9,7 +9,7 @@ const {
   uneAutorisation,
 } = require('../../constructeurs/constructeurAutorisation');
 
-describe("L'abonnement qui met à jour le contact Brevo", () => {
+describe("L'abonnement qui met à jour le contact Brevo du contributeur", () => {
   let crmBrevo;
   let utilisateur;
   let depotDonnees;
@@ -28,7 +28,7 @@ describe("L'abonnement qui met à jour le contact Brevo", () => {
 
   it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
     try {
-      await metAJourContactBrevo({
+      await metAJourContactBrevoDuContributeur({
         crmBrevo,
         depotDonnees,
       })({
@@ -57,7 +57,7 @@ describe("L'abonnement qui met à jour le contact Brevo", () => {
       autorisationsRecues = a;
     };
 
-    await metAJourContactBrevo({
+    await metAJourContactBrevoDuContributeur({
       crmBrevo,
       depotDonnees,
     })({

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -36,6 +36,11 @@ class ConstructeurUtilisateur {
     return this;
   }
 
+  avecTelephone(telephone) {
+    this.donnees.telephone = telephone;
+    return this;
+  }
+
   sansEmail() {
     this.donnees.email = null;
     return this;

--- a/test/crm/crmBrevo.spec.js
+++ b/test/crm/crmBrevo.spec.js
@@ -321,4 +321,49 @@ describe('Le CRM Brevo', () => {
       );
     });
   });
+
+  describe('sur demande de mise à jour du contact', () => {
+    const utilisateur = unUtilisateur()
+      .quiSAppelle('Jean Valjean')
+      .avecEmail('jean.valjean@beta.gouv.fr')
+      .avecTelephone('0100000000')
+      .construis();
+
+    it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+      try {
+        await crmBrevo.metAJourProfilContact(null);
+
+        expect().fail("L'instanciation aurait dû lever une exception.");
+      } catch (e) {
+        expect(e.message).to.be(
+          "Impossible de mettre à jour le contact sans l'utilisateur en paramètre."
+        );
+      }
+    });
+
+    it('met à jour les nom, prenom et téléphone du contact Brevo', async () => {
+      let destinataireRecu;
+      let prenomRecu;
+      let nomRecu;
+      let telephoneRecu;
+      adaptateurMail.metAJourContact = async (
+        destinataire,
+        prenom,
+        nom,
+        telephone
+      ) => {
+        destinataireRecu = destinataire;
+        prenomRecu = prenom;
+        nomRecu = nom;
+        telephoneRecu = telephone;
+      };
+
+      await crmBrevo.metAJourProfilContact(utilisateur);
+
+      expect(destinataireRecu).to.eql('jean.valjean@beta.gouv.fr');
+      expect(prenomRecu).to.eql('Jean');
+      expect(nomRecu).to.eql('Valjean');
+      expect(telephoneRecu).to.eql('0100000000');
+    });
+  });
 });

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -200,12 +200,14 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         destinataire,
         prenom,
         nom,
+        telephone,
         bloqueEmails,
         bloqueMarketing
       ) => {
         expect(destinataire).to.equal('jean.dupont@mail.fr');
         expect(prenom).to.equal('Jean');
         expect(nom).to.equal('Dupont');
+        expect(telephone).to.equal('0100000000');
         expect(bloqueEmails).to.equal(false);
         expect(bloqueMarketing).to.be(false);
         return Promise.resolve();


### PR DESCRIPTION
A la création et à la mise à jour du profil utilisateur.

Par l'occasion d'ajouter la mise à jour de contact, j'en ai profité pour mettre à jour nom et prénom qui font parti du même ensemble d'informations.