### PR TITLE
[CORRECTION] Ajoute les identifiants numériques à la visite guidée

### DIFF
--- a/svelte/lib/tableauDesMesures/modeVisiteGuidee/donneesVisiteGuidee.ts
+++ b/svelte/lib/tableauDesMesures/modeVisiteGuidee/donneesVisiteGuidee.ts
@@ -13,6 +13,7 @@ export const mesuresVisiteGuidee: Mesures = {
       referentiel: Referentiel.ANSSI,
       statut: 'fait',
       modalites: '',
+      identifiantNumerique: '0006',
     },
     registreTraitements: {
       description: 'Remplir le registre des traitements et le tenir à jour',
@@ -20,6 +21,7 @@ export const mesuresVisiteGuidee: Mesures = {
       indispensable: true,
       descriptionLongue: '',
       referentiel: Referentiel.CNIL,
+      identifiantNumerique: '0015',
     },
     identificationDonneesSensibles: {
       description: 'Identifier les données importantes à protéger',
@@ -27,6 +29,7 @@ export const mesuresVisiteGuidee: Mesures = {
       indispensable: true,
       descriptionLongue: '',
       referentiel: Referentiel.ANSSI,
+      identifiantNumerique: '0008',
     },
     listeEquipements: {
       description:
@@ -35,6 +38,7 @@ export const mesuresVisiteGuidee: Mesures = {
       indispensable: true,
       descriptionLongue: '',
       referentiel: Referentiel.ANSSI,
+      identifiantNumerique: '0011',
     },
     limitationInterconnexions: {
       description:
@@ -43,6 +47,7 @@ export const mesuresVisiteGuidee: Mesures = {
       indispensable: true,
       descriptionLongue: '',
       referentiel: Referentiel.ANSSI,
+      identifiantNumerique: '0009',
     },
   },
   mesuresSpecifiques: [],


### PR DESCRIPTION
On avait oublié de les ajouter après e7b8aeaca5b26c0643753c87905bd3cc9f9457d4.

Cette PR les rajoute. J'ai repris les mêmes ID que dans `donneesReferentiel`.

Ce qui corrige l'affichage de la visite 👇 

![image](https://github.com/user-attachments/assets/8de562f0-2056-4e61-9d81-b8d0f58a52f5)
