### PR TITLE
Utilise du gris pour les vignettes de rôle inconnu

### DIFF
--- a/public/assets/styles/palette.css
+++ b/public/assets/styles/palette.css
@@ -55,6 +55,8 @@
   --systeme-design-etat-gris-actif: #ededed;
   --systeme-design-etat-contour-champs: #dddddd;
 
+  --role-inconnu: #f1f5f9;
+  --role-inconnu-texte: #667892;
   --role-proprietaire: #fff4d9;
   --role-proprietaire-texte: #faa72c;
   --role-lecteur: #e9ddff;

--- a/svelte/lib/gestionContributeurs/kit/Initiales.svelte
+++ b/svelte/lib/gestionContributeurs/kit/Initiales.svelte
@@ -23,6 +23,8 @@
     align-items: center;
     justify-content: center;
     font-weight: 700;
+    background: var(--role-inconnu);
+    color: var(--role-inconnu-texte);
   }
 
   .initiales.persona::before {
@@ -32,7 +34,8 @@
     background: url('/statique/assets/images/persona_invitation_contributeur.svg')
       no-repeat;
     background-size: contain;
-    filter: brightness(0);
+    filter: brightness(0) invert(43%) sepia(28%) saturate(369%)
+      hue-rotate(176deg) brightness(102%) contrast(91%);
   }
 
   .PROPRIETAIRE {


### PR DESCRIPTION
Le rôle est inconnu lorsqu'il est en cours de chargement.

Ou alors, lorsqu'on voit la liste des contributeurs sans être soi-même propriétaire : on ne voit pas le rôle des autres.

![image](https://github.com/user-attachments/assets/1e798427-9ee2-4eed-b74e-76e880c645f4)

![image](https://github.com/user-attachments/assets/f2c99ae1-3e08-4231-a049-d30ef2a90e09)
