### PR TITLE
[SOIN] Rajoute des tests autour de `completudeMesures()`Plan action dans metabase

### DIFF
--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -81,8 +81,12 @@ class Service {
   }
 
   completudeMesures() {
+    const completude = this.mesures.completude();
+    const { nombreTotalMesures, nombreMesuresCompletes } = completude;
+
     return {
-      ...this.mesures.completude(),
+      nombreTotalMesures,
+      nombreMesuresCompletes,
       detailMesures: this.mesures.statutsMesuresPersonnalisees(),
       indiceCyber: this.indiceCyber(),
     };

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -10,7 +10,7 @@ const Referentiel = require('../../src/referentiel');
 
 const elles = it;
 
-describe('Les mesures liées à une homologation', () => {
+describe('Les mesures liées à un service', () => {
   elles('comptent les mesures personnalisees', () => {
     const mesuresPersonnalisees = { uneMesure: {} };
     const mesures = new Mesures(
@@ -294,9 +294,11 @@ describe('Les mesures liées à une homologation', () => {
         { mesure1: {} }
       );
 
-      expect(mesures.statutsMesuresPersonnalisees()).to.eql([
-        { idMesure: 'mesure1', statut: 'fait' },
-      ]);
+      const statuts = mesures.statutsMesuresPersonnalisees();
+
+      expect(statuts.length).to.be(1);
+      expect(statuts[0].idMesure).to.be('mesure1');
+      expect(statuts[0].statut).to.be('fait');
     });
 
     elles(
@@ -314,9 +316,10 @@ describe('Les mesures liées à une homologation', () => {
           seulementMesure1
         );
 
-        expect(mesures.statutsMesuresPersonnalisees()).to.eql([
-          { idMesure: 'mesure1', statut: 'fait' },
-        ]);
+        const statuts = mesures.statutsMesuresPersonnalisees();
+
+        expect(statuts.length).to.be(1);
+        expect(statuts[0].idMesure).to.be('mesure1');
       }
     );
 

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -23,8 +23,8 @@ const {
 } = require('../constructeurs/constructeurAutorisation');
 const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
 
-describe('Une homologation', () => {
-  it('connaît le nom du service', () => {
+describe('Un service', () => {
+  it('connaît son nom', () => {
     const service = new Service({
       id: '123',
       idUtilisateur: '456',


### PR DESCRIPTION
L'objectif actuel est d'ajouter dans Metabase les données de plan d'action qui sont associées aux mesures.

J'ai détecté un potentiel refactoring pour permettre cet ajout en supprimant au passage de la duplication.

Il faudrait refactorer `Service.completudeMesures()`… mais cette méthode était testée de très loin par `evenementCompletudeServiceModifiee.spec.js`.

Ces tests trop lointains empêchent de refactorer. Donc, on rajoute des tests plus proches et précis.