### PR TITLE
[BREVO] Modification des notions d'abonnement Infolettre/Transactionnels

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,7 +22,7 @@ SENDINBLUE_TEMPLATE_TENTATIVE_REINSCRIPTION= # id de template
 SENDINBLUE_TEMPLATE_NOTIFICATION_EXPIRATION_HOMOLOGATION= # id de template
 SENDINBLUE_TEMPLATE_NOTIFICATION_HOMOLOGATION_EXPIREE= # id de template
 SENDINBLUE_TEMPLATE_FELICITATION_HOMOLOGATION = # id de template
-SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE= # l'ID de la liste de contacts utilisée pour les mails transactionnels de relance
+SENDINBLUE_ID_LISTE_POUR_INFOLETTRE= # l'ID de la liste de contacts utilisée pour les mails d'informations (newsletter)
 
 ADRESSES_IP_AUTORISEES= # Seules ces IP seront autorisées. Les autres ne seront pas servies. Séparées par des ',' s'il y en a plusieurs. Supprimer la variable d'env pour désactiver le filtrage.
 

--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -429,6 +429,22 @@ class ConsoleAdministration {
     // eslint-disable-next-line no-console
     console.log('DONE');
   }
+
+  async basculeBlocklistBrevo() {
+    const tousUtilisateurs = await this.depotDonnees.tousUtilisateurs();
+    const utilisateursTransactionnels = tousUtilisateurs.filter(
+      (u) => u.transactionnelAccepte
+    );
+    const afficheErreur = (utilisateur) => `Erreur pour ${utilisateur.email}`;
+    const rattrapeUtilisateur = async (utilisateur) =>
+      adaptateurMail.inscrisEmailsTransactionnels(utilisateur.email);
+
+    return ConsoleAdministration.rattrapage(
+      utilisateursTransactionnels,
+      afficheErreur,
+      rattrapeUtilisateur
+    );
+  }
 }
 
 module.exports = ConsoleAdministration;

--- a/src/adaptateurs/adaptateurMailSendinblue.js
+++ b/src/adaptateurs/adaptateurMailSendinblue.js
@@ -13,8 +13,8 @@ const enteteJSON = {
   },
 };
 const urlBase = process.env.SENDINBLUE_EMAIL_API_URL_BASE;
-const idListeEmailsMarketing = Number(
-  process.env.SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE
+const idListeInfolettre = Number(
+  process.env.SENDINBLUE_ID_LISTE_POUR_INFOLETTRE
 );
 const basculeInfolettre = (destinataire, etat) =>
   axios
@@ -58,7 +58,7 @@ const creeContact = (
           NOM: decode(nom),
           sync_mss_numero_telephone: numeroTelephoneAvecIndicatif(telephone),
         },
-        ...(!bloqueMarketing && { listIds: [idListeEmailsMarketing] }),
+        ...(!bloqueMarketing && { listIds: [idListeInfolettre] }),
       },
       enteteJSON
     )
@@ -98,7 +98,7 @@ const metAJourContact = (destinataire, prenom, nom, telephone) =>
 const inscrisEmailsTransactionnels = async (destinataire) => {
   // https://developers.brevo.com/reference/addcontacttolist-1
   const url = new URL(
-    `${urlBase}/contacts/lists/${idListeEmailsMarketing}/contacts/add`
+    `${urlBase}/contacts/lists/${idListeInfolettre}/contacts/add`
   );
 
   try {
@@ -120,7 +120,7 @@ const inscrisEmailsTransactionnels = async (destinataire) => {
 const desinscrisEmailsTransactionnels = async (destinataire) => {
   // https://developers.brevo.com/reference/removecontactfromlist
   const url = new URL(
-    `${urlBase}/contacts/lists/${idListeEmailsMarketing}/contacts/remove`
+    `${urlBase}/contacts/lists/${idListeInfolettre}/contacts/remove`
   );
 
   try {

--- a/src/routes/nonConnecte/routesNonConnecteApi.js
+++ b/src/routes/nonConnecte/routesNonConnecteApi.js
@@ -211,7 +211,7 @@ const routesNonConnecteApi = ({
         }
         depotDonnees
           .metsAJourUtilisateur(utilisateur.id, {
-            infolettreAcceptee: false,
+            transactionnelAccepte: false,
           })
           .then(() => reponse.sendStatus(200))
           .catch(suite);

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -651,10 +651,10 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       );
     });
 
-    it("désabonne l'utilisateur de l'infolettre", (done) => {
+    it("désabonne l'utilisateur des mails marketing", (done) => {
       const utilisateur = unUtilisateur()
         .avecId('123')
-        .quiAccepteInfolettre()
+        .quiAccepteEmailsTransactionnels()
         .construis();
       testeur.depotDonnees().utilisateurAvecEmail = (email) => {
         expect(email).to.equal('jean.dujardin@mail.com');
@@ -662,7 +662,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       };
       testeur.depotDonnees().metsAJourUtilisateur = (id, donnees) => {
         expect(id).to.equal('123');
-        expect(donnees).to.eql({ infolettreAcceptee: false });
+        expect(donnees).to.eql({ transactionnelAccepte: false });
         return Promise.resolve();
       };
 


### PR DESCRIPTION
Afin que notre pôle BizDev puisse utiliser Brevo normalement, nous souhaitons faire une bascule sur le fonctionnement des abonnements à l'infolettre et au mail marketing.

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/7a5fb9f6-389c-4345-b412-e757964ffa83)


##### Hier
- Un utilisateur abonné à l'infolettre a le statut `SUBSCRIBED` dans **Brevo**
- Un utilisateur abonné aux mails marketing fait partie de la liste `MARKETING` dans **Brevo**

##### Dans cette PR
- Un utilisateur abonné à l'infolettre fait partie de la liste `NEWSLETTER` dans **Brevo**
- Un utilisateur abonné aux mails marketing a le statut `SUBSCRIBED` dans **Brevo**

On doit aussi modifier l'endpoint appelé par le webhook Brevo.

> [!IMPORTANT]  
> - Un script de rattrapage doit être lancé lors de la MEP.
> - La variable d'environnement `SENDINBLUE_ID_LISTE_POUR_MAILS_TRANSACTIONNELS_DE_RELANCE` doit être changée en `SENDINBLUE_ID_LISTE_POUR_INFOLETTRE` et on doit lui attribuer l'identifiant de la nouvelle liste