### PR TITLE
[CRISP] Ajout de la visualisation des articles de manière générique

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -79,3 +79,4 @@ CRISP_CLE_API= # La clé d'API, au format "API_TOKEN:API_SECRET"
 CRISP_ID_ARTICLE_NOUVEAUTE= # L'identifiant de l'article "Nouveautés"
 CRISP_ID_ARTICLE_DEVENIR_AMBASSADEUR= # L'identifiant de l'article "Devenir ambassadeur"
 CRISP_ID_ARTICLE_FAIRE_CONNAITRE= # L'identifiant de l'article "Faire connaître et recommander"
+CRISP_ID_CATEGORIE_BLOG= # L'identifiant de la catégorie `blog` des articles

--- a/src/adaptateurs/adaptateurCmsCrisp.js
+++ b/src/adaptateurs/adaptateurCmsCrisp.js
@@ -38,8 +38,33 @@ const recupereDevenirAmbassadeur = () =>
 const recupereFaireConnaitreMSS = () =>
   recupereArticle(process.env.CRISP_ID_ARTICLE_FAIRE_CONNAITRE);
 
+const recupereArticlesBlog = async () => {
+  try {
+    const params = new URLSearchParams({
+      filter_category_id: process.env.CRISP_ID_CATEGORIE_BLOG,
+    });
+
+    const reponse = await axios.get(
+      `${urlBase}helpdesk/locale/fr/articles/0?${params}`,
+      enteteCrisp
+    );
+
+    return reponse.data.data.map((a) => ({
+      id: a.article_id,
+      url: a.url,
+    }));
+  } catch (e) {
+    fabriqueAdaptateurGestionErreur().logueErreur(e, {
+      'Erreur renvoyée par API Crisp': e?.response?.data,
+    });
+    throw e;
+  }
+};
+
 module.exports = {
   recupereNouveautes,
   recupereDevenirAmbassadeur,
   recupereFaireConnaitreMSS,
+  recupereArticle,
+  recupereArticlesBlog,
 };

--- a/src/cms/cmsCrisp.js
+++ b/src/cms/cmsCrisp.js
@@ -39,6 +39,13 @@ class CmsCrisp {
       tableDesMatieres: crispMarkdown.tableDesMatieres(),
     };
   }
+
+  async recupereArticleBlog(slug) {
+    await this.adaptateurCmsCrisp.recupereArticleBlog(slug);
+    return {
+      tableDesMatieres: [],
+    };
+  }
 }
 
 module.exports = CmsCrisp;

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -4,6 +4,7 @@ class ErreurApiBrevo extends Error {}
 class ErreurDroitsIncoherents extends Error {}
 class ErreurChainageMiddleware extends Error {}
 class ErreurModele extends Error {}
+class ErreurArticleCrispIntrouvable extends ErreurModele {}
 class ErreurAutorisationExisteDeja extends ErreurModele {}
 class ErreurAutorisationInexistante extends ErreurModele {}
 class ErreurAvisInvalide extends ErreurModele {}
@@ -58,6 +59,7 @@ module.exports = {
   EchecAutorisation,
   EchecEnvoiMessage,
   ErreurApiBrevo,
+  ErreurArticleCrispIntrouvable,
   ErreurAutorisationExisteDeja,
   ErreurAutorisationInexistante,
   ErreurAvisInvalide,

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -5,6 +5,7 @@ const {
   construisUrlAbsolueVersPage,
 } = require('../../http/redirection');
 const CmsCrisp = require('../../cms/cmsCrisp');
+const { ErreurArticleCrispIntrouvable } = require('../../erreurs');
 
 const routesNonConnectePage = ({
   adaptateurCmsCrisp,
@@ -126,6 +127,20 @@ const routesNonConnectePage = ({
       reponse.render('article', donneesArticle);
     }
   );
+
+  routes.get('/articles/:slug', async (requete, reponse, suite) => {
+    try {
+      const cmsCrisp = new CmsCrisp({ adaptateurCmsCrisp });
+      const article = await cmsCrisp.recupereArticleBlog(requete.params.slug);
+      reponse.render('article', article);
+    } catch (e) {
+      if (e instanceof ErreurArticleCrispIntrouvable) {
+        reponse.status(404).send(`Article Crisp inconnu`);
+        return;
+      }
+      suite(e);
+    }
+  });
 
   routes.get('/sitemap.xml', async (_requete, reponse) => {
     reponse.sendFile('/public/assets/fichiers/sitemap.xml', { root: '.' });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -60,6 +60,7 @@ const testeurMss = () => {
       recupereNouveautes: async () => contenuCrisp,
       recupereDevenirAmbassadeur: async () => contenuCrisp,
       recupereFaireConnaitreMSS: async () => contenuCrisp,
+      recupereArticleBlog: async () => contenuCrisp,
     };
     adaptateurMail = adaptateurMailMemoire.fabriqueAdaptateurMailMemoire();
     adaptateurPdf = {
@@ -133,6 +134,7 @@ const testeurMss = () => {
     adaptateurZip: () => adaptateurZip,
     adaptateurTracking: () => adaptateurTracking,
     adaptateurJournalMSS: () => adaptateurJournalMSS,
+    adaptateurCmsCrisp: () => adaptateurCmsCrisp,
     depotDonnees: () => depotDonnees,
     middleware: () => middleware,
     moteurRegles: () => moteurRegles,


### PR DESCRIPTION
On souhaite afficher les articles Crisp du Helpdesk pour la catégorie `blog`, via leur slug
![Capture d’écran 2024-07-29 à 16 21 49](https://github.com/user-attachments/assets/c34ae3d7-27d7-452c-a541-44cc1fd24f06)
