### PR TITLE
Ajoute l’horodatage pour les tâches de service

### DIFF
--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -38,6 +38,7 @@ class CentreNotifications {
         type: 'nouveaute',
         doitNotifierLecture: true,
         date: () => new Date(t.dateDeDeploiement),
+        horodatage: new Date(t.dateDeDeploiement),
       })),
       ...tachesDesServices.map((t) => ({
         ...t,

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -45,6 +45,7 @@ class CentreNotifications {
         type: 'tache',
         doitNotifierLecture: true,
         date: () => t.dateCreation,
+        horodatage: t.dateCreation,
       })),
     ].sort((a, b) => b.date() - a.date());
   }

--- a/svelte/lib/centreNotifications/centreNotifications.d.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.d.ts
@@ -7,13 +7,13 @@ type NotificationBase = {
   lien: string;
   type: TypeNotification;
   doitNotifierLecture: boolean;
+  horodatage?: string;
 };
 
 export type NotificationNouveaute = NotificationBase & {
   type: 'nouveaute';
   image: string;
   sousTitre: string;
-  dateDeDeploiement: string;
 };
 
 export type NotificationTache = NotificationBase & {

--- a/svelte/lib/centreNotifications/kit/Notification.svelte
+++ b/svelte/lib/centreNotifications/kit/Notification.svelte
@@ -55,13 +55,9 @@
       </div>
     {/if}
 
-    {#if notification.type === 'nouveaute'}
+    {#if notification.horodatage}
       <div class="horodatage">
-        <span
-          >{formatteDifferenceDateRelative(
-            notification.dateDeDeploiement
-          )}</span
-        >
+        <span>{formatteDifferenceDateRelative(notification.horodatage)}</span>
       </div>
     {/if}
   </div>

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -288,6 +288,19 @@ describe('Le centre de notifications', () => {
 
     it("indique qu'une tâche est lue si elle a été faite", async () => {
       depotDonnees.tachesDesServices = async (_) => [
+        uneTacheDeService()
+          .avecDateDeCreation(new Date('2024-09-13'))
+          .construis(),
+      ];
+
+      const notifications =
+        await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifications[0].horodatage).to.eql(new Date('2024-09-13'));
+    });
+
+    it('utilise la date de création comme horodatage', async () => {
+      depotDonnees.tachesDesServices = async (_) => [
         uneTacheDeService().faiteMaintenant().construis(),
       ];
 

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -110,6 +110,19 @@ describe('Le centre de notifications', () => {
 
       expect(notifications[0].doitNotifierLecture).to.be(true);
     });
+
+    it('utilise la date de déploiement comme horodatage', async () => {
+      referentiel.enrichis({
+        nouvellesFonctionnalites: [
+          { id: 'N1', dateDeDeploiement: '2024-07-15' },
+        ],
+      });
+
+      const notifications =
+        await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifications[0].horodatage).to.eql(new Date('2024-07-15'));
+    });
   });
 
   describe('sur marquage de nouveauté lue', () => {


### PR DESCRIPTION
Dans le centre de notifications, on souhaite voir l’horodatage pour les tâches de service, comme pour les nouveautés. 

Exemple : 
![image](https://github.com/user-attachments/assets/1a47e93f-0ae5-440e-8d75-74b88746df1a)

Fait en pair-programming avec @CadiChris 