### PR TITLE
[PRÉPARATION CHIFFREMENT] La duplication de service continue de fonctionner

### DIFF
--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -76,7 +76,7 @@ const fabriquePersistance = (
       },
       tous: async () => {
         const donneesServices = await adaptateurPersistance.tousLesServices();
-        return donneesServices.map((s) => new Service(s, referentiel));
+        return Promise.all(donneesServices.map((d) => dechiffreService(d)));
       },
       celuiAvecNom: async (...params) =>
         adaptateurPersistance.serviceAvecNom(...params),

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1304,6 +1304,13 @@ describe('Le dépôt de données des services', () => {
   });
 
   describe("sur une demande d'un index de copie disponible pour un service à dupliquer", () => {
+    let adaptateurChiffrement;
+
+    beforeEach(() => {
+      adaptateurChiffrement = {
+        dechiffre: async (objetDonnee) => objetDonnee,
+      };
+    });
     it("utilise l'index 1 si disponible", (done) => {
       const referentiel = Referentiel.creeReferentielVide();
       const descriptionService = uneDescriptionValide(referentiel)
@@ -1320,6 +1327,7 @@ describe('Le dépôt de données des services', () => {
         });
 
       const depot = DepotDonneesServices.creeDepot({
+        adaptateurChiffrement,
         adaptateurPersistance,
         referentiel,
       });
@@ -1347,6 +1355,7 @@ describe('Le dépôt de données des services', () => {
         });
 
       const depot = DepotDonneesServices.creeDepot({
+        adaptateurChiffrement,
         adaptateurPersistance,
         referentiel,
       });
@@ -1382,6 +1391,7 @@ describe('Le dépôt de données des services', () => {
         });
 
       const depot = DepotDonneesServices.creeDepot({
+        adaptateurChiffrement,
         adaptateurPersistance,
         referentiel,
       });
@@ -1409,6 +1419,7 @@ describe('Le dépôt de données des services', () => {
         });
 
       const depot = DepotDonneesServices.creeDepot({
+        adaptateurChiffrement,
         adaptateurPersistance,
         referentiel,
       });


### PR DESCRIPTION
... car actuellement, on ne passait pas par les méthodes de `dechiffre`.

On en profite pour le faire aussi dans la méthode `tous` qui est utilisée par la console d'administration.