### PR TITLE
[SÉCURISER] Ajout de la ligne de titre

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+# TODO
+
+- champ affiché sur le tableau, si feature flag
+- onglet dans le tiroir
+- champ dans le tiroir
+- je peux enregistrer la valeur depuis le tiroir
+- je peux enregistrer la valeur depuis le tableau

--- a/svelte/lib/tableauDesMesures/BandeauActions.svelte
+++ b/svelte/lib/tableauDesMesures/BandeauActions.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import { EtatEnregistrement } from './tableauDesMesures.d';
+  import {
+    afficheTiroirDeMesure,
+    afficheTiroirExportDesMesures,
+  } from './actionsTiroir';
+
+  const { EnCours } = EtatEnregistrement;
+
+  export let etatEnregistrement: EtatEnregistrement;
+</script>
+
+<tr>
+  <th colspan="2">
+    <div class="actions">
+      <button
+        class="bouton-action-mesure"
+        on:click={() => afficheTiroirDeMesure()}
+        disabled={etatEnregistrement === EnCours}
+      >
+        <img src="/statique/assets/images/icone_plus_gris.svg" alt="" />
+        Ajouter une mesure
+      </button>
+      <button
+        class="bouton-action-mesure"
+        on:click={afficheTiroirExportDesMesures}
+      >
+        <img src="/statique/assets/images/icone_export_gris.svg" alt="" />
+        Exporter la liste des mesures
+      </button>
+      {#if etatEnregistrement === EnCours}
+        <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
+      {/if}
+    </div>
+  </th>
+</tr>
+
+<style>
+  .enregistrement-en-cours {
+    font-size: 1.1em;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #0c5c98;
+  }
+
+  .enregistrement-en-cours:before {
+    content: '';
+    display: flex;
+    width: 24px;
+    height: 24px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-image: url('/statique/assets/images/icone_enregistrement_en_cours.svg');
+    animation: rotation 1s linear infinite;
+  }
+
+  @keyframes rotation {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  tr th {
+    padding: 0;
+  }
+
+  .bouton-action-mesure {
+    padding: 6px 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+    color: var(--gris-fonce);
+    cursor: pointer;
+    background: none;
+    border: none;
+    border-radius: 4px;
+  }
+
+  .bouton-action-mesure:hover {
+    background: var(--fond-gris-pale);
+    color: var(--bleu-anssi);
+  }
+
+  .bouton-action-mesure:hover img {
+    filter: brightness(0) invert(21%) sepia(87%) saturate(646%)
+      hue-rotate(168deg) brightness(89%) contrast(103%);
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 18px 16px;
+    border: 1px solid var(--liseres-fonce);
+    border-radius: 0 4px 0 0;
+    transform: translateY(1px);
+    margin-left: -0.5px;
+    margin-right: -0.5px;
+  }
+
+  .actions p {
+    margin: 0;
+  }
+</style>

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -238,6 +238,10 @@
         </th>
       </tr>
     {/if}
+    <tr class="titres">
+      <th>Mesure</th>
+      <th>Statut</th>
+    </tr>
   </thead>
   <tbody>
     {#if $nombreResultats.aucunResultat}
@@ -396,6 +400,18 @@
 
   thead tr th {
     padding: 0;
+  }
+
+  thead tr.titres {
+    border: 1px solid var(--liseres-fonce);
+  }
+
+  thead tr.titres th {
+    padding: 9px 0 9px 32px;
+    font-size: 0.875rem;
+    font-weight: normal;
+    text-align: left;
+    color: var(--texte-clair);
   }
 
   .ligne-onglet {

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
-  import type {
-    IdCategorie,
-    IdMesureGenerale,
-    IdService,
-    MesureGenerale,
-    MesureSpecifique,
+  import {
+    EtatEnregistrement,
+    type IdCategorie,
+    type IdMesureGenerale,
+    type IdService,
   } from './tableauDesMesures.d';
   import LigneMesure from './ligne/LigneMesure.svelte';
   import {
     enregistreMesureGenerale,
     enregistreMesuresSpecifiques,
-    metEnFormeMesures,
     recupereMesures,
   } from './tableauDesMesures.api';
   import { onMount } from 'svelte';
@@ -31,12 +29,8 @@
   import { storeNotifications } from '../ui/stores/notifications.store';
   import Avertissement from '../ui/Avertissement.svelte';
   import TagStatutMesure from '../ui/TagStatutMesure.svelte';
-
-  enum EtatEnregistrement {
-    Jamais,
-    EnCours,
-    Fait,
-  }
+  import BandeauActions from './BandeauActions.svelte';
+  import { afficheTiroirDeMesure } from './actionsTiroir';
 
   const { Jamais, EnCours, Fait } = EtatEnregistrement;
 
@@ -89,34 +83,6 @@
     ) {
       $rechercheParAvancement = 'enAction';
     }
-  };
-
-  type MesureAEditer = {
-    mesure: MesureSpecifique | MesureGenerale;
-    metadonnees: {
-      typeMesure: 'GENERALE' | 'SPECIFIQUE';
-      idMesure: string | number;
-    };
-  };
-  const afficheTiroirDeMesure = (mesureAEditer?: MesureAEditer) => {
-    document.body.dispatchEvent(
-      new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
-        detail: {
-          mesuresExistantes: metEnFormeMesures($mesures),
-          titreTiroir:
-            mesureAEditer && mesureAEditer.metadonnees.typeMesure === 'GENERALE'
-              ? mesureAEditer.mesure.description
-              : '',
-          ...(mesureAEditer && { mesureAEditer }),
-        },
-      })
-    );
-  };
-
-  const afficheTiroirExportDesMesures = () => {
-    document.body.dispatchEvent(
-      new CustomEvent('svelte-affiche-tiroir-export-mesures')
-    );
   };
 
   const marqueNouveauteLue = async () => {
@@ -213,30 +179,7 @@
       </th>
     </tr>
     {#if !estLectureSeule}
-      <tr>
-        <th colspan="2">
-          <div class="actions">
-            <button
-              class="bouton-action-mesure"
-              on:click={() => afficheTiroirDeMesure()}
-              disabled={etatEnregistrement === EnCours}
-            >
-              <img src="/statique/assets/images/icone_plus_gris.svg" alt="" />
-              Ajouter une mesure
-            </button>
-            <button
-              class="bouton-action-mesure"
-              on:click={afficheTiroirExportDesMesures}
-            >
-              <img src="/statique/assets/images/icone_export_gris.svg" alt="" />
-              Exporter la liste des mesures
-            </button>
-            {#if etatEnregistrement === EnCours}
-              <p class="enregistrement-en-cours">Enregistrement en cours ...</p>
-            {/if}
-          </div>
-        </th>
-      </tr>
+      <BandeauActions {etatEnregistrement} />
     {/if}
     <tr class="titres">
       <th>Mesure</th>
@@ -263,10 +206,7 @@
           on:click={() =>
             afficheTiroirDeMesure({
               mesure,
-              metadonnees: {
-                typeMesure: 'GENERALE',
-                idMesure: id,
-              },
+              metadonnees: { typeMesure: 'GENERALE', idMesure: id },
             })}
           estLectureSeule={estLectureSeule || etatEnregistrement === EnCours}
         />
@@ -321,55 +261,6 @@
     padding: 0;
   }
 
-  .enregistrement-en-cours {
-    font-size: 1.1em;
-    font-weight: 500;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #0c5c98;
-  }
-
-  .enregistrement-en-cours:before {
-    content: '';
-    display: flex;
-    width: 24px;
-    height: 24px;
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-image: url('/statique/assets/images/icone_enregistrement_en_cours.svg');
-    animation: rotation 1s linear infinite;
-  }
-
-  @keyframes rotation {
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-
-  .bouton-action-mesure {
-    padding: 6px 8px;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-weight: 500;
-    color: var(--gris-fonce);
-    cursor: pointer;
-    background: none;
-    border: none;
-    border-radius: 4px;
-  }
-
-  .bouton-action-mesure:hover {
-    background: var(--fond-gris-pale);
-    color: var(--bleu-anssi);
-  }
-
-  .bouton-action-mesure:hover img {
-    filter: brightness(0) invert(21%) sepia(87%) saturate(646%)
-      hue-rotate(168deg) brightness(89%) contrast(103%);
-  }
-
   .tableau-des-mesures {
     border-collapse: collapse;
   }
@@ -380,22 +271,6 @@
 
   colgroup .statut-mesure {
     width: 20%;
-  }
-
-  .actions {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 18px 16px;
-    border: 1px solid var(--liseres-fonce);
-    border-radius: 0 4px 0 0;
-    transform: translateY(1px);
-    margin-left: -0.5px;
-    margin-right: -0.5px;
-  }
-
-  .actions p {
-    margin: 0;
   }
 
   thead tr th {

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -181,10 +181,12 @@
     {#if !estLectureSeule}
       <BandeauActions {etatEnregistrement} />
     {/if}
-    <tr class="titres">
-      <th>Mesure</th>
-      <th>Statut</th>
-    </tr>
+    {#if !$nombreResultats.aucunResultat}
+      <tr class="titres">
+        <th>Mesure</th>
+        <th>Statut</th>
+      </tr>
+    {/if}
   </thead>
   <tbody>
     {#if $nombreResultats.aucunResultat}

--- a/svelte/lib/tableauDesMesures/actionsTiroir.ts
+++ b/svelte/lib/tableauDesMesures/actionsTiroir.ts
@@ -1,0 +1,33 @@
+import { get } from 'svelte/store';
+import { metEnFormeMesures } from './tableauDesMesures.api';
+import type { MesureGenerale, MesureSpecifique } from './tableauDesMesures.d';
+import { mesures } from './stores/mesures.store';
+
+type MesureAEditer = {
+  mesure: MesureSpecifique | MesureGenerale;
+  metadonnees: {
+    typeMesure: 'GENERALE' | 'SPECIFIQUE';
+    idMesure: string | number;
+  };
+};
+
+export const afficheTiroirDeMesure = (mesureAEditer?: MesureAEditer) => {
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
+      detail: {
+        mesuresExistantes: metEnFormeMesures(get(mesures)),
+        titreTiroir:
+          mesureAEditer && mesureAEditer.metadonnees.typeMesure === 'GENERALE'
+            ? mesureAEditer.mesure.description
+            : '',
+        ...(mesureAEditer && { mesureAEditer }),
+      },
+    })
+  );
+};
+
+export const afficheTiroirExportDesMesures = () => {
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-affiche-tiroir-export-mesures')
+  );
+};

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -42,3 +42,9 @@ export type Mesures = {
   mesuresGenerales: Record<IdMesureGenerale, MesureGenerale>;
   mesuresSpecifiques: MesureSpecifique[];
 };
+
+export enum EtatEnregistrement {
+  Jamais,
+  EnCours,
+  Fait,
+}


### PR DESCRIPTION
Cette PR ajoute la ligne de titre au-dessus des champs, pour préparer l'arrivée des champs du plan d'action 👇 

![image](https://github.com/user-attachments/assets/358ade9d-9c8b-463e-8a98-8409b0b26403)


On en profite pour extraire `<BandeauActions />` pour gagner en lisibilité