### PR TITLE
[CORRECTION] Erreur spécifique si le nom du service existe déjà lors de la modification d'un service

### DIFF
--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -133,6 +133,10 @@ const routesConnecteApiService = ({
 
         reponse.send({ idService: requete.service.id });
       } catch (e) {
+        if (e instanceof ErreurNomServiceDejaExistant)
+          reponse
+            .status(422)
+            .json({ erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } });
         if (e instanceof ErreurModele) reponse.status(422).send(e.message);
         else suite(e);
       }

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -269,14 +269,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it('retourne une erreur HTTP 422 si la validation des propriétés obligatoires échoue', (done) => {
+    it('retourne une erreur HTTP 422 si le nom du service existe déjà', (done) => {
       testeur.depotDonnees().ajouteDescriptionService = async () => {
         throw new ErreurNomServiceDejaExistant('oups');
       };
 
       testeur.verifieRequeteGenereErreurHTTP(
         422,
-        'oups',
+        { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } },
         {
           method: 'put',
           url: 'http://localhost:1234/api/service/456',


### PR DESCRIPTION
... afin de déclencher l'affichage de l'erreur spécifique sur la première page du formulaire de DÉCRIRE