### PR TITLE
Supprime les responsables de mesures à la suppression d'un contributeur

### DIFF
--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -139,6 +139,7 @@ const creeDepot = (config = {}) => {
     await verifieAutorisationExiste();
     await verifieSuppressionPermise();
     await adaptateurPersistance.supprimeAutorisation(idContributeur, idService);
+    await depotServices.supprimeContributeur(idService, idContributeur);
     await publieAutorisationsDuService(idService);
   };
 

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -380,6 +380,15 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  const supprimeContributeur = async (idService, idUtilisateur) => {
+    const unService = await p.lis.un(idService);
+
+    unService.supprimeResponsableMesures(idUtilisateur);
+
+    const { id, ...donnees } = unService.donneesAPersister().toutes();
+    return p.sauvegarde(id, donnees);
+  };
+
   return {
     ajouteDescriptionService,
     ajouteDossierCourantSiNecessaire,
@@ -396,6 +405,7 @@ const creeDepot = (config = {}) => {
     service,
     services,
     remplaceRisquesSpecifiquesDuService,
+    supprimeContributeur,
     supprimeHomologation,
     tousLesServices,
     trouveIndexDisponible,

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -38,6 +38,10 @@ class MesureGenerale extends Mesure {
     return Mesure.statutRenseigne(this.statut);
   }
 
+  supprimeResponsable(idUtilisateur) {
+    this.responsables = this.responsables.filter((r) => r !== idUtilisateur);
+  }
+
   static valide({ id, statut, priorite, echeance }, referentiel) {
     super.valide({ statut, priorite, echeance }, referentiel);
 

--- a/src/modeles/mesureSpecifique.js
+++ b/src/modeles/mesureSpecifique.js
@@ -27,6 +27,10 @@ class MesureSpecifique extends Mesure {
     return Mesure.statutRenseigne(this.statut);
   }
 
+  supprimeResponsable(idUtilisateur) {
+    this.responsables = this.responsables.filter((r) => r !== idUtilisateur);
+  }
+
   static proprietesObligatoires() {
     return ['description', 'categorie', 'statut'];
   }

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -134,6 +134,11 @@ class Mesures extends InformationsService {
       this.referentiel
     );
   }
+
+  supprimeResponsable(idUtilisateur) {
+    this.mesuresGenerales.supprimeResponsable(idUtilisateur);
+    this.mesuresSpecifiques.supprimeResponsable(idUtilisateur);
+  }
 }
 
 module.exports = Mesures;

--- a/src/modeles/mesuresGenerales.js
+++ b/src/modeles/mesuresGenerales.js
@@ -43,6 +43,10 @@ class MesuresGenerales extends ElementsConstructibles {
       .reduce(rangeMesureParStatut, accumulateur);
   }
 
+  supprimeResponsable(idUtilisateur) {
+    this.toutes().forEach((m) => m.supprimeResponsable(idUtilisateur));
+  }
+
   statutSaisie() {
     if (this.nonSaisies()) return MesuresGenerales.A_SAISIR;
     if (

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -22,6 +22,10 @@ class MesuresSpecifiques extends ElementsConstructibles {
     }, accumulateur);
   }
 
+  supprimeResponsable(idUtilisateur) {
+    this.toutes().forEach((m) => m.supprimeResponsable(idUtilisateur));
+  }
+
   nombreDeSansStatut() {
     return this.toutes().filter((ms) => !ms.statutRenseigne()).length;
   }

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -229,6 +229,10 @@ class Service {
     this.mesures.metsAJourMesuresSpecifiques(mesures, this.referentiel);
   }
 
+  supprimeResponsableMesures(idUtilisateur) {
+    this.mesures.supprimeResponsable(idUtilisateur);
+  }
+
   nombreDossiers() {
     return this.dossiers.nombre();
   }

--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -130,7 +130,11 @@
 <svelte:body
   on:mesure-modifiee={rafraichisMesures}
   on:collaboratif-service-modifie={() =>
-    Promise.all([rafraichisContributeurs(), rafraichisAutorisations()])}
+    Promise.all([
+      rafraichisContributeurs(), // Pour avoir une liste à jour dans la sélection des responsables
+      rafraichisAutorisations(), // Pour avoir des pastilles de couleur à jour sur les droits
+      rafraichisMesures(), // Pour avoir les responsables de mesures à jour
+    ])}
 />
 <Toaster />
 <div class="barre-filtres">

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -25,6 +25,8 @@ const {
 } = require('../../src/bus/evenementAutorisationsServiceModifiees');
 const { fabriqueBusPourLesTests } = require('../bus/aides/busPourLesTests');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
+const { unService } = require('../constructeurs/constructeurService');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
 
 const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 const { ECRITURE, LECTURE } = Permissions;
@@ -352,6 +354,11 @@ describe('Le dépôt de données des autorisations', () => {
 
     it('supprime le contributeur', async () => {
       const avecUneAutorisation = unePersistanceMemoire()
+        .ajouteUnService(
+          unService().avecId('S1').avecDescription({ nom: 'S1' }).donnees
+        )
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
         .ajouteUneAutorisation(
           uneAutorisation().deContributeur('U1', 'S1').donnees
         )
@@ -405,6 +412,11 @@ describe('Le dépôt de données des autorisations', () => {
     it("publie les autorisations à jour sur le bus d'événements", async () => {
       const bus = fabriqueBusPourLesTests();
       const avecDeuxExistantes = unePersistanceMemoire()
+        .ajouteUnService(
+          unService().avecId('S1').avecDescription({ nom: 'S1' }).donnees
+        )
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
         .ajouteUneAutorisation(
           uneAutorisation().avecId('A1').deProprietaire('U1', 'S1').donnees
         )


### PR DESCRIPTION
Lors de la suppression d'un contributeur d'un service, on souhaite supprimer ses assignations en tant que responsable d'une mesure.