### PR TITLE
[CORRECTION] Résolution du problème de « parameter tampering »

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionExport.mjs
+++ b/public/modules/tableauDeBord/actions/ActionExport.mjs
@@ -14,11 +14,12 @@ class ActionExport extends ActionAbstraite {
 
   // eslint-disable-next-line class-methods-use-this
   initialise({ idServices }) {
+    const queryString = new URLSearchParams();
+    idServices.forEach((id) => queryString.append('idsServices', id));
+
     $('#action-export-csv').attr(
       'href',
-      `/api/services/export.csv?idsServices=${encodeURIComponent(
-        JSON.stringify(idServices)
-      )}`
+      `/api/services/export.csv?${queryString}`
     );
   }
 

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -84,6 +84,13 @@ const routesConnecteApi = ({
     async (requete, reponse) => {
       const { idsServices = [] } = requete.query;
 
+      const mauvaisType =
+        !Array.isArray(idsServices) && typeof idsServices !== 'string';
+      if (mauvaisType) {
+        reponse.sendStatus(400);
+        return;
+      }
+
       const donneesCsvServices = (services, autorisations) => {
         const servicesSansIndice = objetGetServices.donnees(
           services,

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -176,7 +176,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
   describe('quand requête GET sur `/api/services/export.csv`', () => {
     beforeEach(() => {
-      testeur.adaptateurCsv().genereCsvServices = () => Promise.resolve();
+      testeur.adaptateurCsv().genereCsvServices = async () => {};
       testeur.referentiel().recharge({
         statutsHomologation: {
           nonRealisee: { libelle: 'Non réalisée', ordre: 1 },

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -210,6 +210,32 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       );
     });
 
+    describe('concernant le paramètre en query string `idsServices`', () => {
+      it("retourne une erreur 400 si le paramètre n'est pas un tableau", async () => {
+        try {
+          await axios.get(
+            'http://localhost:1234/api/services/export.csv?idsServices[a]=1' // Sera interprété par express comme {a: 1}
+          );
+          expect().fail("L'appel aurait dû jeter une erreur");
+        } catch (e) {
+          expect(e.response.status).to.be(400);
+        }
+      });
+
+      it("fonctionne dans le cas où le tableau ne comporte qu'un seul élément", async () => {
+        // Dans le cas d'un seul ID envoyé, express va interpréter cet ID en `string`, pas en `array`.
+        // Ce cas de test vérifie qu'on sait bien gérer ce cas d'une `string` qui arrive à l'API
+        const queryString = new URLSearchParams();
+        queryString.append('idsServices', '123');
+
+        const reponse = await axios.get(
+          `http://localhost:1234/api/services/export.csv?${queryString}`
+        );
+
+        expect(reponse.status).to.be(200);
+      });
+    });
+
     it("interroge le dépôt de données pour récupérer les autorisations de l'utilisateur", async () => {
       let donneesPassees = {};
       testeur.middleware().reinitialise({ idUtilisateur: '123' });


### PR DESCRIPTION
Cette PR change la route `export.csv` pour [corriger l'issue de sécurité sur le _parameter tampering_](https://github.com/betagouv/mon-service-securise/security/code-scanning/154).

Dorénavant la route vérifie précisément le type du paramètre qu'elle reçoit.
On en profite pour modifier le front : il envoie désormais une query string correctement formée.