### PR TITLE
[SOIN] Empêche un test de fail… et passe des tests en `async`

### DIFF
--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -139,7 +139,7 @@ const routesConnecteApiService = ({
           reponse
             .status(422)
             .json({ erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } });
-        if (e instanceof ErreurModele) reponse.status(422).send(e.message);
+        else if (e instanceof ErreurModele) reponse.status(422).send(e.message);
         else suite(e);
       }
     }

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -429,16 +429,15 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       expect(reponse.data).to.eql({ idUtilisateur: '123' });
     });
 
-    it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'Mot de passe trop simple',
         {
           method: 'put',
           url: 'http://localhost:1234/api/motDePasse',
           data: { motDePasse: '1234' },
-        },
-        done
+        }
       );
     });
 
@@ -521,16 +520,15 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
 
       describe("et que l'utilisateur n'est pas en train de les accepter", () => {
-        it('renvoie une erreur HTTP 422', (done) => {
-          testeur.verifieRequeteGenereErreurHTTP(
+        it('renvoie une erreur HTTP 422', async () => {
+          await testeur.verifieRequeteGenereErreurHTTPAsync(
             422,
             'CGU non acceptées',
             {
               method: 'put',
               url: 'http://localhost:1234/api/motDePasse',
               data: { motDePasse: 'mdp_12345' },
-            },
-            done
+            }
           );
         });
 
@@ -628,16 +626,15 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       expect(reponse.data).to.eql({ idUtilisateur: '123' });
     });
 
-    it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'Mot de passe trop simple',
         {
           method: 'patch',
           url: 'http://localhost:1234/api/motDePasse',
           data: { motDePasse: '1234' },
-        },
-        done
+        }
       );
     });
 
@@ -700,18 +697,17 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       );
     });
 
-    it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", (done) => {
+    it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", async () => {
       donneesRequete.prenom = '';
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'La mise à jour de l\'utilisateur a échoué car les paramètres sont invalides. La propriété "prenom" est requise',
         {
           method: 'put',
           url: 'http://localhost:1234/api/utilisateur',
           data: donneesRequete,
-        },
-        done
+        }
       );
     });
 
@@ -1114,15 +1110,14 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       );
     });
 
-    it('retourne une erreur HTTP 400 si le terme de recherche est vide', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it('retourne une erreur HTTP 400 si le terme de recherche est vide', async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         'Le terme de recherche ne peut pas être vide',
         {
           method: 'get',
           url: 'http://localhost:1234/api/annuaire/contributeurs',
-        },
-        done
+        }
       );
     });
 

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -975,16 +975,15 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       );
     });
 
-    it('retourne une erreur HTTP 422 si les droits sont incohérents', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it('retourne une erreur HTTP 422 si les droits sont incohérents', async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         { erreur: { code: 'DROITS_INCOHERENTS' } },
         {
           method: 'post',
           url: 'http://localhost:1234/api/autorisation',
           data: { droits: { RUBRIQUE_INCONNUE: 2 } },
-        },
-        done
+        }
       );
     });
   });

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -958,21 +958,16 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       }
     });
 
