### PR TITLE
[SUGGESTIONS D'ACTIONS] Nettoyage post-MEP

### DIFF
--- a/public/modules/tableauDeBord/tableauDesServices.mjs
+++ b/public/modules/tableauDeBord/tableauDesServices.mjs
@@ -35,7 +35,6 @@ const donneesVisiteGuidee = {
       id: 'ID-SERVICE-VISITE-GUIDEE',
       nomService: 'MonServiceSécurisé',
       organisationResponsable: 'ANSSI',
-      statutSaisieDescription: 'completes',
       contributeurs: [],
       statutHomologation: {
         id: 'activee',
@@ -258,8 +257,7 @@ const tableauDesServices = {
                                 ${service.organisationResponsable}
                               </div>
                               ${
-                                service.statutSaisieDescription ===
-                                  'aCompleter' || service.aUneSuggestionAction
+                                service.aUneSuggestionAction
                                   ? `<div class="avertissement-completion">
                                    <img src="/statique/assets/images/icone_danger_bleu.svg" alt="" />
                                      Informations à mettre à jour

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -15,7 +15,6 @@ const donnees = (service, autorisation, referentiel) => {
     nomService: service.nomService(),
     organisationResponsable:
       service.descriptionService.organisationResponsable.nom ?? '',
-    statutSaisieDescription: service.descriptionService.statutSaisie(),
     contributeurs: service.contributeurs.map((c) => ({
       id: c.id,
       prenomNom: c.prenomNom(),

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -27,6 +27,7 @@ const donneesReferentielVide = {
   nombreOrganisationsUtilisatrices: [],
   estimationNombreServices: [],
   etapesVisiteGuidee: [],
+  naturesSuggestionsActions: {},
 };
 
 const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
@@ -288,8 +289,17 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     Object.keys(donnees.etapesVisiteGuidee || {}).length;
   const natureTachesService = (nature) =>
     (donnees.naturesTachesService || {})[nature];
-  const natureSuggestionAction = (nature) =>
-    (donnees.naturesSuggestionsActions || {})[nature];
+  const natureSuggestionAction = (nature) => {
+    const natures = donnees.naturesSuggestionsActions;
+
+    if (!Object.keys(natures).includes(nature)) {
+      throw new ErreurDonneesReferentielIncorrectes(
+        `La nature ${nature} n'est pas une nature de suggestion d'action connue.`
+      );
+    }
+
+    return natures[nature];
+  };
 
   valideDonnees();
 

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -71,7 +71,6 @@ describe("L'objet d'API de `GET /service`", () => {
       id: '123',
       nomService: 'Un service',
       organisationResponsable: 'Une organisation',
-      statutSaisieDescription: 'aCompleter',
       contributeurs: [
         {
           id: 'A',

--- a/test/referentiel.spec.js
+++ b/test/referentiel.spec.js
@@ -1000,4 +1000,17 @@ describe('Le référentiel', () => {
     expect(referentiel.etapeVisiteGuideeExiste('DECRIRE')).to.be(true);
     expect(referentiel.etapeVisiteGuideeExiste('MAUVAIS_ID')).to.be(false);
   });
+
+  it("lève une exception lorsqu'on lui demande une nature de suggestion d'action inconnue", () => {
+    const sansNature = Referentiel.creeReferentielVide();
+
+    expect(() =>
+      sansNature.natureSuggestionAction('INCONNUE')
+    ).to.throwException((e) => {
+      expect(e).to.be.an(ErreurDonneesReferentielIncorrectes);
+      expect(e.message).to.equal(
+        "La nature INCONNUE n'est pas une nature de suggestion d'action connue."
+      );
+    });
+  });
 });

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -1574,7 +1574,6 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           enCoursEdition: true,
           etapeCourante: 'autorite',
         },
-        statutSaisieDescription: 'completes',
         nombreContributeurs: 2,
         estProprietaire: false,
         documentsPdfDisponibles: [],


### PR DESCRIPTION
Après avoir MEP les suggestions d'actions, on peut nettoyer le code qui restait présent pour faire du « double run » avec l'ancienne abstraction.