### PR TITLE
[CI/CD] Ajoute un `hash` aux fichiers compilés `Svelte`

### DIFF
--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -52,6 +52,12 @@ const featureFlag = () => ({
   visiteGuideeActive: () => process.env.FEATURE_FLAG_VISITE_GUIDEE === 'true',
 });
 
+const versionDeBuild = () => {
+  const versionCommit =
+    process.env.SOURCE_VERSION || process.env.CC_COMMIT_ID || '1';
+  return versionCommit.substring(0, 8);
+};
+
 module.exports = {
   chiffrement,
   emailMemoire,
@@ -62,4 +68,5 @@ module.exports = {
   sendinblue,
   sentry,
   statistiques,
+  versionDeBuild,
 };

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -308,7 +308,13 @@ const middleware = (configuration = {}) => {
     });
   };
 
+  const ajouteVersionFichierCompiles = (_requete, reponse, suite) => {
+    reponse.locals.version = adaptateurEnvironnement.versionDeBuild();
+    suite();
+  };
+
   return {
+    ajouteVersionFichierCompiles,
     aseptise,
     aseptiseListe,
     aseptiseListes,

--- a/src/mss.js
+++ b/src/mss.js
@@ -1,6 +1,7 @@
 const cookieSession = require('cookie-session');
 const cookieParser = require('cookie-parser');
 const express = require('express');
+
 const {
   CACHE_CONTROL_FICHIERS_STATIQUES,
   DUREE_SESSION,
@@ -64,6 +65,7 @@ const creeServeur = (
 
   app.use(middleware.positionneHeaders);
   app.use(middleware.repousseExpirationCookie);
+  app.use(middleware.ajouteVersionFichierCompiles);
 
   app.disable('x-powered-by');
 

--- a/src/vues/conseilsCyber.pug
+++ b/src/vues/conseilsCyber.pug
@@ -8,7 +8,7 @@ block title
   title!= 'Conseils Cyber | MonServiceSécurisé'
 
 block append styles
-  link(href = `/statique/composants-svelte/style.css${version ? `?v=${version}` : ''}`, rel = 'stylesheet')
+  +feuilleDeStyleSvelte()
 
 block append scripts
   script(type = 'module', src='/statique/scripts/conseilsCyber.js')

--- a/src/vues/conseilsCyber.pug
+++ b/src/vues/conseilsCyber.pug
@@ -12,7 +12,7 @@ block append styles
 
 block append scripts
   script(type = 'module', src='/statique/scripts/conseilsCyber.js')
-  +composantSvelteAvecVersion('blog.js')
+  +composantSvelte('blog.js')
   script(id = 'sections-blog', type = 'application/json').
     !{JSON.stringify(sections)}
   script(id = 'articles-blog', type = 'application/json').

--- a/src/vues/conseilsCyber.pug
+++ b/src/vues/conseilsCyber.pug
@@ -12,7 +12,7 @@ block append styles
 
 block append scripts
   script(type = 'module', src='/statique/scripts/conseilsCyber.js')
-  script(src = "/statique/composants-svelte/blog.js", type = "module")
+  +composantSvelteAvecVersion('blog.js')
   script(id = 'sections-blog', type = 'application/json').
     !{JSON.stringify(sections)}
   script(id = 'articles-blog', type = 'application/json').

--- a/src/vues/conseilsCyber.pug
+++ b/src/vues/conseilsCyber.pug
@@ -8,7 +8,7 @@ block title
   title!= 'Conseils Cyber | MonServiceSécurisé'
 
 block append styles
-  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
+  link(href = `/statique/composants-svelte/style.css${version ? `?v=${version}` : ''}`, rel = 'stylesheet')
 
 block append scripts
   script(type = 'module', src='/statique/scripts/conseilsCyber.js')

--- a/src/vues/fragments/composantSvelte.pug
+++ b/src/vues/fragments/composantSvelte.pug
@@ -1,4 +1,4 @@
-mixin composantSvelteAvecVersion(nomDuComposant)
+mixin composantSvelte(nomDuComposant)
     // `version` est pris dans `reponse.locals`
     script(type = 'module', src = `/statique/composants-svelte/${nomDuComposant}?v=${version}`)
 

--- a/src/vues/fragments/composantSvelteAvecVersion.pug
+++ b/src/vues/fragments/composantSvelteAvecVersion.pug
@@ -1,3 +1,6 @@
 mixin composantSvelteAvecVersion(nomDuComposant)
     // `version` est pris dans `reponse.locals`
     script(type = 'module', src = `/statique/composants-svelte/${nomDuComposant}?v=${version}`)
+
+mixin feuilleDeStyleSvelte()
+    link(href = `/statique/composants-svelte/style.css?v=${version}`, rel = 'stylesheet')

--- a/src/vues/fragments/composantSvelteAvecVersion.pug
+++ b/src/vues/fragments/composantSvelteAvecVersion.pug
@@ -1,0 +1,3 @@
+mixin composantSvelteAvecVersion(nomDuComposant)
+    // `version` est pris dans `reponse.locals`
+    script(type = 'module', src = `/statique/composants-svelte/${nomDuComposant}?v=${version}`)

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -1,5 +1,5 @@
 extends ./base
-include ./fragments/composantSvelteAvecVersion
+include fragments/composantSvelte
 
 block page
   block scripts

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -1,4 +1,5 @@
 extends ./base
+include ./fragments/composantSvelteAvecVersion
 
 block page
   block scripts

--- a/src/vues/mssConnecte.pug
+++ b/src/vues/mssConnecte.pug
@@ -6,7 +6,7 @@ block append styles
   +feuilleDeStyleSvelte()
 
 block append scripts
-  +composantSvelteAvecVersion('centreNotifications.js')
+  +composantSvelte('centreNotifications.js')
 
 block navigation
   #centre-notifications
@@ -22,7 +22,7 @@ block append session
       a.bouton(href = '/connexion') Reconnexion
 
   script(type = 'module', src = '/statique/mssConnecte.js')
-  +composantSvelteAvecVersion('visiteGuidee.js')
+  +composantSvelte('visiteGuidee.js')
 
 block bom-contenu
   p Vous souhaitez :

--- a/src/vues/mssConnecte.pug
+++ b/src/vues/mssConnecte.pug
@@ -3,7 +3,7 @@ extends mss
 block append styles
   link(href = '/statique/assets/styles/headerLarge.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modale.css', rel = 'stylesheet')
-  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
+  link(href = `/statique/composants-svelte/style.css${version ? `?v=${version}` : ''}`, rel = 'stylesheet')
 
 block append scripts
   script(src = "/statique/composants-svelte/centreNotifications.js", type = "module")

--- a/src/vues/mssConnecte.pug
+++ b/src/vues/mssConnecte.pug
@@ -3,7 +3,7 @@ extends mss
 block append styles
   link(href = '/statique/assets/styles/headerLarge.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modale.css', rel = 'stylesheet')
-  link(href = `/statique/composants-svelte/style.css${version ? `?v=${version}` : ''}`, rel = 'stylesheet')
+  +feuilleDeStyleSvelte()
 
 block append scripts
   +composantSvelteAvecVersion('centreNotifications.js')

--- a/src/vues/mssConnecte.pug
+++ b/src/vues/mssConnecte.pug
@@ -6,7 +6,7 @@ block append styles
   link(href = `/statique/composants-svelte/style.css${version ? `?v=${version}` : ''}`, rel = 'stylesheet')
 
 block append scripts
-  script(src = "/statique/composants-svelte/centreNotifications.js", type = "module")
+  +composantSvelteAvecVersion('centreNotifications.js')
 
 block navigation
   #centre-notifications
@@ -22,7 +22,7 @@ block append session
       a.bouton(href = '/connexion') Reconnexion
 
   script(type = 'module', src = '/statique/mssConnecte.js')
-  script(type = 'module', src = '/statique/composants-svelte/visiteGuidee.js')
+  +composantSvelteAvecVersion('visiteGuidee.js')
 
 block bom-contenu
   p Vous souhaitez :

--- a/src/vues/parcoursService.pug
+++ b/src/vues/parcoursService.pug
@@ -11,7 +11,7 @@ block append styles
 
 block append scripts
   script(type = 'module', src = '/statique/scripts/menuNavigation.js')
-  script(type = 'module', src = '/statique/composants-svelte/gestionContributeurs.js')
+  +composantSvelteAvecVersion('gestionContributeurs.js')
 
 block header-gauche
   .conteneur-logo

--- a/src/vues/parcoursService.pug
+++ b/src/vues/parcoursService.pug
@@ -11,7 +11,7 @@ block append styles
 
 block append scripts
   script(type = 'module', src = '/statique/scripts/menuNavigation.js')
-  +composantSvelteAvecVersion('gestionContributeurs.js')
+  +composantSvelte('gestionContributeurs.js')
 
 block header-gauche
   .conteneur-logo

--- a/src/vues/service/decrire.pug
+++ b/src/vues/service/decrire.pug
@@ -4,7 +4,7 @@ block title
   title Décrire | MonServiceSécurisé
 
 block append scripts
-  +composantSvelteAvecVersion('niveauxDeSecurite.js')
+  +composantSvelte('niveauxDeSecurite.js')
 
 block append styles
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')

--- a/src/vues/service/decrire.pug
+++ b/src/vues/service/decrire.pug
@@ -4,7 +4,7 @@ block title
   title Décrire | MonServiceSécurisé
 
 block append scripts
-  script(type = 'module', src = '/statique/composants-svelte/niveauxDeSecurite.js')
+  +composantSvelteAvecVersion('niveauxDeSecurite.js')
 
 block append styles
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')

--- a/src/vues/service/decrire.pug
+++ b/src/vues/service/decrire.pug
@@ -7,7 +7,6 @@ block append scripts
   script(type = 'module', src = '/statique/composants-svelte/niveauxDeSecurite.js')
 
 block append styles
-  link(href = '/statique/composants-svelte/style.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
 
 block titre

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -9,7 +9,7 @@ block append styles
   link(href = '/statique/assets/styles/homologation/indiceCyber.css', rel = 'stylesheet')
 
 block append scripts
-  +composantSvelteAvecVersion('indiceCyber.js')
+  +composantSvelte('indiceCyber.js')
   script(type = 'module', src = '/statique/service/indiceCyber.js')
   script(id = 'indice-cyber', type = 'application/json').
     !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax() })}

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -9,7 +9,7 @@ block append styles
   link(href = '/statique/assets/styles/homologation/indiceCyber.css', rel = 'stylesheet')
 
 block append scripts
-  script(type = 'module', src = '/statique/composants-svelte/indiceCyber.js')
+  +composantSvelteAvecVersion('indiceCyber.js')
   script(type = 'module', src = '/statique/service/indiceCyber.js')
   script(id = 'indice-cyber', type = 'application/json').
     !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax() })}

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -8,10 +8,10 @@ block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
 
 block append scripts
