### PR TITLE
[DÉCRIRE] Permet de naviguer directement vers une étape

### DIFF
--- a/public/modules/interactions/validation.mjs
+++ b/public/modules/interactions/validation.mjs
@@ -57,12 +57,18 @@ const declencheValidationFormulairesMultiple = (
   selecteurConteneurFormulaires
 ) => {
   let tousFormulaireValides = true;
-  $('form', selecteurConteneurFormulaires).each((_i, element) => {
-    if (!element.checkValidity()) tousFormulaireValides = false;
+  let indicePremierFormulaireInvalide = null;
+  $('form', selecteurConteneurFormulaires).each((index, element) => {
+    if (!element.checkValidity()) {
+      tousFormulaireValides = false;
+      indicePremierFormulaireInvalide = index + 1;
+    }
   });
 
   if (tousFormulaireValides)
     selecteurConteneurFormulaires.trigger(EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE);
+
+  return indicePremierFormulaireInvalide;
 };
 
 export {

--- a/public/modules/soumetsHomologation.mjs
+++ b/public/modules/soumetsHomologation.mjs
@@ -10,6 +10,7 @@ const initialiseComportementFormulaire = (
   selecteurFormulaire,
   selecteurBouton,
   fonctionExtractionParametres,
+  navigationEtapes,
   callbackErreur = () => {},
   adaptateurAjax = adaptateurAjaxAxios
 ) => {
@@ -58,7 +59,10 @@ const initialiseComportementFormulaire = (
 
   $bouton.on('click', () => {
     declencheValidation(selecteurFormulaire);
-    declencheValidationFormulairesMultiple($form);
+    const indicePremierFormulaireInvalide =
+      declencheValidationFormulairesMultiple($form);
+    if (indicePremierFormulaireInvalide)
+      navigationEtapes.afficheEtapeN(indicePremierFormulaireInvalide);
   });
 };
 

--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -132,9 +132,20 @@ const brancheComportementNavigationEtapes = () => {
       afficheEtape();
     }
   });
+
+  const search = new URLSearchParams(window.location.search);
+  if (search.has('etape')) {
+    etapeCourante = parseInt(search.get('etape'), 10);
+    afficheEtape();
+  }
+
   return {
     afficheEtape1: () => {
       etapeCourante = 1;
+      afficheEtape();
+    },
+    afficheEtapeN: (n) => {
+      etapeCourante = n;
       afficheEtape();
     },
   };
@@ -147,6 +158,7 @@ $(() => {
     '#homologation',
     '.bouton#diagnostic',
     extraisParametresDescriptionService,
+    navigationEtapes,
     (e) => {
       if (estNomServiceDejaUtilise(e.response)) {
         messageErreurNomDejaUtilise.affiche();


### PR DESCRIPTION
... en utilisant un `query string` : `?etape=N`.

Cela nous permettra de créer des liens direct vers les étapes concernées par des modifications.

Pour pouvoir s'assurer que les formulaires d'avant sont bien valide, tout de même, on renvoi l'indice du formulaire potentiellement invalide au moment de la `validation`, afin de pouvoir faire réagir le `front` en fonction. 