### PR TITLE
[PLAN D'ACTION] Ajout des champs du plan d'action dans l'export des mesures

### DIFF
--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -5,6 +5,7 @@ const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
 const { featureFlag } = require('./adaptateurEnvironnement');
+const { dateEnFrancais } = require('../utilitaires/date');
 
 const remplaceBooleen = (booleen) => (booleen ? 'Oui' : 'Non');
 const avecBOM = (...contenus) => `\uFEFF${contenus.join('')}`;
@@ -65,6 +66,7 @@ const genereCsvMesures = async (
 
     if (featureFlag().avecPlanAction()) {
       colonnes.push({ id: 'priorite', title: 'Priorité' });
+      colonnes.push({ id: 'echeance', title: 'Échéance' });
     }
   }
 
@@ -80,6 +82,7 @@ const genereCsvMesures = async (
       statut: referentiel.descriptionStatutMesure(m.statut),
       commentaires: sansRetoursChariots(decode(m.modalites)),
       priorite: referentiel.prioritesMesures()[m.priorite]?.libelleCourt,
+      echeance: m.echeance ? dateEnFrancais(m.echeance) : null,
     }))
     .concat(
       mesuresSpecifiques.map((m) => ({
@@ -92,6 +95,7 @@ const genereCsvMesures = async (
         statut: referentiel.descriptionStatutMesure(m.statut),
         commentaires: sansRetoursChariots(decode(m.modalites)),
         priorite: referentiel.prioritesMesures()[m.priorite]?.libelleCourt,
+        echeance: m.echeance ? dateEnFrancais(m.echeance) : null,
       }))
     );
 

--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -4,6 +4,7 @@ const { stripHtml } = require('string-strip-html');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
+const { featureFlag } = require('./adaptateurEnvironnement');
 
 const remplaceBooleen = (booleen) => (booleen ? 'Oui' : 'Non');
 const avecBOM = (...contenus) => `\uFEFF${contenus.join('')}`;
@@ -48,7 +49,7 @@ const genereCsvMesures = async (
   avecDonneesAdditionnnelles,
   referentiel
 ) => {
-  // Les `id` correspondent aux noms des propriétés dans notre modèle Mesure
+  // Les `id` doivent correspondrent aux champs des objets dans `donneesCsv`
   const colonnes = [
     { id: 'identifiant', title: 'Identifiant de la mesure' },
     { id: 'description', title: 'Nom de la mesure' },
@@ -61,6 +62,10 @@ const genereCsvMesures = async (
   if (avecDonneesAdditionnnelles) {
     colonnes.push({ id: 'statut', title: 'Statut' });
     colonnes.push({ id: 'commentaires', title: 'Commentaires' });
+
+    if (featureFlag().avecPlanAction()) {
+      colonnes.push({ id: 'priorite', title: 'Priorité' });
+    }
   }
 
   const { mesuresGenerales, mesuresSpecifiques } = donneesMesures;
@@ -74,6 +79,7 @@ const genereCsvMesures = async (
       descriptionLongue: stripHtml(m.descriptionLongue).result,
       statut: referentiel.descriptionStatutMesure(m.statut),
       commentaires: sansRetoursChariots(decode(m.modalites)),
+      priorite: referentiel.prioritesMesures()[m.priorite]?.libelleCourt,
     }))
     .concat(
       mesuresSpecifiques.map((m) => ({
@@ -85,6 +91,7 @@ const genereCsvMesures = async (
         descriptionLongue: '',
         statut: referentiel.descriptionStatutMesure(m.statut),
         commentaires: sansRetoursChariots(decode(m.modalites)),
+        priorite: referentiel.prioritesMesures()[m.priorite]?.libelleCourt,
       }))
     );
 

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -50,6 +50,8 @@ const chiffrement = () => ({
 
 const featureFlag = () => ({
   visiteGuideeActive: () => process.env.FEATURE_FLAG_VISITE_GUIDEE === 'true',
+  avecPlanAction: () =>
+    process.env.VITE_FEATURE_FLAG_AVEC_PLAN_ACTION === 'true',
 });
 
 const versionDeBuild = () => {


### PR DESCRIPTION
Cette PR rajoute les champs `Priorité` et `Échéance` dans l'export avec données additionnelles.

![image](https://github.com/user-attachments/assets/12c24fe9-4def-47f4-9205-d6daa62cda99)


Il faut que le feature flag soit activé pour que les colonnes apparaissent.
Le champ « Responsables » n'est pas encore exporté. Il sera à rajouter lorsqu'il sera disponible.