### PR TITLE
[CORRECTION] Utilise la variable `CONTAINER_VERSION`

### DIFF
--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -54,7 +54,7 @@ const featureFlag = () => ({
 
 const versionDeBuild = () => {
   const versionCommit =
-    process.env.SOURCE_VERSION || process.env.CC_COMMIT_ID || '1';
+    process.env.CONTAINER_VERSION || process.env.CC_COMMIT_ID || '1';
   return versionCommit.substring(0, 8);
 };
 


### PR DESCRIPTION
... plutôt que `SOURCE_VERSION`, car cette dernière n'est disponible qu'au moment du build sur Scalingo.