### PR TITLE
[NOTIFICATIONS] Ajoute l'affichage des notifications de type "tâche"

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -27,7 +27,28 @@ module.exports = {
     },
   ],
 
-  tachesCompletudeProfil: [],
+  tachesCompletudeProfil: [
+    {
+      id: 'profil',
+      lien: '/utilisateur/edition',
+      titre: 'Nous vous invitons à compléter votre profil.',
+      titreCta: 'Aller sur mon profil',
+    },
+    {
+      id: 'siret',
+      lien: '/utilisateur/edition#siret',
+      titre:
+        'Nous vous invitons à renseigner le numéro de SIRET de votre organisation.',
+      titreCta: 'Aller sur mon profil',
+    },
+    {
+      id: 'estimationNombreServices',
+      lien: '/utilisateur/edition#estimation-nombre-services',
+      titre:
+        'Nous vous invitons à estimer le nombre de services publics à sécuriser.',
+      titreCta: 'Aller sur mon profil',
+    },
+  ],
 
   nombreOrganisationsUtilisatrices: [
     { label: 'Mon organisation uniquement', borneBasse: 1, borneHaute: 1 },

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -31,22 +31,26 @@ module.exports = {
     {
       id: 'profil',
       lien: '/utilisateur/edition',
-      titre: 'Nous vous invitons à compléter votre profil.',
-      titreCta: 'Aller sur mon profil',
+      entete: 'Complétez votre profil',
+      titre:
+        'Nous vous invitons à mettre à jour les informations de votre profil.',
+      titreCta: 'Compléter mon profil',
     },
     {
       id: 'siret',
       lien: '/utilisateur/edition#siret',
+      entete: 'Mettez à jour votre SIRET',
       titre:
         'Nous vous invitons à renseigner le numéro de SIRET de votre organisation.',
-      titreCta: 'Aller sur mon profil',
+      titreCta: 'Mettre à jour le SIRET',
     },
     {
       id: 'estimationNombreServices',
       lien: '/utilisateur/edition#estimation-nombre-services',
+      entete: 'Estimez les services publics à sécuriser',
       titre:
         'Nous vous invitons à estimer le nombre de services publics à sécuriser.',
-      titreCta: 'Aller sur mon profil',
+      titreCta: 'Estimer le nombre de service',
     },
   ],
 

--- a/public/assets/images/notifications/tache.svg
+++ b/public/assets/images/notifications/tache.svg
@@ -1,0 +1,7 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="danger">
+<path id="Vector" d="M10 17.8417H4.94998C2.05832 17.8417 0.849985 15.7751 2.24998 13.2501L4.84999 8.56675L7.29999 4.16677C8.78336 1.49177 11.2167 1.49177 12.7 4.16677L15.15 8.57508L17.75 13.2584C19.15 15.7834 17.9334 17.8501 15.05 17.8501H10V17.8417Z" stroke="#FAA72C" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M10 7.50012V11.6668" stroke="#FAA72C" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M9.99536 14.1667H10.0029" stroke="#FAA72C" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/svelte/lib/centreNotifications/centreNotifications.d.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.d.ts
@@ -1,9 +1,23 @@
-export type Notification = {
+export type TypeNotification = 'nouveaute' | 'tache';
+
+type NotificationBase = {
   id: string;
   titre: string;
+  statutLecture: 'lue' | 'nonLue';
+  lien: string;
+  type: TypeNotification;
+};
+
+export type NotificationNouveaute = NotificationBase & {
+  type: 'nouveaute';
   image: string;
   sousTitre: string;
   dateDeDeploiement: string;
-  statutLecture: 'lue' | 'nonLue';
-  lien: string;
 };
+
+export type NotificationTache = NotificationBase & {
+  type: 'tache';
+  titreCta: string;
+};
+
+export type Notification = NotificationNouveaute | NotificationTache;

--- a/svelte/lib/centreNotifications/centreNotifications.d.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.d.ts
@@ -18,6 +18,7 @@ export type NotificationNouveaute = NotificationBase & {
 export type NotificationTache = NotificationBase & {
   type: 'tache';
   titreCta: string;
+  entete: string;
 };
 
 export type Notification = NotificationNouveaute | NotificationTache;

--- a/svelte/lib/centreNotifications/kit/Notification.svelte
+++ b/svelte/lib/centreNotifications/kit/Notification.svelte
@@ -8,9 +8,7 @@
 
   const dispatch = createEventDispatcher();
   const enteteNotification =
-    notification.type === 'nouveaute'
-      ? 'Nouveautés'
-      : 'Informations à mettre à jour';
+    notification.type === 'nouveaute' ? 'Nouveautés' : notification.entete;
   const cibleCta = notification.type === 'nouveaute' ? '_blank' : '';
   const relationCta = notification.type === 'nouveaute' ? 'noopener' : '';
   const actionClick =

--- a/svelte/lib/centreNotifications/kit/Notification.svelte
+++ b/svelte/lib/centreNotifications/kit/Notification.svelte
@@ -10,10 +10,25 @@
   const enteteNotification =
     notification.type === 'nouveaute'
       ? 'Nouveautés'
-      : 'Mettre à jour les informations';
+      : 'Informations à mettre à jour';
+  const cibleCta = notification.type === 'nouveaute' ? '_blank' : '';
+  const relationCta = notification.type === 'nouveaute' ? 'noopener' : '';
+  const actionClick =
+    notification.type === 'nouveaute'
+      ? async () => {
+          await marqueNotificationCommeLue(notification.id);
+          dispatch('notificationMiseAJour');
+        }
+      : () => {};
 </script>
 
-<div class="notification">
+<a
+  class="notification"
+  href={notification.lien}
+  rel={relationCta}
+  target={cibleCta}
+  on:click={actionClick}
+>
   <div class="conteneur-pictogramme {notification.type}">
     {#if notification.statutLecture === 'nonLue'}
       <div class="pastille-non-lue" />
@@ -34,22 +49,13 @@
         />
         <div>
           <p class="sous-titre">{notification.sousTitre}</p>
-          <a
-            href={notification.lien}
-            class="cta"
-            rel="noopener"
-            target="_blank"
-            on:click={async () => {
-              await marqueNotificationCommeLue(notification.id);
-              dispatch('notificationMiseAJour');
-            }}>Découvrir</a
-          >
+          <div class="cta">Découvrir</div>
         </div>
       </div>
     {:else}
-      <a href={notification.lien} class="cta cta-tache"
-        >{notification.titreCta}
-      </a>
+      <div class="cta cta-tache">
+        {notification.titreCta}
+      </div>
     {/if}
 
     {#if notification.type === 'nouveaute'}
@@ -62,7 +68,7 @@
       </div>
     {/if}
   </div>
-</div>
+</a>
 
 <style>
   .type-notification {
@@ -79,6 +85,11 @@
     display: flex;
     flex-direction: row;
     gap: 8px;
+    cursor: pointer;
+  }
+
+  .notification:hover {
+    background: var(--systeme-design-etat-gris-survol);
   }
 
   .conteneur-pictogramme {
@@ -116,22 +127,18 @@
     max-width: 86px;
   }
 
-  a.cta {
+  .cta {
     color: var(--bleu-mise-en-avant);
     padding: 4px 8px;
     border: 1px solid var(--bleu-mise-en-avant);
     border-radius: 4px;
-    cursor: pointer;
     font-size: 12px;
+    background: none;
+    width: fit-content;
   }
 
-  a.cta-tache {
-    margin-top: 8px;
-  }
-
-  a.cta:hover {
-    background: var(--bleu-mise-en-avant) !important;
-    color: white;
+  .cta-tache {
+    margin-top: 16px;
   }
 
   p.sous-titre {

--- a/svelte/lib/centreNotifications/kit/Notification.svelte
+++ b/svelte/lib/centreNotifications/kit/Notification.svelte
@@ -7,45 +7,60 @@
   export let notification: Notification;
 
   const dispatch = createEventDispatcher();
+  const enteteNotification =
+    notification.type === 'nouveaute'
+      ? 'Nouveautés'
+      : 'Mettre à jour les informations';
 </script>
 
 <div class="notification">
-  <div class="conteneur-pictogramme">
+  <div class="conteneur-pictogramme {notification.type}">
     {#if notification.statutLecture === 'nonLue'}
       <div class="pastille-non-lue" />
     {/if}
     <img
-      src="/statique/assets/images/notifications/nouveaute.svg"
-      alt="Icône de nouveauté"
+      src="/statique/assets/images/notifications/{notification.type}.svg"
+      alt="Icône de {notification.type}"
     />
   </div>
   <div class="conteneur-notification">
-    <p class="type-notification">Nouveautés</p>
+    <p class="type-notification">{enteteNotification}</p>
     <p class="titre">{notification.titre}</p>
-    <div class="cartouche-cta">
-      <img
-        src="/statique/assets/images/notifications/illustrations/{notification.image}"
-        alt="Illustration de la nouveauté {notification.titre}"
-      />
-      <div>
-        <p class="sous-titre">{notification.sousTitre}</p>
-        <a
-          href={notification.lien}
-          class="cta"
-          rel="noopener"
-          target="_blank"
-          on:click={async () => {
-            await marqueNotificationCommeLue(notification.id);
-            dispatch('notificationMiseAJour');
-          }}>Découvrir</a
+    {#if notification.type === 'nouveaute'}
+      <div class="cartouche-cta">
+        <img
+          src="/statique/assets/images/notifications/illustrations/{notification.image}"
+          alt="Illustration de la nouveauté {notification.titre}"
+        />
+        <div>
+          <p class="sous-titre">{notification.sousTitre}</p>
+          <a
+            href={notification.lien}
+            class="cta"
+            rel="noopener"
+            target="_blank"
+            on:click={async () => {
+              await marqueNotificationCommeLue(notification.id);
+              dispatch('notificationMiseAJour');
+            }}>Découvrir</a
+          >
+        </div>
+      </div>
+    {:else}
+      <a href={notification.lien} class="cta cta-tache"
+        >{notification.titreCta}
+      </a>
+    {/if}
+
+    {#if notification.type === 'nouveaute'}
+      <div class="horodatage">
+        <span
+          >{formatteDifferenceDateRelative(
+            notification.dateDeDeploiement
+          )}</span
         >
       </div>
-    </div>
-    <div class="horodatage">
-      <span
-        >{formatteDifferenceDateRelative(notification.dateDeDeploiement)}</span
-      >
-    </div>
+    {/if}
   </div>
 </div>
 
@@ -73,11 +88,18 @@
     max-width: var(--taille);
     max-height: var(--taille);
     border-radius: 50%;
-    background: var(--fond-bleu-pale);
     display: flex;
     align-items: center;
     justify-content: center;
     position: relative;
+  }
+
+  .conteneur-pictogramme.tache {
+    background: var(--fond-ocre-pale);
+  }
+
+  .conteneur-pictogramme.nouveaute {
+    background: var(--fond-bleu-pale);
   }
 
   .cartouche-cta {
@@ -101,6 +123,10 @@
     border-radius: 4px;
     cursor: pointer;
     font-size: 12px;
+  }
+
+  a.cta-tache {
+    margin-top: 8px;
   }
 
   a.cta:hover {

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -26,6 +26,14 @@ class ConstructeurUtilisateur {
     };
   }
 
+  quiEstInvite() {
+    this.donnees.prenom = '';
+    this.donnees.nom = '';
+    this.donnees.siret = '';
+    this.donnees.estimationNombreServices = {};
+    return this;
+  }
+
   avecId(idUtilisateur) {
     this.donnees.id = idUtilisateur;
     return this;

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -141,17 +141,18 @@ describe('Le centre de notifications', () => {
       expect(taches.length).to.be(0);
     });
 
-    describe("lorsque le nom de l'utilisateur est manquant", () => {
+    describe("lorsque le siret de l'utilisateur est manquant", () => {
       beforeEach(() => {
         depotDonnees.utilisateur = async () =>
           unUtilisateur()
-            .quiTravaillePourUneEntiteAvecSiret('12345')
+            .quiSAppelle('Jeanine Valjean')
+            .quiTravaillePourUneEntiteAvecSiret(null)
             .construis();
       });
 
       it('renvoie la notification correspondant au champ non renseigné du profil', async () => {
         referentiel = Referentiel.creeReferentiel({
-          tachesCompletudeProfil: [{ id: 'nom', titre: 'Titre tâche' }],
+          tachesCompletudeProfil: [{ id: 'siret', titre: 'Titre tâche' }],
         });
         const centreNotifications = new CentreNotifications({
           referentiel,
@@ -179,6 +180,27 @@ describe('Le centre de notifications', () => {
         expect(taches.length).to.be(0);
       });
     });
+    describe("lorsque l'utilisateur est invité'", () => {
+      it('renvoie uniquement la notification de profil', async () => {
+        depotDonnees.utilisateur = async () =>
+          unUtilisateur().quiEstInvite().construis();
+        referentiel = Referentiel.creeReferentiel({
+          tachesCompletudeProfil: [
+            { id: 'profil', titre: 'Titre tâche' },
+            { id: 'siret', titre: 'Titre tâche' },
+          ],
+        });
+        const centreNotifications = new CentreNotifications({
+          referentiel,
+          depotDonnees,
+        });
+
+        const taches = await centreNotifications.toutesTachesEnAttente('U1');
+
+        expect(taches.length).to.be(1);
+        expect(taches[0].id).to.be('profil');
+      });
+    });
   });
 
   describe('sur demande de toutes les notifications', () => {
@@ -186,9 +208,9 @@ describe('Le centre de notifications', () => {
 
     beforeEach(() => {
       depotDonnees.utilisateur = async () =>
-        unUtilisateur().quiTravaillePourUneEntiteAvecSiret('12345').construis();
+        unUtilisateur().quiSAppelle('Jean Valjean').construis();
       referentiel = Referentiel.creeReferentiel({
-        tachesCompletudeProfil: [{ id: 'nom', titre: 'Titre tâche' }],
+        tachesCompletudeProfil: [{ id: 'siret', titre: 'Titre tâche' }],
         nouvellesFonctionnalites: [
           { id: 'N1', dateDeDeploiement: '2024-01-01' },
         ],
@@ -203,7 +225,7 @@ describe('Le centre de notifications', () => {
       const notifications = await centreNotifications.toutesNotifications('U1');
 
       expect(notifications.length).to.be(2);
-      expect(notifications[0].id).to.be('nom');
+      expect(notifications[0].id).to.be('siret');
       expect(notifications[1].id).to.be('N1');
     });
 


### PR DESCRIPTION
Suite à l'ajout du nouveau type de notification "tâche" pour représenter les actions que l'utilisateur doit accomplir, on les affiche dans le centre de notifications.
Elles n'ont pas d'horodatage et sont toujours affichées "non lues".
On ajoute le cas particulier de l'utilisateur invité qui a son profil vide : plutôt que d'afficher de multiples notifications pour chaque champ vide de son profil, on ne lui en affiche qu'une pour l'inviter à compléter son profil.