-  +composantSvelteAvecVersion('mesure.js')
-  +composantSvelteAvecVersion('tableauDesMesures.js')
-  +composantSvelteAvecVersion('completudeMesure.js')
-  +composantSvelteAvecVersion('indiceCyber.js')
+  +composantSvelte('mesure.js')
+  +composantSvelte('tableauDesMesures.js')
+  +composantSvelte('completudeMesure.js')
+  +composantSvelte('indiceCyber.js')
   script(type = 'module', src = '/statique/service/mesures.js')
   script(id = 'referentiel-categories-mesures', type = 'application/json').
     !{JSON.stringify(referentiel.categoriesMesures())}

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -8,10 +8,10 @@ block append styles
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
 
 block append scripts
-  script(type = 'module', src = '/statique/composants-svelte/mesure.js')
-  script(type = 'module', src = '/statique/composants-svelte/tableauDesMesures.js')
-  script(type = 'module', src = '/statique/composants-svelte/completudeMesure.js')
-  script(type = 'module', src = '/statique/composants-svelte/indiceCyber.js')
+  +composantSvelteAvecVersion('mesure.js')
+  +composantSvelteAvecVersion('tableauDesMesures.js')
+  +composantSvelteAvecVersion('completudeMesure.js')
+  +composantSvelteAvecVersion('indiceCyber.js')
   script(type = 'module', src = '/statique/service/mesures.js')
   script(id = 'referentiel-categories-mesures', type = 'application/json').
     !{JSON.stringify(referentiel.categoriesMesures())}

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -29,7 +29,7 @@ block append styles
 
 block append scripts
   script(src = "/statique/bibliotheques/selectize-0.15.2.min.js")
