### PR TITLE
[CORRECTION] Exécute correctement le script

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,3 +1,1 @@
-[
-  "* * * * * node $ROOT/scripts/taches/tacheEnvoieMailsNotificationExpiration.sh"
-]
+["* * * * * $ROOT/scripts/taches/tacheEnvoieMailsNotificationExpiration.sh"]


### PR DESCRIPTION
Inutile de lancer `node` : il s'agit d'un script shell à exécuter.