### PR TITLE
[PLAN D'ACTION] Ajout du champ "Échéance" dans le tableau des mesures

### DIFF
--- a/public/assets/images/icone_calendrier.svg
+++ b/public/assets/images/icone_calendrier.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 2.00012V5.00012" stroke="#667892" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 2.00012V5.00012" stroke="#667892" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.2 21.4001C19.9673 21.4001 21.4 19.9674 21.4 18.2001C21.4 16.4328 19.9673 15.0001 18.2 15.0001C16.4327 15.0001 15 16.4328 15 18.2001C15 19.9674 16.4327 21.4001 18.2 21.4001Z" stroke="#667892" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M22 22.0001L21 21.0001" stroke="#667892" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3.5 9.09009L20.5 9.09009" stroke="#667892" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.37 22.0001H8C4.5 22.0001 3 20.0001 3 17.0001L3 8.50012C3 5.50012 4.5 3.50012 8 3.50012L16 3.50012C19.5 3.50012 21 5.50012 21 8.50012V13.0001" stroke="#667892" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.9956 13.7001H12.0046" stroke="#667892" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.29443 13.7001H8.30341" stroke="#667892" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8.29443 16.7001H8.30341" stroke="#667892" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/svelte/lib/tableauDesMesures/BandeauActions.svelte
+++ b/svelte/lib/tableauDesMesures/BandeauActions.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <tr>
-  <th colspan="3">
+  <th colspan="4">
     <div class="actions">
       <button
         class="bouton-action-mesure"

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -159,7 +159,7 @@
 <table class="tableau-des-mesures">
   <thead>
     <tr class="ligne-onglet">
-      <th colspan="3">
+      <th colspan="4">
         <div class="conteneur-onglet">
           {#if $volumetrieMesures.totalSansStatut}
             <Onglet
@@ -198,6 +198,7 @@
         <th>Mesure</th>
         {#if affichePlanAction}
           <th>Priorité</th>
+          <th>Échéance</th>
         {/if}
         <th>Statut</th>
       </tr>
@@ -223,6 +224,10 @@
           }}
           on:modificationPriorite={(e) => {
             mesures.metAJourPrioriteMesureGenerale(id, e.detail.priorite);
+            metsAJourMesureGenerale(id);
+          }}
+          on:modificationEcheance={(e) => {
+            mesures.metAJourEcheanceMesureGenerale(id, e.detail.echeance);
             metsAJourMesureGenerale(id);
           }}
           on:click={() =>
@@ -252,6 +257,13 @@
             mesures.metAJourPrioriteMesureSpecifique(
               indexReel,
               e.detail.priorite
+            );
+            metsAJourMesuresSpecifiques(indexReel);
+          }}
+          on:modificationEcheance={(e) => {
+            mesures.metAJourEcheanceMesureSpecifique(
+              indexReel,
+              e.detail.echeance
             );
             metsAJourMesuresSpecifiques(indexReel);
           }}

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -16,6 +16,7 @@
   import CartoucheIdentifiantMesure from '../../ui/CartoucheIdentifiantMesure.svelte';
   import { rechercheTextuelle } from '../stores/rechercheTextuelle.store';
   import SelectionPriorite from '../../ui/SelectionPriorite.svelte';
+  import SelectionEcheance from './SelectionEcheance.svelte';
 
   type IdDom = string;
 
@@ -64,6 +65,13 @@
         {priorites}
         on:input={(e) =>
           dispatch('modificationPriorite', { priorite: e.detail.priorite })}
+      />
+    </td>
+    <td>
+      <SelectionEcheance
+        bind:echeance={mesure.echeance}
+        {estLectureSeule}
+        on:modificationEcheance
       />
     </td>
   {/if}

