### PR TITLE
[CHIFFREMENT] Ajoute une méthode dans la console d'admin pour chiffrer tous les utilisateurs et tous les services

### DIFF
--- a/consoleAdministration.js
+++ b/consoleAdministration.js
@@ -34,6 +34,7 @@ const {
   consigneCompletudeDansJournal,
 } = require('./src/bus/abonnements/consigneCompletudeDansJournal');
 const DescriptionService = require('./src/modeles/descriptionService');
+const adaptateurChiffrementQuiChiffreVraiment = require('./src/adaptateurs/adaptateurChiffrementVault');
 
 const log = {
   jaune: (txt) => process.stdout.write(`\x1b[33m${txt}\x1b[0m`),
@@ -518,6 +519,68 @@ class ConsoleAdministration {
       afficheErreur,
       rattrapeUtilisateur
     );
+  }
+
+  async chiffreDonneesServiceEtUtilisateur(
+    tailleDesChunks = 10,
+    intervalMs = 500
+  ) {
+    const chiffreEtSauvegardeService = async ({ id, donnees }) => {
+      if (!donnees.descriptionService)
+        throw new Error(
+          'Cette méthode ne peut être utilisée que sur une base de données non chiffrée !'
+        );
+
+      const donneesChiffrees =
+        await adaptateurChiffrementQuiChiffreVraiment.chiffre(donnees);
+
+      const nomServiceHash =
+        adaptateurChiffrementQuiChiffreVraiment.hacheSha256(
+          donnees.descriptionService.nomService
+        );
+
+      return this.adaptateurPersistance.sauvegardeService(
+        id,
+        donneesChiffrees,
+        nomServiceHash
+      );
+    };
+
+    const chiffreEtSauvegardeUtilisateur = async ({ donnees, id }) => {
+      const emailHash = adaptateurChiffrementQuiChiffreVraiment.hacheSha256(
+        donnees.email
+      );
+      const donneesChiffreesASauvegarder =
+        await adaptateurChiffrementQuiChiffreVraiment.chiffre(donnees);
+      await this.adaptateurPersistance.metsAJourUtilisateur(
+        id,
+        donneesChiffreesASauvegarder,
+        emailHash
+      );
+    };
+
+    async function temporise(donnees, methode) {
+      while (donnees.length) {
+        const chunk = donnees.splice(0, tailleDesChunks);
+        // eslint-disable-next-line no-console
+        console.log(
+          `[${new Date().toISOString()}]: Nouveau chunk avec ${
+            chunk.length
+          } données`
+        );
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.all(chunk.map(methode));
+        // eslint-disable-next-line no-await-in-loop,no-promise-executor-return
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      }
+    }
+    const donneesDeTousLesServices =
+      await this.adaptateurPersistance.tousLesServices();
+    await temporise(donneesDeTousLesServices, chiffreEtSauvegardeService);
+
+    const donneesDeTousUtilisateurs =
+      await this.adaptateurPersistance.tousUtilisateurs();
+    await temporise(donneesDeTousUtilisateurs, chiffreEtSauvegardeUtilisateur);
   }
 }
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -210,7 +210,7 @@ const nouvelAdaptateur = (env) => {
 
   const tousUtilisateurs = () =>
     knex('utilisateurs').then((tous) =>
-      tous.map(convertisLigneEnObjetSansMiseAPlatDonnees())
+      tous.map(convertisLigneEnObjetSansMiseAPlatDonnees)
     );
 
   const autorisation = (id) => elementDeTable('autorisations', id);


### PR DESCRIPTION
Cette méthode ne fonctionne que si les données de la base ne sont pas chiffrées.
Cette méthode a également besoin que les variables d'env suivantes soient renseignées :

- `CHIFFREMENT_URL_BASE_DU_SERVICE`
- `CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT`
- `CHIFFREMENT_TOKEN_VAULT`
- `VAULT_CLE_CHIFFREMENT_AES256`

Et que les utilisateurs ne soient pas en train de modifier les données.