### PR TITLE
[PLAN D'ACTION] Ajout du "Toaster" pour les changements de statuts

### DIFF
--- a/public/assets/images/icone_enregistrement_termine.svg
+++ b/public/assets/images/icone_enregistrement_termine.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7.75 11.9999L10.58 14.8299L16.25 9.16992" stroke="#0E972B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/public/assets/images/toasts/icone_info.svg
+++ b/public/assets/images/toasts/icone_info.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.5 2.5H4.5C3.39543 2.5 2.5 3.39543 2.5 4.5V19.5C2.5 20.6046 3.39543 21.5 4.5 21.5H19.5C20.6046 21.5 21.5 20.6046 21.5 19.5V4.5C21.5 3.39543 20.6046 2.5 19.5 2.5ZM13 7H11V9H13V7ZM13 11H11V17H13V11Z" fill="white"/>
+</svg>

--- a/public/assets/images/toasts/icone_succes.svg
+++ b/public/assets/images/toasts/icone_succes.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 22C6.477 22 2 17.523 2 12C2 6.477 6.477 2 12 2C17.523 2 22 6.477 22 12C22 17.523 17.523 22 12 22ZM11.003 16L18.073 8.929L16.659 7.515L11.003 13.172L8.174 10.343L6.76 11.757L11.003 16Z" fill="white"/>
+</svg>

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -21,24 +21,6 @@
   export let mesuresExistantes: MesuresExistantes;
   export let estLectureSeule: boolean;
 
-  const afficheToastChangementStatut = (
-    mesure: MesureGenerale | MesureSpecifique
-  ) => {
-    if (mesure.statut === 'fait') {
-      toasterStore.succes(
-        'Félicitation !',
-        `Le statut de la mesure <b>• ${mesure.description}</b> est désormais "<b>faite</b>" !`
-      );
-    } else if (mesure.statut) {
-      toasterStore.info(
-        'Modification du statut',
-        `Le statut de la mesure <b>• ${
-          mesure.description
-        }</b> est désormais "<b>${statuts[mesure.statut].toLowerCase()}</b>".`
-      );
-    }
-  };
-
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
     enCoursEnvoi = true;
@@ -63,7 +45,10 @@
         detail: { sourceDeModification: 'tiroir' },
       })
     );
-    afficheToastChangementStatut($store.mesureEditee.mesure);
+    toasterStore.afficheToastChangementStatutMesure(
+      $store.mesureEditee.mesure,
+      statuts
+    );
   };
 
   $: texteSurligne = $store.mesureEditee.mesure.descriptionLongue?.replace(

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -8,6 +8,11 @@
   import { enregistreMesures, enregistreRetourUtilisateur } from './mesure.api';
   import SelectionStatut from '../ui/SelectionStatut.svelte';
   import { rechercheTextuelle } from '../tableauDesMesures/tableauDesMesures.store';
+  import type {
+    MesureGenerale,
+    MesureSpecifique,
+  } from '../tableauDesMesures/tableauDesMesures.d';
+  import { toasterStore } from '../ui/stores/toaster.store';
 
   export let idService: string;
   export let categories: Record<string, string>;
@@ -15,6 +20,24 @@
   export let retoursUtilisateur: Record<string, string>;
   export let mesuresExistantes: MesuresExistantes;
   export let estLectureSeule: boolean;
+
+  const afficheToastChangementStatut = (
+    mesure: MesureGenerale | MesureSpecifique
+  ) => {
+    if (mesure.statut === 'fait') {
+      toasterStore.succes(
+        'Félicitation !',
+        `Le statut de la mesure <b>• ${mesure.description}</b> est désormais "<b>faite</b>" !`
+      );
+    } else if (mesure.statut) {
+      toasterStore.info(
+        'Modification du statut',
+        `Le statut de la mesure <b>• ${
+          mesure.description
+        }</b> est désormais "<b>${statuts[mesure.statut].toLowerCase()}</b>".`
+      );
+    }
+  };
 
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
@@ -40,6 +63,7 @@
         detail: { sourceDeModification: 'tiroir' },
       })
     );
