### PR TITLE
[NOTIFICATIONS] Ajout des notifications de types « tâches de service »

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -72,6 +72,8 @@ module.exports = {
     },
   ],
 
+  naturesTachesService: {},
+
   nombreOrganisationsUtilisatrices: [
     { label: 'Mon organisation uniquement', borneBasse: 1, borneHaute: 1 },
     { label: '2', borneBasse: 2, borneHaute: 2 },

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -78,6 +78,7 @@ module.exports = {
       titreCta: 'Voir le changement',
       titre:
         'Votre service [%NOM_SERVICE%] a désormais des besoins de sécurité %nouveauxBesoins%.',
+      lien: '/service/%ID_SERVICE%/descriptionService?etape=3',
     },
   },
 

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -77,7 +77,7 @@ module.exports = {
       entete: 'Le besoin de sécurité a été modifié',
       titreCta: 'Voir le changement',
       titre:
-        'Votre service [%NOM_SERVICE%] a désormais des besoins de sécurité %NOUVEAU_NIVEAU%.',
+        'Votre service [%NOM_SERVICE%] a désormais des besoins de sécurité %nouveauxBesoins%.',
     },
   },
 

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -72,7 +72,14 @@ module.exports = {
     },
   ],
 
-  naturesTachesService: {},
+  naturesTachesService: {
+    niveauSecuriteRetrograde: {
+      entete: 'Le besoin de sécurité a été modifié',
+      titreCta: 'Voir le changement',
+      titre:
+        'Votre service [%NOM_SERVICE%] a désormais des besoins de sécurité %NOUVEAU_NIVEAU%.',
+    },
+  },
 
   nombreOrganisationsUtilisatrices: [
     { label: 'Mon organisation uniquement', borneBasse: 1, borneHaute: 1 },

--- a/migrations/20240710075904_creationTableTachesService.js
+++ b/migrations/20240710075904_creationTableTachesService.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) =>
+  knex.schema.createTable('taches_service', (table) => {
+    table.uuid('id');
+    table.primary('id');
+    table.uuid('id_service');
+    table.date('date_creation');
+    table.string('nature');
+    table.datetime('date_faite');
+  });
+
+exports.down = async (knex) => knex.schema.dropTable('taches_service');

