### PR TITLE
[CORRECTION] Corrige l'affiche du footer dans le parcours service

### DIFF
--- a/public/assets/styles/parcoursService.css
+++ b/public/assets/styles/parcoursService.css
@@ -80,3 +80,9 @@ main {
   text-decoration: none;
   flex: 1;
 }
+
+nav.marges-fixes {
+  width: 1200px;
+  margin: 0 auto;
+  height: unset;
+}


### PR DESCRIPTION
Le footer ne s'affiche plus correctement, à cause des nouvelles règles CSS sur `marges-fixes`

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/9ea8cd9c-ed01-4b23-ab36-05fc9e08195c)
