### PR TITLE
[CORRECTION] Évite de laisser toujours visible la pastille des filtres

### DIFF
--- a/svelte/lib/tableauDesMesures/filtres/IconeFiltre.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/IconeFiltre.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  export let filtresActifs: boolean = false;
+</script>
+
+<picture class:filtres-actifs={filtresActifs}>
+  <img src="/statique/assets/images/icone_filtre.svg" alt="" />
+</picture>
+Filtres
+
+<style>
+  picture {
+    height: 24px;
+    width: 24px;
+  }
+
+  .filtres-actifs::after {
+    display: block;
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1px solid white;
+    background: var(--bleu-mise-en-avant);
+    position: relative;
+    top: -28px;
+    left: 18px;
+  }
+</style>

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -9,6 +9,7 @@
     rechercheStatut,
   } from '../tableauDesMesures.store';
   import NombreResultatsFiltres from './NombreResultatsFiltres.svelte';
+  import IconeFiltre from './IconeFiltre.svelte';
 
   export let categories: Record<IdCategorie, string>;
   export let statuts: Record<IdStatut, string>;
@@ -44,20 +45,14 @@
 <MenuFlottant parDessusDeclencheur={true}>
   <div slot="declencheur">
     <button class="bouton bouton-secondaire bouton-filtre">
-      <picture class:filtres-actifs={$nombreResultats.aDesFiltresAppliques}
-        ><img src="/statique/assets/images/icone_filtre.svg" alt="" />
-      </picture>
-      Filtres
+      <IconeFiltre filtresActifs={$nombreResultats.aDesFiltresAppliques} />
     </button>
   </div>
 
   <div class="filtres-disponibles">
     <div class="entete">
       <div class="titre-filtres">
-        <picture class:filtres-actifs={$nombreResultats.aDesFiltresAppliques}>
-          <img src="/statique/assets/images/icone_filtre.svg" alt="" />
-        </picture>
-        Filtres
+        <IconeFiltre filtresActifs={$nombreResultats.aDesFiltresAppliques} />
       </div>
       <NombreResultatsFiltres />
     </div>
@@ -229,23 +224,5 @@
 
   .decalage-checkbox {
     margin-left: 12px;
-  }
-
-  picture {
-    height: 24px;
-    width: 24px;
-  }
-
-  .filtres-actifs::after {
-    display: block;
-    content: '';
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    border: 1px solid white;
-    background: var(--bleu-mise-en-avant);
-    position: relative;
-    top: -28px;
-    left: 18px;
   }
 </style>

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -44,10 +44,9 @@
 <MenuFlottant parDessusDeclencheur={true}>
   <div slot="declencheur">
     <button class="bouton bouton-secondaire bouton-filtre">
-      <img src="/statique/assets/images/icone_filtre.svg" alt="" />
-      {#if $nombreResultats.aDesFiltresAppliques}
-        <div class="rond-actif" />
-      {/if}
+      <picture class:filtres-actifs={$nombreResultats.aDesFiltresAppliques}
+        ><img src="/statique/assets/images/icone_filtre.svg" alt="" />
+      </picture>
       Filtres
     </button>
   </div>
@@ -55,7 +54,9 @@
   <div class="filtres-disponibles">
     <div class="entete">
       <div class="titre-filtres">
-        <img src="/statique/assets/images/icone_filtre.svg" alt="" />
+        <picture class:filtres-actifs={$nombreResultats.aDesFiltresAppliques}>
+          <img src="/statique/assets/images/icone_filtre.svg" alt="" />
+        </picture>
         Filtres
       </div>
       <NombreResultatsFiltres />
@@ -230,15 +231,21 @@
     margin-left: 12px;
   }
 
-  .rond-actif {
+  picture {
+    height: 24px;
+    width: 24px;
+  }
+
+  .filtres-actifs::after {
+    display: block;
+    content: '';
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     border: 1px solid white;
     background: var(--bleu-mise-en-avant);
-    width: 8px;
-    height: 8px;
-    position: absolute;
-    top: 8px;
-    left: 32px;
-    z-index: 1000;
+    position: relative;
+    top: -28px;
+    left: 18px;
   }
 </style>


### PR DESCRIPTION
🐞 **Reproduction** :
- activer un filtre
- scroller vers le bas dans la boîte des filtres

**Attendu** : l'icône des filtres n'est plus visible et la pastille non plus

**Observé** : l'icône des filtres défile bien vers le haut, mais la pastille reste visible 👇 

![image](https://github.com/betagouv/mon-service-securise/assets/24898521/c21e6261-a6bf-4acd-a6c2-80210a09551d)

Cette PR passe par un `:after` et un `relative` pour que la pastille ne sorte pas du flow de la page.