### PR TITLE
[NIVEAU DE SÉCURITÉ] Ajoute une méthode permettant d'estimer le niveau de sécurité 

### DIFF
--- a/src/modeles/descriptionService.js
+++ b/src/modeles/descriptionService.js
@@ -123,6 +123,32 @@ class DescriptionService extends InformationsHomologation {
       );
     }
   }
+
+  estimeNiveauDeSecurite() {
+    const estDeNiveau3 =
+      this.fonctionnalites.includes('signatureElectronique') ||
+      this.donneesCaracterePersonnel.includes('sensibiliteParticuliere') ||
+      this.delaiAvantImpactCritique === 'moinsUneHeure' ||
+      this.risqueJuridiqueFinancierReputationnel;
+    if (estDeNiveau3) return 'niveau3';
+
+    const fonctionnalitesNiveau2 = [
+      'reseauSocial',
+      'visionconference',
+      'messagerie',
+      'edition',
+      'paiement',
+    ];
+    const donneesPersonnelNiveau2 = ['identite', 'situation', 'mineurs'];
+    const estDeNiveau2 =
+      this.fonctionnalites.some((f) => fonctionnalitesNiveau2.includes(f)) ||
+      this.donneesCaracterePersonnel.some((f) =>
+        donneesPersonnelNiveau2.includes(f)
+      );
+    if (estDeNiveau2) return 'niveau2';
+
+    return 'niveau1';
+  }
 }
 
 module.exports = DescriptionService;

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -247,4 +247,60 @@ describe('La description du service', () => {
       InformationsHomologation.COMPLETES
     );
   });
+
+  describe("sur demande d'estimation du niveau de sécurité", () => {
+    [
+      ['fonctionnalites', ['signatureElectronique']],
+      ['delaiAvantImpactCritique', 'moinsUneHeure'],
+      ['donneesCaracterePersonnel', ['sensibiliteParticuliere']],
+      ['risqueJuridiqueFinancierReputationnel', true],
+    ].forEach(([cle, propriete]) => {
+      it(`retourne 'niveau3' si la propriété '${propriete}' est présente dans '${cle}'`, () => {
+        const descriptionDeNiveau3 = new DescriptionService({
+          nomService: 'Super Service',
+          [cle]: propriete,
+        });
+
+        const estimation = descriptionDeNiveau3.estimeNiveauDeSecurite();
+
+        expect(estimation).to.be('niveau3');
+      });
+    });
+
+    [
+      ['fonctionnalites', ['reseauSocial']],
+      ['fonctionnalites', ['visionconference']],
+      ['fonctionnalites', ['messagerie']],
+      ['fonctionnalites', ['edition']],
+      ['fonctionnalites', ['paiement']],
+      ['donneesCaracterePersonnel', ['identite']],
+      ['donneesCaracterePersonnel', ['situation']],
+      ['donneesCaracterePersonnel', ['mineurs']],
+    ].forEach(([cle, propriete]) => {
+      it(`retourne 'niveau2' si la propriété '${propriete}' est présente dans '${cle}'`, () => {
+        const descriptionDeNiveau2 = new DescriptionService({
+          nomService: 'Super Service',
+          [cle]: propriete,
+        });
+
+        const estimation = descriptionDeNiveau2.estimeNiveauDeSecurite();
+
+        expect(estimation).to.be('niveau2');
+      });
+    });
+
+    it('retourne "niveau1" par défaut', () => {
+      const descriptionDeNiveau1 = new DescriptionService({
+        nomService: 'Super Service',
+        fonctionnalites: ['uneAutreFonctionnalite'],
+        donneesCaracterePersonnel: ['uneAutreDonnees'],
+        risqueJuridiqueFinancierReputationnel: false,
+        delaiAvantImpactCritique: 'autreDelai',
+      });
+
+      const estimation = descriptionDeNiveau1.estimeNiveauDeSecurite();
+
+      expect(estimation).to.be('niveau1');
+    });
+  });
 });


### PR DESCRIPTION
…recommandé en fonction d'une description de service.

On choisit volontairement de réaliser cette estimation "en dur", car les règles métier ne devraient pas changer. De plus, il semble cohérent que le modèle `DescriptionService` puisse estimer son propre niveau de sécurité