-    it('retourne une erreur HTTP 422 si la procédure a levé une `ErreurModele`', (done) => {
+    it('retourne une erreur HTTP 422 si la procédure a levé une `ErreurModele`', async () => {
       testeur.procedures().ajoutContributeurSurServices = async () => {
         throw new ErreurModele('oups');
       };
 
-      testeur.verifieRequeteGenereErreurHTTP(
-        422,
-        'oups',
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/autorisation',
-          data: { droits: tousDroitsEnEcriture() },
-        },
-        done
-      );
+      await testeur.verifieRequeteGenereErreurHTTPAsync(422, 'oups', {
+        method: 'post',
+        url: 'http://localhost:1234/api/autorisation',
+        data: { droits: tousDroitsEnEcriture() },
+      });
     });
 
     it('retourne une erreur HTTP 422 si les droits sont incohérents', async () => {

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -430,7 +430,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         'Mot de passe trop simple',
         {
@@ -521,7 +521,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       describe("et que l'utilisateur n'est pas en train de les accepter", () => {
         it('renvoie une erreur HTTP 422', async () => {
-          await testeur.verifieRequeteGenereErreurHTTPAsync(
+          await testeur.verifieRequeteGenereErreurHTTP(
             422,
             'CGU non acceptées',
             {
@@ -627,7 +627,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         'Mot de passe trop simple',
         {
@@ -700,7 +700,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", async () => {
       donneesRequete.prenom = '';
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         'La mise à jour de l\'utilisateur a échoué car les paramètres sont invalides. La propriété "prenom" est requise',
         {
@@ -959,7 +959,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         throw new ErreurModele('oups');
       };
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(422, 'oups', {
+      await testeur.verifieRequeteGenereErreurHTTP(422, 'oups', {
         method: 'post',
         url: 'http://localhost:1234/api/autorisation',
         data: { droits: tousDroitsEnEcriture() },
@@ -967,7 +967,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it('retourne une erreur HTTP 422 si les droits sont incohérents', async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         { erreur: { code: 'DROITS_INCOHERENTS' } },
         {
@@ -1111,7 +1111,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it('retourne une erreur HTTP 400 si le terme de recherche est vide', async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         'Le terme de recherche ne peut pas être vide',
         {

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -102,34 +102,28 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         ]);
     });
 
-    it('retourne une erreur HTTP 422 si les données de description de service sont invalides', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it('retourne une erreur HTTP 422 si les données de description de service sont invalides', async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'Le statut de déploiement "statutInvalide" est invalide',
         {
           method: 'post',
           url: 'http://localhost:1234/api/service',
           data: { statutDeploiement: 'statutInvalide' },
-        },
-        done
+        }
       );
     });
 
-    it('retourne une erreur HTTP 422 si données insuffisantes pour création service', (done) => {
+    it('retourne une erreur HTTP 422 si données insuffisantes pour création service', async () => {
       testeur.depotDonnees().nouveauService = async () => {
         throw new ErreurDonneesObligatoiresManquantes('oups');
       };
 
-      testeur.verifieRequeteGenereErreurHTTP(
-        422,
-        'oups',
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service',
-          data: {},
-        },
-        done
-      );
+      await testeur.verifieRequeteGenereErreurHTTPAsync(422, 'oups', {
+        method: 'post',
+        url: 'http://localhost:1234/api/service',
+        data: {},
+      });
     });
 
     it('retourne une erreur HTTP 422 si le nom du service existe déjà', (done) => {
@@ -256,33 +250,31 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(reponse.data).to.eql({ idService: '456' });
     });
 
-    it('retourne une erreur HTTP 422 si le validateur du modèle échoue', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it('retourne une erreur HTTP 422 si le validateur du modèle échoue', async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'Le statut de déploiement "statutInvalide" est invalide',
         {
           method: 'put',
           url: 'http://localhost:1234/api/service/456',
           data: { statutDeploiement: 'statutInvalide' },
-        },
-        done
+        }
       );
     });
 
-    it('retourne une erreur HTTP 422 si le nom du service existe déjà', (done) => {
+    it('retourne une erreur HTTP 422 si le nom du service existe déjà', async () => {
       testeur.depotDonnees().ajouteDescriptionService = async () => {
         throw new ErreurNomServiceDejaExistant('oups');
       };
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } },
         {
           method: 'put',
           url: 'http://localhost:1234/api/service/456',
           data: { nomService: 'service déjà existant' },
-        },
-        done
+        }
       );
     });
   });
@@ -757,16 +749,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(risquesRemplaces).to.be(true);
     });
 
-    it('retourne une erreur HTTP 422 si les données sont invalides', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it('retourne une erreur HTTP 422 si les données sont invalides', async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'Données invalides',
         {
           method: 'post',
           url: 'http://localhost:1234/api/service/456/risques',
           data: { 'commentaire-unRisqueInvalide': 'Un commentaire' },
-        },
-        done
+        }
       );
     });
   });
@@ -1333,20 +1324,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         );
     });
 
-    it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", (done) => {
+    it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", async () => {
       const autorisationNonTrouvee = undefined;
       testeur
         .middleware()
         .reinitialise({ autorisationACharger: autorisationNonTrouvee });
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         403,
         'Droits insuffisants pour supprimer le service',
-        {
-          method: 'delete',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
+        { method: 'delete', url: 'http://localhost:1234/api/service/123' }
       );
     });
 
@@ -1431,59 +1418,46 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", (done) => {
+    it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", async () => {
       const autorisationNonTrouvee = undefined;
       testeur
         .middleware()
         .reinitialise({ autorisationACharger: autorisationNonTrouvee });
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         403,
         'Droits insuffisants pour dupliquer le service',
-        {
-          method: 'copy',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
+        { method: 'copy', url: 'http://localhost:1234/api/service/123' }
       );
     });
 
