### PR TITLE
Filtre mesures applicables

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -223,10 +223,6 @@ class Homologation {
     return this.risques.risquesSpecifiques;
   }
 
-  statistiquesMesures() {
-    return this.mesures.statistiques();
-  }
-
   statistiquesMesuresGenerales() {
     return this.mesures.statistiquesMesuresGenerales();
   }

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -8,6 +8,21 @@ const {
 const { IndiceCyber } = require('./indiceCyber');
 const { CompletudeMesures } = require('./completudeMesures');
 
+function mesuresGeneralesApplicables(
+  mesuresPersonnalisees,
+  mesuresGenerales,
+  referentiel
+) {
+  const idMesuresPersonnalisees = Object.keys(mesuresPersonnalisees);
+  const donneesMesuresGeneralesApplicables = idMesuresPersonnalisees.map(
+    (id) => ({ id, ...mesuresGenerales.avecId(id) })
+  );
+  return new MesuresGenerales(
+    { mesuresGenerales: donneesMesuresGeneralesApplicables },
+    referentiel
+  );
+}
+
 class Mesures extends InformationsHomologation {
   constructor(
     donnees = {},
@@ -52,37 +67,27 @@ class Mesures extends InformationsHomologation {
   }
 
   parStatutEtCategorie() {
-    const idMesuresPersonnalisees = Object.keys(this.mesuresPersonnalisees);
-    const donneesMesuresGeneralesApplicables = this.mesuresGenerales
-      .toutes()
-      .filter((mesure) => idMesuresPersonnalisees.includes(mesure.id));
-    const mesuresGeneralesApplicables = new MesuresGenerales(
-      { mesuresGenerales: donneesMesuresGeneralesApplicables },
+    const applicables = mesuresGeneralesApplicables(
+      this.mesuresPersonnalisees,
+      this.mesuresGenerales,
       this.referentiel
     );
 
-    const mesuresGeneralesParStatut =
-      mesuresGeneralesApplicables.parStatutEtCategorie();
+    const mesuresGeneralesParStatut = applicables.parStatutEtCategorie();
     return this.mesuresSpecifiques.parStatutEtCategorie(
       mesuresGeneralesParStatut
     );
   }
 
   statutSaisie() {
-    const idMesuresPersonnalisees = Object.keys(this.mesuresPersonnalisees);
-    const donneesMesuresGeneralesApplicables = idMesuresPersonnalisees.map(
-      (id) => ({
-        id,
-        ...this.mesuresGenerales.avecId(id),
-      })
-    );
-    const mesuresGeneralesApplicables = new MesuresGenerales(
-      { mesuresGenerales: donneesMesuresGeneralesApplicables },
+    const applicables = mesuresGeneralesApplicables(
+      this.mesuresPersonnalisees,
+      this.mesuresGenerales,
       this.referentiel
     );
 
     const generalesSontCompletes =
-      mesuresGeneralesApplicables.statutSaisie() === Mesures.COMPLETES;
+      applicables.statutSaisie() === Mesures.COMPLETES;
     const specifiquesCompletes =
       this.mesuresSpecifiques.statutSaisie() === Mesures.COMPLETES ||
       this.mesuresSpecifiques.nombre() === 0;

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -69,15 +69,27 @@ class Mesures extends InformationsHomologation {
   }
 
   statutSaisie() {
-    const statutSaisieMesures = super.statutSaisie();
-    if (
-      statutSaisieMesures === Mesures.COMPLETES &&
-      this.nombreMesuresPersonnalisees() !== this.mesuresGenerales.nombre()
-    ) {
-      return Mesures.A_COMPLETER;
-    }
+    const idMesuresPersonnalisees = Object.keys(this.mesuresPersonnalisees);
+    const donneesMesuresGeneralesApplicables = idMesuresPersonnalisees.map(
+      (id) => ({
+        id,
+        ...this.mesuresGenerales.avecId(id),
+      })
+    );
+    const mesuresGeneralesApplicables = new MesuresGenerales(
+      { mesuresGenerales: donneesMesuresGeneralesApplicables },
+      this.referentiel
+    );
 
-    return statutSaisieMesures;
+    const generalesSontCompletes =
+      mesuresGeneralesApplicables.statutSaisie() === Mesures.COMPLETES;
+    const specifiquesCompletes =
+      this.mesuresSpecifiques.statutSaisie() === Mesures.COMPLETES ||
+      this.mesuresSpecifiques.nombre() === 0;
+
+    return generalesSontCompletes && specifiquesCompletes
+      ? Mesures.COMPLETES
+      : Mesures.A_COMPLETER;
   }
 
   statutsMesuresPersonnalisees() {

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -52,8 +52,17 @@ class Mesures extends InformationsHomologation {
   }
 
   parStatutEtCategorie() {
+    const idMesuresPersonnalisees = Object.keys(this.mesuresPersonnalisees);
+    const donneesMesuresGeneralesApplicables = this.mesuresGenerales
+      .toutes()
+      .filter((mesure) => idMesuresPersonnalisees.includes(mesure.id));
+    const mesuresGeneralesApplicables = new MesuresGenerales(
+      { mesuresGenerales: donneesMesuresGeneralesApplicables },
+      this.referentiel
+    );
+
     const mesuresGeneralesParStatut =
-      this.mesuresGenerales.parStatutEtCategorie();
+      mesuresGeneralesApplicables.parStatutEtCategorie();
     return this.mesuresSpecifiques.parStatutEtCategorie(
       mesuresGeneralesParStatut
     );

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -68,13 +68,6 @@ class Mesures extends InformationsHomologation {
     );
   }
 
-  statistiques() {
-    return this.mesuresGenerales.statistiques(
-      this.mesuresPersonnalisees,
-      this.mesuresSpecifiques
-    );
-  }
-
   statutSaisie() {
     const statutSaisieMesures = super.statutSaisie();
     if (

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -293,13 +293,6 @@ describe('Une homologation', () => {
     });
     const moteur = { mesures: () => ({ m1: {}, m2: {} }) };
 
-    it('détecte que la liste des mesures reste à saisir', () => {
-      const homologation = new Homologation({ id: '123' });
-      expect(homologation.statutSaisie('mesures')).to.equal(
-        InformationsHomologation.A_SAISIR
-      );
-    });
-
     it('détecte que la liste des mesures est à compléter', () => {
       const homologation = new Homologation(
         {

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -287,16 +287,6 @@ describe('Une homologation', () => {
     expect(homologation.mesuresSpecifiques().nombre()).to.equal(1);
   });
 
-  it('délègue aux mesures le calcul des statistiques', () => {
-    let calculDelegueAuxMesures = false;
-
-    const homologation = new Homologation({ id: '123', mesuresGenerales: [] });
-    homologation.mesures.statistiques = () => (calculDelegueAuxMesures = true);
-
-    homologation.statistiquesMesures();
-    expect(calculDelegueAuxMesures).to.be(true);
-  });
-
   describe('sur évaluation du statut de saisie des mesures', () => {
     const referentiel = Referentiel.creeReferentiel({
       mesures: { m1: {}, m2: {} },

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -107,6 +107,7 @@ describe('Les mesures liées à une homologation', () => {
 
   describe('sur une demande des mesures par statut', () => {
     let referentiel;
+    let statutVide;
 
     beforeEach(() => {
       referentiel = Referentiel.creeReferentiel({
@@ -119,22 +120,49 @@ describe('Les mesures liées à une homologation', () => {
         },
       });
       referentiel.identifiantsCategoriesMesures = () => ['categorie1'];
+      statutVide = {
+        enCours: {},
+        nonFait: {},
+        aLancer: {},
+      };
     });
 
-    elles('récupère les mesures générales triées', () => {
+    elles('récupère les mesures générales groupées', () => {
       const mesures = new Mesures(
         { mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] },
         referentiel,
         { mesure1: {} }
       );
-      mesures.mesuresGenerales.parStatutEtCategorie = () => ({
-        fait: { categorie1: [{ description: 'mesure1', indispensable: true }] },
-      });
 
       expect(mesures.parStatutEtCategorie()).to.eql({
-        fait: { categorie1: [{ description: 'mesure1', indispensable: true }] },
+        ...statutVide,
+        fait: {
+          categorie1: [
+            {
+              description: 'Mesure une',
+              modalites: undefined,
+              indispensable: true,
+            },
+          ],
+        },
       });
     });
+
+    elles(
+      'filtrent les mesures générales en fonction du moteur de règle',
+      () => {
+        const mesures = new Mesures(
+          { mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] },
+          referentiel,
+          {}
+        );
+
+        expect(mesures.parStatutEtCategorie()).to.eql({
+          ...statutVide,
+          fait: {},
+        });
+      }
+    );
 
     elles('ajoutent les mesures spécifiques', () => {
       const mesures = new Mesures(
@@ -174,13 +202,18 @@ describe('Les mesures liées à une homologation', () => {
         referentiel,
         { mesure1: {} }
       );
-      mesures.mesuresGenerales.parStatutEtCategorie = () => ({
-        fait: { categorie1: [{ description: 'mesure1', indispensable: true }] },
-      });
+
       mesures.mesuresSpecifiques.parStatutEtCategorie = (mesuresParStatut) => {
         expect(mesuresParStatut).to.eql({
+          ...statutVide,
           fait: {
-            categorie1: [{ description: 'mesure1', indispensable: true }],
+            categorie1: [
+              {
+                description: 'Mesure une',
+                modalites: undefined,
+                indispensable: true,
+              },
+            ],
           },
         });
         return {

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -57,29 +57,6 @@ describe('Les mesures liées à une homologation', () => {
     }
   );
 
-  elles('délèguent le calcul statistique aux mesures générales', () => {
-    let calculStatistiqueAppele = false;
-
-    const mesuresRecommandees = {};
-    const mesures = new Mesures(
-      {},
-      Referentiel.creeReferentielVide(),
-      mesuresRecommandees
-    );
-    mesures.mesuresGenerales.statistiques = (
-      identifiantsMesuresPersonnalisees
-    ) => {
-      expect(identifiantsMesuresPersonnalisees).to.equal(mesuresRecommandees);
-      calculStatistiqueAppele = true;
-      return 'résultat';
-    };
-
-    const stats = mesures.statistiques();
-
-    expect(calculStatistiqueAppele).to.be(true);
-    expect(stats).to.equal('résultat');
-  });
-
   elles('connaissent le nombre total de mesures générales', () => {
     const referentiel = Referentiel.creeReferentielVide();
 

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -1,6 +1,9 @@
 const expect = require('expect.js');
 
-const { A_COMPLETER } = require('../../src/modeles/informationsHomologation');
+const {
+  A_COMPLETER,
+  COMPLETES,
+} = require('../../src/modeles/informationsHomologation');
 const Mesures = require('../../src/modeles/mesures');
 const MesuresSpecifiques = require('../../src/modeles/mesuresSpecifiques');
 const Referentiel = require('../../src/referentiel');
@@ -40,20 +43,84 @@ describe('Les mesures liées à une homologation', () => {
   );
 
   elles(
-    'sont à completer si toutes les mesures nécessaires ne sont pas complétées',
+    'ont comme statut `COMPLETES` lorsque toutes les mesures personnalisées sont renseignées et sans mesures spécifiques ',
     () => {
       const referentiel = Referentiel.creeReferentielVide();
-      referentiel.identifiantsMesures = () => ['mesure 1', 'mesure 2'];
-
+      referentiel.identifiantsMesures = () => ['mesure1'];
       const mesures = new Mesures(
         {
-          mesuresGenerales: [{ id: 'mesure 1', statut: 'fait' }],
+          mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }],
           mesuresSpecifiques: [],
         },
-        referentiel
+        referentiel,
+        { mesure1: {} }
       );
 
-      expect(mesures.statutSaisie()).to.equal(A_COMPLETER);
+      expect(mesures.statutSaisie()).to.equal(COMPLETES);
+    }
+  );
+
+  elles(
+    'ont comme statut `COMPLETES` lorsque toutes les mesures personnalisées sont renseignées et avec mesures spécifiques ',
+    () => {
+      const referentiel = Referentiel.creeReferentielVide();
+      referentiel.identifiantsMesures = () => ['mesure1'];
+      referentiel.identifiantsCategoriesMesures = () => ['gouvernance'];
+      const mesures = new Mesures(
+        {
+          mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }],
+          mesuresSpecifiques: [
+            {
+              description: 'Faire une étude',
+              categorie: 'gouvernance',
+              statut: 'fait',
+            },
+          ],
+        },
+        referentiel,
+        { mesure1: {} }
+      );
+
+      expect(mesures.statutSaisie()).to.equal(COMPLETES);
+    }
+  );
+
+  elles(
+    'ont comme statut `A_COMPLETER` lorsque certaines mesures sont renseignées, mais pas toutes',
+    () => {
+      const referentiel = Referentiel.creeReferentielVide();
+      referentiel.identifiantsMesures = () => ['mesure1', 'mesure2'];
+      const sansMesure2 = new Mesures(
+        {
+          mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }],
+          mesuresSpecifiques: [],
+        },
+        referentiel,
+        { mesure1: {}, mesure2: {} }
+      );
+
+      expect(sansMesure2.statutSaisie()).to.equal(A_COMPLETER);
+    }
+  );
+
+  elles(
+    'ont comme statut `COMPLETES` même s’il y a des mesures qui ne sont plus d’actualité',
+    () => {
+      const referentiel = Referentiel.creeReferentielVide();
+      referentiel.identifiantsMesures = () => ['mesure1', 'mesure2'];
+      const avecMesure2EnTrop = new Mesures(
+        {
+          mesuresGenerales: [
+            { id: 'mesure1', statut: 'fait' },
+            { id: 'mesure2', statut: 'fait' },
+          ],
+          mesuresSpecifiques: [],
+        },
+        referentiel,
+        { mesure1: {} }
+      );
+
+      expect(avecMesure2EnTrop.statutSaisie()).to.equal(COMPLETES);
     }
   );
 


### PR DESCRIPTION
L’objectif est de ne pas prendre en compte les mesures du service qui sont renseignées mais plus retournées par le moteur de règle.
Cette PR corrige deux points qui posaient problème :
- le statut par catégorie (pour le pdf des annexes)
- le statut de saisie pour les mesures (à compléter / complètes)