### PR TITLE
[CORRECTION] Ne sauvegarde pas les id de service dans la colonne `données`

### DIFF
--- a/migrations/20240812132827_supprimeIdDonneesService.js
+++ b/migrations/20240812132827_supprimeIdDonneesService.js
@@ -1,0 +1,10 @@
+exports.up = (knex) =>
+  knex('services').then((lignes) => {
+    const suppressions = lignes.map(
+      ({ id, donnees: { id: _, ...autresDonnees } }) =>
+        knex('services').where({ id }).update({ donnees: autresDonnees })
+    );
+    return Promise.all(suppressions);
+  });
+
+exports.down = () => {};

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -349,7 +349,8 @@ const creeDepot = (config = {}) => {
     if (typeof s === 'undefined')
       throw new ErreurServiceInexistant(`Service "${unService.id}" non trouvé`);
 
-    await p.sauvegarde(unService.id, unService.donneesAPersister().toutes());
+    const { id, ...donnees } = unService.donneesAPersister().toutes();
+    await p.sauvegarde(unService.id, donnees);
   };
 
   const metsAJourMesureGeneraleDuService = async (


### PR DESCRIPTION
Le JSON des données de service contenait l'id dans certains cas, à cause d'une erreur dans un appel à `sauvegarde`.