### PR TITLE
[CORRECTION] Décode les "/" des échéances

### DIFF
--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -263,6 +263,9 @@ const routesConnecteApiService = ({
     middleware.aseptise('statut', 'modalites', 'priorite', 'echeance'),
     async (requete, reponse, suite) => {
       const { service, idUtilisateurCourant, body, params } = requete;
+      if (body.echeance) {
+        body.echeance = body.echeance.replaceAll('&#x2F;', '/');
+      }
       const mesureGenerale = {
         ...body,
         id: params.idMesure,

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -231,8 +231,12 @@ const routesConnecteApiService = ({
         body: mesuresSpecifiques,
       } = requete;
       try {
+        const donneesMesuresSpecifiques = mesuresSpecifiques.map((m) => {
+          if (m.echeance) m.echeance = m.echeance.replaceAll('&#x2F;', '/');
+          return m;
+        });
         const mesures = new MesuresSpecifiques(
-          { mesuresSpecifiques },
+          { mesuresSpecifiques: donneesMesuresSpecifiques },
           referentiel
         );
         await depotDonnees.metsAJourMesuresSpecifiquesDuService(

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -647,6 +647,30 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         expect(e.response.data).to.be('La mesure est invalide.');
       }
     });
+
+    it("décode les 'slash' de la date d'échéance ", async () => {
+      const slash = '&#x2F;';
+      let donneesRecues;
+      testeur.depotDonnees().metsAJourMesureGeneraleDuService = (
+        _,
+        __,
+        donnees
+      ) => {
+        donneesRecues = donnees;
+      };
+
+      const mesureGenerale = {
+        statut: 'fait',
+        echeance: `01${slash}01${slash}2024`,
+      };
+
+      await axios.put(
+        'http://localhost:1234/api/service/456/mesures/audit',
+        mesureGenerale
+      );
+
+      expect(donneesRecues.echeance).to.equal('01/01/2024');
+    });
   });
 
   describe('quand requête POST sur `/api/service/:id/rolesResponsabilites`', () => {

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -519,6 +519,45 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         expect(e.response.data).to.be('L\'échéance "pasUneDate" est invalide');
       }
     });
+
+    it("décode les 'slash' des dates d'échéance ", async () => {
+      const slash = '&#x2F;';
+      let donneesRecues;
+      testeur.depotDonnees().metsAJourMesuresSpecifiquesDuService = async (
+        _,
+        __,
+        mesuresSpecifiques
+      ) => {
+        donneesRecues = mesuresSpecifiques;
+      };
+
+      await axios.put(
+        'http://localhost:1234/api/service/456/mesures-specifiques',
+        [
+          {
+            description: 'd1',
+            categorie: 'uneCategorie',
+            statut: 'fait',
+            modalites: 'm1',
+            echeance: `01${slash}01${slash}2024`,
+          },
+          {
+            description: 'd2',
+            categorie: 'uneCategorie',
+            statut: 'nonFait',
+            modalites: 'm2',
+          },
+        ]
+      );
+
+      expect(donneesRecues.item(0).toJSON().echeance).to.eql('01/01/2024');
+      expect(donneesRecues.item(1).toJSON()).to.eql({
+        description: 'd2',
+        categorie: 'uneCategorie',
+        statut: 'nonFait',
+        modalites: 'm2',
+      });
+    });
   });
 
   describe('quand requête PUT sur `/api/service/:id/mesures/:idMesure`', () => {


### PR DESCRIPTION
... car sinon, l'aseptisation les remplace par `&#x2F;`, qui créé une date invalide.