### PR TITLE
[DECRIRE] Affiche le message en cas de doublon de nom

### DIFF
--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -8,7 +8,7 @@ import {
 
 const messageErreurNomDejaUtilise = {
   affiche: () => {
-    $('#nom-deja-utilise').show();
+    $('#nom-deja-utilise').css('display', 'flex');
     const $champNomService = $('#nom-service');
     $champNomService
       .get(0)
@@ -132,11 +132,17 @@ const brancheComportementNavigationEtapes = () => {
       afficheEtape();
     }
   });
+  return {
+    afficheEtape1: () => {
+      etapeCourante = 1;
+      afficheEtape();
+    },
+  };
 };
 
 $(() => {
   afficheBanniereMiseAJourSiret();
-  brancheComportementNavigationEtapes();
+  const navigationEtapes = brancheComportementNavigationEtapes();
   initialiseComportementFormulaire(
     '#homologation',
     '.bouton#diagnostic',
@@ -144,6 +150,7 @@ $(() => {
     (e) => {
       if (estNomServiceDejaUtilise(e.response)) {
         messageErreurNomDejaUtilise.affiche();
+        navigationEtapes.afficheEtape1();
       }
     }
   );


### PR DESCRIPTION
Lorsque le nom de service existe déjà, on revient automatiquement à la première étape pour voir et corriger l’erreur de validation