-    it("retourne une erreur HTTP 403 si l'utilisateur courant n'est pas le créateur du service", (done) => {
+    it("retourne une erreur HTTP 403 si l'utilisateur courant n'est pas le créateur du service", async () => {
       testeur.middleware().reinitialise({
         autorisationACharger: uneAutorisation().deContributeur().construis(),
       });
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         403,
         'Droits insuffisants pour dupliquer le service',
-        {
-          method: 'copy',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
+        { method: 'copy', url: 'http://localhost:1234/api/service/123' }
       );
     });
 
-    it('retourne une erreur HTTP 424 si des données obligatoires ne sont pas renseignées', (done) => {
-      testeur.depotDonnees().dupliqueService = () =>
-        Promise.reject(
-          new ErreurDonneesObligatoiresManquantes(
-            'Certaines données obligatoires ne sont pas renseignées'
-          )
+    it('retourne une erreur HTTP 424 si des données obligatoires ne sont pas renseignées', async () => {
+      testeur.depotDonnees().dupliqueService = async () => {
+        throw new ErreurDonneesObligatoiresManquantes(
+          'Certaines données obligatoires ne sont pas renseignées'
         );
+      };
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         424,
         {
           type: 'DONNEES_OBLIGATOIRES_MANQUANTES',
           message:
             'La duplication a échoué car certaines données obligatoires ne sont pas renseignées',
         },
-        {
-          method: 'copy',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
+        { method: 'copy', url: 'http://localhost:1234/api/service/123' }
       );
     });
 
@@ -2057,8 +2031,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 424 si l'id du retour utilisateur est inconnu", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it("retourne une erreur HTTP 424 si l'id du retour utilisateur est inconnu", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         424,
         {
           type: 'DONNEES_INCORRECTES',
@@ -2068,8 +2042,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           method: 'post',
           url: 'http://localhost:1234/api/service/456/retourUtilisateurMesure',
           data: { idRetour: 'idRetourInconnu' },
-        },
-        done
+        }
       );
     });
 
@@ -2144,18 +2117,17 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 422 si le service n'a pas de dossier courant", (done) => {
+    it("retourne une erreur HTTP 422 si le service n'a pas de dossier courant", async () => {
       const service = unService().construis();
       testeur.middleware().reinitialise({ serviceARenvoyer: service });
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'Les dossiers ne comportent pas de dossier courant',
         {
           method: 'delete',
           url: 'http://localhost:1234/api/service/123/homologation/dossierCourant',
-        },
-        done
+        }
       );
     });
 
@@ -2242,17 +2214,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(resultat.data.niveauDeSecuriteMinimal).to.be('niveau1');
     });
 
-    it('retourne une erreur HTTP 400 si les données de description de service sont invalides', (done) => {
+    it('retourne une erreur HTTP 400 si les données de description de service sont invalides', async () => {
       const donneesInvalides = { statutDeploiement: 'statutInvalide' };
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         'La description du service est invalide',
         {
           method: 'post',
           url: 'http://localhost:1234/api/service/estimationNiveauSecurite',
           data: donneesInvalides,
-        },
-        done
+        }
       );
     });
   });

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -103,7 +103,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('retourne une erreur HTTP 422 si les données de description de service sont invalides', async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         'Le statut de déploiement "statutInvalide" est invalide',
         {
@@ -119,7 +119,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         throw new ErreurDonneesObligatoiresManquantes('oups');
       };
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(422, 'oups', {
+      await testeur.verifieRequeteGenereErreurHTTP(422, 'oups', {
         method: 'post',
         url: 'http://localhost:1234/api/service',
         data: {},
@@ -131,7 +131,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         throw new ErreurNomServiceDejaExistant('oups');
       };
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } },
         {
@@ -250,7 +250,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('retourne une erreur HTTP 422 si le validateur du modèle échoue', async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         'Le statut de déploiement "statutInvalide" est invalide',
         {
@@ -266,7 +266,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         throw new ErreurNomServiceDejaExistant('oups');
       };
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } },
         {
@@ -749,15 +749,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('retourne une erreur HTTP 422 si les données sont invalides', async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
-        422,
-        'Données invalides',
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service/456/risques',
-          data: { 'commentaire-unRisqueInvalide': 'Un commentaire' },
-        }
-      );
+      await testeur.verifieRequeteGenereErreurHTTP(422, 'Données invalides', {
+        method: 'post',
+        url: 'http://localhost:1234/api/service/456/risques',
+        data: { 'commentaire-unRisqueInvalide': 'Un commentaire' },
+      });
     });
   });
 
