### PR TITLE
[SUGGESTIONS D'ACTIONS] Encapsule la suggestion d'action renvoyée par l'API

### DIFF
--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -259,8 +259,7 @@ const tableauDesServices = {
                               </div>
                               ${
                                 service.statutSaisieDescription ===
-                                  'aCompleter' ||
-                                service.suggestionActionPrioritaire
+                                  'aCompleter' || service.aUneSuggestionAction
                                   ? `<div class="avertissement-completion">
                                    <img src="/statique/assets/images/icone_danger_bleu.svg" alt="" />
                                      Informations à mettre à jour

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -39,7 +39,7 @@ const donnees = (service, autorisation, referentiel) => {
     permissions: {
       gestionContributeurs: autorisation.peutGererContributeurs(),
     },
-    suggestionActionPrioritaire: service.suggestionActionPrioritaire(),
+    aUneSuggestionAction: !!service.suggestionActionPrioritaire(),
   };
 };
 

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -8,8 +8,6 @@ const {
 const {
   Rubriques: { HOMOLOGUER },
   Permissions: { LECTURE },
-  Rubriques,
-  Permissions,
 } = require('../../../src/modeles/autorisations/gestionDroits');
 const { unService } = require('../../constructeurs/constructeurService');
 const {
@@ -101,14 +99,7 @@ describe("L'objet d'API de `GET /service`", () => {
       estProprietaire: false,
       documentsPdfDisponibles: [],
       permissions: { gestionContributeurs: false },
-      suggestionActionPrioritaire: {
-        nature: 'siret-a-renseigner',
-        lien: '/service',
-        permissionRequise: {
-          rubrique: Rubriques.DECRIRE,
-          niveau: Permissions.ECRITURE,
-        },
-      },
+      aUneSuggestionAction: true,
     });
   });
 

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -1579,6 +1579,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         estProprietaire: false,
         documentsPdfDisponibles: [],
         permissions: { gestionContributeurs: false },
+        aUneSuggestionAction: false,
       });
     });
   });


### PR DESCRIPTION
Inutile de donner du détail sur la suggestion.
Le front a simplement besoin de savoir s'il y en a une ou pas.