### PR TITLE
[PLAN D'ACTION] Ajout des responsables dans le tiroir de Mesure

### DIFF
--- a/public/modules/tableauDeBord/gestionnaireEvenements.mjs
+++ b/public/modules/tableauDeBord/gestionnaireEvenements.mjs
@@ -7,7 +7,7 @@ const gestionnaireEvenements = {
   brancheComportement: () => {
     gestionnaireTiroir.brancheComportement();
 
-    $(document.body).on('jquery-recharge-services', () => {
+    $(document.body).on('collaboratif-service-modifie', () => {
       tableauDesServices.recupereServices();
     });
 

--- a/public/scripts/menuNavigation.js
+++ b/public/scripts/menuNavigation.js
@@ -17,7 +17,7 @@ const tiroirContributeur = (idService, modeVisiteGuidee = false) => {
     brancheComportement: async () => {
       if (idService) await chargeDonneesDuService();
 
-      $(document.body).on('jquery-recharge-services', async () => {
+      $(document.body).on('collaboratif-service-modifie', async () => {
         await chargeDonneesDuService();
       });
 

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -36,7 +36,7 @@ block titre
   h1 Sécuriser
 
 block sous-titre
-  h2 Mettre en oeuvre des mesures de sécurité adaptées
+  h2 Mettre en œuvre des mesures de sécurité adaptées
 
 block formulaire
   #tableau-des-mesures

--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -6,6 +6,7 @@
   import { onMount } from 'svelte';
   import PersonnalisationContributeur from './personnalisation/PersonnalisationContributeur.svelte';
   import { autorisationsVisiteGuidee } from './modeVisiteGuidee/donneesVisiteGuidee';
+  import { storeAutorisations } from './stores/autorisations.store';
 
   export let modeVisiteGuidee: boolean;
 
@@ -14,12 +15,12 @@
   $: contributeurs = serviceUnique.contributeurs;
 
   onMount(async () => {
-    if (modeVisiteGuidee) store.autorisations.charge(autorisationsVisiteGuidee);
+    if (modeVisiteGuidee) storeAutorisations.charge(autorisationsVisiteGuidee);
     else if (surServiceUnique) {
       const reponse = await axios.get(
         `/api/service/${serviceUnique.id}/autorisations`
       );
-      store.autorisations.charge(reponse.data);
+      storeAutorisations.charge(reponse.data);
     }
   });
 </script>

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.store.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.store.ts
@@ -1,10 +1,5 @@
 import { writable } from 'svelte/store';
-import type {
-  Autorisation,
-  IdUtilisateur,
-  Service,
-  Utilisateur,
-} from './gestionContributeurs.d';
+import type { Service, Utilisateur } from './gestionContributeurs.d';
 
 type Etape =
   | 'ListeContributeurs'
@@ -17,7 +12,6 @@ type EtatGestionContributeursStore = {
   utilisateurEnCoursDeSuppression: Utilisateur | null;
   utilisateurEnCoursDePersonnalisation: Utilisateur | null;
   services: Service[];
-  autorisations: Record<IdUtilisateur, Autorisation>;
 };
 
 const valeurParDefaut: EtatGestionContributeursStore = {
@@ -25,7 +19,6 @@ const valeurParDefaut: EtatGestionContributeursStore = {
   utilisateurEnCoursDeSuppression: null,
   utilisateurEnCoursDePersonnalisation: null,
   services: [],
-  autorisations: {},
 };
 
 const { subscribe, update, set } =
@@ -66,26 +59,5 @@ export const store = {
         );
         return { ...etat, services: [serviceUnique] };
       }),
-  },
-  autorisations: {
-    charge: (autorisations: Autorisation[]) => {
-      const parIdUtilisateur = autorisations.reduce(
-        (acc: Record<IdUtilisateur, Autorisation>, a: Autorisation) => ({
-          ...acc,
-          [a.idUtilisateur]: a,
-        }),
-        {}
-      );
-      update((etat) => ({ ...etat, autorisations: parIdUtilisateur }));
-    },
-    remplace: (cible: Autorisation) => {
-      update((etat) => ({
-        ...etat,
-        autorisations: {
-          ...etat.autorisations,
-          [cible.idUtilisateur]: cible,
-        },
-      }));
-    },
   },
 };

--- a/svelte/lib/gestionContributeurs/invitation/InvitationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/invitation/InvitationContributeur.svelte
@@ -69,7 +69,9 @@
     await api.envoieInvitations(Object.values(invitations), services);
     invitations = {};
     etapeCourante = 'Rapport';
-    document.body.dispatchEvent(new CustomEvent('jquery-recharge-services'));
+    document.body.dispatchEvent(
+      new CustomEvent('collaboratif-service-modifie')
+    );
   };
 </script>
 

--- a/svelte/lib/gestionContributeurs/kit/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/kit/LigneContributeur.svelte
@@ -5,6 +5,7 @@
   import TagNiveauDroit from './TagNiveauDroit.svelte';
   import { enDroitsSurRubrique } from '../gestionContributeurs.d';
   import type { ResumeNiveauDroit } from '../../ui/types';
+  import { storeAutorisations } from '../stores/autorisations.store';
 
   export let droitsModifiables: boolean;
   export let afficheDroits: boolean = true;
@@ -12,7 +13,7 @@
 
   let serviceUnique: Service;
   $: serviceUnique = $store.services[0];
-  $: autorisation = $store.autorisations[utilisateur.id];
+  $: autorisation = $storeAutorisations.autorisations[utilisateur.id];
 
   const changeDroits = async (nouveauDroit: ResumeNiveauDroit) => {
     const idAutorisation = autorisation!.idAutorisation;
@@ -22,7 +23,7 @@
       { droits: enDroitsSurRubrique(nouveauDroit) }
     );
 
-    store.autorisations.remplace(autorisationMAJ);
+    storeAutorisations.remplace(autorisationMAJ);
   };
 </script>
 

--- a/svelte/lib/gestionContributeurs/personnalisation/PersonnalisationContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/personnalisation/PersonnalisationContributeur.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
   import { store } from '../gestionContributeurs.store';
   import PersonnalisationDroits from './PersonnalisationDroits.svelte';
+  import { storeAutorisations } from '../stores/autorisations.store';
+  import type { Autorisation, Utilisateur } from '../gestionContributeurs.d';
 
-  $: contributeur = $store.utilisateurEnCoursDePersonnalisation!;
-  $: originaux = $store.autorisations[contributeur.id];
+  let contributeur: Utilisateur;
+  let originaux: Autorisation;
+
+  $: {
+    contributeur = $store.utilisateurEnCoursDePersonnalisation!;
+    if (contributeur)
+      originaux = $storeAutorisations.autorisations[contributeur.id];
+  }
 
   const envoyerDroits = async (droits: any) => {
     const idService = $store.services[0].id;
@@ -12,7 +20,7 @@
       `/api/service/${idService}/autorisations/${idAutorisation}`,
       { droits }
     );
-    store.autorisations.remplace(nouvelleAutorisation);
+    storeAutorisations.remplace(nouvelleAutorisation);
     store.navigation.afficheEtapeListe();
   };
 </script>
@@ -21,8 +29,5 @@
   utilisateur={contributeur}
   droitsOriginaux={originaux.droits}
   on:valider={({ detail: nouveauxDroits }) => envoyerDroits(nouveauxDroits)}
-  on:annuler={() => {
-    store.autorisations.remplace(originaux);
-    store.navigation.afficheEtapeListe();
-  }}
+  on:annuler={() => store.navigation.afficheEtapeListe()}
 />

--- a/svelte/lib/gestionContributeurs/stores/autorisations.store.ts
+++ b/svelte/lib/gestionContributeurs/stores/autorisations.store.ts
@@ -1,0 +1,30 @@
+import type { IdUtilisateur, Autorisation } from '../gestionContributeurs.d';
+import { writable } from 'svelte/store';
+
+type AutorisationsStore = {
+  autorisations: Record<IdUtilisateur, Autorisation>;
+};
+
+const valeurParDefaut: AutorisationsStore = {
+  autorisations: {},
+};
+
+const { subscribe, update } = writable<AutorisationsStore>(valeurParDefaut);
+
+export const storeAutorisations = {
+  subscribe,
+
+  charge: (autorisations: Autorisation[]) => {
+    const parIdUtilisateur = Object.fromEntries(
+      autorisations.map((a) => [a.idUtilisateur, a])
+    );
+    update((etat) => ({ ...etat, autorisations: parIdUtilisateur }));
+  },
+
+  remplace: (cible: Autorisation) => {
+    update((etat) => ({
+      ...etat,
+      autorisations: { ...etat.autorisations, [cible.idUtilisateur]: cible },
+    }));
+  },
+};

--- a/svelte/lib/gestionContributeurs/suppression/SuppressionContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/suppression/SuppressionContributeur.svelte
@@ -10,7 +10,9 @@
       params: { idService: service.id, idContributeur: utilisateur.id },
     });
     store.contributeurs.supprime(utilisateur);
-    document.body.dispatchEvent(new CustomEvent('jquery-recharge-services'));
+    document.body.dispatchEvent(
+      new CustomEvent('collaboratif-service-modifie')
+    );
     store.navigation.afficheEtapeListe();
   };
 </script>

