### PR TITLE
Dechiffre les services et les utilisateurs avec des scripts

### DIFF
--- a/scripts/chiffrage/dechiffreService.sh
+++ b/scripts/chiffrage/dechiffreService.sh
@@ -1,0 +1,9 @@
+data=$(psql -h localhost -U postgres mss -c "SELECT donnees from services where id='$1'" -A -t)
+
+data=`echo $data | cut -d "\"" -f 2`
+
+export VAULT_ADDR='http://0.0.0.0:8200'
+vault login root
+
+# entrer le mot de passe 'root'
+vault write -field="plaintext" transit/decrypt/cle-mss ciphertext=$data | base64 --decode | jq .

--- a/scripts/chiffrage/dechiffreUtilisateur.sh
+++ b/scripts/chiffrage/dechiffreUtilisateur.sh
@@ -1,0 +1,9 @@
+data=$(psql -h localhost -U postgres mss -c "SELECT donnees from utilisateurs where id='$1'" -A -t)
+
+data=`echo $data | cut -d "\"" -f 2`
+
+export VAULT_ADDR='http://0.0.0.0:8200'
+vault login root
+
+# entrer le mot de passe 'root'
+vault write -field="plaintext" transit/decrypt/cle-mss ciphertext=$data | base64 --decode | jq .


### PR DESCRIPTION
Deux scripts bash qui permettent de déchiffrer un utilisateur ou un service sur une base de données local chiffrée. Chaque script a le même fonctionnement :
1. requête sur la base postgres de la donnée chiffrée
2. suppression des guillemets en début et fin de la chaîne
3. envoie à vault pour déchiffrage
4. décodage en base 64
5. affichage joli du json déchiffré
