### PR TITLE
[SECURISER] Modification de l'aspect des filtres actifs

### DIFF
--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -46,6 +46,9 @@
   <div slot="declencheur">
     <button class="bouton bouton-secondaire bouton-filtre">
       <img src="/statique/assets/images/icone_filtre.svg" alt="" />
+      {#if $nombreResultats.aDesFiltresAppliques}
+        <div class="rond-actif" />
+      {/if}
       Filtres
     </button>
   </div>
@@ -226,5 +229,17 @@
 
   .decalage-checkbox {
     margin-left: 12px;
+  }
+
+  .rond-actif {
+    border-radius: 50%;
+    border: 1px solid white;
+    background: var(--bleu-mise-en-avant);
+    width: 8px;
+    height: 8px;
+    position: absolute;
+    top: 8px;
+    left: 32px;
+    z-index: 1000;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -44,10 +44,7 @@
 
 <MenuFlottant parDessusDeclencheur={true}>
   <div slot="declencheur">
-    <button
-      class="bouton bouton-secondaire bouton-filtre"
-      class:actif={$nombreResultats.aDesFiltresAppliques}
-    >
+    <button class="bouton bouton-secondaire bouton-filtre">
       <img src="/statique/assets/images/icone_filtre.svg" alt="" />
       Filtres
     </button>
@@ -155,22 +152,11 @@
     </button>
   </div>
 </MenuFlottant>
-<NombreResultatsFiltres />
 
 <style>
   .bouton-filtre {
     display: flex;
     gap: 8px;
-  }
-
-  .bouton-filtre.actif {
-    color: #08416a;
-    border-color: #08416a;
-  }
-
-  .bouton-filtre.actif img {
-    filter: brightness(0) invert(15%) sepia(24%) saturate(4604%)
-      hue-rotate(184deg) brightness(107%) contrast(94%);
   }
 
   .entete {
@@ -189,13 +175,8 @@
     gap: 8px;
     padding: calc(0.5em + 1px) calc(1em - 16px + 1px);
     font-weight: 500;
-    color: #08416a;
+    color: var(--bleu-mise-en-avant);
     margin-bottom: 8px;
-  }
-
-  .titre-filtres img {
-    filter: brightness(0) invert(16%) sepia(87%) saturate(1447%)
-      hue-rotate(183deg) brightness(91%) contrast(94%);
   }
 
   .filtres-disponibles {

--- a/svelte/lib/tableauDesMesures/filtres/NombreResultatsFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/NombreResultatsFiltres.svelte
@@ -19,6 +19,7 @@
     color: #0079d0;
     opacity: 0;
     margin: 0;
+    white-space: nowrap;
   }
 
   .nombre-resultat.visible {


### PR DESCRIPTION
On ajoute maintenant une "pastille" indiquant qu'il y a des filtres actifs

![image](https://github.com/betagouv/mon-service-securise/assets/1643465/6a6ae270-a602-4b82-bcdc-dc28f1b9ffc9)

