### PR TITLE
[NOTIFICATIONS] Canal de diffusion des 'Nouveautés'

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -25,6 +25,7 @@ module.exports = {
       sousTitre:
         "Valorisez l'effort de sécurisation mis en œuvre et renforcez la confiance de vos usagers dans vos services",
       image: 'encart_homologation.png',
+      canalDiffusion: 'centreNotifications',
     },
     {
       id: 'communauteMSS',
@@ -34,6 +35,7 @@ module.exports = {
       sousTitre:
         'Devenez membre de la communauté MonServiceSécurisé et échangez avec vos pairs',
       image: 'communauteMSS.png',
+      canalDiffusion: 'centreNotifications',
     },
     {
       id: 'mesuresPartielles',
@@ -42,6 +44,7 @@ module.exports = {
       titre: "Le calcul de l'Indice Cyber évolue !",
       sousTitre: 'Il prend désormais en compte les mesures "partielles"',
       image: 'indiceCyber.png',
+      canalDiffusion: 'centreNotifications',
     },
     {
       id: 'besoinsSecurite',
@@ -51,6 +54,7 @@ module.exports = {
       sousTitre:
         "Choisissez les besoins adaptés à vos services et adaptez la démarche d'homologation, grâce aux indications fournies par l'ANSSI",
       image: 'besoinsSecurite.svg',
+      canalDiffusion: 'centreNotifications',
     },
   ],
 

--- a/svelte/lib/centreNotifications/CentreNotifications.svelte
+++ b/svelte/lib/centreNotifications/CentreNotifications.svelte
@@ -14,12 +14,16 @@
   const calculNbNonLue = (notifications: Notification[]) =>
     notifications.filter((n) => n.statutLecture === 'nonLue').length;
 
-  $: nbNonLue = calculNbNonLue($storeNotifications);
+  $: nbNonLue = calculNbNonLue($storeNotifications.pourCentreNotifications);
 
   $: notificationsParOnglet = {
-    aFaire: $storeNotifications.filter((n) => n.type === 'tache'),
-    nouveautes: $storeNotifications.filter((n) => n.type === 'nouveaute'),
-    toutes: $storeNotifications,
+    aFaire: $storeNotifications.pourCentreNotifications.filter(
+      (n) => n.type === 'tache'
+    ),
+    nouveautes: $storeNotifications.pourCentreNotifications.filter(
+      (n) => n.type === 'nouveaute'
+    ),
+    toutes: $storeNotifications.pourCentreNotifications,
   };
 
   onMount(async () => {

--- a/svelte/lib/centreNotifications/kit/ListeNotifications.svelte
+++ b/svelte/lib/centreNotifications/kit/ListeNotifications.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import ComposantNotification from './Notification.svelte';
-  import type { Notification } from '../centreNotifications.d';
+  import type { Notification } from '../../ui/types.d';
 
   export let notifications: Notification[];
 </script>

--- a/svelte/lib/ui/stores/notifications.store.ts
+++ b/svelte/lib/ui/stores/notifications.store.ts
@@ -1,7 +1,14 @@
 import { writable } from 'svelte/store';
 import type { Notification, TypeNotification } from '../types.d';
 
-const { subscribe, set } = writable<Notification[]>([]);
+type Notifications = {
+  pourCentreNotifications: Notification[];
+  pourPage: Notification[];
+};
+const { subscribe, set } = writable<Notifications>({
+  pourCentreNotifications: [],
+  pourPage: [],
+});
 
 const routes: Record<TypeNotification, string> = {
   nouveaute: 'nouveautes',
@@ -12,7 +19,15 @@ export const storeNotifications = {
   subscribe,
   rafraichis: async () => {
     const reponse = await axios.get('/api/notifications');
-    set(reponse.data.notifications);
+    const toutesNotifications = reponse.data.notifications;
+    set({
+      pourCentreNotifications: toutesNotifications.filter(
+        (n: Notification) => n.canalDiffusion === 'centreNotifications'
+      ),
+      pourPage: toutesNotifications.filter(
+        (n: Notification) => n.canalDiffusion === 'page'
+      ),
+    });
   },
   marqueLue: async (type: TypeNotification, id: string) => {
     await axios.put(`/api/notifications/${routes[type]}/${id}`);

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -18,6 +18,7 @@ type NotificationBase = {
   type: TypeNotification;
   doitNotifierLecture: boolean;
   horodatage?: string;
+  canalDiffusion: 'centreNotifications' | 'page';
 };
 
 export type NotificationNouveaute = NotificationBase & {


### PR DESCRIPTION
On ajoute le `canalDiffusion` dans les nouveautés, afin de pouvoir trier celles qui vont dans le centre de notifications et celles qui vont être affichées dans la page "Sécuriser".