--- a/svelte/lib/tableauDesMesures/ligne/SelectionEcheance.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/SelectionEcheance.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import type { EcheanceMesure } from '../../ui/types';
+
+  export let echeance: string | undefined;
+  export let estLectureSeule = false;
+
+  let elementDate: HTMLInputElement;
+
+  const afficheSelectionDate = () => {
+    elementDate.showPicker();
+  };
+
+  const formatteur = new Intl.DateTimeFormat('fr-FR');
+  let dateFormatte: string | undefined = undefined;
+  $: {
+    try {
+      if (echeance) dateFormatte = formatteur.format(new Date(echeance));
+      else dateFormatte = undefined;
+    } catch (e) {
+      dateFormatte = undefined;
+    }
+  }
+
+  const dispatch = createEventDispatcher<{
+    modificationEcheance: { echeance: EcheanceMesure };
+  }>();
+  const modifieEcheance = () => {
+    if (echeance) dispatch('modificationEcheance', { echeance });
+  };
+</script>
+
+<div class="conteneur-date">
+  <button
+    type="button"
+    on:click|stopPropagation={afficheSelectionDate}
+    class:vide={!dateFormatte}
+    disabled={estLectureSeule}
+  >
+    {dateFormatte ?? 'Échéance'}
+  </button>
+  <input
+    type="date"
+    bind:value={echeance}
+    bind:this={elementDate}
+    on:change={modifieEcheance}
+  />
+</div>
+
+<style>
+  .conteneur-date {
+    position: relative;
+  }
+
+  input[type='date'] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    visibility: hidden;
+  }
+
+  button {
+    white-space: nowrap;
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 24px;
+    text-align: center;
+    color: var(--texte-clair);
+    border: none;
+    background: none;
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    gap: 6px;
+    align-items: center;
+    justify-content: start;
+  }
+
+  button.vide::before {
+    content: '';
+    width: 24px;
+    height: 24px;
+    display: flex;
+    background: url('/statique/assets/images/icone_calendrier.svg');
+  }
+</style>

--- a/svelte/lib/tableauDesMesures/stores/mesures.store.ts
+++ b/svelte/lib/tableauDesMesures/stores/mesures.store.ts
@@ -1,6 +1,6 @@
 import type { Mesures } from '../tableauDesMesures.d';
 import { writable } from 'svelte/store';
-import type { PrioriteMesure } from '../../ui/types';
+import type { EcheanceMesure, PrioriteMesure } from '../../ui/types';
 
 export const mesuresParDefaut = (): Mesures => ({
   mesuresGenerales: {},
@@ -14,6 +14,24 @@ export const mesures = {
   subscribe: toutesLesMesures.subscribe,
   reinitialise: (mesures?: Mesures) =>
     toutesLesMesures.set(mesures ?? mesuresParDefaut()),
+  metAJourEcheanceMesureGenerale: (
+    idMesure: string,
+    echeance: EcheanceMesure
+  ) => {
+    toutesLesMesures.update((valeur) => {
+      valeur.mesuresGenerales[idMesure].echeance = echeance;
+      return valeur;
+    });
+  },
+  metAJourEcheanceMesureSpecifique: (
+    idMesure: number,
+    echeance: EcheanceMesure
+  ) => {
+    toutesLesMesures.update((valeur) => {
+      valeur.mesuresSpecifiques[idMesure].echeance = echeance;
+      return valeur;
+    });
+  },
   metAJourStatutMesureGenerale: (idMesure: string, statut: string) =>
     toutesLesMesures.update((valeur) => {
       valeur.mesuresGenerales[idMesure].statut = statut;

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
@@ -72,6 +72,7 @@ export const enregistreMesureGenerale = async (
   await axios.put(`/api/service/${idService}/mesures/${idMesure}`, {
     statut: donneesMesure.statut,
     priorite: donneesMesure.priorite,
+    echeance: donneesMesure.echeance,
     ...(donneesMesure.modalites && { modalites: donneesMesure.modalites }),
   });
 };

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -1,4 +1,8 @@
-import { type PrioriteMesure, Referentiel } from '../ui/types.d';
+import {
+  type EcheanceMesure,
+  type PrioriteMesure,
+  Referentiel,
+} from '../ui/types.d';
 
 declare global {
   interface HTMLElementEventMap {
@@ -28,6 +32,7 @@ export type MesureGenerale = {
   referentiel: Referentiel;
   identifiantNumerique: string;
   priorite?: PrioriteMesure;
+  echeance?: EcheanceMesure;
 };
 
 export type MesureSpecifique = {
@@ -37,6 +42,7 @@ export type MesureSpecifique = {
   modalites: string;
   identifiantNumerique: string;
   priorite?: PrioriteMesure;
+  echeance?: EcheanceMesure;
 };
 
 export type IdMesureGenerale = string;

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -43,3 +43,5 @@ export type LibellePriorite = {
   libelleCourt: string;
   libelleComplet: string;
 };
+
+export type EcheanceMesure = string;


### PR DESCRIPTION
... afin de pouvoir assigner une date d'échéance pour une mesure.

Pour l'instant, le back-end n'en tient pas compte.

On utilise un subterfuge pour faire fonctionner le `<input type="date">` standard :
- On utilise un `input` de ce type, mais il est caché par dessus un bouton
- On affiche manuellement le sélecteur de date avec [showPicker()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker)
- On fait remonter l'événement de modification de valeur comme pour la priorité et le statut