### PR TITLE
Chiffre le contenu d'un service

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -59,16 +59,16 @@ const nouvelAdaptateur = (
     return Promise.all(lesIds.map(service));
   };
 
-  const serviceAvecHashNom = (
+  const serviceExisteAvecHashNom = async (
     idUtilisateur,
     hashNomService,
     idServiceMisAJour
-  ) =>
-    services(idUtilisateur).then((lesServices) =>
-      lesServices.find(
-        (s) => s.id !== idServiceMisAJour && s.nomServiceHash === hashNomService
-      )
+  ) => {
+    const lesServices = await services(idUtilisateur);
+    return lesServices.some(
+      (s) => s.id !== idServiceMisAJour && s.nomServiceHash === hashNomService
     );
+  };
 
   const metsAJourService = async (id, donneesService, nomServiceHash) => {
     const s = await service(id);
@@ -267,7 +267,7 @@ const nouvelAdaptateur = (
     contributeursService,
     suggestionsActionsService,
     service,
-    serviceAvecHashNom,
+    serviceExisteAvecHashNom,
     services,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -49,13 +49,6 @@ const nouvelAdaptateur = (
 
   const service = async (id) => donnees.services.find((h) => h.id === id);
 
-  const serviceDeprecated = async (id) => {
-    const serviceTrouve = donnees.services.find((s) => s.id === id);
-    if (serviceTrouve) serviceTrouve.contributeurs = contributeursService(id);
-
-    return serviceTrouve;
-  };
-
   const services = async (idUtilisateur) => {
     const as = await autorisations(idUtilisateur);
     return Promise.all(as.map(({ idService }) => service(idService)));
@@ -290,7 +283,6 @@ const nouvelAdaptateur = (
     sauvegardeNotificationsExpirationHomologation,
     sauvegardeParcoursUtilisateur,
     sauvegardeService,
-    serviceDeprecated,
     supprimeAutorisation,
     supprimeAutorisations,
     supprimeAutorisationsContribution,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -72,7 +72,7 @@ const nouvelAdaptateur = (
 
   const metsAJourService = async (id, donneesService, nomServiceHash) => {
     const s = await service(id);
-    Object.assign(s, { nomServiceHash, ...donneesService });
+    Object.assign(s, { nomServiceHash, donnees: donneesService });
   };
 
   const sauvegardeAutorisation = async (id, donneesAutorisation) => {

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -17,7 +17,7 @@ const nouvelAdaptateur = (
   };
 
   const ajouteService = async (id, donneesService, nomServiceHash) => {
-    donnees.services.push({ id, ...donneesService, nomServiceHash });
+    donnees.services.push({ id, donnees: donneesService, nomServiceHash });
   };
 
   const ajouteUtilisateur = async (id, donneesUtilisateur, emailHash) => {

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -56,7 +56,7 @@ const nouvelAdaptateur = (
 
   const tousLesServices = async () => {
     const lesIds = donnees.services.map((s) => s.id);
-    return lesIds.map(service);
+    return Promise.all(lesIds.map(service));
   };
 
   const serviceAvecHashNom = (

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -113,8 +113,6 @@ const nouvelAdaptateur = (env) => {
       .where({ id_service: id, date_acquittement: null })
       .select({ nature: 'nature' });
 
-  const serviceDeprecated = (id) => elementDeTable('services', id);
-
   const serviceAvecHashNom = (
     idUtilisateur,
     hashNomService,
@@ -474,7 +472,6 @@ const nouvelAdaptateur = (env) => {
     nouveautesPourUtilisateur,
     contributeursDesServicesDe,
     sauvegardeService,
-    serviceDeprecated,
     sauvegardeAutorisation,
     sauvegardeNotificationsExpirationHomologation,
     sauvegardeParcoursUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -88,17 +88,11 @@ const nouvelAdaptateur = (env) => {
 
   const arreteTout = () => knex.destroy();
 
-  const service = async (id) => {
-    const s = await knex('services')
+  const service = async (id) =>
+    knex('services')
       .where('id', id)
       .select({ id: 'id', donnees: 'donnees' })
       .first();
-
-    return {
-      id: s.id,
-      ...s.donnees,
-    };
-  };
 
   const contributeursService = async (id) =>
     knex('autorisations as a')
@@ -137,7 +131,7 @@ const nouvelAdaptateur = (env) => {
       .whereRaw('services.nom_service_hash=?', hashNomService)
       .select('services.*')
       .first()
-      .then(convertisLigneEnObjet)
+      .then(convertisLigneEnObjetSansMiseAPlatDonnees)
       .catch(() => undefined);
 
   const services = (idUtilisateur) => {

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -148,17 +148,15 @@ const nouvelAdaptateur = (env) => {
     return avecPMapPourChaqueElement(Promise.resolve(ids), service);
   };
 
-  const metsAJourService = (id, donneesService, nomServiceHash) =>
+  const metsAJourService = (id, donnees, nomServiceHash) =>
     knex('services')
       .where({ id })
       .first()
-      .then(({ donnees }) =>
-        knex('services')
-          .where({ id })
-          .update({
-            donnees: Object.assign(donnees, donneesService),
-            nom_service_hash: nomServiceHash,
-          })
+      .then(() =>
+        knex('services').where({ id }).update({
+          donnees,
+          nom_service_hash: nomServiceHash,
+        })
       );
 
   const metsAJourIdResetMdpUtilisateur = (id, idResetMotDePasse) =>

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -113,24 +113,23 @@ const nouvelAdaptateur = (env) => {
       .where({ id_service: id, date_acquittement: null })
       .select({ nature: 'nature' });
 
-  const serviceAvecHashNom = (
+  const serviceExisteAvecHashNom = async (
     idUtilisateur,
     hashNomService,
     idServiceMisAJour
   ) =>
-    knex('services')
-      .join(
-        'autorisations',
-        knex.raw("(autorisations.donnees->>'idService')::uuid"),
-        'services.id'
-      )
-      .whereRaw("autorisations.donnees->>'idUtilisateur'=?", idUtilisateur)
-      .whereRaw('not services.id::text=?', idServiceMisAJour)
-      .whereRaw('services.nom_service_hash=?', hashNomService)
-      .select('services.*')
-      .first()
-      .then(convertisLigneEnObjetSansMiseAPlatDonnees)
-      .catch(() => undefined);
+    (
+      await knex('services')
+        .join(
+          'autorisations',
+          knex.raw("(autorisations.donnees->>'idService')::uuid"),
+          'services.id'
+        )
+        .whereRaw("autorisations.donnees->>'idUtilisateur'=?", idUtilisateur)
+        .whereRaw('not services.id::text=?', idServiceMisAJour)
+        .whereRaw('services.nom_service_hash=?', hashNomService)
+        .count('services.*')
+    )[0].count >= 1;
 
   const services = (idUtilisateur) => {
     const idsServices = knex('autorisations')
@@ -457,7 +456,7 @@ const nouvelAdaptateur = (env) => {
     autorisationsDuService,
     contributeursService,
     service,
-    serviceAvecHashNom,
+    serviceExisteAvecHashNom,
     services,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -83,14 +83,13 @@ const fabriquePersistance = (
         const donneesServices = await adaptateurPersistance.tousLesServices();
         return Promise.all(donneesServices.map((d) => enrichisService(d)));
       },
-      // TODO : refactorer -> renommer et retourner un bool
-      celuiAvecNom: async (
+      existeAvecNom: async (
         idUtilisateur,
         nomService,
         idServiceMisAJour = ''
       ) => {
         const hashNom = adaptateurChiffrement.hacheSha256(nomService);
-        return adaptateurPersistance.serviceAvecHashNom(
+        return adaptateurPersistance.serviceExisteAvecHashNom(
           idUtilisateur,
           hashNom,
           idServiceMisAJour
@@ -216,18 +215,8 @@ const creeDepot = (config = {}) => {
   const ajouteRisqueGeneralAService = (...params) =>
     ajouteAItemsDuService('risquesGeneraux', ...params);
 
-  const serviceExiste = async (
-    idUtilisateur,
-    nomService,
-    idServiceMisAJour
-  ) => {
-    const s = await p.lis.celuiAvecNom(
-      idUtilisateur,
-      nomService,
-      idServiceMisAJour
-    );
-    return !!s;
-  };
+  const serviceExiste = async (idUtilisateur, nomService, idServiceMisAJour) =>
+    p.lis.existeAvecNom(idUtilisateur, nomService, idServiceMisAJour);
 
   const valideDescriptionService = async (
     idUtilisateur,

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -39,21 +39,15 @@ const fabriquePersistance = (
 ) => {
   const { chiffre, dechiffre } = fabriqueChiffrement(adaptateurChiffrement);
 
-  const dechiffreService = async (donneesService) => {
-    const { donnees, ...autreProprietes } = donneesService;
-    const donneesEnClair = await dechiffre.donneesService(donnees);
-    return new Service(
-      {
-        ...autreProprietes,
-        ...donneesEnClair,
-      },
-      referentiel
-    );
-  };
-
   const dechiffreDonneesService = async (donneesService) => {
     const { donnees, ...autreProprietes } = donneesService;
-    return { ...autreProprietes, ...(await dechiffre.donneesService(donnees)) };
+    const donneesEnClair = await dechiffre.donneesService(donnees);
+    return { ...autreProprietes, ...donneesEnClair };
+  };
+
+  const dechiffreService = async (donneesService) => {
+    const donneesServiceEnClair = await dechiffreDonneesService(donneesService);
+    return new Service(donneesServiceEnClair, referentiel);
   };
 
   const enrichisService = async (service) => {

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -23,13 +23,7 @@ const fabriqueChiffrement = (adaptateurChiffrement) => {
 
   return {
     chiffre: {
-      donneesService: async (donnees) => {
-        const { descriptionService } = donnees;
-        return {
-          ...donnees,
-          descriptionService: await chiffre(descriptionService),
-        };
-      },
+      donneesService: async (donneesEnClair) => chiffre(donneesEnClair),
     },
     dechiffre: {
       donneesService: async (donneesChiffrees) => dechiffre(donneesChiffrees),

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -45,11 +45,6 @@ const fabriquePersistance = (
     return { ...autreProprietes, ...donneesEnClair };
   };
 
-  const dechiffreService = async (donneesService) => {
-    const donneesServiceEnClair = await dechiffreDonneesService(donneesService);
-    return new Service(donneesServiceEnClair, referentiel);
-  };
-
   const enrichisService = async (service) => {
     const donneesContributeurs =
       await adaptateurPersistance.contributeursService(service.id);
@@ -86,8 +81,7 @@ const fabriquePersistance = (
       },
       tous: async () => {
         const donneesServices = await adaptateurPersistance.tousLesServices();
-        // TODO : Les services devraient être 'enrichis' ici
-        return Promise.all(donneesServices.map((d) => dechiffreService(d)));
+        return Promise.all(donneesServices.map((d) => enrichisService(d)));
       },
       // TODO : refactorer -> renommer et retourner un bool
       celuiAvecNom: async (

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -53,7 +53,7 @@ const fabriquePersistance = (
 
   const dechiffreDonneesService = async (donneesService) => {
     const { donnees, ...autreProprietes } = donneesService;
-    return { ...(await dechiffre.donneesService(donnees)), ...autreProprietes };
+    return { ...autreProprietes, ...(await dechiffre.donneesService(donnees)) };
   };
 
   const enrichisService = async (service) => {

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -17,8 +17,10 @@ class ConstructeurAdaptateurPersistanceMemoire {
   }
 
   ajouteUnService(service) {
+    const { id, ...donnees } = service;
     this.services.push({
-      ...service,
+      id,
+      donnees,
       nomServiceHash: this.adaptateurChiffrement.hacheSha256(
         service.descriptionService.nomService
       ),

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1154,8 +1154,10 @@ describe('Le dépôt de données des services', () => {
     it("n'écrase pas les autres dossiers si l'ID est différent", (done) => {
       const donneesHomologations = {
         id: '123',
-        descriptionService: { nomService: 'Un service' },
-        dossiers: [{ id: '888', finalise: true }],
+        donnees: {
+          descriptionService: { nomService: 'Un service' },
+          dossiers: [{ id: '888', finalise: true }],
+        },
       };
       const adaptateurPersistance =
         AdaptateurPersistanceMemoire.nouvelAdaptateur({
@@ -1189,8 +1191,10 @@ describe('Le dépôt de données des services', () => {
       const donneesDossierAvecDecision = { id: '999', decision };
       const donneesService = {
         id: '123',
-        descriptionService: { nomService: 'Un service' },
-        dossiers: [donneesDossierAvecDecision],
+        donnees: {
+          descriptionService: { nomService: 'Un service' },
+          dossiers: [donneesDossierAvecDecision],
+        },
       };
 
       const adaptateurPersistance =

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -148,13 +148,10 @@ describe('Le dépôt de données des services', () => {
   });
 
   it('peut retrouver un service à partir de son identifiant', async () => {
-    let donneeDechiffree;
     const adaptateurChiffrement = {
       dechiffre: async (objetDonnee) => {
-        donneeDechiffree = objetDonnee;
-        donneeDechiffree.chiffre = false;
-        const { chiffre, ...reste } = objetDonnee;
-        return reste;
+        objetDonnee.descriptionService.nomService = `${objetDonnee.descriptionService.nomService}-dechiffre`;
+        return objetDonnee;
       },
     };
 
@@ -162,7 +159,6 @@ describe('Le dépôt de données des services', () => {
       .ajouteUnService({
         id: '789',
         descriptionService: { nomService: 'nom' },
-        chiffre: true,
       })
       .construis();
     const referentiel = Referentiel.creeReferentielVide();
@@ -177,11 +173,7 @@ describe('Le dépôt de données des services', () => {
     expect(service).to.be.a(Service);
     expect(service.id).to.equal('789');
     expect(service.referentiel).to.equal(referentiel);
-    expect(service.nomService()).to.be('nom');
-    expect(donneeDechiffree).to.eql({
-      descriptionService: { nomService: 'nom' },
-      chiffre: false,
-    });
+    expect(service.nomService()).to.be('nom-dechiffre');
   });
 
   it('associe ses contributeurs au service', async () => {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -664,7 +664,7 @@ describe('Le dépôt de données des services', () => {
       expect(donneesPersistees.descriptionService.nomService).to.equal(
         'Service A'
       );
-      expect(donneesPersistees.descriptionService.chiffre).to.equal(true);
+      expect(donneesPersistees.chiffre).to.equal(true);
     });
 
     it('stocke le SHA-256 du nom du service', async () => {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -152,6 +152,7 @@ describe('Le dépôt de données des services', () => {
     const adaptateurChiffrement = {
       dechiffre: async (objetDonnee) => {
         donneeDechiffree = objetDonnee;
+        donneeDechiffree.chiffre = false;
         const { chiffre, ...reste } = objetDonnee;
         return reste;
       },
@@ -160,7 +161,8 @@ describe('Le dépôt de données des services', () => {
     const adaptateurPersistance = unePersistanceMemoire()
       .ajouteUnService({
         id: '789',
-        descriptionService: { nomService: 'nom', chiffre: true },
+        descriptionService: { nomService: 'nom' },
+        chiffre: true,
       })
       .construis();
     const referentiel = Referentiel.creeReferentielVide();
@@ -176,7 +178,10 @@ describe('Le dépôt de données des services', () => {
     expect(service.id).to.equal('789');
     expect(service.referentiel).to.equal(referentiel);
     expect(service.nomService()).to.be('nom');
-    expect(donneeDechiffree).to.eql({ nomService: 'nom', chiffre: true });
+    expect(donneeDechiffree).to.eql({
+      descriptionService: { nomService: 'nom' },
+      chiffre: false,
+    });
   });
 
   it('associe ses contributeurs au service', async () => {


### PR DESCRIPTION
Chiffre les données des services.
On ne mets plus "à plat" les données qui sortent de la persistance afin de pouvoir facilement déchiffré grâce à `donneesPersistee.donnees`.