### PR TITLE
[PRÉPARATION CHIFFREMENT] L’inscription et le login utilisateur continuent à fonctionner

### DIFF
--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -86,6 +86,7 @@ const main = async () => {
     });
     const adaptateurChiffrement = fabriqueAdaptateurChiffrement();
     const depotDonnees = DepotDonnees.creeDepot({
+      adaptateurPersistance,
       adaptateurRechercheEntite,
       adaptateurChiffrement,
       busEvenements,

--- a/creeUtilisateurDemo.js
+++ b/creeUtilisateurDemo.js
@@ -92,7 +92,7 @@ const main = async () => {
     });
 
     /* eslint-disable no-console */
-    const u = await adaptateurPersistance.utilisateurAvecEmail(
+    const u = await depotDonnees.utilisateurAvecEmail(
       process.env.EMAIL_UTILISATEUR_DEMO
     );
 

--- a/migrations/20240813070055_ajouteColonneEmailHashUtilisateurs.js
+++ b/migrations/20240813070055_ajouteColonneEmailHashUtilisateurs.js
@@ -1,0 +1,11 @@
+const tableUtilisateurs = 'utilisateurs';
+
+exports.up = (knex) =>
+  knex.schema.alterTable(tableUtilisateurs, (table) =>
+    table.string('email_hash')
+  );
+
+exports.down = (knex) =>
+  knex.schema.alterTable(tableUtilisateurs, (table) =>
+    table.dropColumn('email_hash')
+  );

--- a/migrations/20240813070846_insereEmailHashUtilisateurs.js
+++ b/migrations/20240813070846_insereEmailHashUtilisateurs.js
@@ -1,0 +1,26 @@
+const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+
+const hache = (email) => hacheSha256(email);
+
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const utilisateurs = await trx('utilisateurs');
+
+    const maj = utilisateurs.map(({ id, donnees }) => {
+      const { email } = donnees;
+      const emailHash = hache(email);
+
+      return trx('utilisateurs')
+        .where({ id })
+        .update({ email_hash: emailHash });
+    });
+
+    await Promise.all(maj);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.transaction(async (trx) =>
+    trx('utilisateurs').update({ email_hash: null })
+  );
+};

--- a/migrations/20240813121201_rendColonneEmailHashNonNullable.js
+++ b/migrations/20240813121201_rendColonneEmailHashNonNullable.js
@@ -1,0 +1,11 @@
+const tableUtilisateurs = 'utilisateurs';
+
+exports.up = (knex) =>
+  knex.schema.alterTable(tableUtilisateurs, (table) =>
+    table.string('email_hash', 64).notNullable().alter()
+  );
+
+exports.down = (knex) =>
+  knex.schema.alterTable(tableUtilisateurs, (table) =>
+    table.string('email_hash', 64).nullable().alter()
+  );

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -21,17 +21,15 @@ const nouvelAdaptateur = (
       .then((e) => Object.assign(e, donneesAMettreAJour))
       .then(() => {});
 
-  const supprimeEnregistrement = (nomTable, id) => {
+  const supprimeEnregistrement = async (nomTable, id) => {
     donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
-    return Promise.resolve();
   };
 
-  const ajouteService = (id, donneesService) => {
+  const ajouteService = async (id, donneesService) => {
     donnees.services.push({ id, ...donneesService });
-    return Promise.resolve();
   };
 
-  const ajouteUtilisateur = (id, donneesUtilisateur, emailHash) => {
+  const ajouteUtilisateur = async (id, donneesUtilisateur, emailHash) => {
     donnees.utilisateurs.push(
       Object.assign(donneesUtilisateur, {
         id,
@@ -39,17 +37,16 @@ const nouvelAdaptateur = (
         emailHash,
       })
     );
-    return Promise.resolve();
   };
 
-  const autorisations = (idUtilisateur) => {
+  const autorisations = async (idUtilisateur) => {
     const seulementUnUtilisateur = typeof idUtilisateur !== 'undefined';
 
     const filtre = seulementUnUtilisateur
       ? (a) => a.idUtilisateur === idUtilisateur
       : (a) => a.estProprietaire;
 
-    return Promise.resolve(donnees.autorisations.filter(filtre));
+    return donnees.autorisations.filter(filtre);
   };
 
   const contributeursService = (idService) =>
@@ -60,27 +57,27 @@ const nouvelAdaptateur = (
   const suggestionsActionsService = (idService) =>
     donnees.suggestionsActions.filter((s) => s.idService === idService);
 
-  const service = (id) => {
+  const service = async (id) => {
     const serviceTrouve = donnees.services.find((h) => h.id === id);
     if (serviceTrouve) {
       serviceTrouve.contributeurs = contributeursService(id);
       serviceTrouve.suggestionsActions = suggestionsActionsService(id);
     }
 
-    return Promise.resolve(serviceTrouve);
+    return serviceTrouve;
   };
 
-  const serviceDeprecated = (id) => {
+  const serviceDeprecated = async (id) => {
     const serviceTrouve = donnees.services.find((s) => s.id === id);
     if (serviceTrouve) serviceTrouve.contributeurs = contributeursService(id);
 
-    return Promise.resolve(serviceTrouve);
+    return serviceTrouve;
   };
 
-  const services = (idUtilisateur) =>
-    autorisations(idUtilisateur).then((as) =>
-      Promise.all(as.map(({ idService }) => service(idService)))
-    );
+  const services = async (idUtilisateur) => {
+    const as = await autorisations(idUtilisateur);
+    return Promise.all(as.map(({ idService }) => service(idService)));
+  };
 
   const tousLesServices = async () => {
     const lesIds = donnees.services.map((s) => s.id);
@@ -116,21 +113,19 @@ const nouvelAdaptateur = (
   const supprimeService = (...params) =>
     supprimeEnregistrement('services', ...params);
 
-  const supprimeServices = () => {
+  const supprimeServices = async () => {
     donnees.services = [];
-    return Promise.resolve();
   };
 
   const supprimeUtilisateur = (...params) =>
     supprimeEnregistrement('utilisateurs', ...params);
 
-  const supprimeUtilisateurs = () => {
+  const supprimeUtilisateurs = async () => {
     donnees.utilisateurs = [];
-    return Promise.resolve();
   };
 
-  const utilisateur = (id) =>
-    Promise.resolve(donnees.utilisateurs.find((u) => u.id === id));
+  const utilisateur = async (id) =>
+    donnees.utilisateurs.find((u) => u.id === id);
 
   const metsAJourUtilisateur = (id, donneesAMettreAJour, emailHash) =>
     utilisateur(id)
@@ -138,52 +133,43 @@ const nouvelAdaptateur = (
       .then((e) => emailHash && Object.assign(e, { emailHash }))
       .then(() => {});
 
-  const utilisateurAvecEmailHash = (emailHash) =>
-    Promise.resolve(
-      donnees.utilisateurs.find((u) => u.emailHash === emailHash)
-    );
+  const utilisateurAvecEmailHash = async (emailHash) =>
+    donnees.utilisateurs.find((u) => u.emailHash === emailHash);
 
-  const utilisateurAvecIdReset = (idReset) =>
-    Promise.resolve(
-      donnees.utilisateurs.find((u) => u.idResetMotDePasse === idReset)
-    );
+  const utilisateurAvecIdReset = async (idReset) =>
+    donnees.utilisateurs.find((u) => u.idResetMotDePasse === idReset);
 
-  const tousUtilisateurs = () => Promise.resolve(donnees.utilisateurs);
+  const tousUtilisateurs = async () => donnees.utilisateurs;
 
-  const autorisation = (id) =>
-    Promise.resolve(donnees.autorisations.find((a) => a.id === id));
+  const autorisation = async (id) =>
+    donnees.autorisations.find((a) => a.id === id);
 
   const autorisationsDuService = async (idService) =>
     donnees.autorisations.filter((a) => a.idService === idService);
 
-  const autorisationPour = (idUtilisateur, idService) =>
-    Promise.resolve(
-      donnees.autorisations.find(
-        (a) => a.idUtilisateur === idUtilisateur && a.idService === idService
-      )
+  const autorisationPour = async (idUtilisateur, idService) =>
+    donnees.autorisations.find(
+      (a) => a.idUtilisateur === idUtilisateur && a.idService === idService
     );
 
-  const ajouteAutorisation = (id, donneesAutorisation) => {
+  const ajouteAutorisation = async (id, donneesAutorisation) => {
     donnees.autorisations.push(Object.assign(donneesAutorisation, { id }));
-    return Promise.resolve();
   };
 
-  const nbAutorisationsProprietaire = (idUtilisateur) =>
-    Promise.resolve(
-      donnees.autorisations.filter(
-        (a) => a.idUtilisateur === idUtilisateur && a.estProprietaire
-      ).length
-    );
+  const nbAutorisationsProprietaire = async (idUtilisateur) =>
+    donnees.autorisations.filter(
+      (a) => a.idUtilisateur === idUtilisateur && a.estProprietaire
+    ).length;
 
-  const supprimeAutorisation = (idUtilisateur, idService) => {
+  const supprimeAutorisation = async (idUtilisateur, idService) => {
     donnees.autorisations = donnees.autorisations.filter(
       (a) => a.idUtilisateur !== idUtilisateur || a.idService !== idService
     );
-    return Promise.resolve();
   };
 
-  const supprimeAutorisations = () =>
-    Promise.resolve((donnees.autorisations = []));
+  const supprimeAutorisations = async () => {
+    donnees.autorisations = [];
+  };
 
   const supprimeAutorisationsContribution = async (idUtilisateur) => {
     donnees.autorisations = donnees.autorisations.filter(
@@ -191,11 +177,10 @@ const nouvelAdaptateur = (
     );
   };
 
-  const supprimeAutorisationsHomologation = (idService) => {
+  const supprimeAutorisationsHomologation = async (idService) => {
     donnees.autorisations = donnees.autorisations.filter(
       (a) => a.idService !== idService
     );
-    return Promise.resolve();
   };
 
   const lisParcoursUtilisateur = async (id) =>

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -31,11 +31,12 @@ const nouvelAdaptateur = (
     return Promise.resolve();
   };
 
-  const ajouteUtilisateur = (id, donneesUtilisateur) => {
+  const ajouteUtilisateur = (id, donneesUtilisateur, emailHash) => {
     donnees.utilisateurs.push(
       Object.assign(donneesUtilisateur, {
         id,
         dateCreation: adaptateurHorloge.maintenant(),
+        emailHash,
       })
     );
     return Promise.resolve();

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -138,8 +138,10 @@ const nouvelAdaptateur = (
       .then((e) => emailHash && Object.assign(e, { emailHash }))
       .then(() => {});
 
-  const utilisateurAvecEmail = (email) =>
-    Promise.resolve(donnees.utilisateurs.find((u) => u.email === email));
+  const utilisateurAvecEmailHash = (emailHash) =>
+    Promise.resolve(
+      donnees.utilisateurs.find((u) => u.emailHash === emailHash)
+    );
 
   const utilisateurAvecIdReset = (idReset) =>
     Promise.resolve(
@@ -328,7 +330,7 @@ const nouvelAdaptateur = (
     tousLesServices,
     tousUtilisateurs,
     utilisateur,
-    utilisateurAvecEmail,
+    utilisateurAvecEmailHash,
     utilisateurAvecIdReset,
   };
 };

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -132,8 +132,11 @@ const nouvelAdaptateur = (
   const utilisateur = (id) =>
     Promise.resolve(donnees.utilisateurs.find((u) => u.id === id));
 
-  const metsAJourUtilisateur = (...params) =>
-    metsAJourEnregistrement(utilisateur, ...params);
+  const metsAJourUtilisateur = (id, donneesAMettreAJour, emailHash) =>
+    utilisateur(id)
+      .then((e) => Object.assign(e, donneesAMettreAJour))
+      .then((e) => emailHash && Object.assign(e, { emailHash }))
+      .then(() => {});
 
   const utilisateurAvecEmail = (email) =>
     Promise.resolve(donnees.utilisateurs.find((u) => u.email === email));

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -13,7 +13,11 @@ const Entite = require('../modeles/entite');
 const EvenementUtilisateurModifie = require('../bus/evenementUtilisateurModifie');
 const EvenementUtilisateurInscrit = require('../bus/evenementUtilisateurInscrit');
 
-function fabriquePersistance({ adaptateurPersistance, adaptateurJWT }) {
+function fabriquePersistance({
+  adaptateurPersistance,
+  adaptateurJWT,
+  adaptateurChiffrement,
+}) {
   return {
     lis: {
       donnees: {
@@ -43,8 +47,16 @@ function fabriquePersistance({ adaptateurPersistance, adaptateurJWT }) {
         );
       },
     },
-    ajoute: async (id, donneesUtilisateur) =>
-      adaptateurPersistance.ajouteUtilisateur(id, donneesUtilisateur),
+    ajoute: async (id, donneesUtilisateur) => {
+      const emailHash = adaptateurChiffrement.hacheSha256(
+        donneesUtilisateur.email
+      );
+      return adaptateurPersistance.ajouteUtilisateur(
+        id,
+        donneesUtilisateur,
+        emailHash
+      );
+    },
     sauvegarde: async (id, deltaDonnees) =>
       adaptateurPersistance.metsAJourUtilisateur(id, deltaDonnees),
     supprime: async (id) => {
@@ -64,7 +76,11 @@ const creeDepot = (config = {}) => {
     busEvenements,
   } = config;
 
-  const p = fabriquePersistance({ adaptateurPersistance, adaptateurJWT });
+  const p = fabriquePersistance({
+    adaptateurPersistance,
+    adaptateurJWT,
+    adaptateurChiffrement,
+  });
 
   const utilisateur = async (identifiant) => p.lis.un(identifiant);
 

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -57,8 +57,17 @@ function fabriquePersistance({
         emailHash
       );
     },
-    sauvegarde: async (id, deltaDonnees) =>
-      adaptateurPersistance.metsAJourUtilisateur(id, deltaDonnees),
+    sauvegarde: async (id, deltaDonnees) => {
+      let emailHash;
+      if (deltaDonnees.email) {
+        emailHash = adaptateurChiffrement.hacheSha256(deltaDonnees.email);
+      }
+      return adaptateurPersistance.metsAJourUtilisateur(
+        id,
+        deltaDonnees,
+        emailHash
+      );
+    },
     supprime: async (id) => {
       await adaptateurPersistance.supprimeAutorisationsContribution(id);
       await adaptateurPersistance.supprimeUtilisateur(id);

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -23,15 +23,19 @@ function fabriquePersistance({
       donnees: {
         de: async (idUtilisateur) =>
           adaptateurPersistance.utilisateur(idUtilisateur),
-        deCeluiAvecEmail: async (email) =>
-          adaptateurPersistance.utilisateurAvecEmail(email),
+        deCeluiAvecEmail: async (email) => {
+          const emailHash = adaptateurChiffrement.hacheSha256(email);
+          return adaptateurPersistance.utilisateurAvecEmailHash(emailHash);
+        },
       },
       un: async (idUtilisateur) => {
         const u = await adaptateurPersistance.utilisateur(idUtilisateur);
         return u ? new Utilisateur(u, { adaptateurJWT }) : undefined;
       },
       celuiAvecEmail: async (email) => {
-        const u = await adaptateurPersistance.utilisateurAvecEmail(email);
+        const emailHash = adaptateurChiffrement.hacheSha256(email);
+        const u =
+          await adaptateurPersistance.utilisateurAvecEmailHash(emailHash);
         return u ? new Utilisateur(u, { adaptateurJWT }) : undefined;
       },
       celuiAvecIdReset: async (idReset) => {

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -22,6 +22,7 @@ class Utilisateur extends Base {
         'prenom',
         'nom',
         'email',
+        'emailHash',
         'telephone',
         'cguAcceptees',
         'postes',

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -22,7 +22,6 @@ class Utilisateur extends Base {
         'prenom',
         'nom',
         'email',
-        'emailHash',
         'telephone',
         'cguAcceptees',
         'postes',

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -309,6 +309,33 @@ describe('Le dépôt de données des utilisateurs', () => {
     expect(utilisateur.adaptateurJWT).to.equal(adaptateurJWT);
   });
 
+  it("retourne l'utilisateur associé à un email donné", async () => {
+    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
+      {
+        utilisateurs: [
+          {
+            id: '123',
+            prenom: 'Jean',
+            nom: 'Dupont',
+            email: 'jean.dupont@mail.fr',
+            motDePasse: 'XXX',
+          },
+        ],
+      }
+    );
+    const depot = DepotDonneesUtilisateurs.creeDepot({
+      adaptateurChiffrement,
+      adaptateurJWT,
+      adaptateurPersistance,
+    });
+
+    const utilisateur = await depot.utilisateurAvecEmail('jean.dupont@mail.fr');
+
+    expect(utilisateur).to.be.an(Utilisateur);
+    expect(utilisateur.id).to.equal('123');
+    expect(utilisateur.adaptateurJWT).to.equal(adaptateurJWT);
+  });
+
   it('retourne tous les utilisateurs enregistrés', (done) => {
     const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
       {

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -57,8 +57,6 @@ describe('Le dépôt de données des utilisateurs', () => {
       adaptateurPersistance: unePersistanceMemoire()
         .ajouteUnUtilisateur({
           id: '123',
-          prenom: 'Jean',
-          nom: 'Dupont',
           email: 'jean.dupont@mail.fr',
           emailHash: 'jean.dupont@mail.fr-haché256',
           motDePasse: '12345-chiffré',
@@ -83,8 +81,6 @@ describe('Le dépôt de données des utilisateurs', () => {
       adaptateurPersistance: unePersistanceMemoire()
         .ajouteUnUtilisateur({
           id: '123',
-          prenom: 'Jean',
-          nom: 'Dupont',
           email: 'jean.dupont@mail.fr',
           emailHash: 'jean.dupont@mail.fr-haché256',
           motDePasse: 'mdp_origine-chiffré',

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -507,6 +507,16 @@ describe('Le dépôt de données des utilisateurs', () => {
         expect(utilisateur.dateCreation).to.eql(adaptateurHorloge.maintenant());
       });
 
+      it("sauvegarde le hash256 de l'email de l'utilisateur", async () => {
+        const utilisateur = await depot.nouvelUtilisateur(
+          unUtilisateur().avecEmail('jean.dupont@mail.fr').donnees
+        );
+
+        expect(utilisateur).to.be.an(Utilisateur);
+        expect(utilisateur.email).to.equal('jean.dupont@mail.fr');
+        expect(utilisateur.emailHash).to.eql('jean.dupont@mail.fr-haché256');
+      });
+
       it("publie sur le bus d'événements l'inscription de l'utilisateur", async () => {
         await depot.nouvelUtilisateur(
           unUtilisateur()

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -37,12 +37,13 @@ describe('Le dépôt de données des utilisateurs', () => {
     bus = fabriqueBusPourLesTests();
   });
 
-  it("retourne l'utilisateur authentifié", async () => {
+  it("retourne l'utilisateur authentifié en cherchant par hash d'email", async () => {
     adaptateurChiffrement = {
       hacheBCrypt: async (chaine) => {
         expect(chaine).to.equal('mdp_12345');
         return '12345-chiffré';
       },
+      hacheSha256: (chaine) => `${chaine}-haché256`,
       compareBCrypt: async (chaine1, chaine2) => {
         expect(chaine1).to.equal('mdp_12345');
         expect(chaine2).to.equal('12345-chiffré');
@@ -59,6 +60,7 @@ describe('Le dépôt de données des utilisateurs', () => {
           prenom: 'Jean',
           nom: 'Dupont',
           email: 'jean.dupont@mail.fr',
+          emailHash: 'jean.dupont@mail.fr-haché256',
           motDePasse: '12345-chiffré',
         })
         .construis(),
@@ -84,6 +86,7 @@ describe('Le dépôt de données des utilisateurs', () => {
           prenom: 'Jean',
           nom: 'Dupont',
           email: 'jean.dupont@mail.fr',
+          emailHash: 'jean.dupont@mail.fr-haché256',
           motDePasse: 'mdp_origine-chiffré',
         })
         .construis(),
@@ -318,6 +321,7 @@ describe('Le dépôt de données des utilisateurs', () => {
             prenom: 'Jean',
             nom: 'Dupont',
             email: 'jean.dupont@mail.fr',
+            emailHash: 'jean.dupont@mail.fr-haché256',
             motDePasse: 'XXX',
           },
         ],
@@ -585,7 +589,13 @@ describe('Le dépôt de données des utilisateurs', () => {
       it('lève une `ErreurUtilisateurExistant`', (done) => {
         const adaptateurPersistance =
           AdaptateurPersistanceMemoire.nouvelAdaptateur({
-            utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
+            utilisateurs: [
+              {
+                id: '123',
+                email: 'jean.dupont@mail.fr',
+                emailHash: 'jean.dupont@mail.fr-haché256',
+              },
+            ],
           });
         depot = DepotDonneesUtilisateurs.creeDepot({
           adaptateurChiffrement,
@@ -645,7 +655,11 @@ describe('Le dépôt de données des utilisateurs', () => {
           genereUUID: () => '11111111-1111-1111-1111-111111111111',
         },
         adaptateurPersistance: unePersistanceMemoire()
-          .ajouteUnUtilisateur({ id: '123', email: 'jean.dupont@mail.fr' })
+          .ajouteUnUtilisateur({
+            id: '123',
+            email: 'jean.dupont@mail.fr',
+            emailHash: 'jean.dupont@mail.fr-haché256',
+          })
           .construis(),
       });
 

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -136,6 +136,30 @@ describe('Le dépôt de données des utilisateurs', () => {
       expect(u.nom).to.equal('Dubois');
     });
 
+    it("met le hash de l'email à jour", async () => {
+      await depot.metsAJourUtilisateur(
+        '123',
+        unUtilisateur().avecId('123').avecEmail('jean.dubois@mail.fr').donnees
+      );
+      const u = await depot.utilisateur('123');
+      expect(u.emailHash).to.equal('jean.dubois@mail.fr-haché256');
+    });
+
+    it("ne modifie pas le hash de l'email s'il ne fait pas partie du delta de données", async () => {
+      await depot.metsAJourUtilisateur(
+        '123',
+        unUtilisateur().avecId('123').avecEmail('jean.dubois@mail.fr').donnees
+      );
+
+      await depot.metsAJourUtilisateur('123', {
+        nom: 'Dupont',
+        prenom: 'Jean',
+      });
+
+      const u = await depot.utilisateur('123');
+      expect(u.emailHash).to.equal('jean.dubois@mail.fr-haché256');
+    });
+
     it("complète les informations de l'entité et les enregistre", async () => {
       adaptateurRechercheEntite.rechercheOrganisations = async () => [
         {

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -2,6 +2,7 @@ const fauxAdaptateurChiffrement = () => ({
   chiffre: async (chaine) => chaine,
   dechiffre: async (chaine) => chaine,
   hacheBCrypt: (chaine) => Promise.resolve(`${chaine}-haché`),
+  hacheSha256: (chaine) => `${chaine}-haché256`,
   compareBCrypt: (enClair, chiffreeReference) =>
     fauxAdaptateurChiffrement()
       .hacheBCrypt(enClair)


### PR DESCRIPTION
Afin de préparer le chiffrement du profil utilisateur, on ajoute le hash d'email dans une colonne à part.

On ne souhaite plus, à terme, rechercher un utilisateur par email (qui est une donnée privée) mais par hash d'email (qui n'est pas réversible).

Cette PR ajoute la colonne de base de données, la remplis avec le hash de l'email pour les utilisateurs existants, effectue la recherche par email du dépôt de données en utilisant le hash de l'email dans la persistance, et insère le hash de l'email lors de l'ajout/mise à jour de l'utilisateur.