### PR TITLE
[CORRECTION] Remet le niveau de sécurité précédemment sélectionné

### DIFF
--- a/public/modules/soumetsHomologation.mjs
+++ b/public/modules/soumetsHomologation.mjs
@@ -43,7 +43,7 @@ const initialiseComportementFormulaire = (
       redirige(donnees);
     } catch (e) {
       basculeEnCoursChargement($bouton, false);
-      callbackErreur(e);
+      callbackErreur(e, requete.data);
     }
   });
 

--- a/public/service/descriptionService.js
+++ b/public/service/descriptionService.js
@@ -201,10 +201,11 @@ $(() => {
     '.bouton#diagnostic',
     extraisParametresDescriptionService,
     navigationEtapes,
-    (e) => {
+    (e, donnees) => {
       if (estNomServiceDejaUtilise(e.response)) {
         messageErreurNomDejaUtilise.affiche();
         navigationEtapes.afficheEtape1();
+        $('#niveau-securite-existant').text(`"${donnees.niveauSecurite}"`);
       }
     }
   );


### PR DESCRIPTION
...si la soumission du formulaire a échoué à cause du nom du service déjà utilisé. 

Problème constaté : quand on remplit entièrement Décrire, mais qu'à la soumission on est renvoyé vers l'étape 1 pour modifier un nom de service déjà pris, au retour à l'étape 3 le bouton de soumission n'est pas grisé alors qu'aucun niveau n'est sélectionné.

Plutôt que de griser le bouton, j'ai préféré récupérer le niveau précédemment sélectionné par l'utilisateur pour le remettre en sélection. En effet, le reste du formulaire a ce comportement (aucune valeur oubliée) et ce champ devrait avoir le même comportement selon moi.