### PR TITLE
[CENTRE DE NOTIFICATIONS] Ajout du dépôt pour les nouveautés lues

### DIFF
--- a/migrations/20240604153657_creationTableNotifications.js
+++ b/migrations/20240604153657_creationTableNotifications.js
@@ -1,0 +1,9 @@
+exports.up = async (knex) =>
+  knex.schema.createTable('notifications_nouveaute', (table) => {
+    table.uuid('id_utilisateur');
+    table.string('id_nouveaute');
+    table.primary(['id_utilisateur', 'id_nouveaute']);
+    table.datetime('date_lecture').defaultTo(knex.fn.now());
+  });
+
+exports.down = async (knex) => knex.schema.dropTable('notifications_nouveaute');

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -10,6 +10,7 @@ const nouvelAdaptateur = (
   donnees.autorisations ||= [];
   donnees.parcoursUtilisateurs ||= [];
   donnees.notificationsExpirationHomologation ||= [];
+  donnees.notifications ||= [];
 
   const metsAJourEnregistrement = (
     fonctionRecherche,
@@ -282,6 +283,13 @@ const nouvelAdaptateur = (
       );
   };
 
+  const marqueNouveauteLue = async (idUtilisateur, idNouveaute) => {
+    donnees.notifications[`${idUtilisateur}-${idNouveaute}`] = {
+      idUtilisateur,
+      idNouveaute,
+    };
+  };
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -294,6 +302,7 @@ const nouvelAdaptateur = (
     homologations,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
+    marqueNouveauteLue,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,
     rechercheContributeurs,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -347,6 +347,21 @@ const nouvelAdaptateur = (env) => {
       .where({ id_service: idService })
       .del();
 
+  const marqueNouveauteLue = async (idUtilisateur, idNouveaute) => {
+    const nouveauteDejaLue =
+      (await knex('notifications_nouveaute')
+        .where('id_utilisateur', idUtilisateur)
+        .where('id_nouveaute', idNouveaute)
+        .select()
+        .first()) !== undefined;
+
+    if (!nouveauteDejaLue)
+      await knex('notifications_nouveaute').insert({
+        id_utilisateur: idUtilisateur,
+        id_nouveaute: idNouveaute,
+      });
+  };
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -360,6 +375,7 @@ const nouvelAdaptateur = (env) => {
     homologations,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
+    marqueNouveauteLue,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,
     rechercheContributeurs,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -7,6 +7,7 @@ const depotDonneesHomologations = require('./depots/depotDonneesHomologations');
 const depotDonneesNotificationsExpirationHomologation = require('./depots/depotDonneesNotificationsExpirationHomologation');
 const depotDonneesParcoursUtilisateurs = require('./depots/depotDonneesParcoursUtilisateur');
 const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
+const depotDonneesNotifications = require('./depots/depotDonneesNotifications');
 
 const creeDepot = (config = {}) => {
   const {
@@ -56,6 +57,10 @@ const creeDepot = (config = {}) => {
       adaptateurPersistance,
       adaptateurUUID,
     });
+
+  const depotNotifications = depotDonneesNotifications.creeDepot({
+    adaptateurPersistance,
+  });
 
   const {
     ajouteDescriptionService,
@@ -108,6 +113,8 @@ const creeDepot = (config = {}) => {
   const { lisParcoursUtilisateur, sauvegardeParcoursUtilisateur } =
     depotParcoursUtilisateurs;
 
+  const { marqueNouveauteLue } = depotNotifications;
+
   const {
     lisNotificationsExpirationHomologationEnDate,
     sauvegardeNotificationsExpirationHomologation,
@@ -136,6 +143,7 @@ const creeDepot = (config = {}) => {
     finaliseDossierCourant,
     lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
+    marqueNouveauteLue,
     metsAJourMotDePasse,
     metsAJourUtilisateur,
     metsAJourService,

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -1,0 +1,16 @@
+const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateurPersistance');
+
+const creeDepot = (config = {}) => {
+  const {
+    adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
+  } = config;
+
+  const marqueNouveauteLue = async (idUtilisateur, idNouveaute) =>
+    adaptateurPersistance.marqueNouveauteLue(idUtilisateur, idNouveaute);
+
+  return {
+    marqueNouveauteLue,
+  };
+};
+
+module.exports = { creeDepot };

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -43,6 +43,7 @@ class ErreurStatutMesureInvalide extends ErreurModele {}
 class ErreurSuppressionImpossible extends Error {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
+class ErreurIdentifiantNouveauteInconnu extends ErreurModele {}
 
 class ErreurUtilisateurExistant extends ErreurModele {
   constructor(message, idUtilisateur) {
@@ -74,6 +75,7 @@ module.exports = {
   ErreurDroitsIncoherents,
   ErreurDureeValiditeInvalide,
   ErreurEmailManquant,
+  ErreurIdentifiantNouveauteInconnu,
   ErreurLocalisationDonneesInvalide,
   ErreurMesureInconnue,
   ErreurMotDePasseIncorrect,

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -1,11 +1,14 @@
+const { ErreurIdentifiantNouveauteInconnu } = require('../erreurs');
+
 class CentreNotifications {
-  constructor({ referentiel }) {
-    if (!referentiel) {
+  constructor({ referentiel, depotDonnees }) {
+    if (!referentiel || !depotDonnees) {
       throw new Error(
         "Impossible d'instancier le centre de notifications sans ses dépendances"
       );
     }
     this.referentiel = referentiel;
+    this.depotDonnees = depotDonnees;
   }
 
   toutesNotifications() {
@@ -14,6 +17,16 @@ class CentreNotifications {
       .sort(
         (a, b) => new Date(b.dateDeDeploiement) - new Date(a.dateDeDeploiement)
       );
+  }
+
+  async marqueNouveauteLue(idUtilisateur, idNouveaute) {
+    const identifiantsConnus = this.referentiel
+      .nouvellesFonctionnalites()
+      .map((n) => n.id);
+    if (!identifiantsConnus.includes(idNouveaute)) {
+      throw new ErreurIdentifiantNouveauteInconnu();
+    }
+    await this.depotDonnees.marqueNouveauteLue(idUtilisateur, idNouveaute);
   }
 }
 

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -152,7 +152,11 @@ const routesConnecteApi = ({
     })
   );
 
-  routes.use('/notifications', routesConnecteApiNotifications({ referentiel }));
+  routes.use(
+    '/notifications',
+    middleware.verificationAcceptationCGU,
+    routesConnecteApiNotifications({ referentiel })
+  );
 
   routes.put(
     '/motDePasse',

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -155,7 +155,7 @@ const routesConnecteApi = ({
   routes.use(
     '/notifications',
     middleware.verificationAcceptationCGU,
-    routesConnecteApiNotifications({ referentiel })
+    routesConnecteApiNotifications({ depotDonnees, referentiel })
   );
 
   routes.put(

--- a/src/routes/connecte/routesConnecteApiNotifications.js
+++ b/src/routes/connecte/routesConnecteApiNotifications.js
@@ -1,11 +1,14 @@
 const express = require('express');
 const CentreNotifications = require('../../notifications/centreNotifications');
 
-const routesConnecteApiNotifications = ({ referentiel }) => {
+const routesConnecteApiNotifications = ({ depotDonnees, referentiel }) => {
   const routes = express.Router();
 
   routes.get('/', async (_requete, reponse) => {
-    const centreNotifications = new CentreNotifications({ referentiel });
+    const centreNotifications = new CentreNotifications({
+      depotDonnees,
+      referentiel,
+    });
     reponse.json({ notifications: centreNotifications.toutesNotifications() });
   });
 

--- a/test/depots/depotDonneesNotifications.spec.js
+++ b/test/depots/depotDonneesNotifications.spec.js
@@ -1,0 +1,31 @@
+const expect = require('expect.js');
+const {
+  unePersistanceMemoire,
+} = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
+const { creeDepot } = require('../../src/depots/depotDonneesNotifications');
+
+describe('Le dépôt de données des notifications', () => {
+  let adaptateurPersistance;
+  let depot;
+
+  beforeEach(() => {
+    adaptateurPersistance = unePersistanceMemoire().construis();
+    depot = creeDepot({ adaptateurPersistance });
+  });
+
+  describe("sur demande de marquage d'une nouveauté comme lue", () => {
+    it("délègue à l'adaptateur persistance le marquage", async () => {
+      let donneesRecues;
+      adaptateurPersistance.marqueNouveauteLue = async (
+        idUtilisateur,
+        idNouveaute
+      ) => {
+        donneesRecues = { idUtilisateur, idNouveaute };
+      };
+      await depot.marqueNouveauteLue('U1', 'N1');
+
+      expect(donneesRecues.idUtilisateur).to.be('U1');
+      expect(donneesRecues.idNouveaute).to.be('N1');
+    });
+  });
+});

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -1,8 +1,23 @@
 const expect = require('expect.js');
 const CentreNotifications = require('../../src/notifications/centreNotifications');
 const Referentiel = require('../../src/referentiel');
+const { creeDepot } = require('../../src/depotDonnees');
+const { ErreurIdentifiantNouveauteInconnu } = require('../../src/erreurs');
 
 describe('Le centre de notifications', () => {
+  let referentiel;
+  let depotDonnees;
+
+  beforeEach(() => {
+    referentiel = Referentiel.creeReferentiel({
+      nouvellesFonctionnalites: [
+        { id: 'N1', dateDeDeploiement: '2024-01-01' },
+        { id: 'N2', dateDeDeploiement: '2024-02-02' },
+      ],
+    });
+    depotDonnees = creeDepot();
+  });
+
   it("jette une erreur s'il n'est pas instancié avec les bonnes dépendances", () => {
     expect(() => new CentreNotifications({})).to.throwError((e) => {
       expect(e.message).to.be(
@@ -13,19 +28,50 @@ describe('Le centre de notifications', () => {
 
   describe('sur demande des notifications', () => {
     it("retourne les nouveautés, dans l'ordre antéchronologique", () => {
-      const referentiel = Referentiel.creeReferentiel({
-        nouvellesFonctionnalites: [
-          { id: 'N1', dateDeDeploiement: '2024-01-01' },
-          { id: 'N2', dateDeDeploiement: '2024-02-02' },
-        ],
+      const centreNotifications = new CentreNotifications({
+        referentiel,
+        depotDonnees,
       });
-
-      const centreNotifications = new CentreNotifications({ referentiel });
 
       const notifications = centreNotifications.toutesNotifications();
 
       expect(notifications.length).to.be(2);
       expect(notifications[0].id).to.be('N2');
+    });
+  });
+
+  describe('sur marquage de nouveauté lue', () => {
+    it("jette une erreur si l'identifiant de nouveauté n'est pas présent dans le référentiel", async () => {
+      const centreNotifications = new CentreNotifications({
+        referentiel,
+        depotDonnees,
+      });
+
+      try {
+        await centreNotifications.marqueNouveauteLue(
+          'idUtilisateur',
+          'ID_NOUVEAUTE_INCONNU'
+        );
+        expect().fail("L'appel aurait dû lever une exception.");
+      } catch (e) {
+        expect(e).to.be.an(ErreurIdentifiantNouveauteInconnu);
+      }
+    });
+
+    it("délègue au dépôt de données le marquage à 'lu' de la nouveauté", async () => {
+      let donneesRecues;
+      depotDonnees.marqueNouveauteLue = async (idUtilisateur, idNouveaute) => {
+        donneesRecues = { idUtilisateur, idNouveaute };
+      };
+      const centreNotifications = new CentreNotifications({
+        referentiel,
+        depotDonnees,
+      });
+
+      await centreNotifications.marqueNouveauteLue('U1', 'N1');
+
+      expect(donneesRecues.idUtilisateur).to.be('U1');
+      expect(donneesRecues.idNouveaute).to.be('N1');
     });
   });
 });

--- a/test/routes/connecte/routesConnecteApiNotifications.spec.js
+++ b/test/routes/connecte/routesConnecteApiNotifications.spec.js
@@ -18,6 +18,15 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
       });
     });
 
+    it("vérifie que l'utilisateur a accepté les CGU", (done) => {
+      testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(
+          { method: 'post', url: 'http://localhost:1234/api/notifications' },
+          done
+        );
+    });
+
     it('retourne les notifications', async () => {
       const reponse = await axios.get(
         'http://localhost:1234/api/notifications'


### PR DESCRIPTION
On ajoute ici un méthode à l'objet `CentreNotification` qui permet de marquer une notification de type "Nouveauté" comme lue.

On créer une `table` dédiée aux notifications de nouveauté, car ce sont les seules (pour l'instant) qui peuvent être marquée ainsi.
Le dépôt fait un simple passe plat vers l'adaptateur de persistance.