### PR TITLE
Supprime le filtre de mesures générales dans homologation

### DIFF
--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -48,13 +48,10 @@ class Homologation {
 
     let { mesuresGenerales = [] } = donnees;
     const mesuresPersonnalisees = moteurRegles.mesures(this.descriptionService);
-    const idMesuresPersonnalisees = Object.keys(mesuresPersonnalisees);
-    mesuresGenerales = mesuresGenerales
-      .filter((mesure) => idMesuresPersonnalisees.includes(mesure.id))
-      .map((mesure) => ({
-        ...mesure,
-        rendueIndispensable: !!mesuresPersonnalisees[mesure.id]?.indispensable,
-      }));
+    mesuresGenerales = mesuresGenerales.map((mesure) => ({
+      ...mesure,
+      rendueIndispensable: !!mesuresPersonnalisees[mesure.id]?.indispensable,
+    }));
     this.mesures = new Mesures(
       { mesuresGenerales, mesuresSpecifiques },
       referentiel,

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -356,12 +356,18 @@ describe('Une homologation', () => {
   });
 
   it('délègue aux mesures la récupération des mesures par statut et par catégorie', () => {
-    const homologation = new Homologation({
-      mesuresGenerales: [{ id: 'mesure1', statut: 'enCours' }],
+    const referentiel = Referentiel.creeReferentiel({
+      mesures: { m1: {} },
     });
+    const homologation = new Homologation(
+      { mesuresGenerales: [{ id: 'm1', statut: 'enCours' }] },
+      referentiel
+    );
     homologation.mesures.parStatutEtCategorie = () => ({ unStatut: {} });
 
-    expect(homologation.mesuresParStatutEtCategorie()).to.eql({ unStatut: {} });
+    const parStatutEtCategorie = homologation.mesuresParStatutEtCategorie();
+
+    expect(parStatutEtCategorie).to.eql({ unStatut: {} });
   });
 
   it('sait décrire le statut de déploiement', () => {


### PR DESCRIPTION
Ce filtre supprimait les mesures générales qui n'étaient pas présentes parmi les mesures personnalisées, avant de passer les mesures filtrées au constructeur de mesures.

Cela permet de ne pas écraser de mesure générale obsolète qui serait encore stockée en base, mais plus considérées par le moteur de règle.

Ainsi, en passant de niveau 3 à 2 puis de nouveau à 3, un utilisateur pourra retrouver les mesures de niveau 3 qu'il avait remplies, car elles ne seront pas supprimées par le passage au niveau 2.

Il n'y a pas d'impact sur les calculs et affichages des mesures et indices car ces calculs et affichages sont faits avec les mesures à considérer, donc de la donnée filtrée.