### PR TITLE
Ajoute la possibilité de générer un PDF via `puppeteer.connect()`

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -53,6 +53,10 @@ AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que le « Journal MSS » en 
 AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE= # `true` pour que les e-mails passants par l'adaptateur mémoire soient logués dans la console
 AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE= # `true` pour que les événements envoyés au tracking soient logués dans la console
 AVEC_CHIFFREMENT_PAR_VAULT= # `true` pour utiliser l'adaptateur de chiffrement qui utilise Vault. Cela nécessite de valoriser les variables d'environnement `CHIFFREMENT_…`.
+AVEC_GENERATION_PDF_EXTERNE= # `true` pour utiliser un puppeteer.connect() (au lieu de `.launch()`) pour la génération PDF. `true` nécessite les autres variables `GENERATION_PDF_`.
+
+GENERATION_PDF_URL_DU_SERVICE= # URL du servie de génération de PDF. Il s'agit de l'URL d'une instance de Browserless. En local : ws://mss-browserless:9090
+GENERATION_PDF_TOKEN_DU_SERVICE= # Token de connexion au Browserless. En local, doit correspondre au TOKEN déclaré dans le docker-compose : dev-en-local
 
 # Politique de cache
 CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,24 @@ services:
     volumes:
       - dbvol:/var/lib/postgresql/data
 
+  mss-browserless:
+    image: browserless/chrome:1.61-chrome-stable
+    environment:
+      - DEBUG=browserless:*
+      - MAX_CONCURRENT_SESSIONS=10
+      - CONNECTION_TIMEOUT=60000
+      - MAX_QUEUE_LENGTH=20
+      - PREBOOT_CHROME=true
+      - DEMO_MODE=false
+      - HOST=0.0.0.0
+      - ENABLE_DEBUGGER=false
+      - TOKEN=dev-en-local
+      - PORT=9090
+    networks:
+      - mss-network
+    ports:
+      - '9090:9090'
+
   test:
     <<: *configuration-base
     command: 'npm run test:watch'
@@ -51,6 +69,7 @@ services:
     depends_on:
       - mss-db
       - mss-crypto
+      - mss-browserless
 
   mss-crypto:
     image: hashicorp/vault:1.14


### PR DESCRIPTION
Il s'agit de générer un PDF en utilisant une instance Browserless non embarquée dans MSS.

Cette possibilité va, à terme, remplacer la génération PDF via le Chromium embarqué dans MSS.

On s'inspire de #1474 qui était un POC de l'utilisation de Browserless.

> [!IMPORTANT]
> Cette nouvelle feature s'active à l'aide de variables d'environnement :
> `AVEC_GENERATION_PDF_EXTERNE`
> `GENERATION_PDF_URL_DU_SERVICE`
> `GENERATION_PDF_TOKEN_DU_SERVICE`