### PR TITLE
[CORRECTION] Empêche le bouton de suppression de "voler" le focus dans les points d'accès de DÉCRIRE

### DIFF
--- a/src/vues/fragments/elementsAjoutables/elementsAjoutables.pug
+++ b/src/vues/fragments/elementsAjoutables/elementsAjoutables.pug
@@ -15,10 +15,10 @@ mixin zoneSaisieElementAjoutable(donneesElement, nom, index, lectureSeule, ident
 
 mixin zoneSaisie(nom, donneesElement, index, lectureSeule, identifiantChampTitre)
   .item-ajoute
-    if(!lectureSeule)
-      button.icone-suppression(title="Suppression de l'élément")
     div(id = 'element-' + nom + '-' + index)
       +zoneSaisieElementAjoutable(donneesElement, nom, index, lectureSeule, identifiantChampTitre)
+    if(!lectureSeule)
+      button.icone-suppression(title="Suppression de l'élément" type="button")
 
 mixin elementsAjoutables({ identifiantConteneur, nom, donneesElements = [], texteLienAjouter = 'Ajouter', zoneSaisieVideVisible = false, structureZoneSaisieVide = {}, lectureSeule = false, identifiantChampTitre })
   div(id = identifiantConteneur class = 'elements-ajoutables')


### PR DESCRIPTION
… afin d'éviter que l'appuie sur "entrée" ne supprime le premier élément.