### PR TITLE
[SOIN] Nettoie le modèle pour remplacer homologation en service

### DIFF
--- a/migrations/20240802092436_supprimeIdHomologationDansAutorisation.js
+++ b/migrations/20240802092436_supprimeIdHomologationDansAutorisation.js
@@ -1,0 +1,21 @@
+exports.up = (knex) =>
+  knex('autorisations').then((lignes) => {
+    const suppressions = lignes.map(
+      ({ id, donnees: { idHomologation: _, ...autresDonnees } }) =>
+        knex('autorisations').where({ id }).update({ donnees: autresDonnees })
+    );
+    return Promise.all(suppressions);
+  });
+
+exports.down = (knex) =>
+  knex('autorisations').then((lignes) => {
+    const ajouts = lignes.map(
+      ({ id, donnees: { idService, ...autresDonnees } }) =>
+        knex('autorisations')
+          .where({ id })
+          .update({
+            donnees: { ...autresDonnees, idService, idHomologation: idService },
+          })
+    );
+    return Promise.all(ajouts);
+  });

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -84,7 +84,7 @@ const nouvelAdaptateur = (
 
   const homologations = (idUtilisateur) =>
     autorisations(idUtilisateur).then((as) =>
-      Promise.all(as.map(({ idHomologation }) => service(idHomologation)))
+      Promise.all(as.map(({ idService }) => service(idService)))
     );
 
   const tousLesServices = async () => {

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -75,7 +75,7 @@ const nouvelAdaptateur = (env) => {
         knex.raw("(a.donnees->>'idUtilisateur')::uuid"),
         'u.id'
       )
-      .whereRaw("(a.donnees->>'idHomologation')::uuid = ?", id)
+      .whereRaw("(a.donnees->>'idService')::uuid = ?", id)
       .select({
         id: 'u.id',
         dateCreation: 'u.date_creation',
@@ -114,7 +114,7 @@ const nouvelAdaptateur = (env) => {
     knex('homologations')
       .join(
         'autorisations',
-        knex.raw("(autorisations.donnees->>'idHomologation')::uuid"),
+        knex.raw("(autorisations.donnees->>'idService')::uuid"),
         'homologations.id'
       )
       .whereRaw("autorisations.donnees->>'idUtilisateur'=?", idUtilisateur)
@@ -131,8 +131,8 @@ const nouvelAdaptateur = (env) => {
   const homologations = (idUtilisateur) => {
     const idsHomologations = knex('autorisations')
       .whereRaw("(donnees->>'idUtilisateur')::uuid = ?", idUtilisateur)
-      .select({ idHomologation: knex.raw("(donnees->>'idHomologation')") })
-      .then((lignes) => lignes.map(({ idHomologation }) => idHomologation));
+      .select({ idService: knex.raw("(donnees->>'idService')") })
+      .then((lignes) => lignes.map(({ idService }) => idService));
 
     return avecPMapPourChaqueElement(idsHomologations, service);
   };
@@ -172,12 +172,12 @@ const nouvelAdaptateur = (env) => {
 
   const autorisation = (id) => elementDeTable('autorisations', id);
 
-  const autorisationPour = (idUtilisateur, idHomologation) =>
+  const autorisationPour = (idUtilisateur, idService) =>
     knex('autorisations')
-      .whereRaw(
-        "donnees->>'idUtilisateur'=? and donnees->>'idHomologation'=?",
-        [idUtilisateur, idHomologation]
-      )
+      .whereRaw("donnees->>'idUtilisateur'=? and donnees->>'idService'=?", [
+        idUtilisateur,
+        idService,
+      ])
       .first()
       .then(convertisLigneEnObjet)
       .catch(() => undefined);
@@ -245,12 +245,12 @@ const nouvelAdaptateur = (env) => {
     else await ajouteLigneDansTable('autorisations', id, donneesAutorisation);
   };
 
-  const supprimeAutorisation = (idUtilisateur, idHomologation) =>
+  const supprimeAutorisation = (idUtilisateur, idService) =>
     knex('autorisations')
-      .whereRaw(
-        "donnees->>'idUtilisateur'=? and donnees->>'idHomologation'=?",
-        [idUtilisateur, idHomologation]
-      )
+      .whereRaw("donnees->>'idUtilisateur'=? and donnees->>'idService'=?", [
+        idUtilisateur,
+        idService,
+      ])
       .del();
 
   const supprimeAutorisations = () => knex('autorisations').del();
@@ -261,10 +261,8 @@ const nouvelAdaptateur = (env) => {
       .whereRaw("(donnees->>'estProprietaire')::boolean=false")
       .del();
 
-  const supprimeAutorisationsHomologation = (idHomologation) =>
-    knex('autorisations')
-      .whereRaw("donnees->>'idHomologation'=?", idHomologation)
-      .del();
+  const supprimeAutorisationsHomologation = (idService) =>
+    knex('autorisations').whereRaw("donnees->>'idService'=?", idService).del();
 
   const lisParcoursUtilisateur = async (id) =>
     elementDeTable('parcours_utilisateurs', id);

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -29,7 +29,7 @@ const creeDepot = (config = {}) => {
   const accesAutorise = async (idUtilisateur, idHomologation, droitsRequis) => {
     const as = await autorisations(idUtilisateur);
     const autorisationPourService = as.find(
-      (a) => a.idHomologation === idHomologation
+      (a) => a.idService === idHomologation
     );
 
     if (!autorisationPourService) return false;

--- a/src/modeles/autorisations/autorisation.js
+++ b/src/modeles/autorisations/autorisation.js
@@ -14,7 +14,6 @@ class Autorisation extends Base {
         'estProprietaire',
         'id',
         'idUtilisateur',
-        'idHomologation',
         'idService',
         'droits',
         'type',

--- a/src/modeles/autorisations/autorisation.js
+++ b/src/modeles/autorisations/autorisation.js
@@ -92,7 +92,6 @@ class Autorisation extends Base {
       estProprietaire: this.estProprietaire,
       id: this.id,
       idService: this.idService,
-      idHomologation: this.idService,
       idUtilisateur: this.idUtilisateur,
       droits: this.droits,
     };

--- a/src/modeles/homologation.js
+++ b/src/modeles/homologation.js
@@ -241,8 +241,8 @@ class Homologation {
     return this.statistiquesMesuresGenerales().recommandees();
   }
 
-  statutSaisie(nomInformationsHomologation) {
-    return this[nomInformationsHomologation].statutSaisie();
+  statutSaisie(nomInformationsService) {
+    return this[nomInformationsService].statutSaisie();
   }
 
   structureDeveloppement() {

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -2,7 +2,7 @@ const express = require('express');
 const { decode } = require('html-entities');
 const Utilisateur = require('../../modeles/utilisateur');
 const Service = require('../../modeles/service');
-const InformationsHomologation = require('../../modeles/informationsService');
+const InformationsService = require('../../modeles/informationsService');
 const routesConnectePageService = require('./routesConnectePageService');
 
 const routesConnectePage = ({
@@ -103,7 +103,7 @@ const routesConnectePage = ({
 
       if (idEtape === 'decrire') {
         reponse.render('service/creation', {
-          InformationsHomologation,
+          InformationsHomologation: InformationsService,
           referentiel,
           service,
           etapeActive: 'descriptionService',
@@ -115,7 +115,7 @@ const routesConnectePage = ({
 
         service.indiceCyber = () => ({ total: 4.3 });
         reponse.render('service/mesures', {
-          InformationsHomologation,
+          InformationsHomologation: InformationsService,
           referentiel,
           service,
           etapeActive: 'mesures',
@@ -124,7 +124,7 @@ const routesConnectePage = ({
         });
       } else if (idEtape === 'homologuer') {
         reponse.render('service/dossiers', {
-          InformationsHomologation,
+          InformationsHomologation: InformationsService,
           decode,
           service,
           etapeActive: 'dossiers',

--- a/src/routes/connecte/routesConnectePageService.js
+++ b/src/routes/connecte/routesConnectePageService.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const { decode } = require('html-entities');
 
-const InformationsHomologation = require('../../modeles/informationsService');
+const InformationsService = require('../../modeles/informationsService');
 
 const {
   Permissions,
@@ -37,7 +37,7 @@ const routesConnectePageService = ({
         .utilisateur(idUtilisateurCourant)
         .then((utilisateur) => {
           reponse.render('service/creation', {
-            InformationsHomologation,
+            InformationsHomologation: InformationsService,
             referentiel,
             service: Service.creePourUnUtilisateur(utilisateur),
             etapeActive: 'descriptionService',
@@ -85,7 +85,7 @@ const routesConnectePageService = ({
         reponse.locals.autorisationsService?.DECRIRE?.estLectureSeule;
 
       reponse.render('service/descriptionService', {
-        InformationsHomologation,
+        InformationsHomologation: InformationsService,
         referentiel,
         service,
         etapeActive: 'descriptionService',
@@ -116,7 +116,7 @@ const routesConnectePageService = ({
       );
 
       reponse.render('service/mesures', {
-        InformationsHomologation,
+        InformationsHomologation: InformationsService,
         referentiel,
         service,
         etapeActive: 'mesures',
@@ -176,7 +176,7 @@ const routesConnectePageService = ({
       const referentielConcernes =
         referentiel.formatteListeDeReferentiels(referentiels);
       reponse.render('service/indiceCyber', {
-        InformationsHomologation,
+        InformationsHomologation: InformationsService,
         service,
         etapeActive: 'mesures',
         referentiel,
@@ -193,7 +193,7 @@ const routesConnectePageService = ({
     (requete, reponse) => {
       const { service } = requete;
       reponse.render('service/rolesResponsabilites', {
-        InformationsHomologation,
+        InformationsHomologation: InformationsService,
         service,
         etapeActive: 'contactsUtiles',
         referentiel,
@@ -209,7 +209,7 @@ const routesConnectePageService = ({
     (requete, reponse) => {
       const { service } = requete;
       reponse.render('service/risques', {
-        InformationsHomologation,
+        InformationsHomologation: InformationsService,
         referentiel,
         service,
         etapeActive: 'risques',
@@ -231,7 +231,7 @@ const routesConnectePageService = ({
         ) && service.dossiers.aUnDossierEnCoursDeValidite();
 
       reponse.render('service/dossiers', {
-        InformationsHomologation,
+        InformationsHomologation: InformationsService,
         decode,
         service,
         etapeActive: 'dossiers',
@@ -272,7 +272,7 @@ const routesConnectePageService = ({
         }
 
         reponse.render(`service/etapeDossier/${idEtape}`, {
-          InformationsHomologation,
+          InformationsHomologation: InformationsService,
           referentiel,
           service: s,
           etapeActive: 'dossiers',

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -109,7 +109,7 @@ describe('Le dépôt de données des autorisations', () => {
       expect(a.estProprietaire).to.be(true);
       expect(a.id).to.equal('456');
       expect(a.idUtilisateur).to.equal('999');
-      expect(a.idHomologation).to.equal('123');
+      expect(a.idService).to.equal('123');
     });
 
     it("retourne `undefined` si l'autorisation est inexistante", async () => {
@@ -217,7 +217,6 @@ describe('Le dépôt de données des autorisations', () => {
       const a = await depot.autorisation('789');
 
       expect(a.estProprietaire).to.be(false);
-      expect(a.idHomologation).to.equal('123');
       expect(a.idService).to.equal('123');
       expect(a.idUtilisateur).to.equal('000');
       expect(a.droits).to.eql({

--- a/test/depots/depotDonneesHomologations.spec.js
+++ b/test/depots/depotDonneesHomologations.spec.js
@@ -660,7 +660,6 @@ describe('Le dépôt de données des homologations', () => {
       expect(apres.length).to.equal(1);
       const autorisation = apres[0];
       expect(autorisation.estProprietaire).to.be(true);
-      expect(autorisation.idHomologation).to.equal('unUUID');
       expect(autorisation.idService).to.equal('unUUID');
       expect(autorisation.idUtilisateur).to.equal('123');
       expect(autorisation.droits).to.eql({

--- a/test/modeles/autorisations/autorisation.spec.js
+++ b/test/modeles/autorisations/autorisation.spec.js
@@ -237,7 +237,6 @@ describe('Une autorisation', () => {
         estProprietaire: false,
         id: 'uuid',
         idService: '123',
-        idHomologation: '123',
         idUtilisateur: '999',
         droits: {
           CONTACTS: 2,
@@ -261,7 +260,6 @@ describe('Une autorisation', () => {
         estProprietaire: true,
         id: 'uuid',
         idService: '123',
-        idHomologation: '123',
         idUtilisateur: '999',
         droits: {
           CONTACTS: 2,

--- a/test/modeles/avis.spec.js
+++ b/test/modeles/avis.spec.js
@@ -5,7 +5,7 @@ const {
   ErreurAvisInvalide,
 } = require('../../src/erreurs');
 const Avis = require('../../src/modeles/avis');
-const InformationsHomologation = require('../../src/modeles/informationsService');
+const InformationsService = require('../../src/modeles/informationsService');
 const Referentiel = require('../../src/referentiel');
 
 describe("Un avis sur un dossier d'homologation", () => {
@@ -24,7 +24,7 @@ describe("Un avis sur un dossier d'homologation", () => {
       referentiel
     );
 
-    expect(avis.statutSaisie()).to.be(InformationsHomologation.COMPLETES);
+    expect(avis.statutSaisie()).to.be(InformationsService.COMPLETES);
   });
 
   it("est incomplet si la liste des collaborateurs n'est pas remplie", () => {
@@ -33,7 +33,7 @@ describe("Un avis sur un dossier d'homologation", () => {
         { statut: 'favorable', dureeValidite: 'unAn', collaborateurs },
         referentiel
       );
-      expect(avis.statutSaisie()).to.be(InformationsHomologation.A_COMPLETER);
+      expect(avis.statutSaisie()).to.be(InformationsService.A_COMPLETER);
     };
 
     verifieAvecCollaborateurs([null]);

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -6,7 +6,7 @@ const {
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 const DescriptionService = require('../../src/modeles/descriptionService');
-const InformationsHomologation = require('../../src/modeles/informationsService');
+const InformationsService = require('../../src/modeles/informationsService');
 
 const elle = it;
 
@@ -189,7 +189,7 @@ describe('La description du service', () => {
   elle("détecte qu'elle est encore à saisir", () => {
     const descriptionService = new DescriptionService();
     expect(descriptionService.statutSaisie()).to.equal(
-      InformationsHomologation.A_SAISIR
+      InformationsService.A_SAISIR
     );
   });
 
@@ -198,7 +198,7 @@ describe('La description du service', () => {
       nomService: 'Super Service',
     });
     expect(descriptionService.statutSaisie()).to.equal(
-      InformationsHomologation.A_COMPLETER
+      InformationsService.A_COMPLETER
     );
   });
 
@@ -219,7 +219,7 @@ describe('La description du service', () => {
         referentielAvecStatutValide('accessible')
       );
       expect(descriptionService.statutSaisie()).to.equal(
-        InformationsHomologation.A_COMPLETER
+        InformationsService.A_COMPLETER
       );
     }
   );
@@ -241,7 +241,7 @@ describe('La description du service', () => {
     );
 
     expect(descriptionService.statutSaisie()).to.equal(
-      InformationsHomologation.COMPLETES
+      InformationsService.COMPLETES
     );
   });
 

--- a/test/modeles/homologation.spec.js
+++ b/test/modeles/homologation.spec.js
@@ -4,7 +4,7 @@ const uneDescriptionValide = require('../constructeurs/constructeurDescriptionSe
 const { unDossier } = require('../constructeurs/constructeurDossier');
 
 const Referentiel = require('../../src/referentiel');
-const InformationsHomologation = require('../../src/modeles/informationsService');
+const InformationsService = require('../../src/modeles/informationsService');
 const Homologation = require('../../src/modeles/homologation');
 const MesureGenerale = require('../../src/modeles/mesureGenerale');
 const Utilisateur = require('../../src/modeles/utilisateur');
@@ -395,7 +395,7 @@ describe('Une homologation', () => {
       );
 
       expect(homologation.statutSaisie('mesures')).to.equal(
-        InformationsHomologation.A_COMPLETER
+        InformationsService.A_COMPLETER
       );
     });
 
@@ -412,7 +412,7 @@ describe('Une homologation', () => {
       );
 
       expect(homologation.statutSaisie('mesures')).to.equal(
-        InformationsHomologation.COMPLETES
+        InformationsService.COMPLETES
       );
     });
   });
@@ -421,7 +421,7 @@ describe('Une homologation', () => {
     it('détecte que la liste des risques reste à vérifier', () => {
       const homologation = new Homologation({ id: '123' });
       expect(homologation.statutSaisie('risques')).to.equal(
-        InformationsHomologation.A_SAISIR
+        InformationsService.A_SAISIR
       );
     });
   });

--- a/test/modeles/informationsHomologation.spec.js
+++ b/test/modeles/informationsHomologation.spec.js
@@ -1,12 +1,12 @@
 /* eslint-disable max-classes-per-file */
 const expect = require('expect.js');
 
-const InformationsHomologation = require('../../src/modeles/informationsService');
+const InformationsService = require('../../src/modeles/informationsService');
 const ElementsConstructibles = require('../../src/modeles/elementsConstructibles');
 
 const elles = it;
 
-class AgregatAvecStatutSaisieDetermine extends InformationsHomologation {
+class AgregatAvecStatutSaisieDetermine extends InformationsService {
   constructor(donnees) {
     super({ proprietesAtomiquesFacultatives: ['statut'] });
     this.renseigneProprietes(donnees);
@@ -30,13 +30,13 @@ describe("Les informations d'une homologation", () => {
     elles(
       'retournent `COMPLETES` quand aucune propriété atomique requise',
       () => {
-        const objetMetier = new InformationsHomologation({
+        const objetMetier = new InformationsService({
           proprietesAtomiquesFacultatives: ['prop'],
         });
         objetMetier.renseigneProprietes({ prop: 'valeur' });
 
         expect(objetMetier.statutSaisieProprietesAtomiques()).to.equal(
-          InformationsHomologation.COMPLETES
+          InformationsService.COMPLETES
         );
       }
     );
@@ -47,7 +47,7 @@ describe("Les informations d'une homologation", () => {
 
     beforeEach(
       () =>
-        (objetMetier = new InformationsHomologation({
+        (objetMetier = new InformationsService({
           listesAgregats: { agregats1: Agregats, agregats2: Agregats },
         }))
     );
@@ -56,12 +56,12 @@ describe("Les informations d'une homologation", () => {
       'retournent `COMPLETES` si tous les agrégats ont pour statut `COMPLETES`',
       () => {
         objetMetier.renseigneProprietes({
-          agregats1: [{ statut: InformationsHomologation.COMPLETES }],
-          agregats2: [{ statut: InformationsHomologation.COMPLETES }],
+          agregats1: [{ statut: InformationsService.COMPLETES }],
+          agregats2: [{ statut: InformationsService.COMPLETES }],
         });
 
         expect(objetMetier.statutSaisieAgregats()).to.equal(
-          InformationsHomologation.COMPLETES
+          InformationsService.COMPLETES
         );
       }
     );
@@ -69,7 +69,7 @@ describe("Les informations d'une homologation", () => {
     elles("retournent `A_SAISIR` si aucun agrégat n'est saisi", () => {
       objetMetier.renseigneProprietes({ agregats1: [], agregats2: [] });
       expect(objetMetier.statutSaisieAgregats()).to.equal(
-        InformationsHomologation.A_SAISIR
+        InformationsService.A_SAISIR
       );
     });
 
@@ -77,12 +77,12 @@ describe("Les informations d'une homologation", () => {
       "retournent `COMPLETES` s'il y a au moins un agrégat saisi et si aucun n'est à compléter",
       () => {
         objetMetier.renseigneProprietes({
-          agregats1: [{ statut: InformationsHomologation.COMPLETES }],
+          agregats1: [{ statut: InformationsService.COMPLETES }],
           agregats2: [],
         });
 
         expect(objetMetier.statutSaisieAgregats()).to.equal(
-          InformationsHomologation.COMPLETES
+          InformationsService.COMPLETES
         );
       }
     );
@@ -91,12 +91,12 @@ describe("Les informations d'une homologation", () => {
       'retournent `A_COMPLETER` si au moins un des agrégats a pour statut `A_COMPLETER`',
       () => {
         objetMetier.renseigneProprietes({
-          agregats1: [{ statut: InformationsHomologation.A_COMPLETER }],
-          agregats2: [{ statut: InformationsHomologation.COMPLETES }],
+          agregats1: [{ statut: InformationsService.A_COMPLETER }],
+          agregats2: [{ statut: InformationsService.COMPLETES }],
         });
 
         expect(objetMetier.statutSaisieAgregats()).to.equal(
-          InformationsHomologation.A_COMPLETER
+          InformationsService.A_COMPLETER
         );
       }
     );
@@ -107,7 +107,7 @@ describe("Les informations d'une homologation", () => {
 
     beforeEach(
       () =>
-        (objetMetier = new InformationsHomologation({
+        (objetMetier = new InformationsService({
           proprietesAtomiquesRequises: ['propriete', 'autrePropriete'],
           listesAgregats: { agregats: Agregats },
         }))
@@ -117,10 +117,10 @@ describe("Les informations d'une homologation", () => {
       'retournent `A_COMPLETER` si les agrégats ont pour statut `A_COMPLETER`',
       () => {
         objetMetier.renseigneProprietes({
-          agregats: [{ statut: InformationsHomologation.A_COMPLETER }],
+          agregats: [{ statut: InformationsService.A_COMPLETER }],
         });
         expect(objetMetier.statutSaisie()).to.equal(
-          InformationsHomologation.A_COMPLETER
+          InformationsService.A_COMPLETER
         );
       }
     );
@@ -131,10 +131,10 @@ describe("Les informations d'une homologation", () => {
         objetMetier.renseigneProprietes({
           propriete: 'valeur',
           autrePropriete: 'autre valeur',
-          agregats: [{ statut: InformationsHomologation.COMPLETES }],
+          agregats: [{ statut: InformationsService.COMPLETES }],
         });
         expect(objetMetier.statutSaisie()).to.equal(
-          InformationsHomologation.COMPLETES
+          InformationsService.COMPLETES
         );
       }
     );
@@ -143,10 +143,10 @@ describe("Les informations d'une homologation", () => {
       'retournent `A_COMPLETER` si les agrégats sont saisis mais pas les propriétés atomiques',
       () => {
         objetMetier.renseigneProprietes({
-          agregats: [{ statut: InformationsHomologation.COMPLETES }],
+          agregats: [{ statut: InformationsService.COMPLETES }],
         });
         expect(objetMetier.statutSaisie()).to.equal(
-          InformationsHomologation.A_COMPLETER
+          InformationsService.A_COMPLETER
         );
       }
     );
@@ -156,16 +156,14 @@ describe("Les informations d'une homologation", () => {
       () => {
         objetMetier.renseigneProprietes({ propriete: 'valeur' });
         expect(objetMetier.statutSaisie()).to.equal(
-          InformationsHomologation.A_COMPLETER
+          InformationsService.A_COMPLETER
         );
       }
     );
 
     elles('retournent `A_SAISIR` si aucune information saisie', () => {
       objetMetier.renseigneProprietes({});
-      expect(objetMetier.statutSaisie()).to.equal(
-        InformationsHomologation.A_SAISIR
-      );
+      expect(objetMetier.statutSaisie()).to.equal(InformationsService.A_SAISIR);
     });
   });
 });

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -7,7 +7,7 @@ const {
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 const MesureGenerale = require('../../src/modeles/mesureGenerale');
-const InformationsHomologation = require('../../src/modeles/informationsService');
+const InformationsService = require('../../src/modeles/informationsService');
 
 describe('Une mesure de sécurité', () => {
   let referentiel;
@@ -163,6 +163,6 @@ describe('Une mesure de sécurité', () => {
       referentiel
     );
 
-    expect(mesure.statutSaisie()).to.equal(InformationsHomologation.COMPLETES);
+    expect(mesure.statutSaisie()).to.equal(InformationsService.COMPLETES);
   });
 });

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -6,7 +6,7 @@ const {
   ErreurPrioriteMesureInvalide,
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
-const InformationsHomologation = require('../../src/modeles/informationsService');
+const InformationsService = require('../../src/modeles/informationsService');
 const MesureSpecifique = require('../../src/modeles/mesureSpecifique');
 
 const elle = it;
@@ -57,9 +57,7 @@ describe('Une mesure spécifique', () => {
         referentiel
       );
 
-      expect(mesure.statutSaisie()).to.equal(
-        InformationsHomologation.COMPLETES
-      );
+      expect(mesure.statutSaisie()).to.equal(InformationsService.COMPLETES);
     }
   );
 

--- a/test/modeles/partiesPrenantes/partiePrenante.spec.js
+++ b/test/modeles/partiesPrenantes/partiePrenante.spec.js
@@ -1,7 +1,7 @@
 const expect = require('expect.js');
 
 const PartiePrenante = require('../../../src/modeles/partiesPrenantes/partiePrenante');
-const InformationsHomologation = require('../../../src/modeles/informationsService');
+const InformationsService = require('../../../src/modeles/informationsService');
 
 const elle = it;
 
@@ -12,7 +12,7 @@ describe('Une partie prenante', () => {
     const partiePrenante = new PartiePrenante({ nom: 'hébergeur' });
 
     expect(partiePrenante.statutSaisie()).to.equal(
-      InformationsHomologation.COMPLETES
+      InformationsService.COMPLETES
     );
   });
 
@@ -20,7 +20,7 @@ describe('Une partie prenante', () => {
     const partiePrenante = new PartiePrenante();
 
     expect(partiePrenante.statutSaisie()).to.equal(
-      InformationsHomologation.A_SAISIR
+      InformationsService.A_SAISIR
     );
   });
 

--- a/test/modeles/rolesResponsabilites.spec.js
+++ b/test/modeles/rolesResponsabilites.spec.js
@@ -1,6 +1,6 @@
 const expect = require('expect.js');
 
-const InformationsHomologation = require('../../src/modeles/informationsService');
+const InformationsService = require('../../src/modeles/informationsService');
 const Hebergement = require('../../src/modeles/partiesPrenantes/hebergement');
 const RolesResponsabilites = require('../../src/modeles/rolesResponsabilites');
 
@@ -97,7 +97,7 @@ describe("L'ensemble des rôles et responsabilités", () => {
   it('détermine le statut de saisie', () => {
     const rolesResponsabilites = new RolesResponsabilites();
     expect(rolesResponsabilites.statutSaisie()).to.equal(
-      InformationsHomologation.A_SAISIR
+      InformationsService.A_SAISIR
     );
   });
 


### PR DESCRIPTION
- fin du renommage des informations de service
- suppression de l’id d’homologation de la table `autorisations` (doublé avec le champ idService)