### PR TITLE
[SÉCURISER] Ajoute un titre au tiroir lors de l'ajout d'une mesure spécifique

### DIFF
--- a/svelte/lib/tableauDesMesures/actionsTiroir.ts
+++ b/svelte/lib/tableauDesMesures/actionsTiroir.ts
@@ -19,7 +19,7 @@ export const afficheTiroirDeMesure = (mesureAEditer?: MesureAEditer) => {
         titreTiroir:
           mesureAEditer && mesureAEditer.metadonnees.typeMesure === 'GENERALE'
             ? mesureAEditer.mesure.description
-            : '',
+            : 'Ajouter une mesure',
         ...(mesureAEditer && { mesureAEditer }),
       },
     })


### PR DESCRIPTION
... afin de ne pas avoir un entête vide.

<img src="https://github.com/user-attachments/assets/cb87d4d6-0a1c-4895-8a63-b23811f91483" height=400 />
