### PR TITLE
[CENTRE DE NOTIFICATIONS] Filtre les nouveautés futures

### DIFF
--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -6,14 +6,15 @@ const avecStatutLecture = (notification, statutLecture) => ({
 });
 
 class CentreNotifications {
-  constructor({ referentiel, depotDonnees }) {
-    if (!referentiel || !depotDonnees) {
+  constructor({ referentiel, depotDonnees, adaptateurHorloge }) {
+    if (!referentiel || !depotDonnees || !adaptateurHorloge) {
       throw new Error(
         "Impossible d'instancier le centre de notifications sans ses dépendances"
       );
     }
     this.referentiel = referentiel;
     this.depotDonnees = depotDonnees;
+    this.adaptateurHorloge = adaptateurHorloge;
   }
 
   async toutesNotifications(idUtilisateur) {
@@ -30,6 +31,10 @@ class CentreNotifications {
   async toutesNouveautes(idUtilisateur) {
     const toutesNouveautes = this.referentiel
       .nouvellesFonctionnalites()
+      .filter(
+        (n) =>
+          new Date(n.dateDeDeploiement) <= this.adaptateurHorloge.maintenant()
+      )
       .sort(
         (a, b) => new Date(b.dateDeDeploiement) - new Date(a.dateDeDeploiement)
       );

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -155,7 +155,11 @@ const routesConnecteApi = ({
   routes.use(
     '/notifications',
     middleware.verificationAcceptationCGU,
-    routesConnecteApiNotifications({ depotDonnees, referentiel })
+    routesConnecteApiNotifications({
+      adaptateurHorloge,
+      depotDonnees,
+      referentiel,
+    })
   );
 
   routes.put(

--- a/src/routes/connecte/routesConnecteApiNotifications.js
+++ b/src/routes/connecte/routesConnecteApiNotifications.js
@@ -2,13 +2,18 @@ const express = require('express');
 const CentreNotifications = require('../../notifications/centreNotifications');
 const { ErreurIdentifiantNouveauteInconnu } = require('../../erreurs');
 
-const routesConnecteApiNotifications = ({ depotDonnees, referentiel }) => {
+const routesConnecteApiNotifications = ({
+  adaptateurHorloge,
+  depotDonnees,
+  referentiel,
+}) => {
   const routes = express.Router();
 
   routes.get('/', async (requete, reponse) => {
     const centreNotifications = new CentreNotifications({
       depotDonnees,
       referentiel,
+      adaptateurHorloge,
     });
     reponse.json({
       notifications: await centreNotifications.toutesNotifications(
@@ -21,6 +26,7 @@ const routesConnecteApiNotifications = ({ depotDonnees, referentiel }) => {
     const centreNotifications = new CentreNotifications({
       depotDonnees,
       referentiel,
+      adaptateurHorloge,
     });
     try {
       await centreNotifications.marqueNouveauteLue(

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -4,6 +4,7 @@ const Referentiel = require('../../src/referentiel');
 const { creeDepot } = require('../../src/depotDonnees');
 const { ErreurIdentifiantNouveauteInconnu } = require('../../src/erreurs');
 const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+const adaptateurHorloge = require('../../src/adaptateurs/adaptateurHorloge');
 
 describe('Le centre de notifications', () => {
   let referentiel;
@@ -32,6 +33,7 @@ describe('Le centre de notifications', () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
 
       const notifications = await centreNotifications.toutesNouveautes('U1');
@@ -49,6 +51,7 @@ describe('Le centre de notifications', () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
 
       const notifications = await centreNotifications.toutesNouveautes('U1');
@@ -60,6 +63,24 @@ describe('Le centre de notifications', () => {
       expect(notifications[1].id).to.be('N1');
       expect(notifications[1].statutLecture).to.be('nonLue');
     });
+
+    it('ne retourne pas les nouveautés du futur', async () => {
+      referentiel = Referentiel.creeReferentiel({
+        nouvellesFonctionnalites: [
+          { id: 'N1', dateDeDeploiement: '2024-01-01' },
+        ],
+      });
+      const decembre2023 = { maintenant: () => new Date(2023, 11, 1) };
+      const centreNotifications = new CentreNotifications({
+        referentiel,
+        depotDonnees,
+        adaptateurHorloge: decembre2023,
+      });
+
+      const notifications = await centreNotifications.toutesNouveautes('U1');
+
+      expect(notifications.length).to.be(0);
+    });
   });
 
   describe('sur marquage de nouveauté lue', () => {
@@ -67,6 +88,7 @@ describe('Le centre de notifications', () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
 
       try {
@@ -88,6 +110,7 @@ describe('Le centre de notifications', () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
 
       await centreNotifications.marqueNouveauteLue('U1', 'N1');
@@ -106,6 +129,7 @@ describe('Le centre de notifications', () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
 
       await centreNotifications.toutesTachesEnAttente('U1');
@@ -118,6 +142,7 @@ describe('Le centre de notifications', () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
 
       const taches = await centreNotifications.toutesTachesEnAttente('U1');
@@ -134,6 +159,7 @@ describe('Le centre de notifications', () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
 
       const taches = await centreNotifications.toutesTachesEnAttente('U1');
@@ -157,6 +183,7 @@ describe('Le centre de notifications', () => {
         const centreNotifications = new CentreNotifications({
           referentiel,
           depotDonnees,
+          adaptateurHorloge,
         });
 
         const taches = await centreNotifications.toutesTachesEnAttente('U1');
@@ -173,6 +200,7 @@ describe('Le centre de notifications', () => {
         const centreNotifications = new CentreNotifications({
           referentiel,
           depotDonnees,
+          adaptateurHorloge,
         });
 
         const taches = await centreNotifications.toutesTachesEnAttente('U1');
@@ -193,6 +221,7 @@ describe('Le centre de notifications', () => {
         const centreNotifications = new CentreNotifications({
           referentiel,
           depotDonnees,
+          adaptateurHorloge,
         });
 
         const taches = await centreNotifications.toutesTachesEnAttente('U1');
@@ -218,6 +247,7 @@ describe('Le centre de notifications', () => {
       centreNotifications = new CentreNotifications({
         referentiel,
         depotDonnees,
+        adaptateurHorloge,
       });
     });
 

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -3,7 +3,6 @@ const expect = require('expect.js');
 
 const { depotVide } = require('../depots/depotVide');
 const adaptateurGestionErreurVide = require('../../src/adaptateurs/adaptateurGestionErreurVide');
-const adaptateurHorlogeParDefaut = require('../../src/adaptateurs/adaptateurHorloge');
 const adaptateurMailMemoire = require('../../src/adaptateurs/adaptateurMailMemoire');
 const MoteurRegles = require('../../src/moteurRegles');
 const MSS = require('../../src/mss');
@@ -54,7 +53,9 @@ const testeurMss = () => {
 
   const initialise = (done) => {
     serviceAnnuaire = {};
-    adaptateurHorloge = adaptateurHorlogeParDefaut;
+    adaptateurHorloge = {
+      maintenant: () => new Date(),
+    };
     adaptateurMail = adaptateurMailMemoire.fabriqueAdaptateurMailMemoire();
     adaptateurPdf = {
       genereAnnexes: async () => 'PDF Annexe',


### PR DESCRIPTION
Car on ne souhaite pas afficher, dans le centre de notifications, les nouveautés dont la date de déploiement est postérieure à la date du jour