### PR TITLE
[CORRECTION] Affiche un toast de changement de statut de mesure uniquement lorsque le statut est bien modifié

### DIFF
--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -17,6 +17,8 @@
   export let mesuresExistantes: MesuresExistantes;
   export let estLectureSeule: boolean;
 
+  const statutInitial = $store.mesureEditee.mesure.statut;
+
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
     enCoursEnvoi = true;
@@ -41,10 +43,12 @@
         detail: { sourceDeModification: 'tiroir' },
       })
     );
-    toasterStore.afficheToastChangementStatutMesure(
-      $store.mesureEditee.mesure,
-      statuts
-    );
+    if (statutInitial !== $store.mesureEditee.mesure.statut) {
+      toasterStore.afficheToastChangementStatutMesure(
+        $store.mesureEditee.mesure,
+        statuts
+      );
+    }
   };
 
   $: texteSurligne = $store.mesureEditee.mesure.descriptionLongue?.replace(


### PR DESCRIPTION
Car actuellement, on l'affiche dès l'enregistrement de la mesure.