### PR TITLE
[CORRECTION] Ré-affiche la notification de profil incomplet

### DIFF
--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -9,6 +9,11 @@ const avecStatutLecture = (notification, statutLecture) => ({
   statutLecture,
 });
 
+const avecCanalDiffusion = (notification, canalDiffusion) => ({
+  ...notification,
+  canalDiffusion,
+});
+
 class CentreNotifications {
   constructor({ referentiel, depotDonnees, adaptateurHorloge }) {
     if (!referentiel || !depotDonnees || !adaptateurHorloge) {
@@ -128,26 +133,18 @@ class CentreNotifications {
     const completudeProfil = utilisateur.completudeProfil();
     if (completudeProfil.estComplet) return [];
 
-    if (completudeProfil.champsNonRenseignes.includes('nom')) {
-      const tache = this.referentiel.tacheCompletudeProfil('profil');
-      return [
-        {
-          ...avecStatutLecture(tache, CentreNotifications.NOTIFICATION_NON_LUE),
-          canalDiffusion: 'centreNotifications',
-        },
-      ];
-    }
+    const profilDeInvite = completudeProfil.champsNonRenseignes.includes('nom');
 
-    return completudeProfil.champsNonRenseignes
-      .map((champ) => this.referentiel.tacheCompletudeProfil(champ))
-      .filter((t) => t !== undefined)
-      .map((t) =>
-        avecStatutLecture(t, CentreNotifications.NOTIFICATION_NON_LUE)
-      )
-      .map((t) => ({
-        ...t,
-        canalDiffusion: 'centreNotifications',
-      }));
+    const tachesAFaire = profilDeInvite
+      ? [this.referentiel.tacheCompletudeProfil('profil')]
+      : completudeProfil.champsNonRenseignes
+          .map((champ) => this.referentiel.tacheCompletudeProfil(champ))
+          .filter((t) => t !== undefined);
+
+    const { NOTIFICATION_NON_LUE } = CentreNotifications;
+    return tachesAFaire
+      .map((t) => avecStatutLecture(t, NOTIFICATION_NON_LUE))
+      .map((t) => avecCanalDiffusion(t, 'centreNotifications'));
   }
 
   static NOTIFICATION_LUE = 'lue';

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -123,14 +123,10 @@ class CentreNotifications {
 
   async toutesTachesProfilUtilisateur(idUtilisateur) {
     const utilisateur = await this.depotDonnees.utilisateur(idUtilisateur);
-    if (!utilisateur) {
-      return [];
-    }
+    if (!utilisateur) return [];
 
     const completudeProfil = utilisateur.completudeProfil();
-    if (completudeProfil.estComplet) {
-      return [];
-    }
+    if (completudeProfil.estComplet) return [];
 
     if (completudeProfil.champsNonRenseignes.includes('nom')) {
       const tache = this.referentiel.tacheCompletudeProfil('profil');

--- a/src/notifications/centreNotifications.js
+++ b/src/notifications/centreNotifications.js
@@ -131,7 +131,10 @@ class CentreNotifications {
     if (completudeProfil.champsNonRenseignes.includes('nom')) {
       const tache = this.referentiel.tacheCompletudeProfil('profil');
       return [
-        avecStatutLecture(tache, CentreNotifications.NOTIFICATION_NON_LUE),
+        {
+          ...avecStatutLecture(tache, CentreNotifications.NOTIFICATION_NON_LUE),
+          canalDiffusion: 'centreNotifications',
+        },
       ];
     }
 

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -387,8 +387,8 @@ describe('Le centre de notifications', () => {
       });
     });
 
-    describe("lorsque l'utilisateur est invité'", () => {
-      it('renvoie uniquement la notification de profil', async () => {
+    describe("lorsque l'utilisateur vient d'être invité, donc son profil a plein de champs non renseignés", () => {
+      it('renvoie uniquement la notification « globale » de profil à mettre à jour', async () => {
         depotDonnees.utilisateur = async () =>
           unUtilisateur().quiEstInvite().construis();
         referentiel = Referentiel.creeReferentiel({
@@ -402,6 +402,7 @@ describe('Le centre de notifications', () => {
 
         expect(taches.length).to.be(1);
         expect(taches[0].id).to.be('profil');
+        expect(taches[0].canalDiffusion).to.be('centreNotifications');
       });
     });
   });


### PR DESCRIPTION
## AVANT
Le centre de notifications n'affiche plus la notification de « mettez à jour votre profil »

![image](https://github.com/user-attachments/assets/1877e21c-c41d-471d-8db9-6ac26ed69071)


## APRÈS
La notification est de retour.
Il manquait le `canalDiffusion` nécessaire à l'affichage.

![image](https://github.com/user-attachments/assets/c5cefa7c-0ae8-4c47-90ff-a3a275cfaccd)
