### PR TITLE
[CENTRE DE NOTIFICATIONS] Ajoute une route pour les notifications de "Nouveautés"

### DIFF
--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -1,0 +1,20 @@
+class CentreNotifications {
+  constructor({ referentiel }) {
+    if (!referentiel) {
+      throw new Error(
+        "Impossible d'instancier le centre de notifications sans ses dépendances"
+      );
+    }
+    this.referentiel = referentiel;
+  }
+
+  toutesNotifications() {
+    return this.referentiel
+      .nouvellesFonctionnalites()
+      .sort(
+        (a, b) => new Date(b.dateDeDeploiement) - new Date(a.dateDeDeploiement)
+      );
+  }
+}
+
+module.exports = CentreNotifications;

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -245,6 +245,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     }
   };
 
+  const nouvellesFonctionnalites = () => donnees.nouvellesFonctionnalites || [];
+
   const derniereNouvelleFonctionnalite = (dateDeReference) => {
     const fonctionnalitesDechronologique = donnees.nouvellesFonctionnalites
       .filter(
@@ -352,6 +354,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     niveauxGravite,
     nombreOrganisationsUtilisatrices,
     nouvelleFonctionnalite,
+    nouvellesFonctionnalites,
     numeroEtape,
     premiereEtapeParcours,
     provenancesService,

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -26,6 +26,7 @@ const {
   verifieCoherenceDesDroits,
 } = require('../../modeles/autorisations/gestionDroits');
 const routesConnecteApiVisiteGuidee = require('./routesConnecteApiVisiteGuidee');
+const routesConnecteApiNotifications = require('./routesConnecteApiNotifications');
 
 const routesConnecteApi = ({
   middleware,
@@ -150,6 +151,8 @@ const routesConnecteApi = ({
       referentiel,
     })
   );
+
+  routes.use('/notifications', routesConnecteApiNotifications({ referentiel }));
 
   routes.put(
     '/motDePasse',

--- a/src/routes/connecte/routesConnecteApiNotifications.js
+++ b/src/routes/connecte/routesConnecteApiNotifications.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const CentreNotifications = require('../../notifications/centreNotifications');
+
+const routesConnecteApiNotifications = ({ referentiel }) => {
+  const routes = express.Router();
+
+  routes.get('/', async (_requete, reponse) => {
+    const centreNotifications = new CentreNotifications({ referentiel });
+    reponse.json({ notifications: centreNotifications.toutesNotifications() });
+  });
+
+  return routes;
+};
+
+module.exports = routesConnecteApiNotifications;

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -1,0 +1,31 @@
+const expect = require('expect.js');
+const CentreNotifications = require('../../src/notifications/centreNotifications');
+const Referentiel = require('../../src/referentiel');
+
+describe('Le centre de notifications', () => {
+  it("jette une erreur s'il n'est pas instancié avec les bonnes dépendances", () => {
+    expect(() => new CentreNotifications({})).to.throwError((e) => {
+      expect(e.message).to.be(
+        "Impossible d'instancier le centre de notifications sans ses dépendances"
+      );
+    });
+  });
+
+  describe('sur demande des notifications', () => {
+    it("retourne les nouveautés, dans l'ordre antéchronologique", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        nouvellesFonctionnalites: [
+          { id: 'N1', dateDeDeploiement: '2024-01-01' },
+          { id: 'N2', dateDeDeploiement: '2024-02-02' },
+        ],
+      });
+
+      const centreNotifications = new CentreNotifications({ referentiel });
+
+      const notifications = centreNotifications.toutesNotifications();
+
+      expect(notifications.length).to.be(2);
+      expect(notifications[0].id).to.be('N2');
+    });
+  });
+});

--- a/test/routes/connecte/routesConnecteApiNotifications.spec.js
+++ b/test/routes/connecte/routesConnecteApiNotifications.spec.js
@@ -1,0 +1,30 @@
+const axios = require('axios');
+const expect = require('expect.js');
+const testeurMSS = require('../testeurMSS');
+
+describe('Le serveur MSS des routes privées /api/notifications', () => {
+  const testeur = testeurMSS();
+
+  beforeEach(testeur.initialise);
+  afterEach(testeur.arrete);
+
+  describe('quand requête GET sur `/api/notifications`', () => {
+    beforeEach(() => {
+      testeur.referentiel().recharge({
+        nouvellesFonctionnalites: [
+          { id: 'N1', dateDeDeploiement: '2024-01-01' },
+          { id: 'N2', dateDeDeploiement: '2024-02-02' },
+        ],
+      });
+    });
+
+    it('retourne les notifications', async () => {
+      const reponse = await axios.get(
+        'http://localhost:1234/api/notifications'
+      );
+
+      expect(reponse.status).to.be(200);
+      expect(reponse.data.notifications.length).to.be(2);
+    });
+  });
+});


### PR DESCRIPTION
Cette route permet de lire, pour tout utilisateur connecté, l'intégralité des "Nouveautés" présente sur MSS.

Cette PR est un prérequis pour la mise en place du "Centre de notifications"