-  +composantSvelteAvecVersion('gestionContributeurs.js')
+  +composantSvelte('gestionContributeurs.js')
 
 
 block header-gauche

--- a/src/vues/tableauDeBord.pug
+++ b/src/vues/tableauDeBord.pug
@@ -29,7 +29,7 @@ block append styles
 
 block append scripts
   script(src = "/statique/bibliotheques/selectize-0.15.2.min.js")
-  script(src = "/statique/composants-svelte/gestionContributeurs.js", type = "module")
+  +composantSvelteAvecVersion('gestionContributeurs.js')
 
 
 block header-gauche

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -896,4 +896,17 @@ describe('Le middleware MSS', () => {
       });
     });
   });
+
+  it('ajoute la version de build dans `reponse.locals`, le rendant ainsi accessible aux `.pug`', (done) => {
+    const adaptateurEnvironnement = {
+      versionDeBuild: () => '1.1',
+    };
+
+    const middleware = Middleware({ adaptateurEnvironnement });
+
+    middleware.ajouteVersionFichierCompiles(requete, reponse, () => {
+      expect(reponse.locals.version).to.be('1.1');
+      done();
+    });
+  });
 });

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -60,6 +60,7 @@ let suppressionCookieEffectuee = false;
 let traficProtege = false;
 let verificationJWTMenee = false;
 let verificationCGUMenee = false;
