### PR TITLE
[PRÉPARATION CHIFFREMENT] Le dépôt de services utilise le dépôt d'utilisateurs

### DIFF
--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -21,15 +21,6 @@ const creeDepot = (config = {}) => {
     busEvenements,
   } = config;
 
-  const depotServices = depotDonneesServices.creeDepot({
-    adaptateurChiffrement,
-    adaptateurPersistance,
-    adaptateurUUID,
-    adaptateurRechercheEntite,
-    busEvenements,
-    referentiel,
-  });
-
   const depotUtilisateurs = depotDonneesUtilisateurs.creeDepot({
     adaptateurChiffrement,
     adaptateurJWT,
@@ -37,6 +28,16 @@ const creeDepot = (config = {}) => {
     adaptateurUUID,
     adaptateurRechercheEntite,
     busEvenements,
+  });
+
+  const depotServices = depotDonneesServices.creeDepot({
+    adaptateurChiffrement,
+    adaptateurPersistance,
+    adaptateurUUID,
+    adaptateurRechercheEntite,
+    depotDonneesUtilisateurs: depotUtilisateurs,
+    busEvenements,
+    referentiel,
   });
 
   const depotAutorisations = depotDonneesAutorisations.creeDepot({

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -91,6 +91,7 @@ const creeDepot = (config = {}) => {
     adaptateurUUID,
     adaptateurRechercheEntite,
     busEvenements,
+    depotDonneesUtilisateurs,
     referentiel,
   } = config;
 
@@ -229,9 +230,9 @@ const creeDepot = (config = {}) => {
     );
 
     const s = await p.lis.un(idService);
-    const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
+    const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
     await busEvenements.publie(
-      new EvenementDescriptionServiceModifiee({ service: s, utilisateur })
+      new EvenementDescriptionServiceModifiee({ service: s, utilisateur: u })
     );
   };
 

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -362,9 +362,9 @@ const creeDepot = (config = {}) => {
     const s = await p.lis.un(idService);
     s.metsAJourMesureGenerale(mesure);
     await metsAJourService(s);
-    const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
+    const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
     await busEvenements.publie(
-      new EvenementMesuresServiceModifiees({ service: s, utilisateur })
+      new EvenementMesuresServiceModifiees({ service: s, utilisateur: u })
     );
   };
 
@@ -376,9 +376,9 @@ const creeDepot = (config = {}) => {
     const s = await p.lis.un(idService);
     s.metsAJourMesuresSpecifiques(mesures);
     await metsAJourService(s);
-    const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
+    const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
     await busEvenements.publie(
-      new EvenementMesuresServiceModifiees({ service: s, utilisateur })
+      new EvenementMesuresServiceModifiees({ service: s, utilisateur: u })
     );
   };
 

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -280,9 +280,9 @@ const creeDepot = (config = {}) => {
     );
 
     const s = await p.lis.un(idService);
-    const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
+    const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
     await busEvenements.publie(
-      new EvenementNouveauServiceCree({ service: s, utilisateur })
+      new EvenementNouveauServiceCree({ service: s, utilisateur: u })
     );
 
     return idService;

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -79,6 +79,10 @@ const fabriquePersistance = (
     },
     supprime: async (idService) =>
       adaptateurPersistance.supprimeService(idService),
+    autorisations: {
+      ajoute: async (id, donnees) =>
+        adaptateurPersistance.ajouteAutorisation(id, donnees),
+    },
   };
 
   return persistance;
@@ -274,7 +278,7 @@ const creeDepot = (config = {}) => {
       idUtilisateur,
       idService,
     });
