### PR TITLE
Valide la priorité envoyée à l’API

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -41,6 +41,7 @@ class ErreurNiveauGraviteInconnu extends ErreurModele {}
 class ErreurNomServiceDejaExistant extends ErreurModele {}
 class ErreurRisqueInconnu extends ErreurModele {}
 class ErreurStatutDeploiementInvalide extends ErreurModele {}
+class ErreurPrioriteMesureInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
 class ErreurSuppressionImpossible extends Error {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
@@ -90,6 +91,7 @@ module.exports = {
   ErreurServiceInexistant,
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,
+  ErreurPrioriteMesureInvalide,
   ErreurSuppressionImpossible,
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,

--- a/src/modeles/mesure.js
+++ b/src/modeles/mesure.js
@@ -4,7 +4,10 @@
 */
 
 const InformationsHomologation = require('./informationsHomologation');
-const { ErreurStatutMesureInvalide } = require('../erreurs');
+const {
+  ErreurStatutMesureInvalide,
+  ErreurPrioriteMesureInvalide,
+} = require('../erreurs');
 
 const STATUTS = {
   STATUT_FAIT: 'fait',
@@ -43,10 +46,19 @@ class Mesure extends InformationsHomologation {
     return Object.values(STATUTS).includes(statut);
   }
 
-  static valide({ statut }) {
+  static valide({ statut, priorite }, referentiel) {
     if (statut && !this.statutsPossibles().includes(statut)) {
       throw new ErreurStatutMesureInvalide(
         `Le statut "${statut}" est invalide`
+      );
+    }
+
+    if (
+      priorite &&
+      !Object.keys(referentiel.prioritesMesures()).includes(priorite)
+    ) {
+      throw new ErreurPrioriteMesureInvalide(
+        `La priorité "${priorite}" est invalide`
       );
     }
   }

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -37,8 +37,8 @@ class MesureGenerale extends Mesure {
     return Mesure.statutRenseigne(this.statut);
   }
 
-  static valide({ id, statut }, referentiel) {
-    super.valide({ statut }, referentiel);
+  static valide({ id, statut, priorite }, referentiel) {
+    super.valide({ statut, priorite }, referentiel);
 
     const identifiantsMesuresRepertoriees = referentiel.identifiantsMesures();
     if (!identifiantsMesuresRepertoriees.includes(id)) {

--- a/src/modeles/mesureSpecifique.js
+++ b/src/modeles/mesureSpecifique.js
@@ -30,8 +30,8 @@ class MesureSpecifique extends Mesure {
     return ['description', 'categorie', 'statut'];
   }
 
-  static valide({ categorie, statut }, referentiel) {
-    super.valide({ statut });
+  static valide({ categorie, statut, priorite }, referentiel) {
+    super.valide({ statut, priorite }, referentiel);
 
     const identifiantsCategoriesMesures =
       referentiel.identifiantsCategoriesMesures();

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -11,6 +11,7 @@ const {
   ErreurStatutMesureInvalide,
   ErreurMesureInconnue,
   ErreurDonneesReferentielIncorrectes,
+  ErreurPrioriteMesureInvalide,
 } = require('../../erreurs');
 const ActeursHomologation = require('../../modeles/acteursHomologation');
 const Avis = require('../../modeles/avis');
@@ -241,7 +242,8 @@ const routesConnecteApiService = ({
       } catch (e) {
         if (
           e instanceof ErreurCategorieInconnue ||
-          e instanceof ErreurStatutMesureInvalide
+          e instanceof ErreurStatutMesureInvalide ||
+          e instanceof ErreurPrioriteMesureInvalide
         ) {
           reponse.status(400).send(e.message);
           return;
@@ -273,7 +275,8 @@ const routesConnecteApiService = ({
       } catch (e) {
         if (
           e instanceof ErreurMesureInconnue ||
-          e instanceof ErreurStatutMesureInvalide
+          e instanceof ErreurStatutMesureInvalide ||
+          e instanceof ErreurPrioriteMesureInvalide
         ) {
           reponse.status(400).send('La mesure est invalide.');
           return;

--- a/test/modeles/mesure.spec.js
+++ b/test/modeles/mesure.spec.js
@@ -1,6 +1,8 @@
 const expect = require('expect.js');
 
 const Mesure = require('../../src/modeles/mesure');
+const { ErreurPrioriteMesureInvalide } = require('../../src/erreurs');
+const Referentiel = require('../../src/referentiel');
 
 const elle = it;
 
@@ -50,6 +52,30 @@ describe('Une mesure', () => {
 
     elle("répond défavorablement quand le statut n'est pas renseigné", () => {
       expect(Mesure.statutRenseigne()).to.be(false);
+    });
+  });
+
+  describe('sur validation de la priorite', () => {
+    it("ne valide pas si la priorité n'est pas dans le référentiel", () => {
+      const referentiel = Referentiel.creeReferentielVide();
+      referentiel.enrichis({ prioritesMesures: {} });
+
+      try {
+        Mesure.valide({ priorite: 'inconnue' }, referentiel);
+        expect().fail('L’appel aurait dû lancer une exception');
+      } catch (e) {
+        expect(e).to.be.an(ErreurPrioriteMesureInvalide);
+        expect(e.message).to.be('La priorité "inconnue" est invalide');
+      }
+    });
+
+    it('valide la priorité si elle est dans le référentiel', () => {
+      const referentiel = Referentiel.creeReferentielVide();
+      referentiel.enrichis({
+        prioritesMesures: { p1: { libelleCourt: '', libelleComplet: '' } },
+      });
+
+      Mesure.valide({ priorite: 'p1' }, referentiel);
     });
   });
 });

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -3,6 +3,7 @@ const expect = require('expect.js');
 const {
   ErreurMesureInconnue,
   ErreurStatutMesureInvalide,
+  ErreurPrioriteMesureInvalide,
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 const MesureGenerale = require('../../src/modeles/mesureGenerale');
@@ -74,6 +75,20 @@ describe('Une mesure de sécurité', () => {
     }
   });
 
+  it('vérifie la valeur de la priorité', () => {
+    referentiel.enrichis({ prioritesMesures: {} });
+    try {
+      new MesureGenerale(
+        { id: 'identifiantMesure', priorite: 'prioriteInvalide' },
+        referentiel
+      );
+      expect().fail('La création de la mesure aurait dû lever une exception');
+    } catch (e) {
+      expect(e).to.be.a(ErreurPrioriteMesureInvalide);
+      expect(e.message).to.equal('La priorité "prioriteInvalide" est invalide');
+    }
+  });
+
   it('connaît sa description', () => {
     expect(referentiel.mesures().identifiantMesure.description).to.equal(
       'Une description'
@@ -129,6 +144,7 @@ describe('Une mesure de sécurité', () => {
   });
 
   it('connait sa priorité', () => {
+    referentiel.enrichis({ prioritesMesures: { p2: {} } });
     const mesure = new MesureGenerale(
       { id: 'identifiantMesure', priorite: 'p2' },
       referentiel

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -3,6 +3,7 @@ const expect = require('expect.js');
 const {
   ErreurCategorieInconnue,
   ErreurStatutMesureInvalide,
+  ErreurPrioriteMesureInvalide,
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 const InformationsHomologation = require('../../src/modeles/informationsHomologation');
@@ -16,6 +17,8 @@ describe('Une mesure spécifique', () => {
   });
 
   elle('sait se décrire', () => {
+    referentiel.enrichis({ prioritesMesures: { p3: {} } });
+
     const mesure = new MesureSpecifique(
       {
         description: 'Une mesure spécifique',
@@ -68,6 +71,17 @@ describe('Une mesure spécifique', () => {
       expect(e).to.be.an(ErreurStatutMesureInvalide);
       expect(e.message).to.equal('Le statut "statutInconnu" est invalide');
       done();
+    }
+  });
+
+  it('vérifie la valeur de la priorité', () => {
+    referentiel.enrichis({ prioritesMesures: {} });
+    try {
+      new MesureSpecifique({ priorite: 'prioriteInvalide' }, referentiel);
+      expect().fail('La création de la mesure aurait dû lever une exception');
+    } catch (e) {
+      expect(e).to.be.a(ErreurPrioriteMesureInvalide);
+      expect(e.message).to.equal('La priorité "prioriteInvalide" est invalide');
     }
   });
 

--- a/test/modeles/objetsPDF/objetPDFAnnexeMesures.spec.js
+++ b/test/modeles/objetsPDF/objetPDFAnnexeMesures.spec.js
@@ -16,7 +16,8 @@ describe("L'objet PDF de l'annexe des mesures", () => {
       CNIL: 'la ',
     },
   };
-  const referentiel = Referentiel.creeReferentiel(donneesReferentiel);
+  const referentiel = Referentiel.creeReferentielVide();
+  referentiel.enrichis(donneesReferentiel);
   const homologation = new Homologation(
     {
       id: '123',

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -474,6 +474,28 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         expect(e.response.data).to.be('Le statut "plop" est invalide');
       }
     });
+
+    it('retourne une erreur HTTP 400 si la priorite est inconnue', async () => {
+      testeur.depotDonnees().metsAJourMesuresSpecifiquesDuService =
+        async () => {};
+
+      try {
+        await axios.put(
+          'http://localhost:1234/api/service/456/mesures-specifiques',
+          [
+            {
+              description: 'd1',
+              categorie: 'uneCategorie',
+              priorite: 'plop',
+            },
+          ]
+        );
+        expect().fail('L’appel aurait dû lever une erreur');
+      } catch (e) {
+        expect(e.response.status).to.be(400);
+        expect(e.response.data).to.be('La priorité "plop" est invalide');
+      }
+    });
   });
 
   describe('quand requête PUT sur `/api/service/:id/mesures/:idMesure`', () => {
@@ -552,9 +574,26 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(donneesRecues.statut).to.equal('fait');
     });
 
-    it('renvoie une erreur 400 si la mesure est invalide', async () => {
+    it('renvoie une erreur 400 si la mesure est invalide à cause du statut', async () => {
       const mesureGenerale = {
         statut: 'invalide',
+      };
+
+      try {
+        await axios.put(
+          'http://localhost:1234/api/service/456/mesures/audit',
+          mesureGenerale
+        );
+        expect().fail("L'appel aurait du lever une erreur.");
+      } catch (e) {
+        expect(e.response.status).to.be(400);
+        expect(e.response.data).to.be('La mesure est invalide.');
+      }
+    });
+
+    it('renvoie une erreur 400 si la mesure est invalide à cause de la priorité', async () => {
+      const mesureGenerale = {
+        priorite: 'invalide',
       };
 
       try {


### PR DESCRIPTION
Lors d’une mise à jour d’une mesure générale ou des mesures spécifiques, une erreur 400 est renvoyée si la priorité n’est pas dans le référentiel. 