### PR TITLE
[TECHNIQUE] Utilise la commande `docker compose` plutôt que `docker-compose`

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-docker-compose up web
+docker compose up web

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-docker-compose up test
+docker compose up test


### PR DESCRIPTION
... dans les scripts de lancement de l'app et des tests. Cette commande était l'ancienne version, d'une autre dépendance. Désormais, docker comprend les commandes `docker compose` nativement