--- a/migrations/20240711132023_ajouteDonneesATachesDeService.js
+++ b/migrations/20240711132023_ajouteDonneesATachesDeService.js
@@ -1,0 +1,9 @@
+exports.up = (knex) =>
+  knex.schema.alterTable('taches_service', (table) => {
+    table.json('donnees').defaultTo({});
+  });
+
+exports.down = (knex) =>
+  knex.schema.alterTable('taches_service', (table) => {
+    table.dropColumn('donnees');
+  });

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -295,6 +295,8 @@ const nouvelAdaptateur = (
       .filter(([_cle, valeur]) => valeur.idUtilisateur === idUtilisateur)
       .map((_cle, valeur) => valeur.idNouveaute);
 
+  const tachesDeServicePour = async () => [];
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -329,6 +331,7 @@ const nouvelAdaptateur = (
     supprimeService,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    tachesDeServicePour,
     tousLesServices,
     tousUtilisateurs,
     utilisateur,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -297,6 +297,8 @@ const nouvelAdaptateur = (
 
   const tachesDeServicePour = async () => [];
 
+  const marqueTacheDeServiceLue = async () => {};
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -310,6 +312,7 @@ const nouvelAdaptateur = (
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
+    marqueTacheDeServiceLue,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,
     nouveautesPourUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -377,18 +377,17 @@ const nouvelAdaptateur = (env) => {
   const tachesDeServicePour = async (idUtilisateur) => {
     const requete = await knex.raw(
       `
-        select t.*
-        from taches_service t
-               inner join autorisations a
-                          on ((donnees ->> 'idService')::uuid = t.id_service and (donnees ->> 'estProprietaire')::bool = true)
-        where (a.donnees ->> 'idUtilisateur')::uuid = ?`,
+                    select t.*
+                    from taches_service t
+                             inner join autorisations a
+                                        on ((a.donnees ->> 'idService')::uuid = t.id_service and (a.donnees ->> 'estProprietaire')::bool = true)
+                    where (a.donnees ->> 'idUtilisateur')::uuid = ?`,
       [idUtilisateur]
     );
     return requete.rows.map((n) => ({
-      id: n.id,
+      ...n,
       idService: n.id_service,
       dateCreation: new Date(n.date_creation),
-      nature: n.nature,
       dateFaite: n.date_faite ? new Date(n.date_faite) : null,
     }));
   };

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -384,12 +384,16 @@ const nouvelAdaptateur = (env) => {
                     where (a.donnees ->> 'idUtilisateur')::uuid = ?`,
       [idUtilisateur]
     );
-    return requete.rows.map((n) => ({
-      ...n,
-      idService: n.id_service,
-      dateCreation: new Date(n.date_creation),
-      dateFaite: n.date_faite ? new Date(n.date_faite) : null,
-    }));
+    return requete.rows.map(
+      /* eslint-disable camelcase */
+      ({ id_service, date_creation, date_faite, ...reste }) => ({
+        ...reste,
+        idService: id_service,
+        dateCreation: new Date(date_creation),
+        dateFaite: date_faite ? new Date(date_faite) : null,
+      })
+      /* eslint-enable camelcase */
+    );
   };
 
   const marqueTacheDeServiceLue = async (idTache) => {

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -371,7 +371,25 @@ const nouvelAdaptateur = (env) => {
       // eslint-disable-next-line camelcase
       .map(({ id_nouveaute }) => id_nouveaute);
 
-  const tachesDeServicePour = async (idUtilisateur) => [];
+  const tachesDeServicePour = async (idUtilisateur) => {
+    const requete = await knex('taches_service')
+      .innerJoin('autorisations as a', function () {
+        this.on(
+          knex.raw("(a.donnees->>'idService')::uuid"),
+          '=',
+          'taches_service.id_service'
+        ).andOn(knex.raw("(a.donnees->>'estProprietaire')::bool"));
+      })
+      .whereRaw("donnees->>'idUtilisateur'=?", idUtilisateur)
+      .select('taches_service.*');
+    return requete.map((n) => ({
+      id: n.id,
+      idService: n.id_service,
+      dateCreation: new Date(n.date_creation),
+      nature: n.nature,
+      dateFaite: n.date_faite ? new Date(n.date_faite) : null,
+    }));
+  };
 
   return {
     ajouteAutorisation,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -371,6 +371,8 @@ const nouvelAdaptateur = (env) => {
       // eslint-disable-next-line camelcase
       .map(({ id_nouveaute }) => id_nouveaute);
 
+  const tachesDeServicePour = async (idUtilisateur) => [];
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -406,6 +408,7 @@ const nouvelAdaptateur = (env) => {
     supprimeHomologations,
     supprimeUtilisateur,
     supprimeUtilisateurs,
+    tachesDeServicePour,
     tousLesServices,
     tousUtilisateurs,
     utilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -392,6 +392,12 @@ const nouvelAdaptateur = (env) => {
     }));
   };
 
+  const marqueTacheDeServiceLue = async (idTache) => {
+    await knex('taches_service')
+      .where({ id: idTache })
+      .update({ date_faite: knex.fn.now() });
+  };
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -406,6 +412,7 @@ const nouvelAdaptateur = (env) => {
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
+    marqueTacheDeServiceLue,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,
     nouveautesPourUtilisateur,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -114,7 +114,8 @@ const creeDepot = (config = {}) => {
   const { lisParcoursUtilisateur, sauvegardeParcoursUtilisateur } =
     depotParcoursUtilisateurs;
 
-  const { marqueNouveauteLue, nouveautesPourUtilisateur } = depotNotifications;
+  const { marqueNouveauteLue, nouveautesPourUtilisateur, tachesDesServices } =
+    depotNotifications;
 
   const {
     lisNotificationsExpirationHomologationEnDate,
@@ -163,6 +164,7 @@ const creeDepot = (config = {}) => {
     supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
     supprimeUtilisateur,
+    tachesDesServices,
     tousUtilisateurs,
     tousLesServices,
     utilisateur,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -117,7 +117,7 @@ const creeDepot = (config = {}) => {
 
   const {
     marqueNouveauteLue,
-    marqueTacheLue,
+    marqueTacheDeServiceLue,
     nouveautesPourUtilisateur,
     tachesDesServices,
   } = depotNotifications;
@@ -150,7 +150,7 @@ const creeDepot = (config = {}) => {
     lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
-    marqueTacheLue,
+    marqueTacheDeServiceLue,
     metsAJourMotDePasse,
     metsAJourMesureGeneraleDuService,
     metsAJourMesuresSpecifiquesDuService,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -115,8 +115,12 @@ const creeDepot = (config = {}) => {
   const { lisParcoursUtilisateur, sauvegardeParcoursUtilisateur } =
     depotParcoursUtilisateurs;
 
-  const { marqueNouveauteLue, nouveautesPourUtilisateur, tachesDesServices } =
-    depotNotifications;
+  const {
+    marqueNouveauteLue,
+    marqueTacheLue,
+    nouveautesPourUtilisateur,
+    tachesDesServices,
+  } = depotNotifications;
 
   const {
     lisNotificationsExpirationHomologationEnDate,
@@ -146,6 +150,7 @@ const creeDepot = (config = {}) => {
     lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
+    marqueTacheLue,
     metsAJourMotDePasse,
     metsAJourMesureGeneraleDuService,
     metsAJourMesuresSpecifiquesDuService,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -60,6 +60,7 @@ const creeDepot = (config = {}) => {
 
   const depotNotifications = depotDonneesNotifications.creeDepot({
     adaptateurPersistance,
+    depotServices: depotHomologations,
   });
 
   const {

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -25,7 +25,9 @@ const creeDepot = (config = {}) => {
     });
   };
 
-  const marqueTacheLue = async (idTache) => {};
+  const marqueTacheLue = async (idTache) => {
+    await adaptateurPersistance.marqueTacheDeServiceLue(idTache);
+  };
 
   return {
     marqueNouveauteLue,

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -25,8 +25,11 @@ const creeDepot = (config = {}) => {
     });
   };
 
+  const marqueTacheLue = async (idUtilisateur, idTache) => {};
+
   return {
     marqueNouveauteLue,
+    marqueTacheLue,
     nouveautesPourUtilisateur,
     tachesDesServices,
   };

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -25,13 +25,13 @@ const creeDepot = (config = {}) => {
     });
   };
 
-  const marqueTacheLue = async (idTache) => {
+  const marqueTacheDeServiceLue = async (idTache) => {
     await adaptateurPersistance.marqueTacheDeServiceLue(idTache);
   };
 
   return {
     marqueNouveauteLue,
-    marqueTacheLue,
+    marqueTacheDeServiceLue,
     nouveautesPourUtilisateur,
     tachesDesServices,
   };

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -3,6 +3,7 @@ const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateur
 const creeDepot = (config = {}) => {
   const {
     adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
+    depotServices,
   } = config;
 
   const marqueNouveauteLue = async (idUtilisateur, idNouveaute) =>
@@ -11,8 +12,18 @@ const creeDepot = (config = {}) => {
   const nouveautesPourUtilisateur = async (idUtilisateur) =>
     adaptateurPersistance.nouveautesPourUtilisateur(idUtilisateur);
 
-  const tachesDesServices = async (idUtilisateur) =>
-    adaptateurPersistance.tachesDeServicePour(idUtilisateur);
+  const tachesDesServices = async (idUtilisateur) => {
+    const servicesUtilisateur =
+      await depotServices.homologations(idUtilisateur);
+
+    const taches =
+      await adaptateurPersistance.tachesDeServicePour(idUtilisateur);
+
+    return taches.map((t) => {
+      const service = servicesUtilisateur.find((s) => s.id === t.idService);
+      return { ...t, service };
+    });
+  };
 
   return {
     marqueNouveauteLue,

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -11,9 +11,12 @@ const creeDepot = (config = {}) => {
   const nouveautesPourUtilisateur = async (idUtilisateur) =>
     adaptateurPersistance.nouveautesPourUtilisateur(idUtilisateur);
 
+  const tachesDesServices = async () => [];
+
   return {
     marqueNouveauteLue,
     nouveautesPourUtilisateur,
+    tachesDesServices,
   };
 };
 

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -11,7 +11,8 @@ const creeDepot = (config = {}) => {
   const nouveautesPourUtilisateur = async (idUtilisateur) =>
     adaptateurPersistance.nouveautesPourUtilisateur(idUtilisateur);
 
-  const tachesDesServices = async () => [];
+  const tachesDesServices = async (idUtilisateur) =>
+    adaptateurPersistance.tachesDeServicePour(idUtilisateur);
 
   return {
     marqueNouveauteLue,

--- a/src/depots/depotDonneesNotifications.js
+++ b/src/depots/depotDonneesNotifications.js
@@ -25,7 +25,7 @@ const creeDepot = (config = {}) => {
     });
   };
 
-  const marqueTacheLue = async (idUtilisateur, idTache) => {};
+  const marqueTacheLue = async (idTache) => {};
 
   return {
     marqueNouveauteLue,

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -45,6 +45,7 @@ class ErreurSuppressionImpossible extends Error {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
 class ErreurIdentifiantNouveauteInconnu extends ErreurModele {}
+class ErreurIdentifiantTacheInconnu extends ErreurModele {}
 
 class ErreurUtilisateurExistant extends ErreurModele {
   constructor(message, idUtilisateur) {
@@ -92,4 +93,5 @@ module.exports = {
   ErreurUtilisateurExistant,
   ErreurUtilisateurInexistant,
   ErreurDonneesNiveauSecuriteInsuffisant,
+  ErreurIdentifiantTacheInconnu,
 };

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -52,11 +52,21 @@ class CentreNotifications {
 
     return notifications.map((notification) => ({
       ...notification,
-      titre: notification.titre?.replace(
-        '%NOM_SERVICE%',
-        notification.service.nomService()
-      ),
+      titre: CentreNotifications.titreFusionne(notification),
     }));
+  }
+
+  static titreFusionne(notification) {
+    const champsDonnees = Object.keys(notification.donnees || {});
+    const valeurReelle = (champ) => {
+      if (champ === 'NOM_SERVICE') return notification.service?.nomService();
+      return notification.donnees?.[champ];
+    };
+
+    return ['NOM_SERVICE', ...champsDonnees].reduce(
+      (acc, cle) => acc.replace(`%${cle}%`, valeurReelle(cle)),
+      notification.titre || ''
+    );
   }
 
   async toutesNouveautes(idUtilisateur) {

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -98,6 +98,10 @@ class CentreNotifications {
     await this.depotDonnees.marqueNouveauteLue(idUtilisateur, idNouveaute);
   }
 
+  async marqueTacheLue(idUtilisateur, idTache) {
+    await this.depotDonnees.marqueTacheLue(idUtilisateur, idTache);
+  }
+
   async toutesTachesEnAttente(idUtilisateur) {
     const utilisateur = await this.depotDonnees.utilisateur(idUtilisateur);
     if (!utilisateur) {

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -33,6 +33,7 @@ class CentreNotifications {
       ...nouveautes.map((t) => ({
         ...t,
         type: 'nouveaute',
+        doitNotifierLecture: true,
         date: () => new Date(t.dateDeDeploiement),
       })),
       ...tachesDesServices.map((t) => ({

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -21,7 +21,7 @@ class CentreNotifications {
     const [taches, nouveautes, tachesDesServices] = await Promise.all([
       this.toutesTachesEnAttente(idUtilisateur),
       this.toutesNouveautes(idUtilisateur),
-      this.depotDonnees.tachesDesServices(idUtilisateur),
+      this.toutesTachesDeService(idUtilisateur),
     ]);
 
     return [
@@ -41,6 +41,15 @@ class CentreNotifications {
         date: () => t.dateCreation,
       })),
     ].sort((a, b) => b.date() - a.date());
+  }
+
+  async toutesTachesDeService(idUtilisateur) {
+    return (await this.depotDonnees.tachesDesServices(idUtilisateur)).map(
+      (tache) => ({
+        ...tache,
+        ...this.referentiel.natureTachesService(tache.nature),
+      })
+    );
   }
 
   async toutesNouveautes(idUtilisateur) {

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -1,4 +1,7 @@
-const { ErreurIdentifiantNouveauteInconnu } = require('../erreurs');
+const {
+  ErreurIdentifiantNouveauteInconnu,
+  ErreurIdentifiantTacheInconnu,
+} = require('../erreurs');
 
 const avecStatutLecture = (notification, statutLecture) => ({
   ...notification,
@@ -101,6 +104,10 @@ class CentreNotifications {
   }
 
   async marqueTacheLue(idUtilisateur, idTache) {
+    const taches = await this.depotDonnees.tachesDesServices(idUtilisateur);
+    if (!taches.find((t) => t.id)) {
+      throw new ErreurIdentifiantTacheInconnu();
+    }
     await this.depotDonnees.marqueTacheLue(idUtilisateur, idTache);
   }
 

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -108,7 +108,7 @@ class CentreNotifications {
     if (!taches.find((t) => t.id)) {
       throw new ErreurIdentifiantTacheInconnu();
     }
-    await this.depotDonnees.marqueTacheLue(idTache);
+    await this.depotDonnees.marqueTacheDeServiceLue(idTache);
   }
 
   async toutesTachesProfilUtilisateur(idUtilisateur) {

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -58,6 +58,7 @@ class CentreNotifications {
     return notifications.map((notification) => ({
       ...notification,
       titre: CentreNotifications.titreFusionne(notification),
+      lien: notification.lien?.replace('%ID_SERVICE%', notification.service.id),
       statutLecture: notification.dateFaite
         ? CentreNotifications.NOTIFICATION_LUE
         : CentreNotifications.NOTIFICATION_NON_LUE,

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -58,6 +58,9 @@ class CentreNotifications {
     return notifications.map((notification) => ({
       ...notification,
       titre: CentreNotifications.titreFusionne(notification),
+      statutLecture: notification.dateFaite
+        ? CentreNotifications.NOTIFICATION_LUE
+        : CentreNotifications.NOTIFICATION_NON_LUE,
     }));
   }
 

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -46,14 +46,10 @@ class CentreNotifications {
   async toutesNouveautes(idUtilisateur) {
     const avant = this.referentiel.nouvellesFonctionnalites();
 
-    const toutesNouveautes = avant
-      .filter(
-        (n) =>
-          new Date(n.dateDeDeploiement) <= this.adaptateurHorloge.maintenant()
-      )
-      .sort(
-        (a, b) => new Date(b.dateDeDeploiement) - new Date(a.dateDeDeploiement)
-      );
+    const toutesNouveautes = avant.filter(
+      (n) =>
+        new Date(n.dateDeDeploiement) <= this.adaptateurHorloge.maintenant()
+    );
 
     const etatLectureNouveautes =
       await this.depotDonnees.nouveautesPourUtilisateur(idUtilisateur);

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -108,7 +108,7 @@ class CentreNotifications {
     if (!taches.find((t) => t.id)) {
       throw new ErreurIdentifiantTacheInconnu();
     }
-    await this.depotDonnees.marqueTacheLue(idUtilisateur, idTache);
+    await this.depotDonnees.marqueTacheLue(idTache);
   }
 
   async toutesTachesProfilUtilisateur(idUtilisateur) {

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -21,14 +21,14 @@ class CentreNotifications {
   }
 
   async toutesNotifications(idUtilisateur) {
-    const [taches, nouveautes, tachesDesServices] = await Promise.all([
-      this.toutesTachesEnAttente(idUtilisateur),
+    const [tachesProfil, nouveautes, tachesDesServices] = await Promise.all([
+      this.toutesTachesProfilUtilisateur(idUtilisateur),
       this.toutesNouveautes(idUtilisateur),
       this.toutesTachesDeService(idUtilisateur),
     ]);
 
     return [
-      ...taches.map((t) => ({
+      ...tachesProfil.map((t) => ({
         ...t,
         type: 'tache',
         date: () => this.adaptateurHorloge.maintenant(),
@@ -103,7 +103,7 @@ class CentreNotifications {
     await this.depotDonnees.marqueNouveauteLue(idUtilisateur, idNouveaute);
   }
 
-  async marqueTacheLue(idUtilisateur, idTache) {
+  async marqueTacheDeServiceLue(idUtilisateur, idTache) {
     const taches = await this.depotDonnees.tachesDesServices(idUtilisateur);
     if (!taches.find((t) => t.id)) {
       throw new ErreurIdentifiantTacheInconnu();
@@ -111,7 +111,7 @@ class CentreNotifications {
     await this.depotDonnees.marqueTacheLue(idUtilisateur, idTache);
   }
 
-  async toutesTachesEnAttente(idUtilisateur) {
+  async toutesTachesProfilUtilisateur(idUtilisateur) {
     const utilisateur = await this.depotDonnees.utilisateur(idUtilisateur);
     if (!utilisateur) {
       return [];

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -44,12 +44,19 @@ class CentreNotifications {
   }
 
   async toutesTachesDeService(idUtilisateur) {
-    return (await this.depotDonnees.tachesDesServices(idUtilisateur)).map(
-      (tache) => ({
-        ...tache,
-        ...this.referentiel.natureTachesService(tache.nature),
-      })
-    );
+    const taches = await this.depotDonnees.tachesDesServices(idUtilisateur);
+    const notifications = taches.map((tache) => ({
+      ...tache,
+      ...this.referentiel.natureTachesService(tache.nature),
+    }));
+
+    return notifications.map((notification) => ({
+      ...notification,
+      titre: notification.titre?.replace(
+        '%NOM_SERVICE%',
+        notification.service.nomService()
+      ),
+    }));
   }
 
   async toutesNouveautes(idUtilisateur) {

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -39,6 +39,7 @@ class CentreNotifications {
       ...tachesDesServices.map((t) => ({
         ...t,
         type: 'tache',
+        doitNotifierLecture: true,
         date: () => t.dateCreation,
       })),
     ].sort((a, b) => b.date() - a.date());

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -23,16 +23,30 @@ class CentreNotifications {
       this.toutesNouveautes(idUtilisateur),
       this.depotDonnees.tachesDesServices(idUtilisateur),
     ]);
+
     return [
-      ...taches.map((t) => ({ ...t, type: 'tache' })),
-      ...nouveautes.map((t) => ({ ...t, type: 'nouveaute' })),
-      ...tachesDesServices.map((t) => ({ ...t, type: 'tache' })),
-    ];
+      ...taches.map((t) => ({
+        ...t,
+        type: 'tache',
+        date: () => this.adaptateurHorloge.maintenant(),
+      })),
+      ...nouveautes.map((t) => ({
+        ...t,
+        type: 'nouveaute',
+        date: () => new Date(t.dateDeDeploiement),
+      })),
+      ...tachesDesServices.map((t) => ({
+        ...t,
+        type: 'tache',
+        date: () => t.dateCreation,
+      })),
+    ].sort((a, b) => b.date() - a.date());
   }
 
   async toutesNouveautes(idUtilisateur) {
-    const toutesNouveautes = this.referentiel
-      .nouvellesFonctionnalites()
+    const avant = this.referentiel.nouvellesFonctionnalites();
+
+    const toutesNouveautes = avant
       .filter(
         (n) =>
           new Date(n.dateDeDeploiement) <= this.adaptateurHorloge.maintenant()

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -18,13 +18,15 @@ class CentreNotifications {
   }
 
   async toutesNotifications(idUtilisateur) {
-    const [taches, nouveautes] = await Promise.all([
+    const [taches, nouveautes, tachesDesServices] = await Promise.all([
       this.toutesTachesEnAttente(idUtilisateur),
       this.toutesNouveautes(idUtilisateur),
+      this.depotDonnees.tachesDesServices(idUtilisateur),
     ]);
     return [
       ...taches.map((t) => ({ ...t, type: 'tache' })),
       ...nouveautes.map((t) => ({ ...t, type: 'nouveaute' })),
+      ...tachesDesServices.map((t) => ({ ...t, type: 'tache' })),
     ];
   }
 

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -58,7 +58,7 @@ class CentreNotifications {
     return notifications.map((notification) => ({
       ...notification,
       titre: CentreNotifications.titreFusionne(notification),
-      lien: notification.lien?.replace('%ID_SERVICE%', notification.service.id),
+      lien: notification.lien.replace('%ID_SERVICE%', notification.service.id),
       statutLecture: notification.dateFaite
         ? CentreNotifications.NOTIFICATION_LUE
         : CentreNotifications.NOTIFICATION_NON_LUE,
@@ -74,7 +74,7 @@ class CentreNotifications {
 
     return ['NOM_SERVICE', ...champsDonnees].reduce(
       (acc, cle) => acc.replace(`%${cle}%`, valeurReelle(cle)),
-      notification.titre || ''
+      notification.titre
     );
   }
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -286,6 +286,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     donnees.etapesVisiteGuidee[idEtapeCourante]?.idEtapePrecedente ?? null;
   const nbEtapesVisiteGuidee = () =>
     Object.keys(donnees.etapesVisiteGuidee || {}).length;
+  const natureTachesService = (nature) =>
+    (donnees.naturesTachesService || {})[nature];
 
   valideDonnees();
 
@@ -372,6 +374,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     etapeVisiteGuidee,
     etapeVisiteGuideeExiste,
     nbEtapesVisiteGuidee,
+    natureTachesService,
   };
 };
 const creeReferentielVide = () => creeReferentiel(donneesReferentielVide);

--- a/src/routes/connecte/routesConnecteApiNotifications.js
+++ b/src/routes/connecte/routesConnecteApiNotifications.js
@@ -53,7 +53,7 @@ const routesConnecteApiNotifications = ({
       adaptateurHorloge,
     });
     try {
-      await centreNotifications.marqueTacheLue(
+      await centreNotifications.marqueTacheDeServiceLue(
         requete.idUtilisateurCourant,
         requete.params.id
       );

--- a/src/routes/connecte/routesConnecteApiNotifications.js
+++ b/src/routes/connecte/routesConnecteApiNotifications.js
@@ -25,7 +25,7 @@ const routesConnecteApiNotifications = ({
     });
   });
 
-  routes.post('/nouveautes/:id', async (requete, reponse, suite) => {
+  routes.put('/nouveautes/:id', async (requete, reponse, suite) => {
     const centreNotifications = new CentreNotifications({
       depotDonnees,
       referentiel,

--- a/src/routes/connecte/routesConnecteApiNotifications.js
+++ b/src/routes/connecte/routesConnecteApiNotifications.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const CentreNotifications = require('../../notifications/centreNotifications');
-const { ErreurIdentifiantNouveauteInconnu } = require('../../erreurs');
+const {
+  ErreurIdentifiantNouveauteInconnu,
+  ErreurIdentifiantTacheInconnu,
+} = require('../../erreurs');
 
 const routesConnecteApiNotifications = ({
   adaptateurHorloge,
@@ -37,6 +40,27 @@ const routesConnecteApiNotifications = ({
     } catch (e) {
       if (e instanceof ErreurIdentifiantNouveauteInconnu) {
         reponse.status(400).send('Identifiant de nouveauté inconnu');
+        return;
+      }
+      suite(e);
+    }
+  });
+
+  routes.put('/taches/:id', async (requete, reponse, suite) => {
+    const centreNotifications = new CentreNotifications({
+      depotDonnees,
+      referentiel,
+      adaptateurHorloge,
+    });
+    try {
+      await centreNotifications.marqueTacheLue(
+        requete.idUtilisateurCourant,
+        requete.params.id
+      );
+      reponse.sendStatus(200);
+    } catch (e) {
+      if (e instanceof ErreurIdentifiantTacheInconnu) {
+        reponse.status(400).send('Identifiant de tâche inconnu');
         return;
       }
       suite(e);

--- a/svelte/lib/centreNotifications/centreNotifications.api.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.api.ts
@@ -1,8 +1,17 @@
+import type { TypeNotification } from './centreNotifications.d';
+
 export const recupereNotifications = async () => {
   const reponse = await axios.get('/api/notifications');
   return reponse.data.notifications;
 };
 
-export const marqueNotificationCommeLue = async (type: string, id: string) => {
-  await axios.put(`/api/notifications/${type}/${id}`);
+export const marqueNotificationCommeLue = async (
+  type: TypeNotification,
+  id: string
+) => {
+  const routes: Record<TypeNotification, string> = {
+    nouveaute: 'nouveautes',
+    tache: 'taches',
+  };
+  await axios.put(`/api/notifications/${routes[type]}/${id}`);
 };

--- a/svelte/lib/centreNotifications/centreNotifications.api.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.api.ts
@@ -3,6 +3,6 @@ export const recupereNotifications = async () => {
   return reponse.data.notifications;
 };
 
-export const marqueNotificationCommeLue = async (id: string) => {
-  await axios.put(`/api/notifications/nouveautes/${id}`);
+export const marqueNotificationCommeLue = async (type: string, id: string) => {
+  await axios.put(`/api/notifications/${type}/${id}`);
 };

--- a/svelte/lib/centreNotifications/centreNotifications.api.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.api.ts
@@ -4,5 +4,5 @@ export const recupereNotifications = async () => {
 };
 
 export const marqueNotificationCommeLue = async (id: string) => {
-  await axios.post(`/api/notifications/nouveautes/${id}`);
+  await axios.put(`/api/notifications/nouveautes/${id}`);
 };

--- a/svelte/lib/centreNotifications/centreNotifications.d.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.d.ts
@@ -6,6 +6,7 @@ type NotificationBase = {
   statutLecture: 'lue' | 'nonLue';
   lien: string;
   type: TypeNotification;
+  doitNotifierLecture: boolean;
 };
 
 export type NotificationNouveaute = NotificationBase & {

--- a/svelte/lib/centreNotifications/kit/Notification.svelte
+++ b/svelte/lib/centreNotifications/kit/Notification.svelte
@@ -13,10 +13,7 @@
   const relationCta = notification.type === 'nouveaute' ? 'noopener' : '';
   const actionClick = notification.doitNotifierLecture
     ? async () => {
-        await marqueNotificationCommeLue(
-          notification.type + 's',
-          notification.id
-        );
+        await marqueNotificationCommeLue(notification.type, notification.id);
         dispatch('notificationMiseAJour');
       }
     : () => {};

--- a/svelte/lib/centreNotifications/kit/Notification.svelte
+++ b/svelte/lib/centreNotifications/kit/Notification.svelte
@@ -13,7 +13,10 @@
   const relationCta = notification.type === 'nouveaute' ? 'noopener' : '';
   const actionClick = notification.doitNotifierLecture
     ? async () => {
-        await marqueNotificationCommeLue(notification.id);
+        await marqueNotificationCommeLue(
+          notification.type + 's',
+          notification.id
+        );
         dispatch('notificationMiseAJour');
       }
     : () => {};

--- a/svelte/lib/centreNotifications/kit/Notification.svelte
+++ b/svelte/lib/centreNotifications/kit/Notification.svelte
@@ -11,13 +11,12 @@
     notification.type === 'nouveaute' ? 'Nouveautés' : notification.entete;
   const cibleCta = notification.type === 'nouveaute' ? '_blank' : '';
   const relationCta = notification.type === 'nouveaute' ? 'noopener' : '';
-  const actionClick =
-    notification.type === 'nouveaute'
-      ? async () => {
-          await marqueNotificationCommeLue(notification.id);
-          dispatch('notificationMiseAJour');
-        }
-      : () => {};
+  const actionClick = notification.doitNotifierLecture
+    ? async () => {
+        await marqueNotificationCommeLue(notification.id);
+        dispatch('notificationMiseAJour');
+      }
+    : () => {};
 </script>
 
 <a

--- a/test/constructeurs/constructeurTacheDeService.js
+++ b/test/constructeurs/constructeurTacheDeService.js
@@ -1,0 +1,59 @@
+const { unService } = require('./constructeurService');
+
+class ConstructeurTacheDeService {
+  constructor() {
+    this.donnees = {
+      nature: 'natureDeTest',
+      titre: '',
+      service: unService().avecNomService('Le service').construis(),
+    };
+  }
+
+  avecId(id) {
+    this.donnees.id = id;
+    return this;
+  }
+
+  avecUnServiceNomme(nomService) {
+    this.donnees.service = unService().avecNomService(nomService).construis();
+    return this;
+  }
+
+  avecUnServiceId(idService) {
+    this.donnees.service = unService().avecId(idService).construis();
+    return this;
+  }
+
+  avecNature(nature) {
+    this.donnees.nature = nature;
+    return this;
+  }
+
+  avecDateDeCreation(date) {
+    this.donnees.dateCreation = date;
+    return this;
+  }
+
+  faiteMaintenant() {
+    this.donnees.dateFaite = new Date();
+    return this;
+  }
+
+  pasFaite() {
+    this.donnees.dateFaite = null;
+    return this;
+  }
+
+  avecLesDonnees(donnees) {
+    this.donnees.donnees = donnees;
+    return this;
+  }
+
+  construis() {
+    return this.donnees;
+  }
+}
+
+const uneTacheDeService = () => new ConstructeurTacheDeService();
+
+module.exports = { uneTacheDeService };

--- a/test/depots/depotDonneesNotifications.spec.js
+++ b/test/depots/depotDonneesNotifications.spec.js
@@ -49,6 +49,19 @@ describe('Le dépôt de données des notifications', () => {
     });
   });
 
+  describe("sur demande de marquage d'une tâche de service comme 'lue'", () => {
+    it("délègue à l'adaptateur persistance le marquage", async () => {
+      let donneesRecues;
+      adaptateurPersistance.marqueTacheDeServiceLue = async (idTache) => {
+        donneesRecues = { idTache };
+      };
+
+      await depotNotifications.marqueTacheLue('T1');
+
+      expect(donneesRecues.idTache).to.be('T1');
+    });
+  });
+
   describe('sur demande de la liste des tâches de service', () => {
     it('utiliser l’adaptateur de persistance pour récupérer toutes les tâches', async () => {
       let adaptateurAppele;

--- a/test/depots/depotDonneesNotifications.spec.js
+++ b/test/depots/depotDonneesNotifications.spec.js
@@ -56,7 +56,7 @@ describe('Le dépôt de données des notifications', () => {
         donneesRecues = { idTache };
       };
 
-      await depotNotifications.marqueTacheLue('T1');
+      await depotNotifications.marqueTacheDeServiceLue('T1');
 
       expect(donneesRecues.idTache).to.be('T1');
     });

--- a/test/depots/depotDonneesNotifications.spec.js
+++ b/test/depots/depotDonneesNotifications.spec.js
@@ -28,4 +28,21 @@ describe('Le dépôt de données des notifications', () => {
       expect(donneesRecues.idNouveaute).to.be('N1');
     });
   });
+
+  describe('sur demande de la liste des tâches de service', () => {
+    it('utiliser l’adaptateur de persistance pour récupérer toutes les tâches', async () => {
+      let adaptateurAppele;
+      let idUtilisateurUtilise;
+      adaptateurPersistance.tachesDeServicePour = async (idUtilisateur) => {
+        adaptateurAppele = true;
+        idUtilisateurUtilise = idUtilisateur;
+        return [];
+      };
+
+      await depot.tachesDesServices('U1');
+
+      expect(adaptateurAppele).to.be(true);
+      expect(idUtilisateurUtilise).to.be('U1');
+    });
+  });
 });

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -233,6 +233,26 @@ describe('Le centre de notifications', () => {
 
       expect(notifications[0].doitNotifierLecture).to.be(true);
     });
+
+    it("indique qu'une tâche est non lue si elle n'a pas été faite", async () => {
+      depotDonnees.tachesDesServices = async (_) => [{ id: 't1' }];
+
+      const notifications =
+        await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifications[0].statutLecture).to.be('nonLue');
+    });
+
+    it("indique qu'une tâche est lue si elle a été faite", async () => {
+      depotDonnees.tachesDesServices = async (_) => [
+        { id: 't1', dateFaite: new Date() },
+      ];
+
+      const notifications =
+        await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifications[0].statutLecture).to.be('lue');
+    });
   });
 
   describe("concernant les tâches liées à l'utilisateur", () => {

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -120,6 +120,29 @@ describe('Le centre de notifications', () => {
     });
   });
 
+  describe('sur demande des tâches liées aux services', () => {
+    beforeEach(() => {
+      referentiel = Referentiel.creeReferentiel({
+        nouvellesFonctionnalites: [],
+      });
+    });
+
+    it('retourne les tâches', async () => {
+      depotDonnees.tachesDesServices = async (idUtilisateur) =>
+        idUtilisateur === 'U1' ? [{ id: 'T1' }] : [];
+
+      const centre = new CentreNotifications({
+        referentiel,
+        depotDonnees,
+        adaptateurHorloge,
+      });
+
+      const notifs = await centre.toutesNotifications('U1');
+
+      expect(notifs).to.eql([{ id: 'T1', type: 'tache' }]);
+    });
+  });
+
   describe('sur demande des tâches en attente', () => {
     it("utilise le dépôt de données pour récupérer l'utilisateur", async () => {
       let idRecu;

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -51,7 +51,7 @@ describe('Le centre de notifications', () => {
     expect(notifications[1].id).to.be('N1');
   });
 
-  describe('sur demande des nouveautés', () => {
+  describe('concernant les nouveautés', () => {
     it("retourne les nouveautés, dans l'ordre antéchronologique", async () => {
       const centreNotifications = new CentreNotifications({
         referentiel,
@@ -59,7 +59,7 @@ describe('Le centre de notifications', () => {
         adaptateurHorloge,
       });
 
-      const notifications = await centreNotifications.toutesNouveautes('U1');
+      const notifications = await centreNotifications.toutesNotifications('U1');
 
       expect(notifications.length).to.be(2);
       expect(notifications[0].id).to.be('N2');
@@ -77,7 +77,7 @@ describe('Le centre de notifications', () => {
         adaptateurHorloge,
       });
 
-      const notifications = await centreNotifications.toutesNouveautes('U1');
+      const notifications = await centreNotifications.toutesNotifications('U1');
 
       expect(donneesRecues.idUtilisateur).to.be('U1');
 
@@ -100,7 +100,7 @@ describe('Le centre de notifications', () => {
         adaptateurHorloge: decembre2023,
       });
 
-      const notifications = await centreNotifications.toutesNouveautes('U1');
+      const notifications = await centreNotifications.toutesNotifications('U1');
 
       expect(notifications.length).to.be(0);
     });
@@ -143,7 +143,7 @@ describe('Le centre de notifications', () => {
     });
   });
 
-  describe('sur demande des tâches liées aux services', () => {
+  describe('concernant les tâches liées aux services', () => {
     beforeEach(() => {
       referentiel = Referentiel.creeReferentiel({
         nouvellesFonctionnalites: [],
@@ -168,7 +168,7 @@ describe('Le centre de notifications', () => {
     });
   });
 
-  describe('sur demande des tâches en attente', () => {
+  describe("concernant les tâches liées à l'utilisateur", () => {
     it("utilise le dépôt de données pour récupérer l'utilisateur", async () => {
       let idRecu;
       depotDonnees.utilisateur = async (idUtilisateur) => {
@@ -180,7 +180,7 @@ describe('Le centre de notifications', () => {
         adaptateurHorloge,
       });
 
-      await centreNotifications.toutesTachesEnAttente('U1');
+      await centreNotifications.toutesNotifications('U1');
 
       expect(idRecu).to.be('U1');
     });
@@ -193,12 +193,16 @@ describe('Le centre de notifications', () => {
         adaptateurHorloge,
       });
 
-      const taches = await centreNotifications.toutesTachesEnAttente('U1');
+      const taches = await centreNotifications.toutesNotifications('U1');
 
       expect(taches).to.be.an(Array);
     });
 
     it("renvoie un tableau vide si le profil de l'utilisateur est complet", async () => {
+      referentiel = Referentiel.creeReferentiel({
+        nouvellesFonctionnalites: [],
+      });
+
       depotDonnees.utilisateur = async () =>
         unUtilisateur()
           .quiSAppelle('Jean Valjean')
@@ -210,12 +214,12 @@ describe('Le centre de notifications', () => {
         adaptateurHorloge,
       });
 
-      const taches = await centreNotifications.toutesTachesEnAttente('U1');
+      const taches = await centreNotifications.toutesNotifications('U1');
 
       expect(taches.length).to.be(0);
     });
 
-    describe("lorsque le siret de l'utilisateur est manquant", () => {
+    describe("lorsque le SIRET de l'utilisateur est manquant", () => {
       beforeEach(() => {
         depotDonnees.utilisateur = async () =>
           unUtilisateur()
@@ -234,7 +238,7 @@ describe('Le centre de notifications', () => {
           adaptateurHorloge,
         });
 
-        const taches = await centreNotifications.toutesTachesEnAttente('U1');
+        const taches = await centreNotifications.toutesNotifications('U1');
 
         expect(taches.length).to.be(1);
         expect(taches[0].titre).to.be('Titre tâche');
@@ -251,11 +255,12 @@ describe('Le centre de notifications', () => {
           adaptateurHorloge,
         });
 
-        const taches = await centreNotifications.toutesTachesEnAttente('U1');
+        const taches = await centreNotifications.toutesNotifications('U1');
 
         expect(taches.length).to.be(0);
       });
     });
+
     describe("lorsque l'utilisateur est invité'", () => {
       it('renvoie uniquement la notification de profil', async () => {
         depotDonnees.utilisateur = async () =>
@@ -272,7 +277,7 @@ describe('Le centre de notifications', () => {
           adaptateurHorloge,
         });
 
-        const taches = await centreNotifications.toutesTachesEnAttente('U1');
+        const taches = await centreNotifications.toutesNotifications('U1');
 
         expect(taches.length).to.be(1);
         expect(taches[0].id).to.be('profil');

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -152,16 +152,18 @@ describe('Le centre de notifications', () => {
       });
     });
 
-    it('retourne les tâches', async () => {
-      depotDonnees.tachesDesServices = async (idUtilisateur) =>
-        idUtilisateur === 'U1' ? [{ id: 'T1', nature: 'n1' }] : [];
-      const centre = new CentreNotifications({
+    const centreDeNotification = () =>
+      new CentreNotifications({
         referentiel,
         depotDonnees,
         adaptateurHorloge,
       });
 
-      const notifs = await centre.toutesNotifications('U1');
+    it('retourne les tâches', async () => {
+      depotDonnees.tachesDesServices = async (idUtilisateur) =>
+        idUtilisateur === 'U1' ? [{ id: 'T1', nature: 'n1' }] : [];
+
+      const notifs = await centreDeNotification().toutesNotifications('U1');
 
       expect(notifs.length).to.be(1);
       expect(notifs[0].id).to.be('T1');
@@ -184,13 +186,7 @@ describe('Le centre de notifications', () => {
         },
       });
 
-      const centre = new CentreNotifications({
-        referentiel,
-        depotDonnees,
-        adaptateurHorloge,
-      });
-
-      const notifs = await centre.toutesNotifications('U1');
+      const notifs = await centreDeNotification().toutesNotifications('U1');
 
       expect(notifs[0].entete).to.be('Le besoin de sécurité a été modifié');
       expect(notifs[0].titreCta).to.be('Voir le changement');
@@ -208,15 +204,40 @@ describe('Le centre de notifications', () => {
             .construis(),
         },
       ];
-      const centre = new CentreNotifications({
-        referentiel,
-        depotDonnees,
-        adaptateurHorloge,
-      });
 
-      const notifs = await centre.toutesNotifications('U1');
+      const notifs = await centreDeNotification().toutesNotifications('U1');
 
       expect(notifs[0].titre).to.be('--toto--');
+    });
+
+    it('complète le titre avec les informations des données de la tâche', async () => {
+      depotDonnees.tachesDesServices = async (_) => [
+        {
+          titre: '--%nouveauxBesoins%--',
+          service: { nomService: () => '' },
+          donnees: {
+            nouveauxBesoins: 'petits',
+          },
+        },
+      ];
+      const notifs = await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifs[0].titre).to.be('--petits--');
+    });
+
+    it("peut utiliser n'importe quelle donnée de la tâche pour complèter le titre", async () => {
+      depotDonnees.tachesDesServices = async (_) => [
+        {
+          titre: '--%nimportequoi%--',
+          service: { nomService: () => '' },
+          donnees: {
+            nimportequoi: 'nimportequi',
+          },
+        },
+      ];
+      const notifs = await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifs[0].titre).to.be('--nimportequi--');
     });
   });
 

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -5,6 +5,7 @@ const { creeDepot } = require('../../src/depotDonnees');
 const { ErreurIdentifiantNouveauteInconnu } = require('../../src/erreurs');
 const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
 const adaptateurHorloge = require('../../src/adaptateurs/adaptateurHorloge');
+const { unService } = require('../constructeurs/constructeurService');
 
 describe('Le centre de notifications', () => {
   let referentiel;
@@ -169,7 +170,7 @@ describe('Le centre de notifications', () => {
 
     it('complète les informations depuis le référentiel', async () => {
       depotDonnees.tachesDesServices = async (_) => [
-        { nature: 'niveauRetrograde' },
+        { nature: 'niveauRetrograde', service: { nomService: () => '' } },
       ];
       referentiel = Referentiel.creeReferentiel({
         nouvellesFonctionnalites: [],
@@ -196,6 +197,26 @@ describe('Le centre de notifications', () => {
       expect(notifs[0].titre).to.be(
         'Votre service [XXX] a désormais des besoins de sécurité modérés.'
       );
+    });
+
+    it('complète le titre avec les informations liées au service', async () => {
+      depotDonnees.tachesDesServices = async (_) => [
+        {
+          titre: '--%NOM_SERVICE%--',
+          service: unService(Referentiel.creeReferentielVide())
+            .avecNomService('toto')
+            .construis(),
+        },
+      ];
+      const centre = new CentreNotifications({
+        referentiel,
+        depotDonnees,
+        adaptateurHorloge,
+      });
+
+      const notifs = await centre.toutesNotifications('U1');
+
+      expect(notifs[0].titre).to.be('--toto--');
     });
   });
 

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -28,6 +28,29 @@ describe('Le centre de notifications', () => {
     });
   });
 
+  it('trie toutes les notifications retournées', async () => {
+    const enJanvier = '2024-01-01';
+    referentiel = Referentiel.creeReferentiel({
+      nouvellesFonctionnalites: [{ id: 'N1', dateDeDeploiement: enJanvier }],
+    });
+
+    const enFevrier = '2024-02-02';
+    depotDonnees.tachesDesServices = async () => [
+      { id: 'T1', dateCreation: new Date(enFevrier) },
+    ];
+
+    const centre = new CentreNotifications({
+      referentiel,
+      depotDonnees,
+      adaptateurHorloge,
+    });
+
+    const notifications = await centre.toutesNotifications('U1');
+
+    expect(notifications[0].id).to.be('T1');
+    expect(notifications[1].id).to.be('N1');
+  });
+
   describe('sur demande des nouveautés', () => {
     it("retourne les nouveautés, dans l'ordre antéchronologique", async () => {
       const centreNotifications = new CentreNotifications({
@@ -139,7 +162,9 @@ describe('Le centre de notifications', () => {
 
       const notifs = await centre.toutesNotifications('U1');
 
-      expect(notifs).to.eql([{ id: 'T1', type: 'tache' }]);
+      expect(notifs.length).to.be(1);
+      expect(notifs[0].id).to.be('T1');
+      expect(notifs[0].type).to.be('tache');
     });
   });
 

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -352,12 +352,12 @@ describe('Le centre de notifications', () => {
     });
   });
 
-  describe('sur marquage de tâche lue', () => {
+  describe('sur marquage de tâche de service lue', () => {
     it("jette une erreur si l'identifiant de tâche n'est pas présent dans le dépôt", async () => {
       depotDonnees.tachesDesServices = async (_) => [];
 
       try {
-        await centreDeNotification().marqueTacheLue(
+        await centreDeNotification().marqueTacheDeServiceLue(
           'idUtilisateur',
           'ID_INCONNU'
         );
@@ -375,7 +375,7 @@ describe('Le centre de notifications', () => {
         donneesRecues = { idUtilisateur, idTache };
       };
 
-      await centreDeNotification().marqueTacheLue('U1', 'T1');
+      await centreDeNotification().marqueTacheDeServiceLue('U1', 'T1');
 
       expect(donneesRecues.idUtilisateur).to.be('U1');
       expect(donneesRecues.idTache).to.be('T1');

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -215,14 +215,25 @@ describe('Le centre de notifications', () => {
         {
           titre: '--%nimportequoi%--',
           service: { nomService: () => '' },
-          donnees: {
-            nimportequoi: 'nimportequi',
-          },
+          donnees: { nimportequoi: 'nimportequi' },
         },
       ];
       const notifs = await centreDeNotification().toutesNotifications('U1');
 
       expect(notifs[0].titre).to.be('--nimportequi--');
+    });
+
+    it("complète le lien avec l'ID du service", async () => {
+      depotDonnees.tachesDesServices = async (_) => [
+        {
+          lien: '/service/%ID_SERVICE%/page',
+          service: unService().avecId('S1').construis(),
+        },
+      ];
+
+      const notifs = await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifs[0].lien).to.be('/service/S1/page');
     });
 
     it('indique que la tache doit être notifiée de sa lecture', async () => {

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -371,7 +371,7 @@ describe('Le centre de notifications', () => {
       let donneesRecues;
       depotDonnees.tachesDesServices = async (idUtilisateur) =>
         idUtilisateur === 'U1' ? [{ id: 'T1' }] : [];
-      depotDonnees.marqueTacheLue = async (idTache) => {
+      depotDonnees.marqueTacheDeServiceLue = async (idTache) => {
         donneesRecues = { idTache };
       };
 

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -105,6 +105,18 @@ describe('Le centre de notifications', () => {
 
       expect(notifications.length).to.be(0);
     });
+
+    it('indique que la nouveaute doit être notifiée de sa lecture', async () => {
+      const centreNotifications = new CentreNotifications({
+        referentiel,
+        depotDonnees,
+        adaptateurHorloge,
+      });
+
+      const notifications = await centreNotifications.toutesNotifications('U1');
+
+      expect(notifications[0].doitNotifierLecture).to.be(true);
+    });
   });
 
   describe('sur marquage de nouveauté lue', () => {

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -251,6 +251,15 @@ describe('Le centre de notifications', () => {
 
       expect(notifs[0].titre).to.be('--nimportequi--');
     });
+
+    it('indique que la tache doit être notifiée de sa lecture', async () => {
+      depotDonnees.tachesDesServices = async (_) => [{ id: 't1' }];
+
+      const notifications =
+        await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifications[0].doitNotifierLecture).to.be(true);
+    });
   });
 
   describe("concernant les tâches liées à l'utilisateur", () => {

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -371,13 +371,12 @@ describe('Le centre de notifications', () => {
       let donneesRecues;
       depotDonnees.tachesDesServices = async (idUtilisateur) =>
         idUtilisateur === 'U1' ? [{ id: 'T1' }] : [];
-      depotDonnees.marqueTacheLue = async (idUtilisateur, idTache) => {
-        donneesRecues = { idUtilisateur, idTache };
+      depotDonnees.marqueTacheLue = async (idTache) => {
+        donneesRecues = { idTache };
       };
 
       await centreDeNotification().marqueTacheDeServiceLue('U1', 'T1');
 
-      expect(donneesRecues.idUtilisateur).to.be('U1');
       expect(donneesRecues.idTache).to.be('T1');
     });
   });

--- a/test/routes/connecte/routesConnecteApiNotifications.spec.js
+++ b/test/routes/connecte/routesConnecteApiNotifications.spec.js
@@ -74,7 +74,7 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
     it('délègue au dépôt via le centre de notification le marquage à "lue"', async () => {
       let donneesRecues;
       testeur.depotDonnees().tachesDesServices = async (_) => [{ id: 'T1' }];
-      testeur.depotDonnees().marqueTacheLue = async (idTache) => {
+      testeur.depotDonnees().marqueTacheDeServiceLue = async (idTache) => {
         donneesRecues = { idTache };
       };
 
@@ -88,7 +88,7 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
     });
 
     it("reste robuste en cas d'erreur", async () => {
-      testeur.depotDonnees().marqueTacheLue = async () => {
+      testeur.depotDonnees().marqueTacheDeServiceLue = async () => {
         throw new ErreurIdentifiantTacheInconnu();
       };
       try {

--- a/test/routes/connecte/routesConnecteApiNotifications.spec.js
+++ b/test/routes/connecte/routesConnecteApiNotifications.spec.js
@@ -71,14 +71,11 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
   });
 
   describe('quand requête PUT sur `/api/notifications/taches/:id`', () => {
-    it('délègue au centre de notification le marquage à "lue"', async () => {
+    it('délègue au dépôt via le centre de notification le marquage à "lue"', async () => {
       let donneesRecues;
       testeur.depotDonnees().tachesDesServices = async (_) => [{ id: 'T1' }];
-      testeur.depotDonnees().marqueTacheLue = async (
-        idUtilisateur,
-        idTache
-      ) => {
-        donneesRecues = { idUtilisateur, idTache };
+      testeur.depotDonnees().marqueTacheLue = async (idTache) => {
+        donneesRecues = { idTache };
       };
 
       const reponse = await axios.put(
@@ -87,7 +84,6 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
 
       expect(reponse.status).to.be(200);
       expect(donneesRecues).to.be.an('object');
-      expect(donneesRecues.idUtilisateur).to.be('U1');
       expect(donneesRecues.idTache).to.be('T1');
     });
 

--- a/test/routes/connecte/routesConnecteApiNotifications.spec.js
+++ b/test/routes/connecte/routesConnecteApiNotifications.spec.js
@@ -73,6 +73,7 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
   describe('quand requête PUT sur `/api/notifications/taches/:id`', () => {
     it('délègue au centre de notification le marquage à "lue"', async () => {
       let donneesRecues;
+      testeur.depotDonnees().tachesDesServices = async (_) => [{ id: 'T1' }];
       testeur.depotDonnees().marqueTacheLue = async (
         idUtilisateur,
         idTache

--- a/test/routes/connecte/routesConnecteApiNotifications.spec.js
+++ b/test/routes/connecte/routesConnecteApiNotifications.spec.js
@@ -39,7 +39,7 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
     });
   });
 
-  describe('quand requête POST sur `/api/notifications/nouveautes/:id`', () => {
+  describe('quand requête PUT sur `/api/notifications/nouveautes/:id`', () => {
     it('délègue au centre de notification le marquage à "lue"', async () => {
       let donneesRecues;
       testeur.depotDonnees().marqueNouveauteLue = async (
@@ -49,7 +49,7 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
         donneesRecues = { idUtilisateur, idNouveaute };
       };
 
-      const reponse = await axios.post(
+      const reponse = await axios.put(
         'http://localhost:1234/api/notifications/nouveautes/N1'
       );
 
@@ -59,7 +59,7 @@ describe('Le serveur MSS des routes privées /api/notifications', () => {
 
     it("reste robuste en cas d'erreur", async () => {
       try {
-        await axios.post(
+        await axios.put(
           'http://localhost:1234/api/notifications/nouveautes/ID_INCONNU'
         );
         expect().fail("L'appel aurait dû lever une exception");


### PR DESCRIPTION
Cette PR ajoute la possibilité de créer des notifications pour des **tâches de service**.

Exemple 👇 

![image](https://github.com/user-attachments/assets/047147d2-2618-46cd-bc90-6f381bee6e87)


Une notification de tâche de service :
 - s'affiche dans l'onglet `À faire`
 - concerne un unique service ; elle connaît d'ailleurs l'ID du service 
 - contient un _Call To Action_
 - lors du clic sur le CTA :
   -  la notification est marquée comme lue
   - le navigateur va vers la page associée à la notification

L'exemple de cette PR est la notification qui sera créée pour indiquer que les besoins de sécurité ont été modifiés (lorsque nous aurons supprimé la dernière question de DÉCRIRE). Ici au clic, on naviguera vers l'étape 3 du formulaire DÉCRIRE.

Pour qu'une notification de tâche de service existe, elle doit être insérée dans la nouvelle table `taches_service` : 
![image](https://github.com/user-attachments/assets/94bfea93-c367-4d56-948f-dab0a2d03329)


Toute la PR a été faite en pair-programming. On tolère donc les 600+ lignes modifiées.

Pour rappel, nous sommes sur un chemin de PR pour aller chercher les `suggestions d'action sur service` qui permettront de guider les utilisateurs dans le changement du niveau de besoin de sécurité.
Cette PR est la boîte jaune 👇 

![image](https://github.com/user-attachments/assets/c18cd2e9-9711-4197-9553-e6da3e4d518c)