-    await adaptateurPersistance.ajouteAutorisation(
+    await p.autorisations.ajoute(
       idAutorisation,
       proprietaire.donneesAPersister()
     );

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -5,6 +5,7 @@ const DepotDonneesServices = require('../../src/depots/depotDonneesServices');
 const Referentiel = require('../../src/referentiel');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 const fauxAdaptateurRechercheEntreprise = require('../mocks/adaptateurRechercheEntreprise');
+const DepotDonneesUtilisateurs = require('../../src/depots/depotDonneesUtilisateurs');
 
 class ConstructeurDepotDonneesServices {
   constructor() {
@@ -36,12 +37,18 @@ class ConstructeurDepotDonneesServices {
   }
 
   construis() {
+    const adaptateurPersistance =
+      this.constructeurAdaptateurPersistance.construis();
+
     return DepotDonneesServices.creeDepot({
       adaptateurChiffrement: fauxAdaptateurChiffrement(),
-      adaptateurPersistance: this.constructeurAdaptateurPersistance.construis(),
+      adaptateurPersistance,
       adaptateurUUID: this.adaptateurUUID,
       adaptateurRechercheEntite: this.adaptateurRechercheEntite,
       busEvenements: this.busEvenements,
+      depotDonneesUtilisateurs: DepotDonneesUtilisateurs.creeDepot({
+        adaptateurPersistance,
+      }),
       referentiel: this.referentiel,
     });
   }

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -21,6 +21,11 @@ class ConstructeurDepotDonneesServices {
     return this;
   }
 
+  avecAdaptateurUUID(adaptateur) {
+    this.adaptateurUUID = adaptateur;
+    return this;
+  }
+
   avecReferentiel(referentiel) {
     this.referentiel = referentiel;
     return this;

--- a/test/constructeurs/constructeurDepotDonneesServices.js
+++ b/test/constructeurs/constructeurDepotDonneesServices.js
@@ -9,6 +9,7 @@ const DepotDonneesUtilisateurs = require('../../src/depots/depotDonneesUtilisate
 
 class ConstructeurDepotDonneesServices {
   constructor() {
+    this.adaptateurChiffrement = fauxAdaptateurChiffrement();
     this.constructeurAdaptateurPersistance = unePersistanceMemoire();
     this.adaptateurUUID = { genereUUID: () => 'unUUID' };
     this.busEvenements = { publie: () => {}, abonne: () => {} };
@@ -16,13 +17,23 @@ class ConstructeurDepotDonneesServices {
     this.adaptateurRechercheEntite = fauxAdaptateurRechercheEntreprise();
   }
 
-  avecAdaptateurPersistance(constructeurAdaptateurPersistance) {
+  avecConstructeurDePersistance(constructeurAdaptateurPersistance) {
     this.constructeurAdaptateurPersistance = constructeurAdaptateurPersistance;
+    return this;
+  }
+
+  avecAdaptateurPersistance(adaptateur) {
+    this.adaptateurPersistance = adaptateur;
     return this;
   }
 
   avecAdaptateurUUID(adaptateur) {
     this.adaptateurUUID = adaptateur;
+    return this;
+  }
+
+  avecAdaptateurChiffrement(adaptateur) {
+    this.adaptateurChiffrement = adaptateur;
     return this;
   }
 
@@ -43,10 +54,11 @@ class ConstructeurDepotDonneesServices {
 
   construis() {
     const adaptateurPersistance =
+      this.adaptateurPersistance ??
       this.constructeurAdaptateurPersistance.construis();
 
     return DepotDonneesServices.creeDepot({
-      adaptateurChiffrement: fauxAdaptateurChiffrement(),
+      adaptateurChiffrement: this.adaptateurChiffrement,
       adaptateurPersistance,
       adaptateurUUID: this.adaptateurUUID,
       adaptateurRechercheEntite: this.adaptateurRechercheEntite,

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1277,18 +1277,16 @@ describe('Le dépôt de données des services', () => {
         .construis();
     });
 
-    it("reste robuste quand le service n'est pas trouvé", (done) => {
-      depot
-        .dupliqueService('id-invalide', '123')
-        .then(() =>
-          done('La tentative de duplication aurait dû lever une exception')
-        )
-        .catch((e) => {
-          expect(e).to.be.an(ErreurServiceInexistant);
-          expect(e.message).to.equal('Service "id-invalide" non trouvé');
-          done();
-        })
-        .catch(done);
+    it("reste robuste quand le service n'est pas trouvé", async () => {
+      try {
+        await depot.dupliqueService('id-invalide', '123');
+        expect().fail(
+          'La tentative de duplication aurait dû lever une exception'
+        );
+      } catch (e) {
+        expect(e).to.be.an(ErreurServiceInexistant);
+        expect(e.message).to.equal('Service "id-invalide" non trouvé');
+      }
     });
 
     it('peut dupliquer un service à partir de son identifiant', (done) => {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1297,17 +1297,15 @@ describe('Le dépôt de données des services', () => {
       expect(services.length).to.equal(2);
     });
 
-    it('utilise un nom disponible pour le service dupliqué', (done) => {
-      depot
-        .dupliqueService('123-1', '123')
-        .then(() => depot.dupliqueService('123-1', '123'))
-        .then(() => depot.services('123'))
-        .then(([_, s2, s3]) => {
-          expect(s2.nomService()).to.equal('Service à dupliquer - Copie 1');
-          expect(s3.nomService()).to.equal('Service à dupliquer - Copie 2');
-          done();
-        })
-        .catch(done);
+    it('utilise un nom disponible pour le service dupliqué', async () => {
+      await depot.dupliqueService('123-1', '123');
+      await depot.dupliqueService('123-1', '123');
+
+      // eslint-disable-next-line no-unused-vars
+      const [_, s2, s3] = await depot.services('123');
+
+      expect(s2.nomService()).to.equal('Service à dupliquer - Copie 1');
+      expect(s3.nomService()).to.equal('Service à dupliquer - Copie 2');
     });
   });
 

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -41,9 +41,6 @@ const {
 const {
   unDepotDeDonneesServices,
 } = require('../constructeurs/constructeurDepotDonneesServices');
-const {
-  unAdaptateurTracking,
-} = require('../constructeurs/constructeurAdaptateurTracking');
 const { unDossier } = require('../constructeurs/constructeurDossier');
 
 const {
@@ -75,7 +72,7 @@ describe('Le dépôt de données des services', () => {
   it("connaît tous les services d'un utilisateur donné", async () => {
     const referentiel = Referentiel.creeReferentielVide();
 
-    const adaptateurPersistance = unePersistanceMemoire()
+    const persistance = unePersistanceMemoire()
       .ajouteUnService(unService(referentiel).avecId('123').donnees)
       .ajouteUnService(unService(referentiel).avecId('789').donnees)
       .ajouteUnUtilisateur(unUtilisateur().avecId('456').donnees)
@@ -87,7 +84,7 @@ describe('Le dépôt de données des services', () => {
       );
 
     const depot = unDepotDeDonneesServices()
-      .avecAdaptateurPersistance(adaptateurPersistance)
+      .avecConstructeurDePersistance(persistance)
       .avecReferentiel(referentiel)
       .construis();
 
@@ -137,7 +134,7 @@ describe('Le dépôt de données des services', () => {
 
     const depot = unDepotDeDonneesServices()
       .avecReferentiel(r)
-      .avecAdaptateurPersistance(persistance)
+      .avecConstructeurDePersistance(persistance)
       .construis();
 
     const services = await depot.services('U');
@@ -194,7 +191,7 @@ describe('Le dépôt de données des services', () => {
       );
     const depot = unDepotDeDonneesServices()
       .avecReferentiel(r)
-      .avecAdaptateurPersistance(persistance)
+      .avecConstructeurDePersistance(persistance)
       .construis();
 
     const service = await depot.service('S1');
@@ -216,7 +213,7 @@ describe('Le dépôt de données des services', () => {
       .avecUneSuggestionAction({ idService: 'S1', nature: 'siret' });
     const depot = unDepotDeDonneesServices()
       .avecReferentiel(r)
-      .avecAdaptateurPersistance(persistance)
+      .avecConstructeurDePersistance(persistance)
       .construis();
 
     const service = await depot.service('S1');
@@ -238,7 +235,7 @@ describe('Le dépôt de données des services', () => {
     };
 
     const depot = unDepotDeDonneesServices()
-      .avecAdaptateurPersistance(
+      .avecConstructeurDePersistance(
         unePersistanceMemoire().ajouteUnService(donneesService)
       )
       .avecReferentiel(referentiel)
@@ -255,7 +252,7 @@ describe('Le dépôt de données des services', () => {
   });
 
   describe("sur demande de mise à jour de la description d'un service", () => {
-    let adaptateurPersistance;
+    let persistance;
     let bus;
     let depot;
     let referentiel;
@@ -265,7 +262,7 @@ describe('Le dépôt de données des services', () => {
     beforeEach(() => {
       referentiel = Referentiel.creeReferentielVide();
       adaptateurRechercheEntite = fauxAdaptateurRechercheEntreprise();
-      adaptateurPersistance = unePersistanceMemoire()
+      persistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(
           unUtilisateur().avecId('U1').avecEmail('jean.dupont@mail.fr').donnees
         )
@@ -281,7 +278,7 @@ describe('Le dépôt de données des services', () => {
       bus = fabriqueBusPourLesTests();
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
-        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecConstructeurDePersistance(persistance)
         .avecBusEvenements(bus)
         .avecAdaptateurRechercheEntite(adaptateurRechercheEntite)
         .construis();
@@ -347,7 +344,7 @@ describe('Le dépôt de données des services', () => {
         },
       ];
       const depotServices = DepotDonneesServices.creeDepot({
-        adaptateurPersistance: adaptateurPersistance.construis(),
+        adaptateurPersistance: persistance.construis(),
         adaptateurChiffrement,
         referentiel,
       });
@@ -401,7 +398,7 @@ describe('Le dépôt de données des services', () => {
     const r = Referentiel.creeReferentielVide();
     const depot = unDepotDeDonneesServices()
       .avecReferentiel(r)
-      .avecAdaptateurPersistance(
+      .avecConstructeurDePersistance(
         unePersistanceMemoire().ajouteUnService(
           unService(r).avecId('S1').donnees
         )
@@ -431,7 +428,7 @@ describe('Le dépôt de données des services', () => {
       const r = Referentiel.creeReferentielVide();
       const depot = unDepotDeDonneesServices()
         .avecReferentiel(r)
-        .avecAdaptateurPersistance(
+        .avecConstructeurDePersistance(
           unePersistanceMemoire().ajouteUnService(
             unService(r).avecId('S1').donnees
           )
@@ -453,7 +450,7 @@ describe('Le dépôt de données des services', () => {
 
     const depot = unDepotDeDonneesServices()
       .avecReferentiel(r)
-      .avecAdaptateurPersistance(
+      .avecConstructeurDePersistance(
         unePersistanceMemoire().ajouteUnService(
           unService(r).avecId('S1').donnees
         )
@@ -478,7 +475,7 @@ describe('Le dépôt de données des services', () => {
 
     const depot = unDepotDeDonneesServices()
       .avecReferentiel(r)
-      .avecAdaptateurPersistance(
+      .avecConstructeurDePersistance(
         unePersistanceMemoire().ajouteUnService(
           unService(r)
             .avecId('S1')
@@ -507,7 +504,6 @@ describe('Le dépôt de données des services', () => {
   describe("quand il reçoit une demande d'enregistrement d'un nouveau service", () => {
     let adaptateurChiffrement;
     let adaptateurPersistance;
-    let adaptateurTracking;
     let adaptateurUUID;
     let adaptateurRechercheEntite;
     let depot;
@@ -520,20 +516,18 @@ describe('Le dépôt de données des services', () => {
           unUtilisateur().avecId('123').avecEmail('jean.dupont@mail.fr').donnees
         )
         .construis();
-      adaptateurTracking = unAdaptateurTracking().construis();
       adaptateurUUID = { genereUUID: () => 'unUUID' };
       referentiel = Referentiel.creeReferentielVide();
       adaptateurRechercheEntite = fauxAdaptateurRechercheEntreprise();
 
-      depot = DepotDonneesServices.creeDepot({
-        adaptateurChiffrement,
-        adaptateurPersistance,
-        adaptateurTracking,
-        adaptateurUUID,
-        adaptateurRechercheEntite,
-        busEvenements,
-        referentiel,
-      });
+      depot = unDepotDeDonneesServices()
+        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecAdaptateurChiffrement(adaptateurChiffrement)
+        .avecAdaptateurUUID(adaptateurUUID)
+        .avecReferentiel(referentiel)
+        .avecBusEvenements(busEvenements)
+        .avecAdaptateurRechercheEntite(adaptateurRechercheEntite)
+        .construis();
     });
 
     it('ajoute le nouveau service au dépôt', async () => {
@@ -752,7 +746,7 @@ describe('Le dépôt de données des services', () => {
 
       const depot = unDepotDeDonneesServices()
         .avecReferentiel(r)
-        .avecAdaptateurPersistance(persistance)
+        .avecConstructeurDePersistance(persistance)
         .construis();
 
       const existeMauvaisNom = await depot.serviceExiste('U1', 'Mauvais nom');
@@ -776,7 +770,7 @@ describe('Le dépôt de données des services', () => {
 
       const depot = unDepotDeDonneesServices()
         .avecReferentiel(r)
-        .avecAdaptateurPersistance(persistance)
+        .avecConstructeurDePersistance(persistance)
         .construis();
 
       const existeChezU2 = await depot.serviceExiste('U2', 'Service de U1');
@@ -803,7 +797,7 @@ describe('Le dépôt de données des services', () => {
         );
       const depot = unDepotDeDonneesServices()
         .avecReferentiel(r)
-        .avecAdaptateurPersistance(persistance)
+        .avecConstructeurDePersistance(persistance)
         .construis();
 
       const considereEnCours = await depot.serviceExiste('U1', 'Le S1', 'S1');
@@ -1271,7 +1265,7 @@ describe('Le dépôt de données des services', () => {
         );
 
       depot = unDepotDeDonneesServices()
-        .avecAdaptateurPersistance(persistance)
+        .avecConstructeurDePersistance(persistance)
         .avecAdaptateurUUID(fabriqueAdaptateurUUID())
         .avecReferentiel(referentiel)
         .construis();
@@ -1470,12 +1464,12 @@ describe('Le dépôt de données des services', () => {
   });
 
   describe('sur demande de mise à jour des mesures spécifiques d’un service', () => {
-    let adaptateurPersistance;
+    let persistance;
     let depot;
     const referentiel = Referentiel.creeReferentielVide();
 
     beforeEach(() => {
-      adaptateurPersistance = unePersistanceMemoire()
+      persistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(unUtilisateur().avecId('789').donnees)
         .ajouteUnService(
           unService(referentiel).avecId('123').avecNomService('nom').donnees
@@ -1485,7 +1479,7 @@ describe('Le dépôt de données des services', () => {
         );
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
-        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecConstructeurDePersistance(persistance)
         .avecBusEvenements(busEvenements)
         .construis();
     });
@@ -1521,7 +1515,7 @@ describe('Le dépôt de données des services', () => {
   });
 
   describe("sur demande de mise à jour d'une mesure générale d’un service", () => {
-    let adaptateurPersistance;
+    let persistance;
     let depot;
     const referentiel = Referentiel.creeReferentiel({
       categoriesMesures: { gouvernance: 'Gouvernance' },
@@ -1530,7 +1524,7 @@ describe('Le dépôt de données des services', () => {
     });
 
     beforeEach(() => {
-      adaptateurPersistance = unePersistanceMemoire()
+      persistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(unUtilisateur().avecId('789').donnees)
         .ajouteUnService(
           unService(referentiel).avecId('123').avecNomService('nom').donnees
@@ -1540,7 +1534,7 @@ describe('Le dépôt de données des services', () => {
         );
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
-        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecConstructeurDePersistance(persistance)
         .avecBusEvenements(busEvenements)
         .construis();
     });
@@ -1594,13 +1588,13 @@ describe('Le dépôt de données des services', () => {
         .avecId('123')
         .avecMesures(mesures)
         .construis();
-      const adaptateurPersistance = unePersistanceMemoire()
+      const persistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
         .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
         .ajouteUnService(service.donneesAPersister().toutes());
       const depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
-        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecConstructeurDePersistance(persistance)
         .avecBusEvenements(busEvenements)
         .construis();
 
@@ -1630,13 +1624,13 @@ describe('Le dépôt de données des services', () => {
         .avecId('123')
         .avecMesures(mesures)
         .construis();
-      const adaptateurPersistance = unePersistanceMemoire()
+      const persistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
         .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
         .ajouteUnService(service.donneesAPersister().donnees);
       const depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
-        .avecAdaptateurPersistance(adaptateurPersistance)
+        .avecConstructeurDePersistance(persistance)
         .avecBusEvenements(busEvenements)
         .construis();
 

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1289,15 +1289,12 @@ describe('Le dépôt de données des services', () => {
       }
     });
 
-    it('peut dupliquer un service à partir de son identifiant', (done) => {
-      depot
-        .dupliqueService('123-1', '123')
-        .then(() => depot.services('123'))
-        .then((services) => {
-          expect(services.length).to.equal(2);
-          done();
-        })
-        .catch(done);
+    it('peut dupliquer un service à partir de son identifiant', async () => {
+      await depot.dupliqueService('123-1', '123');
+
+      const services = await depot.services('123');
+
+      expect(services.length).to.equal(2);
     });
 
     it('utilise un nom disponible pour le service dupliqué', (done) => {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1258,29 +1258,23 @@ describe('Le dépôt de données des services', () => {
 
     beforeEach(() => {
       const referentiel = Referentiel.creeReferentielVide();
-      const descriptionService = uneDescriptionValide(referentiel)
-        .avecNomService('Service à dupliquer')
-        .construis()
-        .toJSON();
 
-      const adaptateurPersistance =
-        AdaptateurPersistanceMemoire.nouvelAdaptateur({
-          utilisateurs: [{ id: '123', email: 'jean.dupont@mail.fr' }],
-          services: [{ id: '123-1', descriptionService }],
-          autorisations: [
-            uneAutorisation().deProprietaire('123', '123-1').donnees,
-          ],
-        });
+      const persistance = unePersistanceMemoire()
+        .ajouteUnUtilisateur({ id: '123', email: 'jean.dupont@mail.fr' })
+        .ajouteUnService(
+          unService(referentiel)
+            .avecId('123-1')
+            .avecNomService('Service à dupliquer').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('123', '123-1').donnees
+        );
 
-      depot = DepotDonneesServices.creeDepot({
-        adaptateurChiffrement: fauxAdaptateurChiffrement(),
-        adaptateurPersistance,
-        adaptateurTracking: unAdaptateurTracking().construis(),
-        adaptateurUUID: fabriqueAdaptateurUUID(),
-        busEvenements: fabriqueBusPourLesTests(),
-        adaptateurRechercheEntite: fauxAdaptateurRechercheEntreprise(),
-        referentiel,
-      });
+      depot = unDepotDeDonneesServices()
+        .avecAdaptateurPersistance(persistance)
+        .avecAdaptateurUUID(fabriqueAdaptateurUUID())
+        .avecReferentiel(referentiel)
+        .construis();
     });
 
     it("reste robuste quand le service n'est pas trouvé", (done) => {


### PR DESCRIPTION
On prépare l'arrivée du chiffrement.
Le dépôt des services ne peut pas appeler directement la persistance pour récupérer un utilisateur. Car à l'avenir la persistance renverra des données chiffrées.

Donc, il passe par le dépôt des utilisateurs pour récupérer un utilisateur en clair.