--- a/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
@@ -8,6 +8,8 @@
   import { planDActionDisponible } from '../../modeles/mesure';
   import { contributeurs } from '../../tableauDesMesures/stores/contributeurs.store';
   import Initiales from '../../ui/Initiales.svelte';
+  import type { IdUtilisateur } from '../mesure.d';
+  import { storeAutorisations } from '../../gestionContributeurs/stores/autorisations.store';
 
   export let visible: boolean;
   export let estLectureSeule: boolean;
@@ -23,6 +25,9 @@
   const afficheAvertissementStatut = !planDActionDisponible(
     $store.mesureEditee.mesure.statut
   );
+
+  $: niveauDeDroitDe = (idUtilisateur: IdUtilisateur) =>
+    $storeAutorisations.autorisations[idUtilisateur]?.resumeNiveauDroit;
 </script>
 
 <div id="contenu-onglet-plan-action" class:visible>
@@ -77,7 +82,10 @@
     <div class="responsables">
       {#each $contributeurs as contributeur (contributeur.id)}
         <div class="un-responsable">
-          <Initiales valeur={contributeur.initiales} />
+          <Initiales
+            valeur={contributeur.initiales}
+            resumeNiveauDroit={niveauDeDroitDe(contributeur.id)}
+          />
           <div class="nom" class:estLectureSeule={selectionDesactivee}>
             {contributeur.prenomNom}
           </div>

--- a/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
@@ -6,6 +6,8 @@
   import type { ReferentielPriorite, ReferentielStatut } from '../../ui/types';
   import SelectionEcheance from '../../tableauDesMesures/ligne/SelectionEcheance.svelte';
   import { planDActionDisponible } from '../../modeles/mesure';
+  import { contributeurs } from '../../tableauDesMesures/stores/contributeurs.store';
+  import Initiales from '../../ui/Initiales.svelte';
 
   export let visible: boolean;
   export let estLectureSeule: boolean;
@@ -71,6 +73,23 @@
     <p class="sous-titre" class:estLectureSeule={selectionDesactivee}>
       Vous pouvrez attribuer cette mesure à un ou plusieurs responsables.
     </p>
+
+    <div class="responsables">
+      {#each $contributeurs as contributeur (contributeur.id)}
+        <div class="un-responsable">
+          <Initiales valeur={contributeur.initiales} />
+          <div class="nom" class:estLectureSeule={selectionDesactivee}>
+            {contributeur.prenomNom}
+          </div>
+          <input
+            type="checkbox"
+            value={contributeur.id}
+            class="checkbox-contributeur"
+            disabled={selectionDesactivee}
+          />
+        </div>
+      {/each}
+    </div>
   </div>
 </div>
 
@@ -100,7 +119,7 @@
     gap: 16px;
   }
 
-  p.label {
+  .label {
     font-weight: 500;
     line-height: 22px;
     text-align: left;
@@ -108,12 +127,38 @@
     margin: 0 0 4px;
   }
 
-  p.sous-titre {
+  .sous-titre {
     color: var(--texte-clair);
     font-size: 0.8rem;
   }
 
-  p.estLectureSeule {
+  .estLectureSeule {
     color: var(--liseres-fonce);
+  }
+
+  .responsables {
+    display: flex;
+    flex-direction: column;
+    row-gap: 18px;
+    margin-top: 25px;
+    width: calc(100% - 50px);
+  }
+
+  .un-responsable {
+    display: flex;
+    align-items: center;
+
+    & .nom {
+      font-weight: 500;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      margin-left: 8px;
+      width: 15rem;
+    }
+
+    & input {
+      margin: 0 0 0 auto;
+      transform: none;
+    }
   }
 </style>

--- a/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
@@ -45,7 +45,7 @@
     </Avertissement>
   {:else}
     <p class="presentation">
-      Le plan d'action vous permet de mettre en oeuvre plus rapidement les
+      Le plan d'action vous permet de mettre en œuvre plus rapidement les
       mesures en équipe.
     </p>
   {/if}

--- a/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
@@ -86,6 +86,7 @@
             value={contributeur.id}
             class="checkbox-contributeur"
             disabled={selectionDesactivee}
+            bind:group={$store.mesureEditee.mesure.responsables}
           />
         </div>
       {/each}

--- a/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
@@ -78,6 +78,17 @@
     <p class="sous-titre" class:estLectureSeule={selectionDesactivee}>
       Vous pouvrez attribuer cette mesure à un ou plusieurs responsables.
     </p>
+    <p class="sous-titre" class:estLectureSeule={selectionDesactivee}>
+      <button
+        disabled={selectionDesactivee}
+        type="button"
+        on:click={() =>
+          document.body.dispatchEvent(
+            new CustomEvent('jquery-affiche-tiroir-contributeurs')
+          )}>Gerer les contributeurs</button
+      >
+      <span>pour modifier les droits ou ajouter des responsables.</span>
+    </p>
 
     <div class="responsables">
       {#each $contributeurs as contributeur (contributeur.id)}
@@ -139,6 +150,21 @@
   .sous-titre {
     color: var(--texte-clair);
     font-size: 0.8rem;
+    margin-top: 2px;
+
+    & button {
+      background: none;
+      border: none;
+      padding: 0;
+      font-weight: 500;
+      line-height: 20px;
+      text-decoration-line: underline;
+
+      &:not([disabled]) {
+        color: var(--bleu-mise-en-avant);
+        cursor: pointer;
+      }
+    }
   }
 
   .estLectureSeule {

--- a/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletPlanAction.svelte
@@ -12,9 +12,11 @@
   export let priorites: ReferentielPriorite;
   export let statuts: ReferentielStatut;
 
-  $: selectionDesactivee = !planDActionDisponible(
+  $: planDactionNonDisponible = !planDActionDisponible(
     $store.mesureEditee.mesure.statut
   );
+
+  $: selectionDesactivee = estLectureSeule || planDactionNonDisponible;
 
   const afficheAvertissementStatut = !planDActionDisponible(
     $store.mesureEditee.mesure.statut
@@ -53,15 +55,23 @@
     id="priorite"
     bind:priorite={$store.mesureEditee.mesure.priorite}
     label="Priorité"
-    estLectureSeule={estLectureSeule || selectionDesactivee}
+    estLectureSeule={selectionDesactivee}
     avecLibelleOption
     {priorites}
   />
   <SelectionEcheance
     bind:echeance={$store.mesureEditee.mesure.echeance}
     avecLabel={true}
-    estLectureSeule={estLectureSeule || selectionDesactivee}
+    estLectureSeule={selectionDesactivee}
   />
+  <div>
+    <p class="label" class:estLectureSeule={selectionDesactivee}>
+      Responsable(s)
+    </p>
+    <p class="sous-titre" class:estLectureSeule={selectionDesactivee}>
+      Vous pouvrez attribuer cette mesure à un ou plusieurs responsables.
+    </p>
+  </div>
 </div>
 
 <style>
@@ -81,8 +91,6 @@
 
   p.presentation {
     font-weight: bold;
-    line-height: 22px;
-    font-size: 16px;
     margin: 0;
   }
 
@@ -90,5 +98,22 @@
     display: flex;
     flex-direction: column;
     gap: 16px;
+  }
+
+  p.label {
+    font-weight: 500;
+    line-height: 22px;
+    text-align: left;
+    color: var(--texte-clair);
+    margin: 0 0 4px;
+  }
+
+  p.sous-titre {
+    color: var(--texte-clair);
+    font-size: 0.8rem;
+  }
+
+  p.estLectureSeule {
+    color: var(--liseres-fonce);
   }
 </style>

--- a/svelte/lib/mesure/mesure.api.ts
+++ b/svelte/lib/mesure/mesure.api.ts
@@ -10,17 +10,19 @@ export const enregistreMesures = async (
 ) => {
   async function enregistreMesureGenerale() {
     const idMesure = $store.mesureEditee.metadonnees.idMesure;
-    const { modalites, statut, priorite } = $store.mesureEditee.mesure;
+    const { modalites, statut, priorite, responsables } =
+      $store.mesureEditee.mesure;
     let { echeance } = $store.mesureEditee.mesure;
-    if (echeance) {
-      echeance = formatteurDate.format(new Date(echeance));
-    }
+    if (echeance) echeance = formatteurDate.format(new Date(echeance));
+
     mesuresExistantes.mesuresGenerales[idMesure] = { modalites, statut };
+
     await axios.put(`/api/service/${idService}/mesures/${idMesure}`, {
       modalites,
       statut,
       priorite,
       echeance,
+      responsables,
     });
   }
 

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -22,9 +22,11 @@ export type MesuresExistantes = {
   mesuresSpecifiques: MesureSpecifique[];
 };
 
+type IdUtilisateur = string;
 type PlanAction = {
   priorite?: string;
   echeance?: string;
+  responsables?: IdUtilisateur[];
 };
 
 export type MesureGenerale = PlanAction & {

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -22,11 +22,14 @@ export type MesuresExistantes = {
   mesuresSpecifiques: MesureSpecifique[];
 };
 
-export type MesureGenerale = {
-  statut?: StatutMesure;
-  modalites?: string;
+type PlanAction = {
   priorite?: string;
   echeance?: string;
+};
+
+export type MesureGenerale = PlanAction & {
+  statut?: StatutMesure;
+  modalites?: string;
 };
 
 export type MesureGeneraleEnrichie = MesureGenerale & {
@@ -39,7 +42,9 @@ export type MesureGeneraleEnrichie = MesureGenerale & {
   lienBlog?: string;
 };
 
-export type MesureSpecifique = MesureGenerale & {
+export type MesureSpecifique = PlanAction & {
+  statut?: StatutMesure;
+  modalites?: string;
   categorie: string;
   description: string;
   identifiantNumerique: string;

--- a/svelte/lib/mesure/mesure.store.ts
+++ b/svelte/lib/mesure/mesure.store.ts
@@ -42,15 +42,9 @@ export const store = {
     });
   },
   afficheEtapeSuppression: () =>
-    update((etat) => ({
-      ...etat,
-      etape: 'SuppressionSpecifique',
-    })),
+    update((etat) => ({ ...etat, etape: 'SuppressionSpecifique' })),
   afficheEtapeEditionSpecifique: () =>
-    update((etat) => ({
-      ...etat,
-      etape: 'EditionSpecifique',
-    })),
+    update((etat) => ({ ...etat, etape: 'EditionSpecifique' })),
 };
 
 export const configurationAffichage = derived(store, ($store) => {

--- a/svelte/lib/tableauDesMesures/BandeauActions.svelte
+++ b/svelte/lib/tableauDesMesures/BandeauActions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { EtatEnregistrement } from './tableauDesMesures.d';
   import {
-    afficheTiroirDeMesure,
+    afficheTiroirCreeMesure,
     afficheTiroirExportDesMesures,
   } from './actionsTiroir';
 
@@ -15,7 +15,7 @@
     <div class="actions">
       <button
         class="bouton-action-mesure"
-        on:click={() => afficheTiroirDeMesure()}
+        on:click={() => afficheTiroirCreeMesure()}
         disabled={etatEnregistrement === EnCours}
       >
         <img src="/statique/assets/images/icone_plus_gris.svg" alt="" />

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -129,7 +129,7 @@
 
 <svelte:body
   on:mesure-modifiee={rafraichisMesures}
-  on:jquery-recharge-services={() =>
+  on:collaboratif-service-modifie={() =>
     Promise.all([rafraichisContributeurs(), rafraichisAutorisations()])}
 />
 <Toaster />

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -35,7 +35,7 @@
   import Avertissement from '../ui/Avertissement.svelte';
   import TagStatutMesure from '../ui/TagStatutMesure.svelte';
   import BandeauActions from './BandeauActions.svelte';
-  import { afficheTiroirDeMesure } from './actionsTiroir';
+  import { afficheTiroirEditeMesure } from './actionsTiroir';
   import { featureFlags } from '../featureFlags';
   import { contributeurs } from './stores/contributeurs.store';
 
@@ -246,7 +246,7 @@
             metsAJourMesureGenerale(id);
           }}
           on:click={() =>
-            afficheTiroirDeMesure({
+            afficheTiroirEditeMesure({
               mesure,
               metadonnees: { typeMesure: 'GENERALE', idMesure: id },
             })}
@@ -290,7 +290,7 @@
             metsAJourMesuresSpecifiques(indexReel);
           }}
           on:click={() =>
-            afficheTiroirDeMesure({
+            afficheTiroirEditeMesure({
               mesure,
               metadonnees: { typeMesure: 'SPECIFIQUE', idMesure: indexReel },
             })}

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -38,6 +38,7 @@
   import { afficheTiroirEditeMesure } from './actionsTiroir';
   import { featureFlags } from '../featureFlags';
   import { contributeurs } from './stores/contributeurs.store';
+  import { storeAutorisations } from '../gestionContributeurs/stores/autorisations.store';
 
   const { Jamais, EnCours, Fait } = EtatEnregistrement;
 
@@ -58,8 +59,17 @@
     contributeurs.reinitialise(await recupereContributeurs(idService));
   };
 
+  const rafraichisAutorisations = async () => {
+    const reponse = await axios.get(`/api/service/${idService}/autorisations`);
+    storeAutorisations.charge(reponse.data);
+  };
+
   onMount(async () => {
-    await Promise.all([rafraichisMesures(), rafraichisContributeurs()]);
+    await Promise.all([
+      rafraichisMesures(),
+      rafraichisContributeurs(),
+      rafraichisAutorisations(),
+    ]);
     if (!$nombreResultats.nombreParAvancement.statutADefinir)
       $rechercheParAvancement = 'enAction';
   });

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -127,7 +127,11 @@
     $rechercheParAvancement !== 'statutADefinir' && featureFlags.planAction();
 </script>
 
-<svelte:body on:mesure-modifiee={rafraichisMesures} />
+<svelte:body
+  on:mesure-modifiee={rafraichisMesures}
+  on:jquery-recharge-services={() =>
+    Promise.all([rafraichisContributeurs(), rafraichisAutorisations()])}
+/>
 <Toaster />
 <div class="barre-filtres">
   <div class="conteneur-recherche">

--- a/svelte/lib/tableauDesMesures/actionsTiroir.ts
+++ b/svelte/lib/tableauDesMesures/actionsTiroir.ts
@@ -11,16 +11,27 @@ type MesureAEditer = {
   };
 };
 
-export const afficheTiroirDeMesure = (mesureAEditer?: MesureAEditer) => {
+export const afficheTiroirEditeMesure = (mesureAEditer: MesureAEditer) => {
   document.body.dispatchEvent(
     new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
       detail: {
         mesuresExistantes: metEnFormeMesures(get(mesures)),
         titreTiroir:
-          mesureAEditer && mesureAEditer.metadonnees.typeMesure === 'GENERALE'
+          mesureAEditer.metadonnees.typeMesure === 'GENERALE'
             ? mesureAEditer.mesure.description
             : 'Ajouter une mesure',
-        ...(mesureAEditer && { mesureAEditer }),
+        mesureAEditer,
+      },
+    })
+  );
+};
+
+export const afficheTiroirCreeMesure = () => {
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
+      detail: {
+        mesuresExistantes: metEnFormeMesures(get(mesures)),
+        titreTiroir: 'Ajouter une mesure',
       },
     })
   );

--- a/svelte/lib/ui/SelectionResponsables.svelte
+++ b/svelte/lib/ui/SelectionResponsables.svelte
@@ -4,6 +4,7 @@
   import { contributeurs } from '../tableauDesMesures/stores/contributeurs.store';
   import { createEventDispatcher } from 'svelte';
   import Initiales from './Initiales.svelte';
+  import { storeAutorisations } from '../gestionContributeurs/stores/autorisations.store';
 
   export let responsables: IdUtilisateur[] | null;
   export let estLectureSeule: boolean;
@@ -23,6 +24,9 @@
   const modifieResponsables = () => {
     if (responsables) dispatch('modificationResponsables', { responsables });
   };
+
+  $: niveauDeDroitDe = (idUtilisateur: IdUtilisateur) =>
+    $storeAutorisations.autorisations[idUtilisateur]?.resumeNiveauDroit;
 </script>
 
 <MenuFlottant bind:menuOuvert {estLectureSeule} stopPropagation>
@@ -42,7 +46,10 @@
       {#each $contributeurs as contributeur (contributeur.id)}
         <div class="conteneur-contributeur">
           <div class="conteneur-nom">
-            <Initiales valeur={contributeur.initiales} />
+            <Initiales
+              valeur={contributeur.initiales}
+              resumeNiveauDroit={niveauDeDroitDe(contributeur.id)}
+            />
             <span class="nom-contributeur">{contributeur.prenomNom}</span>
           </div>
           <input


### PR DESCRIPTION
Cette PR permet de sélectionner le(s) responsable(s) de mesure dans le tiroir de Mesure 👇 

![image](https://github.com/user-attachments/assets/2f931230-e5c5-45c1-a3da-56c03a5ae250)

Nous avons bien fait attention à synchroniser tous les éléments de la page entre eux.
Lorsqu'on invite / supprime / modifie les droits d'un collaborateur : le changement est reflété dans les choix possibles de responsables.