### PR TITLE
[CORRECTION] Impose la sélection d'un statut dans le tiroir de mesure

### DIFF
--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -12,6 +12,10 @@
   export let requis = false;
 
   const dispatch = createEventDispatcher<{ input: { statut: string } }>();
+
+  $: {
+    if (!statut) statut = '';
+  }
 </script>
 
 <label for={`statut-${id}`} class:requis class:a-label={label !== ''}>
@@ -31,7 +35,7 @@
     }}
     on:click|stopPropagation
   >
-    <option value={undefined} disabled selected>Statut à définir</option>
+    <option value="" disabled selected>Statut à définir</option>
     {#each Object.entries(referentielStatuts) as [valeur, label]}
       <option value={valeur}>{label}</option>
     {/each}


### PR DESCRIPTION
C'est une régression.
Le `undefined` se traduit en `value="undefined"` donc ne déclenchait plus la violation de contrainte `required`. Seule la chaîne vide déclenche ça.

![image](https://github.com/user-attachments/assets/1fa0768f-aac4-49a8-b14c-8c97e820fe54)
