### PR TITLE
[CORRECTION] Change la cible des nouveautés dans la visite guidée

### DIFF
--- a/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
+++ b/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
@@ -5,7 +5,7 @@
   import type { SousEtape } from '../../kit/ModaleSousEtape';
 
   let cibleNomService: HTMLElement;
-  let cibleBandeauNouveaute: HTMLElement;
+  let cibleCentreNotifications: HTMLElement;
   let cibleBOM: HTMLElement;
   let cibleNouveauService: HTMLElement;
   let cibleLignePremierService: HTMLElement;
@@ -31,7 +31,7 @@
       subtree: false,
     });
 
-    cibleBandeauNouveaute = elementDeClasse('bandeau-nouveautes');
+    cibleCentreNotifications = elementDeClasse('centre-notifications');
     cibleBOM = elementDeClasse('bom-modale');
     cibleNouveauService = elementDeClasse('nouveau-service');
   });
@@ -72,7 +72,7 @@
   };
 </script>
 
-{#if cibleNomService && cibleBandeauNouveaute && cibleBOM && cibleNouveauService && cibleLignePremierService}
+{#if cibleNomService && cibleCentreNotifications && cibleBOM && cibleNouveauService && cibleLignePremierService}
   <ModaleSousEtape
     sousEtapes={[
       {
@@ -92,7 +92,7 @@
         animation: '/statique/assets/images/visiteGuidee/tableau_de_bord.gif',
       },
       {
-        cible: cibleBandeauNouveaute,
+        cible: cibleCentreNotifications,
         positionnementModale: 'BasMilieu',
         margeElementMisEnAvant: 3,
         callbackInitialeCible: (cible) => {


### PR DESCRIPTION
... car le bandeau des nouveautés a été remplacé par le centre de notifications.

L’étape de visite guidée ne s’affichait plus.