### PR TITLE
[SUGGESTIONS D'ACTIONS] Affichage de la suggestion « mise à jour SIRET » sur DÉCRIRE

### DIFF
--- a/migrations/20240716144339_ajouteChampDateAcquittementASuggestionsActions.js
+++ b/migrations/20240716144339_ajouteChampDateAcquittementASuggestionsActions.js
@@ -1,0 +1,11 @@
+const tableSuggestions = 'suggestions_actions';
+
+exports.up = (knex) =>
+  knex.schema.alterTable(tableSuggestions, (table) =>
+    table.datetime('date_acquittement')
+  );
+
+exports.down = (knex) =>
+  knex.schema.alterTable(tableSuggestions, (table) =>
+    table.dropColumn('date_acquittement')
+  );

--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -21,15 +21,6 @@ const messageErreurNomDejaUtilise = {
   },
 };
 
-const afficheBanniereMiseAJourSiret = () => {
-  const { siret, estEnCreation } = JSON.parse(
-    $('#infos-siret-manquant').text()
-  );
-  if (!estEnCreation && !siret) {
-    $('.banniere-avertissement').removeClass('invisible');
-  }
-};
-
 const brancheComportementMessageErreur = () => {
   $('#nom-service').on('keydown', () => {
     messageErreurNomDejaUtilise.masque();
@@ -152,7 +143,6 @@ const brancheComportementNavigationEtapes = () => {
 };
 
 $(() => {
-  afficheBanniereMiseAJourSiret();
   const navigationEtapes = brancheComportementNavigationEtapes();
   initialiseComportementFormulaire(
     '#homologation',

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -305,6 +305,8 @@ const nouvelAdaptateur = (
 
   const marqueTacheDeServiceLue = async () => {};
 
+  const marqueSuggestionActionFaiteMaintenant = async () => {};
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -318,6 +320,7 @@ const nouvelAdaptateur = (
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
+    marqueSuggestionActionFaiteMaintenant,
     marqueTacheDeServiceLue,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -83,7 +83,7 @@ const nouvelAdaptateur = (env) => {
       });
 
     const requeteSuggestionsActions = knex('suggestions_actions')
-      .where({ id_service: id })
+      .where({ id_service: id, date_acquittement: null })
       .select({ nature: 'nature' });
 
     const [h, contributeurs, suggestions] = await Promise.all([

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -408,6 +408,15 @@ const nouvelAdaptateur = (env) => {
       .update({ date_faite: knex.fn.now() });
   };
 
+  const marqueSuggestionActionFaiteMaintenant = async (
+    idService,
+    natureSuggestion
+  ) => {
+    await knex('suggestions_actions')
+      .where({ id_service: idService, nature: natureSuggestion })
+      .update({ date_acquittement: knex.fn.now() });
+  };
+
   return {
     ajouteAutorisation,
     ajouteUtilisateur,
@@ -422,6 +431,7 @@ const nouvelAdaptateur = (env) => {
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
+    marqueSuggestionActionFaiteMaintenant,
     marqueTacheDeServiceLue,
     metsAJourUtilisateur,
     nbAutorisationsProprietaire,

--- a/src/bus/abonnements/supprimeSuggestionSiret.js
+++ b/src/bus/abonnements/supprimeSuggestionSiret.js
@@ -1,0 +1,7 @@
+function supprimeSuggestionSiret({ depotDonnees }) {
+  return async ({ service }) => {
+    await depotDonnees.acquitteSuggestionAction(service.id, 'miseAJourSiret');
+  };
+}
+
+module.exports = { supprimeSuggestionSiret };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -68,6 +68,9 @@ const {
 const {
   metAJourContactBrevoDeLUtilisateur,
 } = require('./abonnements/metAJourContactBrevoDeLUtilisateur');
+const {
+  supprimeSuggestionSiret,
+} = require('./abonnements/supprimeSuggestionSiret');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -110,6 +113,7 @@ const cableTousLesAbonnes = (
   ]);
 
   busEvenements.abonnePlusieurs(EvenementDescriptionServiceModifiee, [
+    supprimeSuggestionSiret({ depotDonnees }),
     consigneCompletudeDansJournal({
       adaptateurJournal,
       adaptateurRechercheEntreprise,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -64,7 +64,9 @@ const creeDepot = (config = {}) => {
     depotServices: depotHomologations,
   });
 
-  const depotSuggestionsActions = depotDonneesSuggestionsActions.creeDepot({});
+  const depotSuggestionsActions = depotDonneesSuggestionsActions.creeDepot({
+    adaptateurPersistance,
+  });
 
   const {
     ajouteDescriptionService,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -8,6 +8,7 @@ const depotDonneesNotificationsExpirationHomologation = require('./depots/depotD
 const depotDonneesParcoursUtilisateurs = require('./depots/depotDonneesParcoursUtilisateur');
 const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 const depotDonneesNotifications = require('./depots/depotDonneesNotifications');
+const depotDonneesSuggestionsActions = require('./depots/depotDonneesSuggestionsActions');
 
 const creeDepot = (config = {}) => {
   const {
@@ -62,6 +63,8 @@ const creeDepot = (config = {}) => {
     adaptateurPersistance,
     depotServices: depotHomologations,
   });
+
+  const depotSuggestionsActions = depotDonneesSuggestionsActions.creeDepot({});
 
   const {
     ajouteDescriptionService,
@@ -129,8 +132,11 @@ const creeDepot = (config = {}) => {
     supprimeNotificationsExpirationHomologationPourService,
   } = depotNotificationsExpirationHomologation;
 
+  const { acquitteSuggestionAction } = depotSuggestionsActions;
+
   return {
     accesAutorise,
+    acquitteSuggestionAction,
     ajouteContributeurAuService,
     ajouteDescriptionService,
     ajouteDossierCourantSiNecessaire,

--- a/src/depots/depotDonneesSuggestionsActions.js
+++ b/src/depots/depotDonneesSuggestionsActions.js
@@ -1,0 +1,8 @@
+const creeDepot = () => {
+  const acquitteSuggestionAction = async () => {};
+  return {
+    acquitteSuggestionAction,
+  };
+};
+
+module.exports = { creeDepot };

--- a/src/depots/depotDonneesSuggestionsActions.js
+++ b/src/depots/depotDonneesSuggestionsActions.js
@@ -1,8 +1,12 @@
-const creeDepot = () => {
-  const acquitteSuggestionAction = async () => {};
-  return {
-    acquitteSuggestionAction,
+const creeDepot = ({ adaptateurPersistance }) => {
+  const acquitteSuggestionAction = async (idService, natureSuggestion) => {
+    await adaptateurPersistance.marqueSuggestionActionFaiteMaintenant(
+      idService,
+      natureSuggestion
+    );
   };
+
+  return { acquitteSuggestionAction };
 };
 
 module.exports = { creeDepot };

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -275,6 +275,10 @@ class Homologation {
     return this.suggestionsActions[0];
   }
 
+  pourraitFaire(natureSuggestion) {
+    return this.suggestionsActions.some((s) => s.nature === natureSuggestion);
+  }
+
   routesDesSuggestionsActions() {
     return this.suggestionsActions.map((s) => s.route());
   }

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -75,11 +75,13 @@ mixin formulaireDescriptionService(idHomologation)
               input(type='hidden' name='nomEntite' id='nomEntite' value != entite.nom)
               input(type='hidden' name='siretEntite' id='siretEntite' value != entite.siret)
 
-            .banniere.banniere-avertissement.invisible
-              img(src='/statique/assets/images/icone_danger.svg' alt='')
-              .contenu-texte-avertissement
-                strong Information à mettre à jour
-                p Vous pouvez directement rechercher le nom ou le numéro de SIRET de votre organisation.
+            if service.pourraitFaire('miseAJourSiret')
+              .banniere.banniere-avertissement
+                img(src='/statique/assets/images/icone_danger.svg' alt='')
+                .contenu-texte-avertissement
+                  strong Information à mettre à jour
+                  p Vous pouvez directement rechercher le nom ou le numéro de SIRET de votre organisation.
+
 
         - const { borneBasse, borneHaute } = service.descriptionService.nombreOrganisationsUtilisatrices
         - const valeurService = `${borneBasse}-${borneHaute}`

--- a/src/vues/service/creation.pug
+++ b/src/vues/service/creation.pug
@@ -20,9 +20,6 @@ block etapier
     .etape(data-numero-etape="2")
 
 block formulaire
-  script(id = 'infos-siret-manquant', type = 'application/json').
-    !{JSON.stringify({estEnCreation: true})}
-
   dialog#modale-creation-service
     .contenu-modale
       span.icone

--- a/src/vues/service/descriptionService.pug
+++ b/src/vues/service/descriptionService.pug
@@ -25,7 +25,4 @@ block etapier
     .etape(data-numero-etape="2")
 
 block formulaire
-  script(id = 'infos-siret-manquant', type = 'application/json').
-    !{JSON.stringify({siret: service.descriptionService.organisationResponsable.siret, estEnCreation: false})}
-
   +formulaireDescriptionService(service.id)

--- a/test/bus/abonnements/supprimeSuggestionSiret.spec.js
+++ b/test/bus/abonnements/supprimeSuggestionSiret.spec.js
@@ -1,0 +1,27 @@
+const expect = require('expect.js');
+const {
+  supprimeSuggestionSiret,
+} = require('../../../src/bus/abonnements/supprimeSuggestionSiret');
+const { unService } = require('../../constructeurs/constructeurService');
+
+describe('L’abonnement qui supprime la suggestion de mise à jour du SIRET', () => {
+  it('utilise le dépôt pour supprimer la suggestion', async () => {
+    let suggestionSupprimee;
+    const depotDonnees = {
+      acquitteSuggestionAction: (idService, nature) => {
+        suggestionSupprimee = { idService, nature };
+      },
+    };
+
+    const abonne = supprimeSuggestionSiret({ depotDonnees });
+
+    expect(abonne).to.be.an('function');
+    await abonne({
+      service: unService().avecId('S1').construis(),
+    });
+    expect(suggestionSupprimee).to.eql({
+      idService: 'S1',
+      nature: 'miseAJourSiret',
+    });
+  });
+});

--- a/test/depots/depotDonneesSuggestionsActions.spec.js
+++ b/test/depots/depotDonneesSuggestionsActions.spec.js
@@ -1,0 +1,29 @@
+const expect = require('expect.js');
+const depotDonneesSuggestionsActions = require('../../src/depots/depotDonneesSuggestionsActions');
+const {
+  unePersistanceMemoire,
+} = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
+
+describe("Le dépôt de données des suggestions d'actions", () => {
+  let depot;
+  let adaptateurPersistance;
+
+  beforeEach(() => {
+    adaptateurPersistance = unePersistanceMemoire().construis();
+    depot = depotDonneesSuggestionsActions.creeDepot({ adaptateurPersistance });
+  });
+
+  it('horodate une suggestion acquittée', async () => {
+    let persistanceAppelee = {};
+    adaptateurPersistance.marqueSuggestionActionFaiteMaintenant = async (
+      idService,
+      nature
+    ) => {
+      persistanceAppelee = { idService, nature };
+    };
+
+    await depot.acquitteSuggestionAction('S1', 'SIRET');
+
+    expect(persistanceAppelee).to.eql({ idService: 'S1', nature: 'SIRET' });
+  });
+});

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -93,6 +93,27 @@ describe('Une homologation', () => {
         },
       ]);
     });
+
+    it('sait si une action n’est pas suggérée', () => {
+      const service = unService().construis();
+
+      const pourrait = service.pourraitFaire('miseAJourSiret');
+
+      expect(pourrait).to.be(false);
+    });
+
+    it('sait si une action fait partie des suggestions', () => {
+      const referentiel = Referentiel.creeReferentiel({
+        naturesSuggestionsActions: { miseAJourSiret: { lien: '' } },
+      });
+      const service = unService(referentiel)
+        .avecSuggestionAction({ nature: 'miseAJourSiret' })
+        .construis();
+
+      const pourrait = service.pourraitFaire('miseAJourSiret');
+
+      expect(pourrait).to.be(true);
+    });
   });
 
   it('sait décrire le type service', () => {


### PR DESCRIPTION
Cette PR utilise l'abstraction des `suggestions d'actions` pour afficher le message invitant à mettre à jour le SIRET 👇 

![image](https://github.com/user-attachments/assets/f95db627-a814-4d0e-9417-3de28de5fd82)

La suggestion est affichée si elle est présente dans la table `suggestions_actions`.
Elle est acquittée via un abonné du bus lorsque le service est mis à jour.

ℹ️ Une migration permet d'insérer les suggestions en BDD pour tous les services qui n'ont pas encore MAJ leur SIRET.