### PR TITLE
[CORRECTION] Un statut de mesure ne peut être vide dans l'API

### DIFF
--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -230,6 +230,10 @@ const routesConnecteApiService = ({
         idUtilisateurCourant,
         body: mesuresSpecifiques,
       } = requete;
+      if (mesuresSpecifiques.some((m) => !m.statut)) {
+        reponse.status(400).send('Les statuts des mesures sont obligatoires.');
+        return;
+      }
       try {
         const donneesMesuresSpecifiques = mesuresSpecifiques.map((m) => {
           if (m.echeance) m.echeance = m.echeance.replaceAll('&#x2F;', '/');

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -267,6 +267,10 @@ const routesConnecteApiService = ({
     middleware.aseptise('statut', 'modalites', 'priorite', 'echeance'),
     async (requete, reponse, suite) => {
       const { service, idUtilisateurCourant, body, params } = requete;
+      if (!body.statut) {
+        reponse.status(400).send('Le statut de la mesure est obligatoire.');
+        return;
+      }
       if (body.echeance) {
         body.echeance = body.echeance.replaceAll('&#x2F;', '/');
       }

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -11,6 +11,7 @@
   import ContenuOngletMesure from './contenus/ContenuOngletMesure.svelte';
   import type { ReferentielPriorite, ReferentielStatut } from '../ui/types';
   import ContenuOngletPlanAction from './contenus/ContenuOngletPlanAction.svelte';
+  import { planDActionDisponible } from '../modeles/mesure';
 
   export let idService: string;
   export let categories: Record<string, string>;
@@ -19,10 +20,6 @@
   export let mesuresExistantes: MesuresExistantes;
   export let estLectureSeule: boolean;
   export let priorites: ReferentielPriorite;
-
-  const planDActionDisponible =
-    $store.mesureEditee.mesure.statut === 'aLancer' ||
-    $store.mesureEditee.mesure.statut === 'enCours';
 
   const statutInitial = $store.mesureEditee.mesure.statut;
 
@@ -83,7 +80,8 @@
         cetOnglet="planAction"
         labelOnglet="Plan d'action"
         sansBordureEnBas
-        badge={!planDActionDisponible && 'info'}
+        badge={!planDActionDisponible($store.mesureEditee.mesure.statut) &&
+          'info'}
       />
     </div>
   {/if}

--- a/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
@@ -5,14 +5,12 @@
   import SelectionStatut from '../../ui/SelectionStatut.svelte';
   import type { ReferentielPriorite, ReferentielStatut } from '../../ui/types';
   import SelectionEcheance from '../../tableauDesMesures/ligne/SelectionEcheance.svelte';
+  import { planDActionDisponible } from '../../modeles/mesure';
 
   export let visible: boolean;
   export let estLectureSeule: boolean;
   export let priorites: ReferentielPriorite;
   export let statuts: ReferentielStatut;
-
-  const planDActionDisponible = (statut) =>
-    statut === 'aLancer' || statut === 'enCours';
 
   $: selectionDesactivee = !planDActionDisponible(
     $store.mesureEditee.mesure.statut

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -1,4 +1,5 @@
 import type { Referentiel } from '../ui/types.d';
+import type { StatutMesure } from '../modeles/mesure';
 
 declare global {
   interface HTMLElementEventMap {
@@ -9,7 +10,7 @@ declare global {
 export type MesureProps = {
   idService: string;
   categories: Record<string, string>;
-  statuts: Record<string, string>;
+  statuts: Record<StatutMesure, string>;
   retoursUtilisateur: Record<string, string>;
   estLectureSeule: boolean;
   mesuresExistantes: MesuresExistantes;
@@ -22,7 +23,7 @@ export type MesuresExistantes = {
 };
 
 export type MesureGenerale = {
-  statut?: string;
+  statut?: StatutMesure;
   modalites?: string;
   priorite?: string;
   echeance?: string;

--- a/svelte/lib/modeles/mesure.ts
+++ b/svelte/lib/modeles/mesure.ts
@@ -1,0 +1,4 @@
+export const planDActionDisponible = (statut: StatutMesure) =>
+  statut === 'aLancer' || statut === 'enCours';
+
+export type StatutMesure = string;

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -17,6 +17,7 @@
   import { rechercheTextuelle } from '../stores/rechercheTextuelle.store';
   import SelectionPriorite from '../../ui/SelectionPriorite.svelte';
   import SelectionEcheance from './SelectionEcheance.svelte';
+  import { planDActionDisponible } from '../../modeles/mesure';
 
   type IdDom = string;
 
@@ -61,7 +62,8 @@
       <SelectionPriorite
         bind:priorite={mesure.priorite}
         {id}
-        {estLectureSeule}
+        estLectureSeule={estLectureSeule ||
+          !planDActionDisponible(mesure.statut)}
         {priorites}
         on:input={(e) =>
           dispatch('modificationPriorite', { priorite: e.detail.priorite })}
@@ -70,7 +72,8 @@
     <td>
       <SelectionEcheance
         bind:echeance={mesure.echeance}
-        {estLectureSeule}
+        estLectureSeule={estLectureSeule ||
+          !planDActionDisponible(mesure.statut)}
         on:modificationEcheance
       />
     </td>

--- a/svelte/lib/tableauDesMesures/ligne/SelectionEcheance.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/SelectionEcheance.svelte
@@ -87,7 +87,7 @@
     border-radius: 6px;
   }
 
-  button:not(.avecLabel):hover {
+  button:not(.avecLabel):not([disabled]):hover {
     background: var(--fond-gris-pale);
     color: var(--bleu-anssi);
   }
@@ -100,9 +100,14 @@
     background: url('/statique/assets/images/icone_calendrier.svg');
   }
 
-  button.vide:hover:not(.avecLabel)::before {
+  button.vide:hover:not(.avecLabel):not([disabled])::before {
     filter: brightness(0) invert(17%) sepia(32%) saturate(3822%)
       hue-rotate(185deg) brightness(95%) contrast(94%);
+  }
+
+  button.vide:not(.avecLabel)[disabled]::before {
+    filter: brightness(0) invert(93%) sepia(5%) saturate(618%)
+      hue-rotate(178deg) brightness(93%) contrast(89%);
   }
 
   button.avecLabel {

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -3,6 +3,7 @@ import {
   type PrioriteMesure,
   Referentiel,
 } from '../ui/types.d';
+import type { StatutMesure } from '../modeles/mesure';
 
 declare global {
   interface HTMLElementEventMap {
@@ -12,12 +13,11 @@ declare global {
 
 export type IdService = string;
 export type IdCategorie = string;
-export type IdStatut = string;
 
 export type TableauDesMesuresProps = {
   idService: IdService;
   categories: Record<IdCategorie, string>;
-  statuts: Record<IdStatut, string>;
+  statuts: Record<StatutMesure, string>;
   estLectureSeule: boolean;
   modeVisiteGuidee: boolean;
 };
@@ -27,7 +27,7 @@ export type MesureGenerale = {
   categorie: string;
   indispensable: boolean;
   descriptionLongue: string;
-  statut?: string;
+  statut?: StatutMesure;
   modalites?: string;
   referentiel: Referentiel;
   identifiantNumerique: string;
@@ -38,7 +38,7 @@ export type MesureGenerale = {
 export type MesureSpecifique = {
   categorie: string;
   description: string;
-  statut: string;
+  statut: StatutMesure;
   modalites: string;
   identifiantNumerique: string;
   priorite?: PrioriteMesure;

--- a/svelte/lib/ui/SelectionPriorite.svelte
+++ b/svelte/lib/ui/SelectionPriorite.svelte
@@ -89,6 +89,11 @@
     color: var(--liseres-fonce);
   }
 
+  select:disabled {
+    color: var(--liseres-fonce) !important;
+    background: var(--fond-gris-pale) !important;
+  }
+
   select.avecLibelleOption {
     width: fit-content;
     appearance: auto;

--- a/svelte/lib/ui/stores/toaster.store.ts
+++ b/svelte/lib/ui/stores/toaster.store.ts
@@ -3,7 +3,7 @@ import type {
   MesureGenerale,
   MesureSpecifique,
 } from '../../tableauDesMesures/tableauDesMesures.d';
-import type { IdStatut } from '../types';
+import type { StatutMesure } from '../../modeles/mesure';
 
 export type NiveauMessage = 'info' | 'succes';
 
@@ -33,7 +33,7 @@ export const toasterStore = {
   },
   afficheToastChangementStatutMesure: (
     mesure: MesureGenerale | MesureSpecifique,
-    statuts: Record<IdStatut, string>
+    statuts: Record<StatutMesure, string>
   ) => {
     if (mesure.statut === 'fait') {
       toasterStore.succes(

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -1,12 +1,12 @@
+import type { StatutMesure } from '../modeles/mesure';
+
 export enum Referentiel {
   ANSSI = 'ANSSI',
   SPECIFIQUE = 'Mesures ajoutées',
   CNIL = 'CNIL',
 }
 
-export type IdStatut = string;
-
-export type ReferentielStatut = Record<IdStatut, string>;
+export type ReferentielStatut = Record<StatutMesure, string>;
 
 export type TypeNotification = 'nouveaute' | 'tache';
 

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -454,6 +454,30 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       }
     });
 
+    it('retourne une erreur HTTP 400 si le statut est vide', async () => {
+      testeur.depotDonnees().metsAJourMesuresSpecifiquesDuService =
+        async () => {};
+
+      try {
+        await axios.put(
+          'http://localhost:1234/api/service/456/mesures-specifiques',
+          [
+            {
+              description: 'd1',
+              categorie: 'uneCategorie',
+              statut: '',
+            },
+          ]
+        );
+        expect().fail('L’appel aurait dû lever une erreur');
+      } catch (e) {
+        expect(e.response.status).to.be(400);
+        expect(e.response.data).to.be(
+          'Les statuts des mesures sont obligatoires.'
+        );
+      }
+    });
+
     it('retourne une erreur HTTP 400 si le statut est inconnu', async () => {
       testeur.depotDonnees().metsAJourMesuresSpecifiquesDuService =
         async () => {};
@@ -488,6 +512,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
               description: 'd1',
               categorie: 'uneCategorie',
               priorite: 'plop',
+              statut: 'enCours',
             },
           ]
         );
@@ -510,6 +535,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
               description: 'd1',
               categorie: 'uneCategorie',
               echeance: 'pasUneDate',
+              statut: 'enCours',
             },
           ]
         );

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -607,6 +607,25 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
+    it('jette une erreur 400 si le statut est vide', async () => {
+      const mesureGenerale = {
+        statut: '',
+      };
+
+      try {
+        await axios.put(
+          'http://localhost:1234/api/service/456/mesures/audit',
+          mesureGenerale
+        );
+        expect().fail("L'appel aurait du lever une erreur.");
+      } catch (e) {
+        expect(e.response.status).to.be(400);
+        expect(e.response.data).to.be(
+          'Le statut de la mesure est obligatoire.'
+        );
+      }
+    });
+
     it('délègue au dépôt de données la mise à jour des mesures générales', async () => {
       let donneesRecues;
       let idServiceRecu;
@@ -656,6 +675,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('renvoie une erreur 400 si la mesure est invalide à cause de la priorité', async () => {
       const mesureGenerale = {
         priorite: 'invalide',
+        statut: 'enCours',
       };
 
       try {
@@ -673,6 +693,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it("renvoie une erreur 400 si la mesure est invalide à cause de l'échéance", async () => {
       const mesureGenerale = {
         echeance: 'invalide',
+        statut: 'enCours',
       };
 
       try {


### PR DESCRIPTION
Lors de la mise à jour d'une mesure générale ou spécifique, le statut de la mesure est obligatoire, il ne peut être vide.
Désactive également le plan d'action dans le cas où le statut ne permet pas d'agir sur le plan d'action.
