### PR TITLE
[PLAN D'ACTION] Stocke les échéances au format ISO, en UTC

### DIFF
--- a/migrations/20240812124743_stockeDateEcheanceAuFormatIsoUtc.js
+++ b/migrations/20240812124743_stockeDateEcheanceAuFormatIsoUtc.js
@@ -1,0 +1,28 @@
+const enIso = (chaineDate) => new Date(chaineDate).toISOString();
+
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const services = await trx('services');
+
+    const maj = services.map(({ id, donnees }) => {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const generale of donnees.mesuresGenerales || []) {
+        if (generale.echeance) generale.echeance = enIso(generale.echeance);
+        else delete generale.echeance;
+      }
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const specifique of donnees.mesuresSpecifiques || []) {
+        if (specifique.echeance)
+          specifique.echeance = enIso(specifique.echeance);
+        else delete specifique.echeance;
+      }
+
+      return trx('services').where({ id }).update({ donnees });
+    });
+
+    await Promise.all(maj);
+  });
+};
+
+exports.down = () => {};

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -42,6 +42,13 @@ class MesureGenerale extends Mesure {
     this.responsables = this.responsables.filter((r) => r !== idUtilisateur);
   }
 
+  donneesSerialisees() {
+    return {
+      ...super.donneesSerialisees(),
+      ...(this.echeance && { echeance: new Date(this.echeance).toISOString() }),
+    };
+  }
+
   static valide({ id, statut, priorite, echeance }, referentiel) {
     super.valide({ statut, priorite, echeance }, referentiel);
 

--- a/src/modeles/mesureSpecifique.js
+++ b/src/modeles/mesureSpecifique.js
@@ -27,6 +27,13 @@ class MesureSpecifique extends Mesure {
     return Mesure.statutRenseigne(this.statut);
   }
 
+  donneesSerialisees() {
+    return {
+      ...super.donneesSerialisees(),
+      ...(this.echeance && { echeance: new Date(this.echeance).toISOString() }),
+    };
+  }
+
   supprimeResponsable(idUtilisateur) {
     this.responsables = this.responsables.filter((r) => r !== idUtilisateur);
   }

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -52,7 +52,7 @@ describe('Un événement de complétude modifiée', () => {
             id: 'mesureA',
             statut: 'fait',
             priorite: 'p1',
-            echeance: '9/13/2024',
+            echeance: '2024-09-13',
           },
         ],
       },

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -192,4 +192,16 @@ describe('Une mesure de sécurité', () => {
 
     expect(mesure.statutSaisie()).to.equal(InformationsService.COMPLETES);
   });
+
+  it("persiste sa date d'échéance au format ISO en UTC", () => {
+    const janvierNonIso = '01/23/2024 10:00Z';
+    const avecEcheance = new MesureGenerale(
+      { id: 'identifiantMesure', echeance: janvierNonIso },
+      referentiel
+    );
+
+    const persistance = avecEcheance.donneesSerialisees();
+
+    expect(persistance.echeance).to.be('2024-01-23T10:00:00.000Z');
+  });
 });

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -142,4 +142,16 @@ describe('Une mesure spécifique', () => {
     const mesure = new MesureSpecifique({ statut: 'fait' });
     expect(mesure.statutRenseigne()).to.be(true);
   });
+
+  elle("persiste sa date d'échéance au format ISO en UTC", () => {
+    const janvierNonIso = '01/23/2024 10:00Z';
+    const avecEcheance = new MesureSpecifique(
+      { echeance: janvierNonIso },
+      referentiel
+    );
+
+    const persistance = avecEcheance.donneesSerialisees();
+
+    expect(persistance.echeance).to.be('2024-01-23T10:00:00.000Z');
+  });
 });

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -210,7 +210,7 @@ describe('Un service', () => {
                 id: 'mesureA',
                 statut: 'fait',
                 priorite: 'p1',
-                echeance: '8/28/2024',
+                echeance: '2024-08-28',
                 responsables: ['unIdUtilisateur'],
               },
             ],


### PR DESCRIPTION
Par souci d'homogénéité avec le reste des dates stockées dans les services.

Si l'échéance est absente, alors le champ n'est pas du tout persisté.

![image](https://github.com/user-attachments/assets/cdd836bd-6d41-4ee8-96b7-f33f4daa64f0)

![image](https://github.com/user-attachments/assets/96c7634c-da97-42c0-948c-9ca5015d7900)
