### PR TITLE
[PLAN D'ACTION] Envoi des infos vers Metabase

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,5 @@
 # TODO
 
-- réduire la taille en hauteur du select priorité
-- libellé complet de la priorité dans le tableau
-
-# DONE
-
-- affichage du tiroir et de l’onglet selon avancement
-- champ dans le tiroir
-- filtre sur la priorité
-- je peux enregistrer la valeur depuis le tiroir
-- onglet dans le tiroir
-- champ affiché sur le tableau, si feature flag
-- je peux enregistrer la valeur depuis le tableau
-- tester en lecture seule le tableau
-- filtre sur la priorité
-- tester en lecture seule le tiroir
-  - survol actif avec curseur : ok
-  - padding sur select qui n’a pas de priorité : non, ça s’adapte au contenu on alignera sur l’échéance
+- Refactorer completudeMesures() pour utiliser plutôt la méthode `enrichi`
+- Supprimer la méthode inutilisée et les tests associés
+- Rajouter les champs de prio dans la complétude

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,0 @@
-# TODO
-
-- Refactorer completudeMesures() pour utiliser plutôt la méthode `enrichi`
-- Supprimer la méthode inutilisée et les tests associés
-- Rajouter les champs de prio dans la complétude

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -101,17 +101,6 @@ class Mesures extends InformationsService {
       : Mesures.A_COMPLETER;
   }
 
-  statutsMesuresPersonnalisees() {
-    const personnalisees = ({ id: idMesure }) =>
-      Object.keys(this.mesuresPersonnalisees).includes(idMesure);
-
-    return this.mesuresGenerales
-      .toutes()
-      .filter(personnalisees)
-      .filter((m) => m.statut !== '')
-      .map((m) => ({ idMesure: m.id, statut: m.statut }));
-  }
-
   enrichiesAvecDonneesPersonnalisees() {
     const mesuresEnrichies = Object.entries(this.mesuresPersonnalisees).reduce(
       (acc, mesurePersonnalisee) => {

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -91,11 +91,12 @@ class Service {
 
     const detailMesures = Object.entries(mesuresGenerales)
       .filter(([_id, body]) => !!body.statut)
-      .map(([id, { statut, priorite, echeance }]) => ({
+      .map(([id, { statut, priorite, echeance, responsables }]) => ({
         idMesure: id,
         statut,
         ...(priorite && { priorite }),
         ...(echeance && { echeance: dateEnIso(echeance) }),
+        nbResponsables: responsables.length,
       }));
 
     return {

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -85,10 +85,17 @@ class Service {
     const completude = this.mesures.completude();
     const { nombreTotalMesures, nombreMesuresCompletes } = completude;
 
+    const { mesuresGenerales } =
+      this.mesures.enrichiesAvecDonneesPersonnalisees();
+
+    const detailMesures = Object.entries(mesuresGenerales)
+      .filter(([_id, body]) => !!body.statut)
+      .map(([id, { statut }]) => ({ idMesure: id, statut }));
+
     return {
       nombreTotalMesures,
       nombreMesuresCompletes,
-      detailMesures: this.mesures.statutsMesuresPersonnalisees(),
+      detailMesures,
       indiceCyber: this.indiceCyber(),
     };
   }

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -15,6 +15,7 @@ const ObjetPDFAnnexeRisques = require('./objetsPDF/objetPDFAnnexeRisques');
 const Autorisation = require('./autorisations/autorisation');
 const SuggestionAction = require('./suggestionAction');
 const { ErreurResponsablesMesureInvalides } = require('../erreurs');
+const { dateEnIso } = require('../utilitaires/date');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -90,7 +91,12 @@ class Service {
 
     const detailMesures = Object.entries(mesuresGenerales)
       .filter(([_id, body]) => !!body.statut)
-      .map(([id, { statut }]) => ({ idMesure: id, statut }));
+      .map(([id, { statut, priorite, echeance }]) => ({
+        idMesure: id,
+        statut,
+        ...(priorite && { priorite }),
+        ...(echeance && { echeance: dateEnIso(echeance) }),
+      }));
 
     return {
       nombreTotalMesures,

--- a/src/utilitaires/date.js
+++ b/src/utilitaires/date.js
@@ -17,15 +17,13 @@ const dateEnFrancais = (chaineDate) => {
   return date.toLocaleString('fr-FR', { dateStyle: 'short' });
 };
 
-// On utilise le standard canadien pour obtenir le format YYYY-MM-DD
-const dateYYYYMMDD = (date) =>
-  Intl.DateTimeFormat('fr-CA', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  })
-    .format(date)
-    .replaceAll('-', '');
+const dateEnIso = (chaineDate) => {
+  const date = new Date(chaineDate);
+  // On utilise le standard canadien pour obtenir le format YYYY-MM-DD
+  return date.toLocaleString('fr-CA', { dateStyle: 'short' });
+};
+
+const dateYYYYMMDD = (date) => dateEnIso(date).replaceAll('-', '');
 
 const dateInvalide = (chaineDate) =>
   Number.isNaN(new Date(chaineDate).valueOf());
@@ -33,6 +31,7 @@ const dateInvalide = (chaineDate) =>
 module.exports = {
   ajouteMoisADate,
   dateEnFrancais,
+  dateEnIso,
   dateInvalide,
   dateYYYYMMDD,
 };

--- a/test/constructeurs/constructeurMesures.js
+++ b/test/constructeurs/constructeurMesures.js
@@ -2,7 +2,6 @@ class ConstructeurMesures {
   constructor() {
     this.nombreTotalMesures = 0;
     this.nombreMesuresCompletes = 0;
-    this.statutsMesuresPersonnalisees = [];
     this.indiceCyber = 0.0;
   }
 
@@ -18,7 +17,7 @@ class ConstructeurMesures {
         nombreTotalMesures: this.nombreTotalMesures,
         nombreMesuresCompletes: this.nombreMesuresCompletes,
       }),
-      statutsMesuresPersonnalisees: () => this.statutsMesuresPersonnalisees,
+      enrichiesAvecDonneesPersonnalisees: () => ({ mesuresGenerales: {} }),
       indiceCyber: () => ({ total: this.indiceCyber }),
     };
   }

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -113,6 +113,7 @@ describe('Un événement de complétude modifiée', () => {
             statut: 'fait',
             priorite: 'p1',
             echeance: '2024-09-13',
+            nbResponsables: 0,
           },
         ],
         detailIndiceCyber: [

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -36,16 +36,26 @@ describe('Un événement de complétude modifiée', () => {
 
   it("sait se convertir en JSON sans dévoiler le SIRET de l'organisation responsable", () => {
     const referentiel = Referentiel.creeReferentiel({
-      mesures: { mesureA: {} },
       categoriesMesures: { gouvernance: 'Gouvernance' },
-      statutsMesures: { fait: 'Faite', enCours: 'Partielle' },
       indiceCyber: { noteMax: 5 },
+      prioritesMesures: { p1: {} },
+      mesures: { mesureA: {} },
+      statutsMesures: { fait: 'Faite', enCours: 'Partielle' },
     });
     const mesuresPersonnalises = {
       mesureA: { categorie: 'gouvernance' },
     };
     const mesures = new Mesures(
-      { mesuresGenerales: [{ id: 'mesureA', statut: 'fait' }] },
+      {
+        mesuresGenerales: [
+          {
+            id: 'mesureA',
+            statut: 'fait',
+            priorite: 'p1',
+            echeance: '9/13/2024',
+          },
+        ],
+      },
       referentiel,
       mesuresPersonnalises
     );
@@ -64,9 +74,7 @@ describe('Un événement de complétude modifiée', () => {
         typeService: ['applicationMobile'],
         nombreOrganisationsUtilisatrices: { borneBasse: 1, borneHaute: 5 },
         pointsAcces: ['point A', 'point B'],
-        organisationResponsable: {
-          siret: '12345',
-        },
+        organisationResponsable: { siret: '12345' },
         niveauSecurite: 'niveau3',
       })
       .construis();
@@ -99,7 +107,14 @@ describe('Un événement de complétude modifiée', () => {
         idService: 'ABC',
         nombreTotalMesures: 1,
         nombreMesuresCompletes: 1,
-        detailMesures: [{ idMesure: 'mesureA', statut: 'fait' }],
+        detailMesures: [
+          {
+            idMesure: 'mesureA',
+            statut: 'fait',
+            priorite: 'p1',
+            echeance: '2024-09-13',
+          },
+        ],
         detailIndiceCyber: [
           { categorie: 'total', indice: 5 },
           { categorie: 'gouvernance', indice: 5 },

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -128,10 +128,7 @@ describe('Les mesures liées à un service', () => {
     const referentiel = Referentiel.creeReferentielVide();
 
     const mesures = new Mesures(
-      {
-        mesuresGenerales: [],
-        mesuresSpecifiques: [],
-      },
+      { mesuresGenerales: [], mesuresSpecifiques: [] },
       referentiel,
       { m1: {}, m2: {} }
     );
@@ -164,11 +161,7 @@ describe('Les mesures liées à un service', () => {
         },
       });
       referentiel.identifiantsCategoriesMesures = () => ['categorie1'];
-      statutVide = {
-        enCours: {},
-        nonFait: {},
-        aLancer: {},
-      };
+      statutVide = { enCours: {}, nonFait: {}, aLancer: {} };
     });
 
     elles('récupère les mesures générales groupées', () => {
@@ -275,70 +268,6 @@ describe('Les mesures liées à un service', () => {
         { description: 'mesure1', indispensable: true },
         { description: 'Mesure Spécifique 1' },
       ]);
-    });
-  });
-
-  describe('sur demande des statuts des mesures personnalisées', () => {
-    let referentiel;
-
-    beforeEach(() => {
-      referentiel = Referentiel.creeReferentiel({
-        mesures: { mesure1: {}, mesure2: {} },
-      });
-    });
-
-    elles('donnent les statuts des mesures personnalisées', () => {
-      const mesures = new Mesures(
-        { mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }] },
-        referentiel,
-        { mesure1: {} }
-      );
-
-      const statuts = mesures.statutsMesuresPersonnalisees();
-
-      expect(statuts.length).to.be(1);
-      expect(statuts[0].idMesure).to.be('mesure1');
-      expect(statuts[0].statut).to.be('fait');
-    });
-
-    elles(
-      'ignorent les mesures générales qui ne sont pas des mesures personnalisées',
-      () => {
-        const seulementMesure1 = { mesure1: {} };
-        const mesures = new Mesures(
-          {
-            mesuresGenerales: [
-              { id: 'mesure1', statut: 'fait' },
-              { id: 'mesure2', statut: 'fait' },
-            ],
-          },
-          referentiel,
-          seulementMesure1
-        );
-
-        const statuts = mesures.statutsMesuresPersonnalisees();
-
-        expect(statuts.length).to.be(1);
-        expect(statuts[0].idMesure).to.be('mesure1');
-      }
-    );
-
-    elles("ignorent les mesures dont le statut n'est pas renseigné", () => {
-      const mesures = new Mesures(
-        {
-          mesuresGenerales: [
-            {
-              id: 'mesure1',
-              statut: '',
-              modalites: 'Un commentaire laissé sans valoriser le statut',
-            },
-          ],
-        },
-        referentiel,
-        { mesure1: {} }
-      );
-
-      expect(mesures.statutsMesuresPersonnalisees()).to.be.empty();
     });
   });
 

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -152,9 +152,10 @@ describe('Un service', () => {
     beforeEach(() => {
       referentiel = Referentiel.creeReferentiel({
         categoriesMesures: { gouvernance: {}, protection: {}, resilience: {} },
-        statutsMesures: { fait: {}, enCours: {} },
-        mesures: { mesureA: {}, mesureB: {} },
         indiceCyber: { noteMax: 5 },
+        mesures: { mesureA: {}, mesureB: {} },
+        prioritesMesures: { p1: {} },
+        statutsMesures: { fait: {}, enCours: {} },
       });
     });
 
@@ -203,7 +204,16 @@ describe('Un service', () => {
     describe('inclue le détail des mesures', () => {
       it('avec les données pertinentes', () => {
         const uneGouvernanceFaite = new Mesures(
-          { mesuresGenerales: [{ id: 'mesureA', statut: 'fait' }] },
+          {
+            mesuresGenerales: [
+              {
+                id: 'mesureA',
+                statut: 'fait',
+                priorite: 'p1',
+                echeance: '8/28/2024',
+              },
+            ],
+          },
           referentiel,
           {
             mesureA: { categorie: 'gouvernance' },
@@ -217,7 +227,12 @@ describe('Un service', () => {
         const completudeMesures = s.completudeMesures();
 
         expect(completudeMesures.detailMesures).to.eql([
-          { idMesure: 'mesureA', statut: 'fait' },
+          {
+            idMesure: 'mesureA',
+            statut: 'fait',
+            priorite: 'p1',
+            echeance: '2024-08-28',
+          },
         ]);
       });
 

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -211,6 +211,7 @@ describe('Un service', () => {
                 statut: 'fait',
                 priorite: 'p1',
                 echeance: '8/28/2024',
+                responsables: ['unIdUtilisateur'],
               },
             ],
           },
@@ -232,6 +233,7 @@ describe('Un service', () => {
             statut: 'fait',
             priorite: 'p1',
             echeance: '2024-08-28',
+            nbResponsables: 1,
           },
         ]);
       });


### PR DESCRIPTION
Cette PR rajoute `priorite` et `echeance` à l'événement Metabase `COMPLETUDE_SERVICE_MODIFIEE` 👇 

![image](https://github.com/user-attachments/assets/9daf94b9-f91c-4efc-b750-3bd2376f57f7)

Plutôt grosse PR pour ce petit changement… car elle supprime la méthode `statutsMesuresPersonnalisees()` au profit de la réutilisation de `enrichiesAvecDonneesPersonnalisees()` qui contient tout le nécessaire.