### PR TITLE
Corrige affichage bannières de suggestion d’action

### DIFF
--- a/public/modules/suggestion/suggestionEntite.js
+++ b/public/modules/suggestion/suggestionEntite.js
@@ -73,7 +73,7 @@ $(() => {
       departement = $item.data('departement');
       $('#siretEntite').val(siret);
       if (siret) {
-        $('.banniere-avertissement').addClass('invisible');
+        $('.banniere-avertissement.miseAJourSiret').addClass('invisible');
       }
       $('#departementEntite').val(departement.toString());
       $champSelectizeDepartement[0].selectize.setValue(departement);

--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -29,10 +29,10 @@ const brancheComportementMessageErreur = () => {
 
 const brancheComportementNombreOrganisationsUtilisatrices = () => {
   const $selection = $('#nombre-organisations-utilisatrices');
-  const $conteneur = $('.conteneur-nombre-organisations-utilisatrices');
   $selection.on('change', () => {
-    const nouvelleValeur = $selection.val();
-    $conteneur.toggleClass('vide', nouvelleValeur === '0-0');
+    $(
+      '.banniere-avertissement.miseAJourNombreOrganisationsUtilisatrices'
+    ).addClass('invisible');
   });
 };
 

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -100,7 +100,7 @@ mixin formulaireDescriptionService(idHomologation)
               .message-erreur Ce champ est obligatoire. Veuillez sélectionner une option.
           - const afficheSuggestion = service.pourraitFaire('miseAJourNombreOrganisationsUtilisatrices') && !estLectureSeule
           if afficheSuggestion
-              .banniere.banniere-avertissement
+              .banniere.banniere-avertissement.miseAJourNombreOrganisationsUtilisatrices
                 img(src='/statique/assets/images/icone_danger.svg' alt='')
                 .contenu-texte-avertissement
                   strong Information à mettre à jour

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -76,7 +76,7 @@ mixin formulaireDescriptionService(idHomologation)
               input(type='hidden' name='siretEntite' id='siretEntite' value != entite.siret)
 
             if service.pourraitFaire('miseAJourSiret')
-              .banniere.banniere-avertissement
+              .banniere.banniere-avertissement.miseAJourSiret
                 img(src='/statique/assets/images/icone_danger.svg' alt='')
                 .contenu-texte-avertissement
                   strong Information à mettre à jour


### PR DESCRIPTION
Corrige deux soucis : 
- la bannière de suggestion d’action de mise à jour du nombre d’organisation utilisatrice était cachée par la mise à jour du SIRET
- cette même bannière n’était pas cachée lors de la mise à jour du nombre d’organisation utilisatrice