### PR TITLE
[SOIN] Désactive l’autocomplétion pour les nouveaux mots de passe

### DIFF
--- a/src/vues/motDePasse/edition.pug
+++ b/src/vues/motDePasse/edition.pug
@@ -42,11 +42,11 @@ block main
           .message-erreur-specifique Le mot de passe actuel saisi est incorrect
 
       label.requis Nouveau mot de passe
-        input(id='mot-de-passe', name = 'motDePasse', type='password', required)
+        input(id='mot-de-passe', name = 'motDePasse', type='password', required, autocomplete='new-password')
         .message-erreur Le mot de passe n'est pas assez robuste
 
       label.requis Confirmez mot de passe
-        input(id='mot-de-passe-confirmation', name = 'motDePasseConfirmation', type='password', required)
+        input(id='mot-de-passe-confirmation', name = 'motDePasseConfirmation', type='password', required, autocomplete='new-password')
         .message-erreur Les deux mots de passe sont différents
 
       if !utilisateur.accepteCGU()


### PR DESCRIPTION
Les gestionnaires de mot de passe (type Bitwarden ou Dashlane) complètent tous les champs de type mot de passe. Cette PR permet de ne pas compléter les nouveaux mots de passe. 