### PR TITLE
[CORRECTION] Cible le titre de la mesure pour ouvrir le tiroir

### DIFF
--- a/svelte/lib/visiteGuidee/etapes/securiser/EtapeSecuriser.svelte
+++ b/svelte/lib/visiteGuidee/etapes/securiser/EtapeSecuriser.svelte
@@ -59,7 +59,7 @@
         cible: cibleTiroirMesure,
         callbackInitialeCible: () => {
           document
-            .getElementsByClassName('ligne-de-mesure')[0]
+            .getElementsByClassName('titre-mesure')[0]
             .dispatchEvent(new Event('click'));
           document.querySelector(
             '#conteneur-mesure .conteneur-actions button'


### PR DESCRIPTION
... car la ligne de la mesure ne permet plus l'ouverture, seulement le titre