### PR TITLE
[CORRECTION] Assigne une valeur par défaut au nombre d’entité

### DIFF
--- a/public/modules/parametresDescriptionService.mjs
+++ b/public/modules/parametresDescriptionService.mjs
@@ -3,7 +3,10 @@ import parametres, {
   modifieParametresAvecItemsExtraits,
 } from './parametres.mjs';
 
-const extraisParametresDescriptionService = (selecteurFormulaire) => {
+const extraisParametresDescriptionService = (
+  selecteurFormulaire,
+  pourEstimationNiveauSecurite = false
+) => {
   const idFormulaires = $.map(
     $('form', selecteurFormulaire),
     (formulaire) => formulaire.id
@@ -30,9 +33,16 @@ const extraisParametresDescriptionService = (selecteurFormulaire) => {
   delete params['siretEntite-selectize'];
   delete params['departementEntite-selectize'];
 
-  const [borneBasse, borneHaute] =
-    params.nombreOrganisationsUtilisatrices.split('-');
-  params.nombreOrganisationsUtilisatrices = { borneBasse, borneHaute };
+  if (
+    pourEstimationNiveauSecurite &&
+    !params.nombreOrganisationsUtilisatrices
+  ) {
+    params.nombreOrganisationsUtilisatrices = { borneBasse: 0, borneHaute: 0 };
+  } else {
+    const [borneBasse, borneHaute] =
+      params.nombreOrganisationsUtilisatrices.split('-');
+    params.nombreOrganisationsUtilisatrices = { borneBasse, borneHaute };
+  }
 
   return params;
 };

--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -83,7 +83,7 @@ const brancheComportementNavigationEtapes = () => {
           const reponse = await axios({
             method: 'post',
             url: `/api/service/estimationNiveauSecurite`,
-            data: extraisParametresDescriptionService('#homologation'),
+            data: extraisParametresDescriptionService('#homologation', true),
           });
           niveauDeSecuriteMinimal = reponse.data.niveauDeSecuriteMinimal;
         }


### PR DESCRIPTION
utilisatrice

... si le champ n’est pas rempli dans le cas d’une estimation des besoins de sécurité. 

Cela corrige un problème de chargement infini lorsqu’on veut aller sur l’étape 3 directement.