### PR TITLE
[CI/CD] Autorise les déploiements sans `simple fast-forward` de git

### DIFF
--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -29,7 +29,7 @@ jobs:
           ID_ORGANISATION: ${{ secrets.CLEVER_CLOUD_ID_ORGANISATION }}
         run: |
           clever link -o="$ID_ORGANISATION" "$ID_APP"
-          clever deploy
+          clever deploy --force
 
   deploiement-prod:
     name: Déploiement en PROD


### PR DESCRIPTION
On veut pouvoir déployer même si on a rebase.
Autrement dit : on force le déploiement via la CLI pour que le déploiement puisse toujours se faire.