### PR TITLE
[PRÉPARATION CHIFFREMENT] La création de service continue à fonctionner

### DIFF
--- a/migrations/20240813123753_ajouteColonneNomServiceHash.js
+++ b/migrations/20240813123753_ajouteColonneNomServiceHash.js
@@ -1,0 +1,10 @@
+const services = 'services';
+const nouvelleColonne = 'nom_service_hash';
+
+exports.up = (knex) =>
+  knex.schema.alterTable(services, (table) => table.string(nouvelleColonne));
+
+exports.down = (knex) =>
+  knex.schema.alterTable(services, (table) =>
+    table.dropColumn(nouvelleColonne)
+  );

--- a/migrations/20240819091430_insereNomServiceHash.js
+++ b/migrations/20240819091430_insereNomServiceHash.js
@@ -1,0 +1,25 @@
+const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+
+const hache = (nom) => hacheSha256(nom);
+
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const services = await trx('services');
+
+    const maj = services.map(({ id, donnees }) => {
+      const nomServiceHash = hache(donnees.descriptionService.nomService);
+
+      return trx('services')
+        .where({ id })
+        .update({ nom_service_hash: nomServiceHash });
+    });
+
+    await Promise.all(maj);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.transaction(async (trx) =>
+    trx('services').update({ nom_service_hash: null })
+  );
+};

--- a/migrations/20240819092056_rendNomServiceHashNonNullable.js
+++ b/migrations/20240819092056_rendNomServiceHashNonNullable.js
@@ -1,0 +1,12 @@
+const services = 'services';
+const nomColonne = 'nom_service_hash';
+
+exports.up = (knex) =>
+  knex.schema.alterTable(services, (table) =>
+    table.string(nomColonne).notNullable().alter()
+  );
+
+exports.down = (knex) =>
+  knex.schema.alterTable(services, (table) =>
+    table.string(nomColonne).nullable().alter()
+  );

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -75,12 +75,14 @@ const nouvelAdaptateur = (
     return lesIds.map(service);
   };
 
-  const serviceAvecNom = (idUtilisateur, nomService, idServiceMisAJour) =>
+  const serviceAvecHashNom = (
+    idUtilisateur,
+    hashNomService,
+    idServiceMisAJour
+  ) =>
     services(idUtilisateur).then((lesServices) =>
       lesServices.find(
-        (s) =>
-          s.id !== idServiceMisAJour &&
-          s.descriptionService?.nomService === nomService
+        (s) => s.id !== idServiceMisAJour && s.nomServiceHash === hashNomService
       )
     );
 