@@ -1329,7 +1325,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .middleware()
         .reinitialise({ autorisationACharger: autorisationNonTrouvee });
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour supprimer le service',
         { method: 'delete', url: 'http://localhost:1234/api/service/123' }
@@ -1341,7 +1337,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         autorisationACharger: uneAutorisation().deContributeur().construis(),
       });
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour supprimer le service',
         { method: 'delete', url: 'http://localhost:1234/api/service/123' }
@@ -1419,7 +1415,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .middleware()
         .reinitialise({ autorisationACharger: autorisationNonTrouvee });
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour dupliquer le service',
         { method: 'copy', url: 'http://localhost:1234/api/service/123' }
@@ -1431,7 +1427,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         autorisationACharger: uneAutorisation().deContributeur().construis(),
       });
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour dupliquer le service',
         { method: 'copy', url: 'http://localhost:1234/api/service/123' }
@@ -1445,7 +1441,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         );
       };
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         424,
         {
           type: 'DONNEES_OBLIGATOIRES_MANQUANTES',
@@ -1766,7 +1762,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('jette une erreur 422 si les droits envoyés sont incohérents', async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         { code: 'DROITS_INCOHERENTS' },
         {
@@ -2026,7 +2022,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("retourne une erreur HTTP 424 si l'id du retour utilisateur est inconnu", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         424,
         {
           type: 'DONNEES_INCORRECTES',
@@ -2044,7 +2040,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.referentiel().recharge({
         retoursUtilisateurMesure: { idRetour: 'un retour utilisateur' },
       });
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         424,
         {
           type: 'DONNEES_INCORRECTES',
@@ -2114,7 +2110,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       const service = unService().construis();
       testeur.middleware().reinitialise({ serviceARenvoyer: service });
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         'Les dossiers ne comportent pas de dossier courant',
         {
@@ -2209,7 +2205,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it('retourne une erreur HTTP 400 si les données de description de service sont invalides', async () => {
       const donneesInvalides = { statutDeploiement: 'statutInvalide' };
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         'La description du service est invalide',
         {

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -126,20 +126,19 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('retourne une erreur HTTP 422 si le nom du service existe déjà', (done) => {
+    it('retourne une erreur HTTP 422 si le nom du service existe déjà', async () => {
       testeur.depotDonnees().nouveauService = async () => {
         throw new ErreurNomServiceDejaExistant('oups');
       };
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } },
         {
           method: 'post',
           url: 'http://localhost:1234/api/service',
           data: { nomService: 'Un nom déjà existant' },
-        },
-        done
+        }
       );
     });
 
@@ -1337,19 +1336,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas les droits de suppression du service", (done) => {
+    it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas les droits de suppression du service", async () => {
       testeur.middleware().reinitialise({
         autorisationACharger: uneAutorisation().deContributeur().construis(),
       });
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         403,
         'Droits insuffisants pour supprimer le service',
-        {
-          method: 'delete',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
+        { method: 'delete', url: 'http://localhost:1234/api/service/123' }
       );
     });
 
@@ -1770,16 +1765,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('jette une erreur 422 si les droits envoyés sont incohérents', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it('jette une erreur 422 si les droits envoyés sont incohérents', async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         { code: 'DROITS_INCOHERENTS' },
         {
           method: 'PATCH',
           url: 'http://localhost:1234/api/service/456/autorisations/uuid-1',
           data: { droits: { MAUVAISE_RUBRIQUE: 1 } },
-        },
-        done
+        }
       );
     });
 
@@ -2046,11 +2040,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 424 si l'id de mesure est inconnu", (done) => {
+    it("retourne une erreur HTTP 424 si l'id de mesure est inconnu", async () => {
       testeur.referentiel().recharge({
         retoursUtilisateurMesure: { idRetour: 'un retour utilisateur' },
       });
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         424,
         {
           type: 'DONNEES_INCORRECTES',
@@ -2060,8 +2054,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           method: 'post',
           url: 'http://localhost:1234/api/service/456/retourUtilisateurMesure',
           data: { idMesure: 'idMesureInconnu', idRetour: 'idRetour' },
-        },
-        done
+        }
       );
     });
 

--- a/test/routes/connecte/routesConnecteApiServicePdf.spec.js
+++ b/test/routes/connecte/routesConnecteApiServicePdf.spec.js
@@ -340,7 +340,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 422 si le service n'a pas d'homologation active", (done) => {
+    it("retourne une erreur HTTP 422 si le service n'a pas d'homologation active", async () => {
       const serviceSansDossierActif = unService(referentiel)
         .avecId('456')
         .avecNomService('un service')
@@ -350,14 +350,13 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         .middleware()
         .reinitialise({ serviceARenvoyer: serviceSansDossierActif });
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         "Le service n'a pas d'homologation active",
         {
           method: 'get',
           url: 'http://localhost:1234/api/service/456/archive/tamponHomologation.zip',
-        },
-        done
+        }
       );
     });
 

