### PR TITLE
[CORRECTION] Ajoute la variable d'environnement `NODE_ENV` dans le test du script de création d'utilisateur

### DIFF
--- a/test/creeUtilisateurDemo.spec.js
+++ b/test/creeUtilisateurDemo.spec.js
@@ -3,10 +3,12 @@ const { exec } = require('child_process');
 
 describe("Le script de création d'un utilisateur de Démo", () => {
   it('se lance correctement', () => {
-    const variablesEnvironnement =
-      'CREATION_UTILISATEUR_DEMO=true ' +
-      'EMAIL_UTILISATEUR_DEMO=jean.dujardin@beta.gouv.fr ' +
-      'MOT_DE_PASSE_UTILISATEUR_DEMO=UnMotDePasse';
+    const variablesEnvironnement = [
+      'CREATION_UTILISATEUR_DEMO=true',
+      'EMAIL_UTILISATEUR_DEMO=jean.dujardin@beta.gouv.fr',
+      'MOT_DE_PASSE_UTILISATEUR_DEMO=UnMotDePasse',
+      'NODE_ENV=TEST',
+    ].join(' ');
 
     exec(
       `${variablesEnvironnement} node creeUtilisateurDemo.js`,


### PR DESCRIPTION
... afin de forcer l'utilisation d'un adaptateur de persistance en mémoire.

À savoir que :
- Par défaut, sur la CI de github, le `NODE_ENV` vaut `undefined`
- Dans notre `docker` de test, on force `NODE_ENV` à `test`