@@ -283,7 +285,7 @@ const nouvelAdaptateur = (
     autorisations,
     autorisationsDuService,
     service,
-    serviceAvecNom,
+    serviceAvecHashNom,
     services,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -25,8 +25,8 @@ const nouvelAdaptateur = (
     donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
   };
 
-  const ajouteService = async (id, donneesService) => {
-    donnees.services.push({ id, ...donneesService });
+  const ajouteService = async (id, donneesService, nomServiceHash) => {
+    donnees.services.push({ id, ...donneesService, nomServiceHash });
   };
 
   const ajouteUtilisateur = async (id, donneesUtilisateur, emailHash) => {
@@ -103,11 +103,11 @@ const nouvelAdaptateur = (
     else Object.assign(dejaConnue, { ...donneesAutorisation });
   };
 
-  const sauvegardeService = (id, donneesService) => {
+  const sauvegardeService = (id, donneesService, nomServiceHash) => {
     const dejaConnu = donnees.services.find((s) => s.id === id) !== undefined;
     return dejaConnu
       ? metsAJourService(id, donneesService)
-      : ajouteService(id, donneesService);
+      : ajouteService(id, donneesService, nomServiceHash);
   };
 
   const supprimeService = (...params) =>

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -12,15 +12,6 @@ const nouvelAdaptateur = (
   donnees.notifications ||= [];
   donnees.suggestionsActions ||= [];
 
-  const metsAJourEnregistrement = (
-    fonctionRecherche,
-    id,
-    donneesAMettreAJour
-  ) =>
-    fonctionRecherche(id)
-      .then((e) => Object.assign(e, donneesAMettreAJour))
-      .then(() => {});
-
   const supprimeEnregistrement = async (nomTable, id) => {
     donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
   };
@@ -93,8 +84,10 @@ const nouvelAdaptateur = (
       )
     );
 
-  const metsAJourService = (...params) =>
-    metsAJourEnregistrement(serviceDeprecated, ...params);
+  const metsAJourService = async (id, donneesService, nomServiceHash) => {
+    const s = await service(id);
+    Object.assign(s, { nomServiceHash, ...donneesService });
+  };
 
   const sauvegardeAutorisation = async (id, donneesAutorisation) => {
     const dejaConnue = donnees.autorisations.find((a) => a.id === id);
@@ -106,7 +99,7 @@ const nouvelAdaptateur = (
   const sauvegardeService = (id, donneesService, nomServiceHash) => {
     const dejaConnu = donnees.services.find((s) => s.id === id) !== undefined;
     return dejaConnu
-      ? metsAJourService(id, donneesService)
+      ? metsAJourService(id, donneesService, nomServiceHash)
       : ajouteService(id, donneesService, nomServiceHash);
   };
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -111,7 +111,11 @@ const nouvelAdaptateur = (env) => {
 
   const serviceDeprecated = (id) => elementDeTable('services', id);
 
-  const serviceAvecNom = (idUtilisateur, nomService, idServiceMisAJour) =>
+  const serviceAvecHashNom = (
+    idUtilisateur,
+    hashNomService,
+    idServiceMisAJour
+  ) =>
     knex('services')
       .join(
         'autorisations',
@@ -120,10 +124,7 @@ const nouvelAdaptateur = (env) => {
       )
       .whereRaw("autorisations.donnees->>'idUtilisateur'=?", idUtilisateur)
       .whereRaw('not services.id::text=?', idServiceMisAJour)
-      .whereRaw(
-        "services.donnees#>>'{descriptionService,nomService}'=?",
-        nomService
-      )
+      .whereRaw('services.nom_service_hash=?', hashNomService)
       .select('services.*')
       .first()
       .then(convertisLigneEnObjet)
@@ -461,7 +462,7 @@ const nouvelAdaptateur = (env) => {
     autorisations,
     autorisationsDuService,
     service,
-    serviceAvecNom,
+    serviceAvecHashNom,
     services,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -56,8 +56,9 @@ const nouvelAdaptateur = (env) => {
   const supprimeEnregistrement = (nomTable, id) =>
     knex(nomTable).where({ id }).del();
 
-  const ajouteService = (...params) =>
-    ajouteLigneDansTable('services', ...params);
+  const ajouteService = async (id, donnees, nomServiceHash) =>
+    knex('services').insert({ id, donnees, nom_service_hash: nomServiceHash });
+
   const ajouteUtilisateur = (id, donnees, emailHash) =>
     knex('utilisateurs').insert({
       id,
@@ -225,7 +226,7 @@ const nouvelAdaptateur = (env) => {
       .whereRaw("(donnees->>'estProprietaire')::boolean=true")
       .then(([{ count }]) => parseInt(count, 10));
 
-  const sauvegardeService = (id, donneesService) => {
+  const sauvegardeService = (id, donneesService, nomServiceHash) => {
     const testExistence = knex('services')
       .where('id', id)
       .select({ id: 'id' })
@@ -235,7 +236,7 @@ const nouvelAdaptateur = (env) => {
     return testExistence.then((dejaConnu) =>
       dejaConnu
         ? metsAJourService(id, donneesService)
-        : ajouteService(id, donneesService)
+        : ajouteService(id, donneesService, nomServiceHash)
     );
   };
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -145,7 +145,18 @@ const nouvelAdaptateur = (env) => {
     return avecPMapPourChaqueElement(Promise.resolve(ids), service);
   };
 
-  const metsAJourService = (...params) => metsAJourTable('services', ...params);
+  const metsAJourService = (id, donneesService, nomServiceHash) =>
+    knex('services')
+      .where({ id })
+      .first()
+      .then(({ donnees }) =>
+        knex('services')
+          .where({ id })
+          .update({
+            donnees: Object.assign(donnees, donneesService),
+            nom_service_hash: nomServiceHash,
+          })
+      );
 
   const metsAJourIdResetMdpUtilisateur = (id, idResetMotDePasse) =>
     knex('utilisateurs')
@@ -235,7 +246,7 @@ const nouvelAdaptateur = (env) => {
 
     return testExistence.then((dejaConnu) =>
       dejaConnu
-        ? metsAJourService(id, donneesService)
+        ? metsAJourService(id, donneesService, nomServiceHash)
         : ajouteService(id, donneesService, nomServiceHash)
     );
   };

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -110,7 +110,7 @@ const nouvelAdaptateur = (env) => {
 
   const serviceDeprecated = (id) => elementDeTable('services', id);
 
-  const serviceAvecNom = (idUtilisateur, nomService, idServiceMisAJour = '') =>
+  const serviceAvecNom = (idUtilisateur, nomService, idServiceMisAJour) =>
     knex('services')
       .join(
         'autorisations',

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -78,12 +78,18 @@ const fabriquePersistance = (
         const donneesServices = await adaptateurPersistance.tousLesServices();
         return Promise.all(donneesServices.map((d) => dechiffreService(d)));
       },
-      celuiAvecNom: async (idUtilisateur, nomService, idServiceMisAJour = '') =>
-        adaptateurPersistance.serviceAvecNom(
+      celuiAvecNom: async (
+        idUtilisateur,
+        nomService,
+        idServiceMisAJour = ''
+      ) => {
+        const hashNom = adaptateurChiffrement.hacheSha256(nomService);
+        return adaptateurPersistance.serviceAvecHashNom(
           idUtilisateur,
-          nomService,
+          hashNom,
           idServiceMisAJour
-        ),
+        );
+      },
     },
     sauvegarde: async (id, donneesService) => {
       const donneesChiffrees = await chiffre.donneesService(donneesService);

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -147,7 +147,7 @@ const creeDepot = (config = {}) => {
     await p.sauvegarde(id, donnees);
   };
 
-  const metsAJourProprieteService = (nomPropriete, idOuService, propriete) => {
+  const metsAJourProprieteService = (nomPropriete, idService, propriete) => {
     const metsAJour = (h) => {
       h[nomPropriete] ||= {};
 
@@ -158,16 +158,20 @@ const creeDepot = (config = {}) => {
       return p.sauvegarde(id, donnees);
     };
 
-    const trouveDonneesService = (param) =>
-      typeof param === 'object'
-        ? Promise.resolve(param)
-        : p.lis.un(param).then((h) => h.donneesAPersister().toutes());
+    const trouveDonneesService = (id) =>
+      p.lis.un(id).then((h) => h.donneesAPersister().toutes());
 
-    return trouveDonneesService(idOuService).then(metsAJour);
+    return trouveDonneesService(idService).then(metsAJour);
   };
 
-  const metsAJourDescriptionService = (serviceCible, informations) =>
-    metsAJourProprieteService('descriptionService', serviceCible, informations);
+  const metsAJourDescriptionService = (serviceCible, informations) => {
+    serviceCible.descriptionService ||= {};
+
+    Object.assign(serviceCible.descriptionService, informations.toJSON());
+
+    const { id, ...donnees } = serviceCible;
+    return p.sauvegarde(id, donnees);
+  };
 
   const remplaceProprieteService = async (
     nomPropriete,

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -87,7 +87,16 @@ const fabriquePersistance = (
     },
     sauvegarde: async (id, donneesService) => {
       const donneesChiffrees = await chiffre.donneesService(donneesService);
-      return adaptateurPersistance.sauvegardeService(id, donneesChiffrees);
+
+      const nomServiceHash = adaptateurChiffrement.hacheSha256(
+        donneesService.descriptionService.nomService
+      );
+
+      return adaptateurPersistance.sauvegardeService(
+        id,
+        donneesChiffrees,
+        nomServiceHash
+      );
     },
     supprime: async (idService) => {
       await adaptateurPersistance.supprimeAutorisationsHomologation(idService);

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -78,8 +78,12 @@ const fabriquePersistance = (
         const donneesServices = await adaptateurPersistance.tousLesServices();
         return Promise.all(donneesServices.map((d) => dechiffreService(d)));
       },
-      celuiAvecNom: async (...params) =>
-        adaptateurPersistance.serviceAvecNom(...params),
+      celuiAvecNom: async (idUtilisateur, nomService, idServiceMisAJour = '') =>
+        adaptateurPersistance.serviceAvecNom(
+          idUtilisateur,
+          nomService,
+          idServiceMisAJour
+        ),
     },
     sauvegarde: async (id, donneesService) => {
       const donneesChiffrees = await chiffre.donneesService(donneesService);
@@ -186,13 +190,23 @@ const creeDepot = (config = {}) => {
   const ajouteRisqueGeneralAService = (...params) =>
     ajouteAItemsDuService('risquesGeneraux', ...params);
 
-  const serviceExiste = (...params) =>
-    p.lis.celuiAvecNom(...params).then((h) => !!h);
+  const serviceExiste = async (
+    idUtilisateur,
+    nomService,
+    idServiceMisAJour
+  ) => {
+    const s = await p.lis.celuiAvecNom(
+      idUtilisateur,
+      nomService,
+      idServiceMisAJour
+    );
+    return !!s;
+  };
 
   const valideDescriptionService = async (
     idUtilisateur,
     donnees,
-    idHomologationMiseAJour
+    idServiceMisAJour
   ) => {
     const { nomService } = donnees;
 
@@ -207,13 +221,13 @@ const creeDepot = (config = {}) => {
       throw new ErreurDonneesNiveauSecuriteInsuffisant();
     }
 
-    const serviceExistant = await serviceExiste(
+    const existeDeja = await serviceExiste(
       idUtilisateur,
       nomService,
-      idHomologationMiseAJour
+      idServiceMisAJour
     );
 
-    if (serviceExistant)
+    if (existeDeja)
       throw new ErreurNomServiceDejaExistant(
         `Le nom du service "${nomService}" existe déjà pour un autre service`
       );

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -1,12 +1,14 @@
 const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
+const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 class ConstructeurAdaptateurPersistanceMemoire {
-  constructor() {
+  constructor(adaptateurChiffrement) {
     this.autorisations = [];
     this.services = [];
     this.utilisateurs = [];
     this.notificationsExpirationHomologation = [];
     this.suggestionsActions = [];
+    this.adaptateurChiffrement = adaptateurChiffrement;
   }
 
   ajouteUneAutorisation(autorisation) {
@@ -15,7 +17,12 @@ class ConstructeurAdaptateurPersistanceMemoire {
   }
 
   ajouteUnService(service) {
-    this.services.push(service);
+    this.services.push({
+      ...service,
+      nomServiceHash: this.adaptateurChiffrement.hacheSha256(
+        service.descriptionService.nomService
+      ),
+    });
     return this;
   }
 
@@ -46,7 +53,8 @@ class ConstructeurAdaptateurPersistanceMemoire {
   }
 }
 
-const unePersistanceMemoire = () =>
-  new ConstructeurAdaptateurPersistanceMemoire();
+const unePersistanceMemoire = (
+  adaptateurChiffrement = fauxAdaptateurChiffrement()
+) => new ConstructeurAdaptateurPersistanceMemoire(adaptateurChiffrement);
 
 module.exports = { unePersistanceMemoire };

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -252,7 +252,7 @@ describe('Le dépôt de données des services', () => {
   });
 
   describe("sur demande de mise à jour de la description d'un service", () => {
-    let persistance;
+    let adaptateurPersistance;
     let bus;
     let depot;
     let referentiel;
@@ -262,7 +262,7 @@ describe('Le dépôt de données des services', () => {
     beforeEach(() => {
       referentiel = Referentiel.creeReferentielVide();
       adaptateurRechercheEntite = fauxAdaptateurRechercheEntreprise();
-      persistance = unePersistanceMemoire()
+      adaptateurPersistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(
           unUtilisateur().avecId('U1').avecEmail('jean.dupont@mail.fr').donnees
         )
@@ -271,14 +271,15 @@ describe('Le dépôt de données des services', () => {
         )
         .ajouteUneAutorisation(
           uneAutorisation().deProprietaire('U1', 'S1').donnees
-        );
+        )
+        .construis();
       adaptateurChiffrement = {
         dechiffre: async (objetDonnee) => objetDonnee,
       };
       bus = fabriqueBusPourLesTests();
       depot = unDepotDeDonneesServices()
         .avecReferentiel(referentiel)
-        .avecConstructeurDePersistance(persistance)
+        .avecAdaptateurPersistance(adaptateurPersistance)
         .avecBusEvenements(bus)
         .avecAdaptateurRechercheEntite(adaptateurRechercheEntite)
         .construis();
@@ -344,7 +345,7 @@ describe('Le dépôt de données des services', () => {
         },
       ];
       const depotServices = DepotDonneesServices.creeDepot({
-        adaptateurPersistance: persistance.construis(),
+        adaptateurPersistance,
         adaptateurChiffrement,
         referentiel,
       });

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -612,6 +612,20 @@ describe('Le dépôt de données des services', () => {
       expect(donneesPersistees.descriptionService.chiffre).to.equal(true);
     });
 
+    it('stocke le SHA-256 du nom du service', async () => {
+      const descriptionService = uneDescriptionValide(referentiel)
+        .avecNomService('Super Service')
+        .construis()
+        .donneesSerialisees();
+
+      const idNouveau = await depot.nouveauService('123', {
+        descriptionService,
+      });
+
+      const donnees = await adaptateurPersistance.service(idNouveau);
+      expect(donnees.nomServiceHash).to.be('Super Service-haché256');
+    });
+
     it("déclare un accès en écriture entre l'utilisateur et le service", async () => {
       const depotAutorisations = DepotDonneesAutorisations.creeDepot({
         adaptateurPersistance,

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -296,6 +296,17 @@ describe('Le dépôt de données des services', () => {
       expect(descriptionService.nomService).to.equal('Nouveau Nom');
     });
 
+    it('met à jour le SHA-256 du nom du service', async () => {
+      const description = uneDescriptionValide(referentiel)
+        .avecNomService('Nouveau Nom')
+        .construis();
+
+      await depot.ajouteDescriptionService('U1', 'S1', description);
+
+      const donnees = await adaptateurPersistance.service('S1');
+      expect(donnees.nomServiceHash).to.be('Nouveau Nom-haché256');
+    });
+
     it('lève une exception si des propriétés obligatoires ne sont pas renseignées', async () => {
       const descriptionIncomplete = uneDescriptionValide(referentiel)
         .avecNomService('')

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1479,7 +1479,7 @@ describe('Le dépôt de données des services', () => {
     it("délègue à l'adaptateur persistance la sauvegarde du service", async () => {
       const service = unService(referentiel).avecId('S1').construis();
       const adaptateurPersistance = unePersistanceMemoire()
-        .ajouteUnService({ id: 'S1' })
+        .ajouteUnService(unService().avecId('S1').donnees)
         .construis();
 
       let donneesPersistees;


### PR DESCRIPTION
Afin de préparer le chiffrement des données du service, on ajoute le hash du nom de service dans une colonne à part, afin de pouvoir continuer à rechercher par (hash de) nom de service après que les données aient été chiffrées.

Cette PR ajoute la colonne de base de données, la remplis avec la valeur du hash du nom existant, effectue la recherche par hash, gère l'ajout/mise à jour de service avec cette colonne.
Les données ne possèdent pas cette valeur.