+let versionBuildeeChargee = false;
 
 const middlewareFantaisie = {
   reinitialise: ({
@@ -91,6 +92,12 @@ const middlewareFantaisie = {
     verificationJWTMenee = false;
     verificationCGUMenee = false;
     challengeMotDePasseEffectue = false;
+    versionBuildeeChargee = false;
+  },
+
+  ajouteVersionFichierCompiles: (_requete, _reponse, suite) => {
+    versionBuildeeChargee = true;
+    suite();
   },
 
   aseptise:
@@ -323,6 +330,13 @@ const middlewareFantaisie = {
   verifieChallengeMotDePasse: (...params) => {
     verifieRequeteChangeEtat(
       { lectureEtat: () => challengeMotDePasseEffectue },
+      ...params
+    );
+  },
+
+  verifieChargementDeLaVersionBuildee: (...params) => {
+    verifieRequeteChangeEtat(
+      { lectureEtat: () => versionBuildeeChargee },
       ...params
     );
   },

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -13,6 +13,12 @@ describe('Le serveur MSS', () => {
     testeur.middleware().verifieFiltrageIp('http://localhost:1234', done);
   });
 
+  it('charge la version de build des fichiers', (done) => {
+    testeur
+      .middleware()
+      .verifieChargementDeLaVersionBuildee('http://localhost:1234', done);
+  });
+
   describe('quand une page est servie', () => {
     it('positionne les headers', (done) => {
       testeur


### PR DESCRIPTION
Aujourd'hui on remarque un "cache" lors des déploiements en DEMO et PRODUCTION de nos fichiers de styles `Svelte`.
Afin de contourner cela, on veut ajouter une version dans une `query string` pour ce fichier.

> [!TIP]
> Cette version représente le `short hash` du dernier commit

> [!WARNING]  
> Les variables d'environnement ne sont pas les mêmes chez [Scalingo](https://doc.scalingo.com/platform/app/environment#build-environment-variables) et [CleverCloud](https://developers.clever-cloud.com/doc/reference/reference-environment-variables/#set-by-the-deployment-process).