### PR TITLE
[CORRECTION] Force le tableau des mesures à 100% de la largeur

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -37,6 +37,7 @@
 
 #tableau-des-mesures > .tableau-des-mesures {
   order: 30;
+  width: 100%;
 }
 
 #tableau-des-mesures > .barre-actions {


### PR DESCRIPTION
... dans le cas des mesures avec un titre court, ou de l'affichage "aucun résultat"