### PR TITLE
[DÉVELOPPEMENT] Rendre bloquantes les erreurs Typescript dans Svelte

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Node.js CI
+name: L'intégration continue
 
 on:
   push:
@@ -11,6 +8,8 @@ on:
 
 jobs:
   build:
+    name: Construction de MonServiceSécurisé
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -22,12 +21,22 @@ jobs:
       SECRET_COOKIE: secret
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Cloner le dépôt Git
+        uses: actions/checkout@v4
+
+      - name: Utiliser la version Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npx prettier --check .
-      - run: npx tsc --noEmit -p svelte/tsconfig.json
-      - run: npm test
+
+      - name: Installer les dépendances
+        run: npm ci
+
+      - name: Contrôler la mise en forme avec Prettier
+        run: npx prettier --check .
+
+      - name: Contrôler le Typescript de Svelte
+        run: npx tsc --noEmit -p svelte/tsconfig.json
+
+      - name: Exécuter les tests
+        run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,4 +29,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npx prettier --check .
+      - run: npx tsc --noEmit -p svelte/tsconfig.json
       - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,11 +12,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     env:
       SECRET_COOKIE: secret
 
@@ -24,10 +19,10 @@ jobs:
       - name: Cloner le dépôt Git
         uses: actions/checkout@v4
 
-      - name: Utiliser la version Node.js ${{ matrix.node-version }}
+      - name: Utiliser la version Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
 
       - name: Installer les dépendances
         run: npm ci

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
+npx tsc --noEmit -p svelte/tsconfig.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     command: bash -c "
       export PUPPETEER_EXECUTABLE_PATH=$$(which chromium)
       && npx knex migrate:latest
-      && npx concurrently
+      && npx concurrently -n \"SERVEUR,FRONT SVELTE\"
       \"npx nodemon --inspect=0.0.0.0 server.js\"
       \"npx vite build --watch --minify false --config svelte/vite.config.mts\"
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,14 @@ services:
 
   web:
     <<: *configuration-base
-    command: bash -c "export PUPPETEER_EXECUTABLE_PATH=$$(which chromium) && npx knex migrate:latest && npx concurrently \"npx nodemon --inspect=0.0.0.0 server.js\" \"npx vite build --watch --minify false --config svelte/vite.config.mts\""
+
+    command: bash -c "
+      export PUPPETEER_EXECUTABLE_PATH=$$(which chromium)
+      && npx knex migrate:latest
+      && npx concurrently
+      \"npx nodemon --inspect=0.0.0.0 server.js\"
+      \"npx vite build --watch --minify false --config svelte/vite.config.mts\"
+      "
     environment:
       - NODE_ENV=development
       # Sur Mac M1 le téléchargement de Chromium échoue, car aucune version compatible `arm64`.

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -22,7 +22,7 @@ export type MesuresExistantes = {
 };
 
 export type MesureGenerale = {
-  statut: string;
+  statut?: string;
   modalites?: string;
 };
 

--- a/svelte/lib/mesure/mesure.store.ts
+++ b/svelte/lib/mesure/mesure.store.ts
@@ -18,6 +18,7 @@ const mesureEditeeParDefaut = (): MesureEditee => ({
     description: '',
     statut: undefined,
     modalites: '',
+    identifiantNumerique: '',
   },
   metadonnees: {
     typeMesure: 'SPECIFIQUE',

--- a/svelte/lib/mesure/mesure.ts
+++ b/svelte/lib/mesure/mesure.ts
@@ -12,9 +12,10 @@ let enteteTiroir: EnteteTiroir;
 const changeCartoucheDuReferentiel = () => {
   enteteTiroir?.$destroy();
   const cible = document.querySelector('.titre-tiroir');
-  enteteTiroir = new EnteteTiroir({
-    target: cible,
-  });
+  if (!cible) {
+    throw new Error('Element titre du tiroir non trouvé');
+  }
+  enteteTiroir = new EnteteTiroir({ target: cible });
 };
 
 const reinitialiseStore = (mesureAEditer?: MesureEditee) => {
@@ -32,4 +33,4 @@ const rechargeApp = ({ mesureAEditer, ...autreProps }: MesureProps) => {
   });
 };
 
-export default app;
+export default app!;


### PR DESCRIPTION
🪧 Cette PR s'attaque à 2 soucis : 
 - les erreurs Typescript
 - l'expressivité de notre pipeline de build

## Les erreurs TS
On veut éviter de découvrir par hasard les erreurs Typescript dans nos IDE 👇 

![image](https://github.com/user-attachments/assets/8a77b858-625d-4878-b6c2-89d6952b1f47)


Cette PR vérifie le Typescript en pré-commit et dans une github action.

L'objectif est de ne pas aller en PROD avec des erreurs Typescript.

## Le pipeline de build
En retravaillant le fichier `nodejs.yml` des Github actions, on gagne en expressivité dans le pipeline de build 👇 


AVANT
![image](https://github.com/user-attachments/assets/d0a78f57-8765-4a83-8912-dab6d09a8d44)


APRÈS
![image](https://github.com/user-attachments/assets/f9f4bd54-6b62-46b2-83e8-7bf28c8e2f17)


La build est cassée, mais l'important ici est le nom des `steps`.