### PR TITLE
[DÉPENDANCES] Met à jour la version de `npm`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
       },
       "engines": {
         "node": "18",
-        "npm": "9"
+        "npm": "10"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "engines": {
     "node": "18",
-    "npm": "9"
+    "npm": "10"
   },
   "scripts": {
     "build": "knex migrate:latest && npm run cree-utilisateur-demo && npx vite build --config svelte/vite.config.mts",


### PR DESCRIPTION
... sinon, on peut voir apparaitre, en local comme sur la CI, un message indiquant 
```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'MonServiceSécurisé@1.0.0',
npm warn EBADENGINE   required: { node: '18', npm: '9' },
npm warn EBADENGINE   current: { node: 'v18.20.4', npm: '10.7.0' }
npm warn EBADENGINE }
```