### PR TITLE
[SUGGESTIONS D'ACTIONS] Affichage de la suggestion « mise à jour des organisations utilisatrices » sur DÉCRIRE

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -87,6 +87,10 @@ module.exports = {
       lien: '/descriptionService',
       permissionRequise: { rubrique: 'DECRIRE', niveau: 2 },
     },
+    miseAJourNombreOrganisationsUtilisatrices: {
+      lien: '/descriptionService',
+      permissionRequise: { rubrique: 'DECRIRE', niveau: 2 },
+    },
   },
 
   nombreOrganisationsUtilisatrices: [

--- a/migrations/20240718092812_insereSuggestionsActionsPourOrganisationsUtilisatrices.js
+++ b/migrations/20240718092812_insereSuggestionsActionsPourOrganisationsUtilisatrices.js
@@ -1,0 +1,14 @@
+const nature = 'miseAJourNombreOrganisationsUtilisatrices';
+
+exports.up = (knex) =>
+  knex.raw(
+    `
+        INSERT INTO suggestions_actions (id_service, nature)
+        SELECT id, '${nature}'
+        FROM services
+        WHERE donnees->'descriptionService'->'nombreOrganisationsUtilisatrices'->>'borneBasse' = '0';
+    `
+  );
+
+exports.down = (knex) =>
+  knex.raw(`DELETE FROM suggestions_actions WHERE nature = '${nature}';`);

--- a/public/assets/styles/homologation/descriptionService.css
+++ b/public/assets/styles/homologation/descriptionService.css
@@ -33,27 +33,6 @@
   width: 288px;
 }
 
