### PR TITLE
[CENTRE NOTIFICATIONS] Ne pas afficher les tâches de service déjà lues

### DIFF
--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -25,7 +25,7 @@ class CentreNotifications {
     const [tachesProfil, nouveautes, tachesDesServices] = await Promise.all([
       this.toutesTachesProfilUtilisateur(idUtilisateur),
       this.toutesNouveautes(idUtilisateur),
-      this.toutesTachesDeService(idUtilisateur),
+      this.toutesTachesDeServiceNonLues(idUtilisateur),
     ]);
 
     return [
@@ -51,13 +51,15 @@ class CentreNotifications {
     ].sort((a, b) => b.date() - a.date());
   }
 
-  async toutesTachesDeService(idUtilisateur) {
+  async toutesTachesDeServiceNonLues(idUtilisateur) {
     const taches = await this.depotDonnees.tachesDesServices(idUtilisateur);
-    const notifications = taches.map((tache) => ({
-      ...tache,
-      ...this.referentiel.natureTachesService(tache.nature),
-      canalDiffusion: 'centreNotifications',
-    }));
+    const notifications = taches
+      .filter((tache) => !tache.dateFaite)
+      .map((tache) => ({
+        ...tache,
+        ...this.referentiel.natureTachesService(tache.nature),
+        canalDiffusion: 'centreNotifications',
+      }));
 
     return notifications.map((notification) => ({
       ...notification,

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -173,6 +173,16 @@ describe('Le centre de notifications', () => {
       expect(notifs[0].canalDiffusion).to.be('centreNotifications');
     });
 
+    it('retourne uniquement les tâches non lues', async () => {
+      depotDonnees.tachesDesServices = async () => [
+        uneTacheDeService().avecId('T1').faiteMaintenant().construis(),
+      ];
+
+      const notifs = await centreDeNotification().toutesNotifications('U1');
+
+      expect(notifs.length).to.be(0);
+    });
+
     it('complète les informations depuis le référentiel', async () => {
       depotDonnees.tachesDesServices = async (_) => [
         uneTacheDeService().avecNature('niveauRetrograde').construis(),
@@ -294,18 +304,7 @@ describe('Le centre de notifications', () => {
       expect(notifications[0].doitNotifierLecture).to.be(true);
     });
 
-    it("indique qu'une tâche est non lue si elle n'a pas été faite", async () => {
-      depotDonnees.tachesDesServices = async (_) => [
-        uneTacheDeService().pasFaite().construis(),
-      ];
-
-      const notifications =
-        await centreDeNotification().toutesNotifications('U1');
-
-      expect(notifications[0].statutLecture).to.be('nonLue');
-    });
-
-    it("indique qu'une tâche est lue si elle a été faite", async () => {
+    it('utilise la date de création comme horodatage', async () => {
       depotDonnees.tachesDesServices = async (_) => [
         uneTacheDeService()
           .avecDateDeCreation(new Date('2024-09-13'))
@@ -316,17 +315,6 @@ describe('Le centre de notifications', () => {
         await centreDeNotification().toutesNotifications('U1');
 
       expect(notifications[0].horodatage).to.eql(new Date('2024-09-13'));
-    });
-
-    it('utilise la date de création comme horodatage', async () => {
-      depotDonnees.tachesDesServices = async (_) => [
-        uneTacheDeService().faiteMaintenant().construis(),
-      ];
-
-      const notifications =
-        await centreDeNotification().toutesNotifications('U1');
-
-      expect(notifications[0].statutLecture).to.be('lue');
     });
   });
 


### PR DESCRIPTION
On ne souhaite pas afficher dans le centre de notifications les tâches de service déjà lues, pour ne pas surcharger l'utilisateur.
