### PR TITLE
Ajoute les responsables dans l'export de mesures

### DIFF
--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -10,6 +10,7 @@ const { dateEnFrancais } = require('../utilitaires/date');
 const remplaceBooleen = (booleen) => (booleen ? 'Oui' : 'Non');
 const avecBOM = (...contenus) => `\uFEFF${contenus.join('')}`;
 const sansRetoursChariots = (texte) => texte.replaceAll('\n', ' ');
+const separesParVirgule = (liste) => liste.join(', ');
 
 const genereCsvServices = (tableauServices) => {
   try {
@@ -47,6 +48,7 @@ const genereCsvServices = (tableauServices) => {
 
 const genereCsvMesures = async (
   donneesMesures,
+  contributeurs,
   avecDonneesAdditionnnelles,
   referentiel
 ) => {
@@ -67,10 +69,17 @@ const genereCsvMesures = async (
     if (featureFlag().avecPlanAction()) {
       colonnes.push({ id: 'priorite', title: 'Priorité' });
       colonnes.push({ id: 'echeance', title: 'Échéance' });
+      colonnes.push({ id: 'responsables', title: 'Responsables' });
     }
   }
 
   const { mesuresGenerales, mesuresSpecifiques } = donneesMesures;
+
+  const formatteResponsables = (responsables) =>
+    separesParVirgule(
+      responsables.map((id) => contributeurs[id]).filter((value) => !!value)
+    );
+
   const donneesCsv = Object.values(mesuresGenerales)
     .map((m) => ({
       identifiant: `#${m.identifiantNumerique}`,
@@ -83,6 +92,9 @@ const genereCsvMesures = async (
       commentaires: sansRetoursChariots(decode(m.modalites)),
       priorite: referentiel.prioritesMesures()[m.priorite]?.libelleCourt,
       echeance: m.echeance ? dateEnFrancais(m.echeance) : null,
+      responsables: m.responsables
+        ? formatteResponsables(m.responsables)
+        : null,
     }))
     .concat(
       mesuresSpecifiques.map((m) => ({

--- a/src/routes/connecte/routesConnectePageService.js
+++ b/src/routes/connecte/routesConnectePageService.js
@@ -135,8 +135,12 @@ const routesConnectePageService = ({
       const { avecDonneesAdditionnelles } = requete.query;
 
       try {
+        const contributeurs = Object.fromEntries(
+          service.contributeurs.map((c) => [c.id, c.prenomNom()])
+        );
         const bufferCsv = await adaptateurCsv.genereCsvMesures(
           service.mesures.enrichiesAvecDonneesPersonnalisees(),
+          contributeurs,
           avecDonneesAdditionnelles,
           referentiel
         );

--- a/test/routes/connecte/routesConnectePageService.spec.js
+++ b/test/routes/connecte/routesConnectePageService.spec.js
@@ -360,6 +360,38 @@ describe('Le serveur MSS des routes /service/*', () => {
       });
     });
 
+    it("passe à l'adaptateur les prenomNom des contributeurs du service", async () => {
+      testeur.middleware().reinitialise({
+        serviceARenvoyer: unService()
+          .avecId('456')
+          .ajouteUnContributeur(
+            unUtilisateur().avecId('123').avecEmail('email.createur@mail.fr')
+              .donnees
+          )
+          .ajouteUnContributeur(
+            unUtilisateur()
+              .avecId('145')
+              .avecEmail('email.jeandupont@mail.fr')
+              .quiSAppelle('Jean Dupont').donnees
+          )
+          .construis(),
+      });
+      let contributeursRenseignes;
+      testeur.adaptateurCsv().genereCsvMesures = async (
+        _mesures,
+        contributeurs
+      ) => {
+        contributeursRenseignes = contributeurs;
+      };
+
+      await axios.get('http://localhost:1234/service/456/mesures/export.csv');
+
+      expect(contributeursRenseignes).to.eql({
+        123: 'email.createur@mail.fr',
+        145: 'Jean Dupont',
+      });
+    });
+
     it('sert un fichier de type CSV', (done) => {
       verifieTypeFichierServiEstCSV(
         'http://localhost:1234/service/456/mesures/export.csv',


### PR DESCRIPTION
...la colonne contient le nom et prénom ou l'email si le profil est incomplet, séparés par une virgule pour les différents responsables
<img width="685" alt="Capture d’écran 2024-08-09 à 10 19 27" src="https://github.com/user-attachments/assets/18504fbf-f21a-4581-9576-55696900760f">
