### PR TITLE
[CORRECTION] Ajoute le canal de diffusion aux tâches de service et d'utilisateur

### DIFF
--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -56,6 +56,7 @@ class CentreNotifications {
     const notifications = taches.map((tache) => ({
       ...tache,
       ...this.referentiel.natureTachesService(tache.nature),
+      canalDiffusion: 'centreNotifications',
     }));
 
     return notifications.map((notification) => ({
@@ -141,7 +142,11 @@ class CentreNotifications {
       .filter((t) => t !== undefined)
       .map((t) =>
         avecStatutLecture(t, CentreNotifications.NOTIFICATION_NON_LUE)
-      );
+      )
+      .map((t) => ({
+        ...t,
+        canalDiffusion: 'centreNotifications',
+      }));
   }
 
   static NOTIFICATION_LUE = 'lue';

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -170,6 +170,7 @@ describe('Le centre de notifications', () => {
       expect(notifs.length).to.be(1);
       expect(notifs[0].id).to.be('T1');
       expect(notifs[0].type).to.be('tache');
+      expect(notifs[0].canalDiffusion).to.be('centreNotifications');
     });
 
     it('complète les informations depuis le référentiel', async () => {
@@ -384,6 +385,7 @@ describe('Le centre de notifications', () => {
         expect(taches.length).to.be(1);
         expect(taches[0].titre).to.be('Titre tâche');
         expect(taches[0].statutLecture).to.be('nonLue');
+        expect(taches[0].canalDiffusion).to.be('centreNotifications');
       });
 
       it("reste robuste si les données d'une tâche sont absentes du référentiel", async () => {


### PR DESCRIPTION
...sinon elles ne s'affichent pas dans le centre de notifications. C'est une régression suite à l'introduction du canal de diffusion pour les nouveautés.