### PR TITLE
[CORRECTION] Ne conserve pas les données modifiées de la mesure dans le tiroir

### DIFF
--- a/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
+++ b/svelte/lib/tableauDesMesures/TableauDesMesures.svelte
@@ -295,7 +295,7 @@
           }}
           on:click={() =>
             afficheTiroirEditeMesure({
-              mesure,
+              mesure: { ...mesure },
               metadonnees: { typeMesure: 'GENERALE', idMesure: id },
             })}
           estLectureSeule={estLectureSeule || etatEnregistrement === EnCours}
@@ -339,7 +339,7 @@
           }}
           on:click={() =>
             afficheTiroirEditeMesure({
-              mesure,
+              mesure: { ...mesure },
               metadonnees: { typeMesure: 'SPECIFIQUE', idMesure: indexReel },
             })}
           estLectureSeule={estLectureSeule || etatEnregistrement === EnCours}


### PR DESCRIPTION
Si la mesure n’est pas enregistrée, les modifications sont perdues quand l’utilisateur ferme le tiroir ou s’il ouvre une autre mesure.