### PR TITLE
[NIVEAU DE SÉCURITÉ] Ajoute une route permettant d'obtenir le niveau minimal de sécurité

### DIFF
--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -139,6 +139,43 @@ const routesConnecteApiService = ({
     }
   );
 
+  routes.post(
+    '/estimationNiveauSecurite',
+    middleware.verificationAcceptationCGU,
+    middleware.aseptise(
+      'nomService',
+      'organisationsResponsables.*',
+      'nombreOrganisationsUtilisatrices.*'
+    ),
+    middleware.aseptiseListes([
+      { nom: 'pointsAcces', proprietes: PointsAcces.proprietesItem() },
+      {
+        nom: 'fonctionnalitesSpecifiques',
+        proprietes: FonctionnalitesSpecifiques.proprietesItem(),
+      },
+      {
+        nom: 'donneesSensiblesSpecifiques',
+        proprietes: DonneesSensiblesSpecifiques.proprietesItem(),
+      },
+    ]),
+    async (requete, reponse) => {
+      try {
+        const descriptionService = new DescriptionService(
+          requete.body,
+          referentiel
+        );
+
+        reponse.json({
+          niveauDeSecuriteMinimal: descriptionService.estimeNiveauDeSecurite(),
+        });
+      } catch (e) {
+        if (e instanceof ErreurModele)
+          reponse.status(400).send('La description du service est invalide');
+        else suite(e);
+      }
+    }
+  );
+
   routes.get(
     '/:id',
     middleware.aseptise('id'),

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -2112,4 +2112,76 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(serviceMisAJour.id).to.be('123');
     });
   });
+
+  describe('quand requête POST sur `/api/service/estimationNiveauSecurite`', () => {
+    it("vérifie que l'utilisateur est authentifié", (done) => {
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(
+        {
+          method: 'post',
+          url: 'http://localhost:1234/api/service/estimationNiveauSecurite',
+        },
+        done
+      );
+    });
+
+    it('aseptise les paramètres', (done) => {
+      testeur.middleware().verifieAseptisationParametres(
+        [
+          'nomService',
+          'organisationsResponsables.*',
+          'nombreOrganisationsUtilisatrices.*',
+        ],
+        {
+          method: 'post',
+          url: 'http://localhost:1234/api/service/estimationNiveauSecurite',
+        },
+        done
+      );
+    });
+
+    it('aseptise les listes de paramètres ainsi que leur contenu', async () => {
+      await axios.post(
+        'http://localhost:1234/api/service/estimationNiveauSecurite'
+      );
+
+      testeur
+        .middleware()
+        .verifieAseptisationListe('pointsAcces', ['description']);
+      testeur
+        .middleware()
+        .verifieAseptisationListe('fonctionnalitesSpecifiques', [
+          'description',
+        ]);
+      testeur
+        .middleware()
+        .verifieAseptisationListe('donneesSensiblesSpecifiques', [
+          'description',
+        ]);
+    });
+
+    it("retourne l'estimation du niveau de sécurité pour la description donnée", async () => {
+      const donneesDescriptionNiveau1 = { nomService: 'Mon service' };
+      const resultat = await axios.post(
+        'http://localhost:1234/api/service/estimationNiveauSecurite',
+        donneesDescriptionNiveau1
+      );
+
+      expect(resultat.status).to.be(200);
+      expect(resultat.data.niveauDeSecuriteMinimal).to.be('niveau1');
+    });
+
+    it('retourne une erreur HTTP 400 si les données de description de service sont invalides', (done) => {
+      const donneesInvalides = { statutDeploiement: 'statutInvalide' };
+      testeur.verifieRequeteGenereErreurHTTP(
+        400,
+        'La description du service est invalide',
+        {
+          method: 'post',
+          url: 'http://localhost:1234/api/service/estimationNiveauSecurite',
+          data: donneesInvalides,
+        },
+        done
+      );
+    });
+  });
 });


### PR DESCRIPTION
…requis pour une description de service donnée.

Cette route sera utilisée dans la prochaine PR, afin d'insérer dans la `payload` de création ou modification de service, le niveau de sécurité suggéré par l'ANSSI.

Pour l'instant, l'utilisateur ne pourra pas modifier ce niveau.