--- a/test/routes/connecte/routesConnecteApiServicePdf.spec.js
+++ b/test/routes/connecte/routesConnecteApiServicePdf.spec.js
@@ -350,7 +350,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         .middleware()
         .reinitialise({ serviceARenvoyer: serviceSansDossierActif });
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         "Le service n'a pas d'homologation active",
         {

--- a/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
+++ b/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
@@ -45,15 +45,14 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 400 si l'ID d'étape n'existe pas", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it("retourne une erreur HTTP 400 si l'ID d'étape n'existe pas", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         "Identifiant d'étape inconnu",
         {
           method: 'POST',
           url: 'http://localhost:1234/api/visiteGuidee/MAUVAIS_ID/termine',
-        },
-        done
+        }
       );
     });
 

--- a/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
+++ b/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
@@ -46,7 +46,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
     });
 
     it("retourne une erreur HTTP 400 si l'ID d'étape n'existe pas", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         "Identifiant d'étape inconnu",
         {

--- a/test/routes/connecte/routesConnectePageService.spec.js
+++ b/test/routes/connecte/routesConnectePageService.spec.js
@@ -598,7 +598,7 @@ describe('Le serveur MSS des routes /service/*', () => {
     });
 
     it("répond avec une erreur HTTP 404 si l'identifiant d'étape n'est pas connu du référentiel", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(404, 'Étape inconnue', {
+      await testeur.verifieRequeteGenereErreurHTTP(404, 'Étape inconnue', {
         method: 'get',
         url: 'http://localhost:1234/service/456/homologation/edition/etape/inconnue',
       });

--- a/test/routes/connecte/routesConnectePageService.spec.js
+++ b/test/routes/connecte/routesConnectePageService.spec.js
@@ -597,16 +597,11 @@ describe('Le serveur MSS des routes /service/*', () => {
         );
     });
 
-    it("répond avec une erreur HTTP 404 si l'identifiant d'étape n'est pas connu du référentiel", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
-        404,
-        'Étape inconnue',
-        {
-          method: 'get',
-          url: 'http://localhost:1234/service/456/homologation/edition/etape/inconnue',
-        },
-        done
-      );
+    it("répond avec une erreur HTTP 404 si l'identifiant d'étape n'est pas connu du référentiel", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(404, 'Étape inconnue', {
+        method: 'get',
+        url: 'http://localhost:1234/service/456/homologation/edition/etape/inconnue',
+      });
     });
 
     it('ajoute un dossier courant au service si nécessaire', async () => {

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -499,19 +499,13 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
 
     describe("avec échec de l'authentification de l'utilisateur", () => {
-      it('retourne un HTTP 401', (done) => {
-        testeur.depotDonnees().utilisateurAuthentifie = () =>
-          Promise.resolve(undefined);
+      it('retourne un HTTP 401', async () => {
+        testeur.depotDonnees().utilisateurAuthentifie = async () => {};
 
-        testeur.verifieRequeteGenereErreurHTTP(
+        await testeur.verifieRequeteGenereErreurHTTPAsync(
           401,
           "L'authentification a échoué",
-          {
-            method: 'post',
-            url: 'http://localhost:1234/api/token',
-            data: {},
-          },
-          done
+          { method: 'post', url: 'http://localhost:1234/api/token', data: {} }
         );
       });
     });
@@ -533,15 +527,14 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       );
     });
 
-    it('retourne une erreur HTTP 400 si le terme de recherche est vide', (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it('retourne une erreur HTTP 400 si le terme de recherche est vide', async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         'Le terme de recherche ne peut pas être vide',
         {
           method: 'get',
           url: 'http://localhost:1234/api/annuaire/organisations?departement=75',
-        },
-        done
+        }
       );
     });
 
@@ -591,15 +584,14 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       event: 'unsubscribe',
     };
 
-    it("retourne une erreur HTTP 400 si l'événement n'est pas une désinscription", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it("retourne une erreur HTTP 400 si l'événement n'est pas une désinscription", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         { erreur: "L'événement doit être de type 'unsubscribe'" },
         {
           method: 'post',
           url: 'http://localhost:1234/api/desinscriptionInfolettre',
-        },
-        done
+        }
       );
     });
 

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -127,7 +127,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", async () => {
       donneesRequete.prenom = '';
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         422,
         'La création d\'un nouvel utilisateur a échoué car les paramètres sont invalides. La propriété "prenom" est requise',
         {
@@ -245,7 +245,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       });
 
       it('retourne une erreur HTTP 424', async () => {
-        await testeur.verifieRequeteGenereErreurHTTPAsync(
+        await testeur.verifieRequeteGenereErreurHTTP(
           424,
           "L'envoi de l'email de finalisation d'inscription a échoué",
           {
@@ -286,7 +286,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         throw new ErreurEmailManquant('oups');
       };
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(422, 'oups', {
+      await testeur.verifieRequeteGenereErreurHTTP(422, 'oups', {
         method: 'post',
         url: 'http://localhost:1234/api/utilisateur',
         data: donneesRequete,
@@ -502,7 +502,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       it('retourne un HTTP 401', async () => {
         testeur.depotDonnees().utilisateurAuthentifie = async () => {};
 
-        await testeur.verifieRequeteGenereErreurHTTPAsync(
+        await testeur.verifieRequeteGenereErreurHTTP(
           401,
           "L'authentification a échoué",
           { method: 'post', url: 'http://localhost:1234/api/token', data: {} }
@@ -528,7 +528,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
 
     it('retourne une erreur HTTP 400 si le terme de recherche est vide', async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         'Le terme de recherche ne peut pas être vide',
         {
@@ -540,7 +540,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
 
     it("retourne une erreur HTTP 400 si le département n'est pas dans le referentiel", async () => {
       testeur.referentiel().estCodeDepartement = () => false;
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         'Le département doit être valide (01 à 989)',
         {
@@ -585,7 +585,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     };
 
     it("retourne une erreur HTTP 400 si l'événement n'est pas une désinscription", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         { erreur: "L'événement doit être de type 'unsubscribe'" },
         {
@@ -596,7 +596,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
 
     it("retourne une erreur HTTP 400 si le champ email n'est pas présent", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         { erreur: "Le champ 'email' doit être présent" },
         {
@@ -611,7 +611,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       testeur.depotDonnees().utilisateurAvecEmail = () =>
         Promise.resolve(undefined);
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         424,
         { erreur: "L'email 'jean.dujardin@mail.com' est introuvable" },
         {

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -124,18 +124,17 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         .catch(done);
     });
 
-    it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", (done) => {
+    it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", async () => {
       donneesRequete.prenom = '';
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         422,
         'La création d\'un nouvel utilisateur a échoué car les paramètres sont invalides. La propriété "prenom" est requise',
         {
           method: 'post',
           url: 'http://localhost:1234/api/utilisateur',
           data: donneesRequete,
-        },
-        done
+        }
       );
     });
 
@@ -245,16 +244,15 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         testeur.depotDonnees().supprimeUtilisateur = () => Promise.resolve();
       });
 
-      it('retourne une erreur HTTP 424', (done) => {
-        testeur.verifieRequeteGenereErreurHTTP(
+      it('retourne une erreur HTTP 424', async () => {
+        await testeur.verifieRequeteGenereErreurHTTPAsync(
           424,
           "L'envoi de l'email de finalisation d'inscription a échoué",
           {
             method: 'post',
             url: 'http://localhost:1234/api/utilisateur',
             data: donneesRequete,
-          },
-          done
+          }
         );
       });
     });
@@ -283,20 +281,16 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         .catch((e) => done(e.response?.data || e));
     });
 
-    it("génère une erreur HTTP 422 si l'email n'est pas renseigné", (done) => {
-      testeur.depotDonnees().nouvelUtilisateur = () =>
-        Promise.reject(new ErreurEmailManquant('oups'));
+    it("génère une erreur HTTP 422 si l'email n'est pas renseigné", async () => {
+      testeur.depotDonnees().nouvelUtilisateur = async () => {
+        throw new ErreurEmailManquant('oups');
+      };
 
-      testeur.verifieRequeteGenereErreurHTTP(
-        422,
-        'oups',
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/utilisateur',
-          data: donneesRequete,
-        },
-        done
-      );
+      await testeur.verifieRequeteGenereErreurHTTPAsync(422, 'oups', {
+        method: 'post',
+        url: 'http://localhost:1234/api/utilisateur',
+        data: donneesRequete,
+      });
     });
   });
 
@@ -551,16 +545,15 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 400 si le département n'est pas dans le referentiel", (done) => {
+    it("retourne une erreur HTTP 400 si le département n'est pas dans le referentiel", async () => {
       testeur.referentiel().estCodeDepartement = () => false;
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         'Le département doit être valide (01 à 989)',
         {
           method: 'get',
           url: 'http://localhost:1234/api/annuaire/organisations?recherche=mairie&departement=990',
-        },
-        done
+        }
       );
     });
 
@@ -610,32 +603,30 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       );
     });
 
-    it("retourne une erreur HTTP 400 si le champ email n'est pas présent", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it("retourne une erreur HTTP 400 si le champ email n'est pas présent", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         { erreur: "Le champ 'email' doit être présent" },
         {
           method: 'post',
           url: 'http://localhost:1234/api/desinscriptionInfolettre',
           data: { event: 'unsubscribe' },
-        },
-        done
+        }
       );
     });
 
-    it("retourne une erreur HTTP 424 si l'adresse email est introuvable", (done) => {
+    it("retourne une erreur HTTP 424 si l'adresse email est introuvable", async () => {
       testeur.depotDonnees().utilisateurAvecEmail = () =>
         Promise.resolve(undefined);
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         424,
         { erreur: "L'email 'jean.dujardin@mail.com' est introuvable" },
         {
           method: 'post',
           url: 'http://localhost:1234/api/desinscriptionInfolettre',
           data: donneesRequete,
-        },
-        done
+        }
       );
     });
 

--- a/test/routes/nonConnecte/routesNonConnecteApiBibliotheques.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApiBibliotheques.spec.js
@@ -8,7 +8,7 @@ describe('Le serveur MSS des routes /bibliotheques/*', () => {
   afterEach(testeur.arrete);
 
   it('retourne une erreur HTTP 404 si la bibliothèque est inconnue', async () => {
-    await testeur.verifieRequeteGenereErreurHTTPAsync(
+    await testeur.verifieRequeteGenereErreurHTTP(
       404,
       'Bibliothèque inconnue : bibliothequeInconnue.js',
       {

--- a/test/routes/nonConnecte/routesNonConnecteApiBibliotheques.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApiBibliotheques.spec.js
@@ -7,15 +7,14 @@ describe('Le serveur MSS des routes /bibliotheques/*', () => {
 
   afterEach(testeur.arrete);
 
-  it('retourne une erreur HTTP 404 si la bibliothèque est inconnue', (done) => {
-    testeur.verifieRequeteGenereErreurHTTP(
+  it('retourne une erreur HTTP 404 si la bibliothèque est inconnue', async () => {
+    await testeur.verifieRequeteGenereErreurHTTPAsync(
       404,
       'Bibliothèque inconnue : bibliothequeInconnue.js',
       {
         method: 'get',
         url: 'http://localhost:1234/bibliotheques/bibliothequeInconnue.js',
-      },
-      done
+      }
     );
   });
 });

--- a/test/routes/nonConnecte/routesNonConnecteApiStyles.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApiStyles.spec.js
@@ -8,7 +8,7 @@ describe('Le serveur MSS des routes /styles/*', () => {
   afterEach(testeur.arrete);
 
   it('retourne une erreur HTTP 404 si la feuille de style est inconnue', async () => {
-    await testeur.verifieRequeteGenereErreurHTTPAsync(
+    await testeur.verifieRequeteGenereErreurHTTP(
       404,
       'Feuille de style inconnue',
       { method: 'get', url: 'http://localhost:1234/styles/stylesInconnu.css' }

--- a/test/routes/nonConnecte/routesNonConnecteApiStyles.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApiStyles.spec.js
@@ -7,15 +7,11 @@ describe('Le serveur MSS des routes /styles/*', () => {
 
   afterEach(testeur.arrete);
 
-  it('retourne une erreur HTTP 404 si la feuille de style est inconnue', (done) => {
-    testeur.verifieRequeteGenereErreurHTTP(
+  it('retourne une erreur HTTP 404 si la feuille de style est inconnue', async () => {
+    await testeur.verifieRequeteGenereErreurHTTPAsync(
       404,
       'Feuille de style inconnue',
-      {
-        method: 'get',
-        url: 'http://localhost:1234/styles/stylesInconnu.css',
-      },
-      done
+      { method: 'get', url: 'http://localhost:1234/styles/stylesInconnu.css' }
     );
   });
 });

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -108,7 +108,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
     });
 
     it("retourne une erreur HTTP 400 sur idReset n'est pas un UUID valide", async () => {
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         400,
         'UUID requis',
         'http://localhost:1234/initialisationMotDePasse/999'
@@ -118,7 +118,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
     it('retourne une erreur HTTP 404 si idReset inconnu', async () => {
       testeur.depotDonnees().utilisateurAFinaliser = async () => {};
 
-      await testeur.verifieRequeteGenereErreurHTTPAsync(
+      await testeur.verifieRequeteGenereErreurHTTP(
         404,
         `Identifiant d'initialisation de mot de passe inconnu`,
         `http://localhost:1234/initialisationMotDePasse/${uuid}`

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -107,23 +107,21 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
         );
     });
 
-    it("retourne une erreur HTTP 400 sur idReset n'est pas un UUID valide", (done) => {
-      testeur.verifieRequeteGenereErreurHTTP(
+    it("retourne une erreur HTTP 400 sur idReset n'est pas un UUID valide", async () => {
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         400,
         'UUID requis',
-        'http://localhost:1234/initialisationMotDePasse/999',
-        done
+        'http://localhost:1234/initialisationMotDePasse/999'
       );
     });
 
-    it('retourne une erreur HTTP 404 si idReset inconnu', (done) => {
+    it('retourne une erreur HTTP 404 si idReset inconnu', async () => {
       testeur.depotDonnees().utilisateurAFinaliser = async () => {};
 
-      testeur.verifieRequeteGenereErreurHTTP(
+      await testeur.verifieRequeteGenereErreurHTTPAsync(
         404,
         `Identifiant d'initialisation de mot de passe inconnu`,
-        `http://localhost:1234/initialisationMotDePasse/${uuid}`,
-        done
+        `http://localhost:1234/initialisationMotDePasse/${uuid}`
       );
     });
   });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -35,23 +35,7 @@ const testeurMss = () => {
     suite();
   };
 
-  const verifieRequeteGenereErreurHTTP = (
-    status,
-    messageErreur,
-    requete,
-    suite
-  ) => {
-    axios(requete)
-      .then(() => suite('Réponse OK inattendue'))
-      .catch((erreur) => {
-        expect(erreur.response?.status).to.equal(status);
-        expect(erreur.response?.data).to.eql(messageErreur);
-        suite();
-      })
-      .catch(suite);
-  };
-
-  const verifieRequeteGenereErreurHTTPAsync = async (
+  const verifieRequeteGenereErreurHTTP = async (
     status,
     messageErreur,
     requete
@@ -149,7 +133,6 @@ const testeurMss = () => {
     arrete,
     initialise,
     verifieRequeteGenereErreurHTTP,
-    verifieRequeteGenereErreurHTTPAsync,
     verifieJetonDepose,
   };
 };

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -51,6 +51,20 @@ const testeurMss = () => {
       .catch(suite);
   };
 
+  const verifieRequeteGenereErreurHTTPAsync = async (
+    status,
+    messageErreur,
+    requete
+  ) => {
+    try {
+      await axios(requete);
+      expect().fail('Réponse OK inattendue');
+    } catch (erreur) {
+      expect(erreur.response?.status).to.equal(status);
+      expect(erreur.response?.data).to.eql(messageErreur);
+    }
+  };
+
   const initialise = (done) => {
     serviceAnnuaire = {};
     adaptateurHorloge = {
@@ -135,6 +149,7 @@ const testeurMss = () => {
     arrete,
     initialise,
     verifieRequeteGenereErreurHTTP,
+    verifieRequeteGenereErreurHTTPAsync,
     verifieJetonDepose,
   };
 };


### PR DESCRIPTION
L'objectif de cette PR est de cesser de faire crasher le runner de test WallabyJS.

Sur un test j'avais des `done() called multiple times`.
C'est le premier commit de cette PR qui corrige ça : en ajoutant un `else` devant le `if` on corrige le comportement.

Ensuite, j'ai passé les tests `verifieRequeteGenereErreurHTTP` en `async/await` pour gagner en concision.