### PR TITLE
[SUGGESTIONS D'ACTIONS] Indication sur le tableau de bord, en cas de présence de suggestions

### DIFF
--- a/migrations/20240712144020_creationTableSuggestionsActions.js
+++ b/migrations/20240712144020_creationTableSuggestionsActions.js
@@ -1,0 +1,10 @@
+const tableSuggestionsActions = 'suggestions_actions';
+
+exports.up = (knex) =>
+  knex.schema.createTable(tableSuggestionsActions, (table) => {
+    table.uuid('id_service');
+    table.string('nature');
+    table.primary(['id_service', 'nature']);
+  });
+
+exports.down = (knex) => knex.schema.dropTable(tableSuggestionsActions);

--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -258,7 +258,9 @@ const tableauDesServices = {
                                 ${service.organisationResponsable}
                               </div>
                               ${
-                                service.statutSaisieDescription === 'aCompleter'
+                                service.statutSaisieDescription ===
+                                  'aCompleter' ||
+                                service.suggestionActionPrioritaire
                                   ? `<div class="avertissement-completion">
                                    <img src="/statique/assets/images/icone_danger_bleu.svg" alt="" />
                                      Informations à mettre à jour

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -11,6 +11,7 @@ const nouvelAdaptateur = (
   donnees.parcoursUtilisateurs ||= [];
   donnees.notificationsExpirationHomologation ||= [];
   donnees.notifications ||= [];
+  donnees.suggestionsActions ||= [];
 
   const metsAJourEnregistrement = (
     fonctionRecherche,
@@ -61,10 +62,15 @@ const nouvelAdaptateur = (
       .filter((a) => a.idHomologation === idService)
       .map((a) => donnees.utilisateurs.find((u) => u.id === a.idUtilisateur));
 
+  const suggestionsActionsService = (idService) =>
+    donnees.suggestionsActions.filter((s) => s.idService === idService);
+
   const homologation = (id) => {
     const homologationTrouvee = donnees.homologations.find((h) => h.id === id);
-    if (homologationTrouvee)
+    if (homologationTrouvee) {
       homologationTrouvee.contributeurs = contributeursService(id);
+      homologationTrouvee.suggestionsActions = suggestionsActionsService(id);
+    }
 
     return Promise.resolve(homologationTrouvee);
   };

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -82,9 +82,14 @@ const nouvelAdaptateur = (env) => {
         donnees: 'u.donnees',
       });
 
-    const [h, contributeurs] = await Promise.all([
+    const requeteSuggestionsActions = knex('suggestions_actions')
+      .where({ id_service: id })
+      .select({ nature: 'nature' });
+
+    const [h, contributeurs, suggestions] = await Promise.all([
       requeteHomologation,
       requeteContributeurs,
+      requeteSuggestionsActions,
     ]);
 
     return {
@@ -95,6 +100,7 @@ const nouvelAdaptateur = (env) => {
         dateCreation: c.dateCreation,
         ...c.donnees,
       })),
+      suggestionsActions: suggestions,
     };
   };
 

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -36,6 +36,7 @@ class Homologation {
       risquesGeneraux = [],
       risquesSpecifiques = [],
       rolesResponsabilites = {},
+      suggestionsActions = [],
     } = donnees;
 
     this.id = id;
@@ -63,6 +64,7 @@ class Homologation {
       { risquesGeneraux, risquesSpecifiques },
       referentiel
     );
+    this.suggestionsActions = suggestionsActions;
 
     this.referentiel = referentiel;
   }
@@ -264,6 +266,10 @@ class Homologation {
 
   vueAnnexePDFRisques() {
     return new ObjetPDFAnnexeRisques(this, this.referentiel);
+  }
+
+  suggestionActionPrioritaire() {
+    return this.suggestionsActions[0];
   }
 
   static creePourUnUtilisateur(utilisateur) {

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -39,6 +39,7 @@ const donnees = (service, autorisation, referentiel) => {
     permissions: {
       gestionContributeurs: autorisation.peutGererContributeurs(),
     },
+    suggestionActionPrioritaire: service.suggestionActionPrioritaire(),
   };
 };
 

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -6,6 +6,7 @@ class ConstructeurAdaptateurPersistanceMemoire {
     this.services = [];
     this.utilisateurs = [];
     this.notificationsExpirationHomologation = [];
+    this.suggestionsActions = [];
   }
 
   ajouteUneAutorisation(autorisation) {
@@ -28,6 +29,11 @@ class ConstructeurAdaptateurPersistanceMemoire {
     return this;
   }
 
+  avecUneSuggestionAction(suggestion) {
+    this.suggestionsActions.push(suggestion);
+    return this;
+  }
+
   construis() {
     return AdaptateurPersistanceMemoire.nouvelAdaptateur({
       autorisations: this.autorisations,
@@ -36,6 +42,7 @@ class ConstructeurAdaptateurPersistanceMemoire {
       utilisateurs: this.utilisateurs,
       notificationsExpirationHomologation:
         this.notificationsExpirationHomologation,
+      suggestionsActions: this.suggestionsActions,
     });
   }
 }

--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -9,6 +9,7 @@ class ConstructeurService {
       id: '',
       descriptionService: uneDescriptionValide(referentiel).donnees,
       contributeurs: [],
+      suggestionsActions: [],
     };
     this.mesures = undefined;
     this.risques = undefined;
@@ -71,6 +72,11 @@ class ConstructeurService {
 
   ajouteUnContributeur(contributeur) {
     this.donnees.contributeurs.push(contributeur);
+    return this;
+  }
+
+  avecSuggestionAction(suggestion) {
+    this.donnees.suggestionsActions.push(suggestion);
     return this;
   }
 }

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -206,6 +206,21 @@ describe('Le dépôt de données des homologations', () => {
     expect(contributeurs[1].id).to.equal('U2');
   });
 
+  it('associe ses suggestions d’actions au service', async () => {
+    const r = Referentiel.creeReferentielVide();
+    const persistance = unePersistanceMemoire()
+      .ajouteUnService(unService(r).avecId('S1').donnees)
+      .avecUneSuggestionAction({ idService: 'S1', nature: 'siret' });
+    const depot = unDepotDeDonneesServices()
+      .avecReferentiel(r)
+      .avecAdaptateurPersistance(persistance)
+      .construis();
+
+    const service = await depot.homologation('S1');
+
+    expect(service.suggestionActionPrioritaire().nature).to.be('siret');
+  });
+
   it('renseigne les mesures générales associées à une homologation', async () => {
     const referentiel = Referentiel.creeReferentiel({
       categoriesMesures: { gouvernance: 'Gouvernance' },

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -51,6 +51,16 @@ describe('Une homologation', () => {
     expect(contributeur.id).to.equal('456');
   });
 
+  it('connaît la suggestion d’action la plus prioritaire', () => {
+    const service = unService()
+      .avecSuggestionAction({ nature: 'siret-a-renseigner' })
+      .construis();
+
+    expect(service.suggestionActionPrioritaire().nature).to.be(
+      'siret-a-renseigner'
+    );
+  });
+
   it('sait décrire le type service', () => {
     const referentiel = Referentiel.creeReferentiel({
       typesService: {

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -55,6 +55,7 @@ describe("L'objet d'API de `GET /service`", () => {
     .avecDossiers([
       unDossier(referentiel).quiEstComplet().quiEstNonFinalise().donnees,
     ])
+    .avecSuggestionAction({ nature: 'siret-a-renseigner' })
     .construis();
 
   it('fournit les données nécessaires', () => {
@@ -92,6 +93,7 @@ describe("L'objet d'API de `GET /service`", () => {
       estProprietaire: false,
       documentsPdfDisponibles: [],
       permissions: { gestionContributeurs: false },
+      suggestionActionPrioritaire: { nature: 'siret-a-renseigner' },
     });
   });
 

--- a/test/modeles/objetsApi/objetGetServices.spec.js
+++ b/test/modeles/objetsApi/objetGetServices.spec.js
@@ -50,49 +50,18 @@ describe("L'objet d'API de `GET /services`", () => {
     .avecNomService('Un autre service')
     .construis();
 
-  it('fournit les données nécessaires', () => {
-    const services = [service];
+  it('fournit les données des services', () => {
     const autorisationComplete = uneAutorisation()
       .deProprietaire('A', '123')
       .construis();
 
-    expect(
-      objetGetServices.donnees(services, [autorisationComplete], referentiel)
-        .services
-    ).to.eql([
-      {
-        id: '123',
-        nomService: 'Un service',
-        organisationResponsable: 'Une organisation',
-        contributeurs: [
-          {
-            id: 'A',
-            prenomNom: 'Jean Dupont',
-            initiales: 'JD',
-            poste: 'RSSI',
-            estUtilisateurCourant: true,
-          },
-          {
-            id: 'B',
-            prenomNom: 'Pierre Lecoux',
-            initiales: 'PL',
-            poste: 'Maire',
-            estUtilisateurCourant: false,
-          },
-        ],
-        statutHomologation: {
-          enCoursEdition: false,
-          libelle: 'Non réalisée',
-          id: 'nonRealisee',
-          ordre: 1,
-        },
-        statutSaisieDescription: 'aCompleter',
-        nombreContributeurs: 1 + 1,
-        estProprietaire: true,
-        documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
-        permissions: { gestionContributeurs: true },
-      },
-    ]);
+    const { services } = objetGetServices.donnees(
+      [service],
+      [autorisationComplete],
+      referentiel
+    );
+    expect(services.length).to.be(1);
+    expect(services[0].id).to.be('123');
   });
 
   it('fournit les données de résumé des services', () => {


### PR DESCRIPTION
Cette PR introduit et utilise les suggestions d'actions comme source de données pour afficher la mention « Informations à mettre à jour » 👇 

![image](https://github.com/user-attachments/assets/c4713b7c-251e-44de-b154-1a67e5e8c14a)

Avant cette PR, cette mention s'affiche si le statut de saisie du service est `aCompleter`.

Dorénavant, MSS considère aussi la présence de suggestions d'actions pour déclencher cet affichage.
À terme, le statut de saisie sera totalement ignoré.

#### Nouveaux éléments :
 - une nouvelle table en BDD
 - un nouveau « champ » dans la classe `Service`
 - l'adaptateur de persistance qui fait la glue entre les 2

![image](https://github.com/user-attachments/assets/7c7f0119-5f13-4cc4-8bd8-1f2d000319a5)

![image](https://github.com/user-attachments/assets/44554a74-e20c-45d8-988b-d0f0f2eb4200)

Pair-programming complet sur la PR.