+    afficheToastChangementStatut($store.mesureEditee.mesure);
   };
 
   $: texteSurligne = $store.mesureEditee.mesure.descriptionLongue?.replace(

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -49,29 +49,15 @@
 
   let etatEnregistrement: EtatEnregistrement = Jamais;
 
-  const afficheToastChangementStatut = (
-    mesure: MesureGenerale | MesureSpecifique
-  ) => {
-    if (mesure.statut === 'fait') {
-      toasterStore.succes(
-        'Félicitation !',
-        `Le statut de la mesure <b>• ${mesure.description}</b> est désormais "<b>faite</b>" !`
-      );
-    } else if (mesure.statut) {
-      toasterStore.info(
-        'Modification du statut',
-        `Le statut de la mesure <b>• ${
-          mesure.description
-        }</b> est désormais "<b>${statuts[mesure.statut].toLowerCase()}</b>".`
-      );
-    }
-  };
   const metsAJourMesuresSpecifiques = async (indexReel: number) => {
     etatEnregistrement = EnCours;
     await enregistreMesuresSpecifiques(idService, $mesures.mesuresSpecifiques);
     etatEnregistrement = Fait;
     document.body.dispatchEvent(new CustomEvent('mesure-modifiee'));
-    afficheToastChangementStatut($mesures.mesuresSpecifiques[indexReel]);
+    toasterStore.afficheToastChangementStatutMesure(
+      $mesures.mesuresSpecifiques[indexReel],
+      statuts
+    );
   };
 
   const metsAJourMesureGenerale = async (idMesure: IdMesureGenerale) => {
@@ -83,7 +69,10 @@
     );
     etatEnregistrement = Fait;
     document.body.dispatchEvent(new CustomEvent('mesure-modifiee'));
-    afficheToastChangementStatut($mesures.mesuresGenerales[idMesure]);
+    toasterStore.afficheToastChangementStatutMesure(
+      $mesures.mesuresGenerales[idMesure],
+      statuts
+    );
   };
 
   type MesureAEditer = {

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -149,9 +149,6 @@
             {#if etatEnregistrement === EnCours}
               <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
             {/if}
-            {#if etatEnregistrement === Fait}
-              <p class="enregistrement-termine">Enregistré</p>
-            {/if}
           </div>
         </th>
       </tr>
@@ -239,34 +236,22 @@
     padding: 0;
   }
 
-  .enregistrement-en-cours,
-  .enregistrement-termine {
+  .enregistrement-en-cours {
     font-size: 1.1em;
     font-weight: 500;
     display: flex;
     align-items: center;
     justify-content: center;
+    color: #0c5c98;
   }
 
-  .enregistrement-en-cours:before,
-  .enregistrement-termine:before {
+  .enregistrement-en-cours:before {
     content: '';
     display: flex;
     width: 24px;
     height: 24px;
     background-size: contain;
     background-repeat: no-repeat;
-  }
-
-  .enregistrement-en-cours {
-    color: #0c5c98;
-  }
-
-  .enregistrement-termine {
-    color: #0e972b;
-  }
-
-  .enregistrement-en-cours:before {
     background-image: url('/statique/assets/images/icone_enregistrement_en_cours.svg');
     animation: rotation 1s linear infinite;
   }
@@ -275,10 +260,6 @@
     100% {
       transform: rotate(360deg);
     }
-  }
-
-  .enregistrement-termine:before {
-    background-image: url('/statique/assets/images/icone_enregistrement_termine.svg');
   }
 
   .bouton-action-mesure {

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -58,6 +58,7 @@
     align-items: stretch;
     border-radius: 8px;
     overflow: hidden;
+    box-shadow: 0 12px 20px 0 #0000001f;
   }
 
   .conteneur-icone {

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -83,9 +83,9 @@
   }
 
   .conteneur-texte .texte {
-    font-size: 16px;
+    font-size: 0.9rem;
     font-weight: 400;
-    line-height: 24px;
+    line-height: normal;
   }
 
   .info {

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { toasterStore } from './stores/toaster.store';
+  import { glisse } from './animations/transitions';
 
   const icones = {
     info: 'icone_info',
@@ -9,7 +10,10 @@
 
 <aside>
   {#each $toasterStore.queue as toast (toast.id)}
-    <article class={toast.niveau}>
+    <article
+      class={toast.niveau}
+      transition:glisse={{ depuis: 'right', duree: 250 }}
+    >
       <div class="conteneur-icone">
         <div class="icone">
           <img

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -2,10 +2,7 @@
   import { toasterStore } from './stores/toaster.store';
   import { glisse } from './animations/transitions';
 
-  const icones = {
-    info: 'icone_info',
-    succes: 'icone_succes',
-  };
+  const icones = { info: 'icone_info', succes: 'icone_succes' };
 </script>
 
 <aside>
@@ -17,9 +14,7 @@
       <div class="conteneur-icone">
         <div class="icone">
           <img
-            src={'/statique/assets/images/toasts/' +
-              icones[toast.niveau] +
-              '.svg'}
+            src={`/statique/assets/images/toasts/${icones[toast.niveau]}.svg`}
             alt=""
             width="24"
             height="24"

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -61,6 +61,18 @@
     box-shadow: 0 12px 20px 0 #0000001f;
   }
 
+  /* Donne un fond à l'article pour éviter les traces de blanc sur les `radius` de gauche */
+  article.info {
+    background: linear-gradient(
+      to right,
+      var(--bleu-mise-en-avant) 10px,
+      white 10px
+    );
+  }
+  article.succes {
+    background: linear-gradient(to right, #0c8626 10px, white 10px);
+  }
+
   .conteneur-icone {
     background: var(--couleur);
     padding: 18px 10px;

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import { toasterStore } from './stores/toaster.store';
+
+  const icones = {
+    info: 'icone_info',
+    succes: 'icone_succes',
+  };
+</script>
+
+<aside>
+  {#each $toasterStore.queue as toast (toast.id)}
+    <article class={toast.niveau}>
+      <div class="conteneur-icone">
+        <div class="icone">
+          <img
+            src={'/statique/assets/images/toasts/' +
+              icones[toast.niveau] +
+              '.svg'}
+            alt=""
+            width="24"
+            height="24"
+          />
+        </div>
+      </div>
+      <div class="conteneur-texte">
+        <p class="titre">{toast.titre}</p>
+        <p class="texte">{@html toast.contenu}</p>
+      </div>
+    </article>
+  {/each}
+</aside>
+
+<style>
+  aside {
+    position: fixed;
+    right: 36px;
+    top: 0;
+    width: 540px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 1em;
+    padding-top: 2em;
+    z-index: 99;
+  }
+
+  article {
+    font-size: 0.8em;
+    --couleur: transparent;
+    border: 1px solid var(--couleur);
+    display: flex;
+    flex-direction: row;
+    background: white;
+    align-items: stretch;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .conteneur-icone {
+    background: var(--couleur);
+    padding: 18px 10px;
+  }
+
+  .conteneur-texte {
+    text-align: left;
+    padding: 16px;
+  }
+
+  .conteneur-texte p {
+    margin: 0;
+  }
+
+  .conteneur-texte .titre {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 28px;
+    margin-bottom: 4px;
+  }
+
+  .conteneur-texte .texte {
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 24px;
+  }
+
+  .info {
+    --couleur: var(--bleu-mise-en-avant);
+  }
+
+  .succes {
+    --couleur: #0c8626;
+  }
+</style>

--- a/svelte/lib/ui/animations/transitions.ts
+++ b/svelte/lib/ui/animations/transitions.ts
@@ -1,0 +1,23 @@
+type Direction = 'top' | 'bottom' | 'left' | 'right';
+const directions: Record<Direction, string> = {
+  top: 'translateY(-',
+  bottom: 'translateY(',
+  left: 'translateX(-',
+  right: 'translateX(',
+};
+
+export const glisse = (
+  node: HTMLElement,
+  { depuis = 'top', duree = 200 }: { depuis: Direction; duree: number }
+) => {
+  return {
+    duration: duree,
+    tick: (avancement: number, restant: number) => {
+      node.style.setProperty(
+        'transform',
+        `${directions[depuis]}${restant * 100.0}%)`
+      );
+      node.style.setProperty('opacity', `${avancement}`);
+    },
+  };
+};

--- a/svelte/lib/ui/stores/toaster.store.ts
+++ b/svelte/lib/ui/stores/toaster.store.ts
@@ -1,4 +1,9 @@
 import { writable } from 'svelte/store';
+import type {
+  MesureGenerale,
+  MesureSpecifique,
+} from '../../tableauDesMesures/tableauDesMesures.d';
+import type { IdStatut } from '../types';
 
 export type NiveauMessage = 'info' | 'succes';
 
@@ -25,6 +30,24 @@ export const toasterStore = {
   },
   succes: (titre: string, contenu: string) => {
     afficheToast(titre, contenu, 'succes');
+  },
+  afficheToastChangementStatutMesure: (
+    mesure: MesureGenerale | MesureSpecifique,
+    statuts: Record<IdStatut, string>
+  ) => {
+    if (mesure.statut === 'fait') {
+      toasterStore.succes(
+        'Félicitation !',
+        `Le statut de la mesure <b>• ${mesure.description}</b> est désormais "<b>faite</b>" !`
+      );
+    } else if (mesure.statut) {
+      toasterStore.info(
+        'Modification du statut',
+        `Le statut de la mesure <b>• ${
+          mesure.description
+        }</b> est désormais "<b>${statuts[mesure.statut].toLowerCase()}</b>".`
+      );
+    }
   },
 };
 

--- a/svelte/lib/ui/stores/toaster.store.ts
+++ b/svelte/lib/ui/stores/toaster.store.ts
@@ -1,0 +1,58 @@
+import { writable } from 'svelte/store';
+
+export type NiveauMessage = 'info' | 'succes';
+
+export type MessageToast = {
+  niveau: NiveauMessage;
+  titre: string;
+  contenu: string;
+  timeout: number;
+  id?: number;
+};
+
+type StoreToasterProps = {
+  queue: MessageToast[];
+};
+
+const { subscribe, update } = writable<StoreToasterProps>({
+  queue: [],
+});
+
+export const toasterStore = {
+  subscribe,
+  info: (titre: string, contenu: string) => {
+    afficheToast(titre, contenu, 'info');
+  },
+  succes: (titre: string, contenu: string) => {
+    afficheToast(titre, contenu, 'succes');
+  },
+};
+
+const fabriqueToast = (
+  titre: string,
+  contenu: string,
+  niveau: NiveauMessage,
+  timeout = 5000
+): MessageToast => {
+  return {
+    niveau,
+    titre,
+    contenu,
+    timeout,
+    id: +new Date() + Math.random(),
+  };
+};
+
+function afficheToast(titre: string, contenu: string, niveau: NiveauMessage) {
+  const message = fabriqueToast(titre, contenu, niveau);
+  setTimeout(() => {
+    update((self) => {
+      self.queue.shift();
+      return self;
+    });
+  }, message.timeout);
+  update((self) => {
+    self.queue = [...self.queue, message];
+    return self;
+  });
+}


### PR DESCRIPTION
> [!WARNING]  
> En attente de validation design pour les ombres portées sur les toast ainsi que la taille de police

... afin de permettre l'affichage de "toast" indiquant le changement de statut des mesures.

On utilise un `store` qui possède une `queue` de toutes les notifications à afficher.

> [!NOTE]  
> Les CSPs ne nous permettant pas d'utiliser les `svelte:transition`, on ajoute nous même une transition en suivant l'API [décrite ici.](https://learn.svelte.dev/tutorial/custom-css-transitions)

![image](https://github.com/user-attachments/assets/b256105a-cbda-416b-9eff-d142f3099016)
