### PR TITLE
Redirige vers suggestion d’action prioritaire

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -99,14 +99,17 @@ module.exports = {
     miseAJourSiret: {
       lien: '/descriptionService',
       permissionRequise: { rubrique: 'DECRIRE', niveau: 2 },
+      priorite: 10,
     },
     miseAJourNombreOrganisationsUtilisatrices: {
       lien: '/descriptionService',
       permissionRequise: { rubrique: 'DECRIRE', niveau: 2 },
+      priorite: 10,
     },
     controleBesoinsDeSecuriteRetrogrades: {
       lien: '/descriptionService?etape=3',
       permissionRequise: { rubrique: 'DECRIRE', niveau: 1 },
+      priorite: 20,
     },
   },
 

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -271,8 +271,8 @@ class Homologation {
     return new ObjetPDFAnnexeRisques(this, this.referentiel);
   }
 
-  suggestionActionPrioritaire() {
-    return this.suggestionsActions[0];
+  aUneSuggestionDAction() {
+    return this.suggestionsActions.length > 0;
   }
 
   pourraitFaire(natureSuggestion) {

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -280,7 +280,9 @@ class Homologation {
   }
 
   routesDesSuggestionsActions() {
-    return this.suggestionsActions.map((s) => s.route());
+    return this.suggestionsActions
+      .sort((s1, s2) => s1.priorite - s2.priorite)
+      .map((s) => s.route());
   }
 
   static creePourUnUtilisateur(utilisateur) {

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -38,7 +38,7 @@ const donnees = (service, autorisation, referentiel) => {
     permissions: {
       gestionContributeurs: autorisation.peutGererContributeurs(),
     },
-    aUneSuggestionAction: !!service.suggestionActionPrioritaire(),
+    aUneSuggestionAction: !!service.aUneSuggestionDAction(),
   };
 };
 

--- a/src/modeles/suggestionAction.js
+++ b/src/modeles/suggestionAction.js
@@ -7,6 +7,7 @@ class SuggestionAction {
     const natureDansReferentiel = referentiel.natureSuggestionAction(nature);
 
     this.lien = natureDansReferentiel.lien;
+    this.priorite = natureDansReferentiel.priorite;
     this.permissionRequise = natureDansReferentiel.permissionRequise;
   }
 

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -208,7 +208,9 @@ describe('Le dépôt de données des homologations', () => {
 
   it('associe ses suggestions d’actions au service', async () => {
     const r = Referentiel.creeReferentiel({
-      naturesSuggestionsActions: { siret: { lien: '' } },
+      naturesSuggestionsActions: {
+        siret: { lien: '/lien', permissionRequise: {} },
+      },
     });
     const persistance = unePersistanceMemoire()
       .ajouteUnService(unService(r).avecId('S1').donnees)
@@ -220,7 +222,7 @@ describe('Le dépôt de données des homologations', () => {
 
     const service = await depot.homologation('S1');
 
-    expect(service.suggestionActionPrioritaire().nature).to.be('siret');
+    expect(service.routesDesSuggestionsActions()[0].route).to.be('/lien');
   });
 
   it('renseigne les mesures générales associées à une homologation', async () => {

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -102,6 +102,25 @@ describe('Une homologation', () => {
       ]);
     });
 
+    it("retourne la route des suggestions d'actions la plus prioritaire en premier", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        naturesSuggestionsActions: {
+          a: { lien: '/a', permissionRequise: {}, priorite: 10 },
+          b: { lien: '/b', permissionRequise: {}, priorite: 20 },
+        },
+      });
+
+      const service = unService(referentiel)
+        .avecId('S1')
+        .avecSuggestionAction({ nature: 'b' })
+        .avecSuggestionAction({ nature: 'a' })
+        .construis();
+
+      const routes = service.routesDesSuggestionsActions();
+
+      expect(routes[0].route).to.eql('/a');
+    });
+
     it('sait si une action n’est pas suggérée', () => {
       const service = unService().construis();
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -54,7 +54,7 @@ describe('Une homologation', () => {
   });
 
   describe("concernant les suggestions d'actions", () => {
-    it('connaît la suggestion d’action la plus prioritaire', () => {
+    it("sait quand il a une suggestion d'action", () => {
       const referentiel = Referentiel.creeReferentiel({
         naturesSuggestionsActions: { 'siret-a-renseigner': { lien: '' } },
       });
@@ -63,9 +63,17 @@ describe('Une homologation', () => {
         .avecSuggestionAction({ nature: 'siret-a-renseigner' })
         .construis();
 
-      expect(service.suggestionActionPrioritaire().nature).to.be(
-        'siret-a-renseigner'
-      );
+      expect(service.aUneSuggestionDAction()).to.be(true);
+    });
+
+    it("sait quand il n'a pas de suggestion d'action", () => {
+      const referentiel = Referentiel.creeReferentiel({
+        naturesSuggestionsActions: { 'siret-a-renseigner': { lien: '' } },
+      });
+
+      const service = unService(referentiel).construis();
+
+      expect(service.aUneSuggestionDAction()).to.be(false);
     });
 
     it("sait obtenir les routes MSS des suggestions d'actions", () => {


### PR DESCRIPTION
S’il y a plusieurs suggestions d’actions sur un service, un clic sur le tableau de bord devrait rediriger vers l’étape 1 plutôt que l’étape 3. C’est le cas par exemple si le SIRET n’est pas renseigné ET que les besoins de sécurité doivent être contrôlés.

Pour cela, on ajoute une priorité à chaque nature de suggestion d’action dans le référentiel et on trie les routes en fonction de cette priorité. 