### PR TITLE
[TABLEAU DE BORD] Naviguer vers l'étape liée à une suggestion

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -82,6 +82,10 @@ module.exports = {
     },
   },
 
+  naturesSuggestionsActions: {
+    miseAJourSiret: { lien: '/service/%ID_SERVICE%/descriptionService' },
+  },
+
   nombreOrganisationsUtilisatrices: [
     { label: 'Mon organisation uniquement', borneBasse: 1, borneHaute: 1 },
     { label: '2', borneBasse: 2, borneHaute: 2 },

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -83,7 +83,10 @@ module.exports = {
   },
 
   naturesSuggestionsActions: {
-    miseAJourSiret: { lien: '/service/%ID_SERVICE%/descriptionService' },
+    miseAJourSiret: {
+      lien: '/descriptionService',
+      permissionRequise: { rubrique: 'DECRIRE', niveau: 2 },
+    },
   },
 
   nombreOrganisationsUtilisatrices: [

--- a/src/modeles/autorisations/gestionDroits.js
+++ b/src/modeles/autorisations/gestionDroits.js
@@ -12,18 +12,20 @@ const Rubriques = {
   CONTACTS: 'CONTACTS',
 };
 
+const { LECTURE } = Permissions;
+const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
+
 const premiereRouteDisponible = (autorisation) => {
   const routeParRubrique = [
-    { rubrique: Rubriques.DECRIRE, route: '/descriptionService' },
-    { rubrique: Rubriques.SECURISER, route: '/mesures' },
-    { rubrique: Rubriques.HOMOLOGUER, route: '/dossiers' },
-    { rubrique: Rubriques.RISQUES, route: '/risques' },
-    { rubrique: Rubriques.CONTACTS, route: '/rolesResponsabilites' },
+    { rubrique: DECRIRE, route: '/descriptionService', niveau: LECTURE },
+    { rubrique: SECURISER, route: '/mesures', niveau: LECTURE },
+    { rubrique: HOMOLOGUER, route: '/dossiers', niveau: LECTURE },
+    { rubrique: RISQUES, route: '/risques', niveau: LECTURE },
+    { rubrique: CONTACTS, route: '/rolesResponsabilites', niveau: LECTURE },
   ];
-  const { LECTURE } = Permissions;
 
-  return routeParRubrique.find(({ rubrique }) =>
-    autorisation.aLaPermission(LECTURE, rubrique)
+  return routeParRubrique.find(({ niveau, rubrique }) =>
+    autorisation.aLaPermission(niveau, rubrique)
   )?.route;
 };
 

--- a/src/modeles/autorisations/gestionDroits.js
+++ b/src/modeles/autorisations/gestionDroits.js
@@ -15,8 +15,8 @@ const Rubriques = {
 const { LECTURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
 
-const premiereRouteDisponible = (autorisation) => {
-  const routeParRubrique = [
+const premiereRouteDisponible = (autorisation, routesPersonnalisees = []) => {
+  const routesParDefaut = [
     { rubrique: DECRIRE, route: '/descriptionService', niveau: LECTURE },
     { rubrique: SECURISER, route: '/mesures', niveau: LECTURE },
     { rubrique: HOMOLOGUER, route: '/dossiers', niveau: LECTURE },
@@ -24,8 +24,8 @@ const premiereRouteDisponible = (autorisation) => {
     { rubrique: CONTACTS, route: '/rolesResponsabilites', niveau: LECTURE },
   ];
 
-  return routeParRubrique.find(({ niveau, rubrique }) =>
-    autorisation.aLaPermission(niveau, rubrique)
+  return [...routesPersonnalisees, ...routesParDefaut].find(
+    ({ niveau, rubrique }) => autorisation.aLaPermission(niveau, rubrique)
   )?.route;
 };
 

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -66,7 +66,7 @@ class Homologation {
       referentiel
     );
     this.suggestionsActions = suggestionsActions.map(
-      (s) => new SuggestionAction(s)
+      (s) => new SuggestionAction(s, referentiel)
     );
 
     this.referentiel = referentiel;

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -13,6 +13,7 @@ const ObjetPDFAnnexeDescription = require('./objetsPDF/objetPDFAnnexeDescription
 const ObjetPDFAnnexeMesures = require('./objetsPDF/objetPDFAnnexeMesures');
 const ObjetPDFAnnexeRisques = require('./objetsPDF/objetPDFAnnexeRisques');
 const Autorisation = require('./autorisations/autorisation');
+const SuggestionAction = require('./suggestionAction');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -64,7 +65,9 @@ class Homologation {
       { risquesGeneraux, risquesSpecifiques },
       referentiel
     );
-    this.suggestionsActions = suggestionsActions;
+    this.suggestionsActions = suggestionsActions.map(
+      (s) => new SuggestionAction(s)
+    );
 
     this.referentiel = referentiel;
   }

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -275,6 +275,10 @@ class Homologation {
     return this.suggestionsActions[0];
   }
 
+  routesDesSuggestionsActions() {
+    return this.suggestionsActions.map((s) => s.route());
+  }
+
   static creePourUnUtilisateur(utilisateur) {
     const donneesService = {
       descriptionService: {

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -66,7 +66,7 @@ class Homologation {
       referentiel
     );
     this.suggestionsActions = suggestionsActions.map(
-      (s) => new SuggestionAction(s, referentiel)
+      (s) => new SuggestionAction({ ...s, idService: id }, referentiel)
     );
 
     this.referentiel = referentiel;

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -66,7 +66,7 @@ class Homologation {
       referentiel
     );
     this.suggestionsActions = suggestionsActions.map(
-      (s) => new SuggestionAction({ ...s, idService: id }, referentiel)
+      (s) => new SuggestionAction(s, referentiel)
     );
 
     this.referentiel = referentiel;

--- a/src/modeles/suggestionAction.js
+++ b/src/modeles/suggestionAction.js
@@ -1,0 +1,7 @@
+class SuggestionAction {
+  constructor(donnees) {
+    this.nature = donnees.nature;
+  }
+}
+
+module.exports = SuggestionAction;

--- a/src/modeles/suggestionAction.js
+++ b/src/modeles/suggestionAction.js
@@ -4,9 +4,18 @@ class SuggestionAction {
 
     this.nature = nature;
 
-    this.lien = referentiel
-      .natureSuggestionAction(nature)
-      .lien.replace('%ID_SERVICE%', idService);
+    const natureDansReferentiel = referentiel.natureSuggestionAction(nature);
+
+    this.lien = natureDansReferentiel.lien.replace('%ID_SERVICE%', idService);
+    this.permissionRequise = natureDansReferentiel.permissionRequise;
+  }
+
+  route() {
+    return {
+      rubrique: this.permissionRequise.rubrique,
+      niveau: this.permissionRequise.niveau,
+      route: this.lien,
+    };
   }
 }
 

--- a/src/modeles/suggestionAction.js
+++ b/src/modeles/suggestionAction.js
@@ -1,7 +1,12 @@
 class SuggestionAction {
   constructor(donnees, referentiel) {
-    this.nature = donnees.nature;
-    this.lien = referentiel.natureSuggestionAction(donnees.nature).lien;
+    const { nature, idService } = donnees;
+
+    this.nature = nature;
+
+    this.lien = referentiel
+      .natureSuggestionAction(nature)
+      .lien.replace('%ID_SERVICE%', idService);
   }
 }
 

--- a/src/modeles/suggestionAction.js
+++ b/src/modeles/suggestionAction.js
@@ -1,12 +1,12 @@
 class SuggestionAction {
   constructor(donnees, referentiel) {
-    const { nature, idService } = donnees;
+    const { nature } = donnees;
 
     this.nature = nature;
 
     const natureDansReferentiel = referentiel.natureSuggestionAction(nature);
 
-    this.lien = natureDansReferentiel.lien.replace('%ID_SERVICE%', idService);
+    this.lien = natureDansReferentiel.lien;
     this.permissionRequise = natureDansReferentiel.permissionRequise;
   }
 

--- a/src/modeles/suggestionAction.js
+++ b/src/modeles/suggestionAction.js
@@ -1,6 +1,7 @@
 class SuggestionAction {
-  constructor(donnees) {
+  constructor(donnees, referentiel) {
     this.nature = donnees.nature;
+    this.lien = referentiel.natureSuggestionAction(donnees.nature).lien;
   }
 }
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -288,6 +288,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     Object.keys(donnees.etapesVisiteGuidee || {}).length;
   const natureTachesService = (nature) =>
     (donnees.naturesTachesService || {})[nature];
+  const natureSuggestionAction = (nature) =>
+    (donnees.naturesSuggestionsActions || {})[nature];
 
   valideDonnees();
 
@@ -375,6 +377,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     etapeVisiteGuideeExiste,
     nbEtapesVisiteGuidee,
     natureTachesService,
+    natureSuggestionAction,
   };
 };
 const creeReferentielVide = () => creeReferentiel(donneesReferentielVide);

--- a/src/routes/connecte/routesConnectePageService.js
+++ b/src/routes/connecte/routesConnectePageService.js
@@ -54,7 +54,15 @@ const routesConnectePageService = ({
     middleware.chargeAutorisationsService,
     async (requete, reponse) => {
       const { autorisationService } = requete;
-      const routeRedirection = premiereRouteDisponible(autorisationService);
+
+      const routesDesSuggestions =
+        requete.service.routesDesSuggestionsActions();
+
+      const routeRedirection = premiereRouteDisponible(
+        autorisationService,
+        routesDesSuggestions
+      );
+
       if (!routeRedirection) {
         reponse.redirect('/tableauDeBord');
         return;

--- a/src/routes/connecte/routesConnectePageService.js
+++ b/src/routes/connecte/routesConnectePageService.js
@@ -59,6 +59,7 @@ const routesConnectePageService = ({
         reponse.redirect('/tableauDeBord');
         return;
       }
+
       reponse.redirect(`/service/${requete.params.id}${routeRedirection}`);
     }
   );

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -207,7 +207,9 @@ describe('Le dépôt de données des homologations', () => {
   });
 
   it('associe ses suggestions d’actions au service', async () => {
-    const r = Referentiel.creeReferentielVide();
+    const r = Referentiel.creeReferentiel({
+      naturesSuggestionsActions: { siret: {} },
+    });
     const persistance = unePersistanceMemoire()
       .ajouteUnService(unService(r).avecId('S1').donnees)
       .avecUneSuggestionAction({ idService: 'S1', nature: 'siret' });

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -208,7 +208,7 @@ describe('Le dépôt de données des homologations', () => {
 
   it('associe ses suggestions d’actions au service', async () => {
     const r = Referentiel.creeReferentiel({
-      naturesSuggestionsActions: { siret: {} },
+      naturesSuggestionsActions: { siret: { lien: '' } },
     });
     const persistance = unePersistanceMemoire()
       .ajouteUnService(unService(r).avecId('S1').donnees)

--- a/test/modeles/autorisations/gestionDroits.spec.js
+++ b/test/modeles/autorisations/gestionDroits.spec.js
@@ -1,0 +1,49 @@
+const expect = require('expect.js');
+const {
+  premiereRouteDisponible,
+  Rubriques,
+  Permissions,
+} = require('../../../src/modeles/autorisations/gestionDroits');
+const {
+  uneAutorisation,
+} = require('../../constructeurs/constructeurAutorisation');
+
+describe('Les fonctions de gestion des droits', () => {
+  describe('concernant la première route disponible pour une autorisation', () => {
+    it("considère les routes par défaut de MSS en cas d'absence de routes personnalisées", () => {
+      const lectureSurRisques = uneAutorisation()
+        .avecDroits({ [Rubriques.RISQUES]: Permissions.LECTURE })
+        .construis();
+
+      const aucuneRouteEnPlus = [];
+
+      const route = premiereRouteDisponible(
+        lectureSurRisques,
+        aucuneRouteEnPlus
+      );
+
+      expect(route).to.be('/risques');
+    });
+
+    it('considère en priorité les routes personnalisées', () => {
+      const routePersonnalisee = [
+        {
+          rubrique: Rubriques.SECURISER,
+          niveau: Permissions.ECRITURE,
+          route: '/route-en-parametre',
+        },
+      ];
+
+      const ecritureSurSecuriser = uneAutorisation()
+        .avecDroits({ [Rubriques.SECURISER]: Permissions.ECRITURE })
+        .construis();
+
+      const route = premiereRouteDisponible(
+        ecritureSurSecuriser,
+        routePersonnalisee
+      );
+
+      expect(route).to.be('/route-en-parametre');
+    });
+  });
+});

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -51,33 +51,35 @@ describe('Une homologation', () => {
     expect(contributeur.id).to.equal('456');
   });
 
-  it('connaît la suggestion d’action la plus prioritaire', () => {
-    const referentiel = Referentiel.creeReferentiel({
-      naturesSuggestionsActions: { 'siret-a-renseigner': { lien: '' } },
+  describe("concernant les suggestions d'actions", () => {
+    it('connaît la suggestion d’action la plus prioritaire', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        naturesSuggestionsActions: { 'siret-a-renseigner': { lien: '' } },
+      });
+
+      const service = unService(referentiel)
+        .avecSuggestionAction({ nature: 'siret-a-renseigner' })
+        .construis();
+
+      expect(service.suggestionActionPrioritaire().nature).to.be(
+        'siret-a-renseigner'
+      );
     });
 
-    const service = unService(referentiel)
-      .avecSuggestionAction({ nature: 'siret-a-renseigner' })
-      .construis();
+    it("passe son identifiant à la suggestion d'action la plus prioritaire", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        naturesSuggestionsActions: {
+          'siret-a-renseigner': { lien: '/service/%ID_SERVICE%' },
+        },
+      });
 
-    expect(service.suggestionActionPrioritaire().nature).to.be(
-      'siret-a-renseigner'
-    );
-  });
+      const service = unService(referentiel)
+        .avecId('S1')
+        .avecSuggestionAction({ nature: 'siret-a-renseigner' })
+        .construis();
 
-  it("passe son identifiant à la suggestion d'action la plus prioritaire", () => {
-    const referentiel = Referentiel.creeReferentiel({
-      naturesSuggestionsActions: {
-        'siret-a-renseigner': { lien: '/service/%ID_SERVICE%' },
-      },
+      expect(service.suggestionActionPrioritaire().lien).to.be('/service/S1');
     });
-
-    const service = unService(referentiel)
-      .avecId('S1')
-      .avecSuggestionAction({ nature: 'siret-a-renseigner' })
-      .construis();
-
-    expect(service.suggestionActionPrioritaire().lien).to.be('/service/S1');
   });
 
   it('sait décrire le type service', () => {

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -65,6 +65,21 @@ describe('Une homologation', () => {
     );
   });
 
+  it("passe son identifiant à la suggestion d'action la plus prioritaire", () => {
+    const referentiel = Referentiel.creeReferentiel({
+      naturesSuggestionsActions: {
+        'siret-a-renseigner': { lien: '/service/%ID_SERVICE%' },
+      },
+    });
+
+    const service = unService(referentiel)
+      .avecId('S1')
+      .avecSuggestionAction({ nature: 'siret-a-renseigner' })
+      .construis();
+
+    expect(service.suggestionActionPrioritaire().lien).to.be('/service/S1');
+  });
+
   it('sait décrire le type service', () => {
     const referentiel = Referentiel.creeReferentiel({
       typesService: {

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -53,7 +53,7 @@ describe('Une homologation', () => {
 
   it('connaît la suggestion d’action la plus prioritaire', () => {
     const referentiel = Referentiel.creeReferentiel({
-      naturesSuggestionsActions: { 'siret-a-renseigner': {} },
+      naturesSuggestionsActions: { 'siret-a-renseigner': { lien: '' } },
     });
 
     const service = unService(referentiel)

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -52,7 +52,11 @@ describe('Une homologation', () => {
   });
 
   it('connaît la suggestion d’action la plus prioritaire', () => {
-    const service = unService()
+    const referentiel = Referentiel.creeReferentiel({
+      naturesSuggestionsActions: { 'siret-a-renseigner': {} },
+    });
+
+    const service = unService(referentiel)
       .avecSuggestionAction({ nature: 'siret-a-renseigner' })
       .construis();
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -68,26 +68,11 @@ describe('Une homologation', () => {
       );
     });
 
-    it("passe son identifiant à la suggestion d'action la plus prioritaire", () => {
-      const referentiel = Referentiel.creeReferentiel({
-        naturesSuggestionsActions: {
-          'siret-a-renseigner': { lien: '/service/%ID_SERVICE%' },
-        },
-      });
-
-      const service = unService(referentiel)
-        .avecId('S1')
-        .avecSuggestionAction({ nature: 'siret-a-renseigner' })
-        .construis();
-
-      expect(service.suggestionActionPrioritaire().lien).to.be('/service/S1');
-    });
-
     it("sait obtenir les routes MSS des suggestions d'actions", () => {
       const referentiel = Referentiel.creeReferentiel({
         naturesSuggestionsActions: {
           'siret-a-renseigner': {
-            lien: '/service/%ID_SERVICE%',
+            lien: '/descriptionService',
             permissionRequise: { rubrique: 'SECURISER', niveau: 2 },
           },
         },
@@ -104,7 +89,7 @@ describe('Une homologation', () => {
         {
           rubrique: Rubriques.SECURISER,
           niveau: Permissions.ECRITURE,
-          route: '/service/S1',
+          route: '/descriptionService',
         },
       ]);
     });

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -15,6 +15,8 @@ const { unService } = require('../constructeurs/constructeurService');
 const {
   Rubriques: { DECRIRE, SECURISER, RISQUES, HOMOLOGUER },
   Permissions: { LECTURE },
+  Rubriques,
+  Permissions,
 } = require('../../src/modeles/autorisations/gestionDroits');
 const {
   uneAutorisation,
@@ -79,6 +81,32 @@ describe('Une homologation', () => {
         .construis();
 
       expect(service.suggestionActionPrioritaire().lien).to.be('/service/S1');
+    });
+
+    it("sait obtenir les routes MSS des suggestions d'actions", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        naturesSuggestionsActions: {
+          'siret-a-renseigner': {
+            lien: '/service/%ID_SERVICE%',
+            permissionRequise: { rubrique: 'SECURISER', niveau: 2 },
+          },
+        },
+      });
+
+      const service = unService(referentiel)
+        .avecId('S1')
+        .avecSuggestionAction({ nature: 'siret-a-renseigner' })
+        .construis();
+
+      const routes = service.routesDesSuggestionsActions();
+
+      expect(routes).to.eql([
+        {
+          rubrique: Rubriques.SECURISER,
+          niveau: Permissions.ECRITURE,
+          route: '/service/S1',
+        },
+      ]);
     });
   });
 

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -8,6 +8,8 @@ const {
 const {
   Rubriques: { HOMOLOGUER },
   Permissions: { LECTURE },
+  Rubriques,
+  Permissions,
 } = require('../../../src/modeles/autorisations/gestionDroits');
 const { unService } = require('../../constructeurs/constructeurService');
 const {
@@ -29,7 +31,12 @@ describe("L'objet d'API de `GET /service`", () => {
         id: 'autorite',
       },
     ],
-    naturesSuggestionsActions: { 'siret-a-renseigner': { lien: '/service' } },
+    naturesSuggestionsActions: {
+      'siret-a-renseigner': {
+        lien: '/service',
+        permissionRequise: { rubrique: 'DECRIRE', niveau: 2 },
+      },
+    },
   });
   const lectureSurHomologuer = uneAutorisation()
     .avecDroits({ [HOMOLOGUER]: LECTURE })
@@ -97,6 +104,10 @@ describe("L'objet d'API de `GET /service`", () => {
       suggestionActionPrioritaire: {
         nature: 'siret-a-renseigner',
         lien: '/service',
+        permissionRequise: {
+          rubrique: Rubriques.DECRIRE,
+          niveau: Permissions.ECRITURE,
+        },
       },
     });
   });

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -29,6 +29,7 @@ describe("L'objet d'API de `GET /service`", () => {
         id: 'autorite',
       },
     ],
+    naturesSuggestionsActions: { 'siret-a-renseigner': { lien: '/service' } },
   });
   const lectureSurHomologuer = uneAutorisation()
     .avecDroits({ [HOMOLOGUER]: LECTURE })
@@ -93,7 +94,10 @@ describe("L'objet d'API de `GET /service`", () => {
       estProprietaire: false,
       documentsPdfDisponibles: [],
       permissions: { gestionContributeurs: false },
-      suggestionActionPrioritaire: { nature: 'siret-a-renseigner' },
+      suggestionActionPrioritaire: {
+        nature: 'siret-a-renseigner',
+        lien: '/service',
+      },
     });
   });
 

--- a/test/modeles/suggestionAction.spec.js
+++ b/test/modeles/suggestionAction.spec.js
@@ -1,0 +1,17 @@
+const expect = require('expect.js');
+const SuggestionAction = require('../../src/modeles/suggestionAction');
+const { creeReferentiel } = require('../../src/referentiel');
+
+describe("Une suggestion d'action", () => {
+  it('possède un lien', () => {
+    const r = creeReferentiel({
+      naturesSuggestionsActions: {
+        natureDeTest: { lien: '/service' },
+      },
+    });
+
+    const s = new SuggestionAction({ nature: 'natureDeTest' }, r);
+
+    expect(s.lien).to.be('/service');
+  });
+});

--- a/test/modeles/suggestionAction.spec.js
+++ b/test/modeles/suggestionAction.spec.js
@@ -14,19 +14,4 @@ describe("Une suggestion d'action", () => {
 
     expect(s.lien).to.be('/service');
   });
-
-  it("peut injecter l'ID du service dans le lien", () => {
-    const r = creeReferentiel({
-      naturesSuggestionsActions: {
-        natureDeTest: { lien: '/service/%ID_SERVICE%/page' },
-      },
-    });
-
-    const s = new SuggestionAction(
-      { nature: 'natureDeTest', idService: 'S1' },
-      r
-    );
-
-    expect(s.lien).to.be('/service/S1/page');
-  });
 });

--- a/test/modeles/suggestionAction.spec.js
+++ b/test/modeles/suggestionAction.spec.js
@@ -14,4 +14,19 @@ describe("Une suggestion d'action", () => {
 
     expect(s.lien).to.be('/service');
   });
+
+  it("peut injecter l'ID du service dans le lien", () => {
+    const r = creeReferentiel({
+      naturesSuggestionsActions: {
+        natureDeTest: { lien: '/service/%ID_SERVICE%/page' },
+      },
+    });
+
+    const s = new SuggestionAction(
+      { nature: 'natureDeTest', idService: 'S1' },
+      r
+    );
+
+    expect(s.lien).to.be('/service/S1/page');
+  });
 });


### PR DESCRIPTION
Cette PR permet de naviguer vers une étape liée à une suggestion d'action.

La suggestion s'affiche sur la ligne du tableau de bord 👇 

![image](https://github.com/user-attachments/assets/f7cfa32a-f334-4861-8b52-c5a719fdc016)

Au clic, la route `GET /service/:id` considère maintenant les suggestions d'actions lorsqu'elle décide où rediriger l'utilisateur.
Tout ça tient compte des permissions : on ne redirige pas vers un écran sur lequel l'utilisateur n'a pas suffisamment de droits.