-.conteneur-nombre-organisations-utilisatrices {
-  position: relative;
-}
-
-.conteneur-nombre-organisations-utilisatrices.vide
-  #nombre-organisations-utilisatrices {
-  color: #667892;
-}
-
-.conteneur-nombre-organisations-utilisatrices.vide::before {
-  content: '';
-  display: block;
-  position: absolute;
-  top: -16px;
-  left: -32px;
-  width: calc(100% + 48px);
-  height: calc(100% + 32px);
-  background: #ffdfdf;
-  border-radius: 8px;
-}
-
 .banniere {
   margin-top: -2em;
   margin-bottom: 2em;

--- a/src/bus/abonnements/supprimeSuggestionSiret.js
+++ b/src/bus/abonnements/supprimeSuggestionSiret.js
@@ -1,7 +1,0 @@
-function supprimeSuggestionSiret({ depotDonnees }) {
-  return async ({ service }) => {
-    await depotDonnees.acquitteSuggestionAction(service.id, 'miseAJourSiret');
-  };
-}
-
-module.exports = { supprimeSuggestionSiret };

--- a/src/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.js
+++ b/src/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.js
@@ -1,6 +1,14 @@
 function supprimeSuggestionsSurDesChampsObligatoires({ depotDonnees }) {
   return async ({ service }) => {
+    // Les données pointées par les suggestions d'actions sont des données obligatoires dans le modèle.
+    // Cet abonné est déclenché suite à une mise à jour du service…
+    // …or le service ne peut être sauvegardé que s'il a toutes les données obligatoires.
+    // Donc on acquitte les suggestions d'actions.
     await depotDonnees.acquitteSuggestionAction(service.id, 'miseAJourSiret');
+    await depotDonnees.acquitteSuggestionAction(
+      service.id,
+      'miseAJourNombreOrganisationsUtilisatrices'
+    );
   };
 }
 

--- a/src/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.js
+++ b/src/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.js
@@ -1,0 +1,7 @@
+function supprimeSuggestionsSurDesChampsObligatoires({ depotDonnees }) {
+  return async ({ service }) => {
+    await depotDonnees.acquitteSuggestionAction(service.id, 'miseAJourSiret');
+  };
+}
+
+module.exports = { supprimeSuggestionsSurDesChampsObligatoires };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -69,8 +69,8 @@ const {
   metAJourContactBrevoDeLUtilisateur,
 } = require('./abonnements/metAJourContactBrevoDeLUtilisateur');
 const {
-  supprimeSuggestionSiret,
-} = require('./abonnements/supprimeSuggestionSiret');
+  supprimeSuggestionsSurDesChampsObligatoires,
+} = require('./abonnements/supprimeSuggestionsSurDesChampsObligatoires');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -113,7 +113,7 @@ const cableTousLesAbonnes = (
   ]);
 
   busEvenements.abonnePlusieurs(EvenementDescriptionServiceModifiee, [
-    supprimeSuggestionSiret({ depotDonnees }),
+    supprimeSuggestionsSurDesChampsObligatoires({ depotDonnees }),
     consigneCompletudeDansJournal({
       adaptateurJournal,
       adaptateurRechercheEntreprise,

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -82,11 +82,7 @@ mixin formulaireDescriptionService(idHomologation)
                   strong Information à mettre à jour
                   p Vous pouvez directement rechercher le nom ou le numéro de SIRET de votre organisation.
 
-
-        - const { borneBasse, borneHaute } = service.descriptionService.nombreOrganisationsUtilisatrices
-        - const valeurService = `${borneBasse}-${borneHaute}`
-        - const valeurVide = '0-0'
-        .conteneur-nombre-organisations-utilisatrices(class = `${valeurService === valeurVide && !estLectureSeule && !estEnCreation ? 'vide' : ''}`)
+        .conteneur-nombre-organisations-utilisatrices
           .requis
             label À combien d'organisations publiques est destiné le service ?
               p.description Si le service est mutualisé au profit de plusieurs organisations publiques, merci de préciser combien en bénéficieront.
@@ -102,6 +98,13 @@ mixin formulaireDescriptionService(idHomologation)
                   - const valeurOption = `${tranche.borneBasse}-${tranche.borneHaute}`
                   option(value=valeurOption label=tranche.label selected=(valeurService===valeurOption))
               .message-erreur Ce champ est obligatoire. Veuillez sélectionner une option.
+          - const afficheSuggestion = service.pourraitFaire('miseAJourNombreOrganisationsUtilisatrices') && !estLectureSeule
+          if afficheSuggestion
+              .banniere.banniere-avertissement
+                img(src='/statique/assets/images/icone_danger.svg' alt='')
+                .contenu-texte-avertissement
+                  strong Information à mettre à jour
+                  p Vous pouvez renseigner le nombre d'organisations publiques qui bénéficieront du service.
 
         .requis
           +inputChoix({

--- a/test/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.spec.js
+++ b/test/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.spec.js
@@ -1,11 +1,11 @@
 const expect = require('expect.js');
 const {
-  supprimeSuggestionSiret,
-} = require('../../../src/bus/abonnements/supprimeSuggestionSiret');
+  supprimeSuggestionsSurDesChampsObligatoires,
+} = require('../../../src/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires');
 const { unService } = require('../../constructeurs/constructeurService');
 
-describe('L’abonnement qui supprime la suggestion de mise à jour du SIRET', () => {
-  it('utilise le dépôt pour supprimer la suggestion', async () => {
+describe('L’abonnement qui supprime les suggestions portant sur des données obligatoires', () => {
+  it('utilise le dépôt pour supprimer la suggestion de mise à jour du SIRET', async () => {
     let suggestionSupprimee;
     const depotDonnees = {
       acquitteSuggestionAction: (idService, nature) => {
@@ -13,7 +13,9 @@ describe('L’abonnement qui supprime la suggestion de mise à jour du SIRET', (
       },
     };
 
-    const abonne = supprimeSuggestionSiret({ depotDonnees });
+    const abonne = supprimeSuggestionsSurDesChampsObligatoires({
+      depotDonnees,
+    });
 
     expect(abonne).to.be.an('function');
     await abonne({

--- a/test/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.spec.js
+++ b/test/bus/abonnements/supprimeSuggestionsSurDesChampsObligatoires.spec.js
@@ -6,10 +6,10 @@ const { unService } = require('../../constructeurs/constructeurService');
 
 describe('L’abonnement qui supprime les suggestions portant sur des données obligatoires', () => {
   it('utilise le dépôt pour supprimer la suggestion de mise à jour du SIRET', async () => {
-    let suggestionSupprimee;
+    let idServiceAcquitte;
     const depotDonnees = {
       acquitteSuggestionAction: (idService, nature) => {
-        suggestionSupprimee = { idService, nature };
+        if (nature === 'miseAJourSiret') idServiceAcquitte = idService;
       },
     };
 
@@ -21,9 +21,22 @@ describe('L’abonnement qui supprime les suggestions portant sur des données o
     await abonne({
       service: unService().avecId('S1').construis(),
     });
-    expect(suggestionSupprimee).to.eql({
-      idService: 'S1',
-      nature: 'miseAJourSiret',
-    });
+    expect(idServiceAcquitte).to.be('S1');
+  });
+
+  it('utilise le dépôt pour supprimer la suggestion de mise à jour des organisations utilisatrices', async () => {
+    let idServiceAcquitte;
+    const depotDonnees = {
+      acquitteSuggestionAction: (idService, nature) => {
+        if (nature === 'miseAJourNombreOrganisationsUtilisatrices')
+          idServiceAcquitte = idService;
+      },
+    };
+
+    await supprimeSuggestionsSurDesChampsObligatoires({
+      depotDonnees,
+    })({ service: unService().avecId('S1').construis() });
+
+    expect(idServiceAcquitte).to.be('S1');
   });
 });


### PR DESCRIPTION
En bâtissant sur #1602 on s'attaque désormais au champ `organisationsUtilisatrices` des `Services`.

Comme pour la suggestion `mise à jour SIRET`, la bannière s'affiche sur DECRIRE 👇 

![image](https://github.com/user-attachments/assets/20a8b606-351e-48f4-bce6-88d51e5bf25b)
