### PR TITLE
[CORRECTION] Supprime la bordure sur le sélecteur de priorité lorsqu'il est désactivé ET vide

### DIFF
--- a/svelte/lib/ui/SelectionPriorite.svelte
+++ b/svelte/lib/ui/SelectionPriorite.svelte
@@ -137,7 +137,6 @@
     --couleur-texte-survol: var(--texte-clair);
     --couleur-fond-survol: white;
 
-    border: 1px solid var(--liseres-fonce);
     font-size: 0.9rem;
     line-height: 20px;
   }


### PR DESCRIPTION
… car le style ne s'appliquait que lorsque le sélecteur avait une valeur.