### PR TITLE
[INDICE CYBER PERSONNALISÉ] Ajout de l'indice cyber sur la page dédiée

### DIFF
--- a/public/assets/images/icone_lien_externe.svg
+++ b/public/assets/images/icone_lien_externe.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 12.5L17 7.5" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 9.5V6.5H15" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.85 6.5H9.55C6.3 6.5 5 7.8 5 11.05V14.95C5 18.2 6.3 19.5 9.55 19.5H13.45C16.7 19.5 18 18.2 18 14.95V13.65" stroke="#0C5C98" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -1,10 +1,10 @@
 .zone-principale {
-  margin-bottom: 8em;
   background: white;
 }
 
 .conteneur-indice-cyber {
   text-align: left;
+  padding-bottom: 8em;
 }
 
 .conteneur-indice-cyber .conteneur-titre {

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -279,3 +279,13 @@
 .conteneur-indice-cyber .onglet.actif .note-onglet {
   background: var(--fond-bleu-pale);
 }
+
+.conteneur-indice-cyber .onglets {
+  display: flex;
+  flex-direction: row;
+  gap: 9px;
+}
+
+#indice-cyber-personnalise {
+  display: none;
+}

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -316,3 +316,7 @@
   vertical-align: bottom;
   margin-left: 2px;
 }
+
+.conteneur-indice-cyber .inclusion-exclusion {
+  margin: 18px 0;
+}

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -240,3 +240,42 @@
   font-weight: 500;
   white-space: nowrap;
 }
+
+.conteneur-indice-cyber .onglet {
+  min-width: 140px;
+  padding: 9px 12px;
+  background: #eff6ff;
+  border: none;
+  cursor: pointer;
+  border-top: 2px solid transparent;
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.conteneur-indice-cyber .onglet.actif {
+  background: white;
+  border-top: 2px solid var(--bleu-mise-en-avant);
+  border-left: 1px solid var(--liseres-fonce);
+  border-right: 1px solid var(--liseres-fonce);
+  border-bottom: 1px solid white;
+  color: var(--bleu-mise-en-avant);
+  font-weight: bold;
+}
+
+.conteneur-indice-cyber .onglet .note-onglet {
+  padding: 3px 8px 5px 8px;
+  border-radius: 4px;
+  background: white;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  color: var(--texte-fonce);
+}
+
+.conteneur-indice-cyber .onglet.actif .note-onglet {
+  background: var(--fond-bleu-pale);
+}

--- a/public/assets/styles/homologation/indiceCyber.css
+++ b/public/assets/styles/homologation/indiceCyber.css
@@ -30,7 +30,7 @@
   background: #eff6ff;
   border-radius: 8px 8px 0px 0px;
   padding: 24px;
-  margin-top: 120px;
+  margin-top: 66px;
   color: #0c5c98;
   display: flex;
   flex-direction: row;
@@ -39,7 +39,7 @@
 }
 
 .conteneur-descriptif p {
-  margin: 0;
+  margin: 0 0 4px;
 }
 
 .conteneur-descriptif .disque-indice {
@@ -51,7 +51,7 @@
   height: 8em;
   font-size: 1.3em;
   position: absolute;
-  top: -5em;
+  top: -24px;
 }
 
 #conteneur-indice-cyber {
@@ -288,4 +288,31 @@
 
 #indice-cyber-personnalise {
   display: none;
+}
+
+.conteneur-indice-cyber h4 {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 28px;
+  color: var(--texte-fonce);
+  margin: 16px 0;
+}
+
+.conteneur-indice-cyber .contenu-descriptif a {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 24px;
+  text-decoration-line: underline;
+  color: var(--bleu-survol);
+  margin-top: 4px;
+}
+
+.conteneur-indice-cyber .contenu-descriptif a::after {
+  display: inline-block;
+  content: '';
+  width: 24px;
+  height: 24px;
+  background: url('/statique/assets/images/icone_lien_externe.svg');
+  vertical-align: bottom;
+  margin-left: 2px;
 }

--- a/public/service/indiceCyber.js
+++ b/public/service/indiceCyber.js
@@ -1,6 +1,11 @@
 $(() => {
   const idService = $('.page-service').data('id-service');
-  const { indiceCyber, noteMax } = JSON.parse($('#indice-cyber').text());
+  const { indiceCyber, noteMax } = JSON.parse(
+    $('#donnees-indice-cyber').text()
+  );
+  const { indiceCyberPersonnalise } = JSON.parse(
+    $('#donnees-indice-cyber-personnalise').text()
+  );
 
   const brancheOnglets = () => {
     const $onglets = $('.conteneur-indice-cyber .onglets .onglet');
@@ -21,6 +26,11 @@ $(() => {
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-indice-cyber', {
       detail: { indiceCyber, noteMax, idService },
+    })
+  );
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-recharge-indice-cyber-personnalise', {
+      detail: { indiceCyberPersonnalise, noteMax },
     })
   );
   brancheOnglets();

--- a/public/service/indiceCyber.js
+++ b/public/service/indiceCyber.js
@@ -2,9 +2,26 @@ $(() => {
   const idService = $('.page-service').data('id-service');
   const { indiceCyber, noteMax } = JSON.parse($('#indice-cyber').text());
 
+  const brancheOnglets = () => {
+    const $onglets = $('.conteneur-indice-cyber .onglets .onglet');
+    const $tousContenus = $('.contenu-global');
+
+    function basculeOnglets() {
+      $onglets.removeClass('actif');
+      $(this).addClass('actif');
+
+      $tousContenus.hide();
+      const idCible = $(this).data('cible');
+      $(`#${idCible}`).show();
+    }
+
+    $onglets.on('click', basculeOnglets);
+  };
+
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-indice-cyber', {
       detail: { indiceCyber, noteMax, idService },
     })
   );
+  brancheOnglets();
 });

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -54,6 +54,13 @@ class Mesures extends InformationsService {
     ).indiceCyber();
   }
 
+  indiceCyberPersonnalise() {
+    return new IndiceCyber(
+      this.statistiquesMesures().totauxParTypeEtParCategorie(),
+      this.referentiel
+    ).indiceCyber();
+  }
+
   nombreMesuresPersonnalisees() {
     return Object.keys(this.mesuresPersonnalisees).length;
   }
@@ -132,6 +139,18 @@ class Mesures extends InformationsService {
         mesuresPersonnalisees: this.mesuresPersonnalisees,
       },
       this.referentiel
+    );
+  }
+
+  statistiquesMesures() {
+    return new StatistiquesMesuresGenerales(
+      {
+        mesuresGenerales: this.mesuresGenerales,
+        mesuresPersonnalisees: this.mesuresPersonnalisees,
+        mesuresSpecifiques: this.mesuresSpecifiques.items,
+      },
+      this.referentiel,
+      true
     );
   }
 

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -73,6 +73,22 @@ class Mesures extends InformationsService {
     return this.nombreMesuresPersonnalisees();
   }
 
+  nombreTotalNonFait() {
+    const statistiquesAvecNonFait = new StatistiquesMesuresGenerales(
+      {
+        mesuresGenerales: this.mesuresGenerales,
+        mesuresPersonnalisees: this.mesuresPersonnalisees,
+        mesuresSpecifiques: this.mesuresSpecifiques.items,
+      },
+      this.referentiel,
+      false
+    );
+    return (
+      statistiquesAvecNonFait.indispensables().nonFait +
+      statistiquesAvecNonFait.recommandees().nonFait
+    );
+  }
+
   metsAJourMesuresSpecifiques(mesures) {
     this.mesuresSpecifiques = mesures;
   }

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -82,6 +82,10 @@ class Service {
     return this.mesures.indiceCyber();
   }
 
+  indiceCyberPersonnalise() {
+    return this.mesures.indiceCyberPersonnalise();
+  }
+
   completudeMesures() {
     const completude = this.mesures.completude();
     const { nombreTotalMesures, nombreMesuresCompletes } = completude;
@@ -271,6 +275,10 @@ class Service {
 
   risquesSpecifiques() {
     return this.risques.risquesSpecifiques;
+  }
+
+  statistiquesMesures() {
+    return this.mesures.statistiquesMesures();
   }
 
   statistiquesMesuresGenerales() {

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -249,6 +249,10 @@ class Service {
     return this.mesures.nombreTotalMesuresGenerales();
   }
 
+  nombreTotalMesuresNonFait() {
+    return this.mesures.nombreTotalNonFait();
+  }
+
   nombreTotalMesuresARemplirToutesCategories() {
     return this.statistiquesMesuresGenerales().toutesCategories.sansStatut;
   }

--- a/src/vues/fragments/indiceCyber/radarIndiceCyber.pug
+++ b/src/vues/fragments/indiceCyber/radarIndiceCyber.pug
@@ -1,7 +1,7 @@
 block append styles
   link(href = '/statique/assets/styles/radarIndiceCyber.css', rel = 'stylesheet')
 
-mixin radarIndiceCyber(indicesCyber, indiceMax)
+mixin radarIndiceCyber(indicesCyber, indiceMax, idCible)
   - const labels = ['Gouvernance', 'Résilience', 'Défense', 'Protection']
 
   -
@@ -46,7 +46,7 @@ mixin radarIndiceCyber(indicesCyber, indiceMax)
         text.echelle(x=centre[0] y=(centre[1] - radius) dx=2 dy=2)= index
     - const pointsIndiceCyber = generePointsValeur(indicesCyber, indiceMax, centre)
     polygon(
-      stroke="url(#gradient-lineaire-anssi)"
+      stroke=`url(#gradient-lineaire-anssi-${idCible})`
       stroke-width="1.5"
       stroke-linejoin="round"
       points=tableauVersPointsPolygone(pointsIndiceCyber)
@@ -60,11 +60,11 @@ mixin radarIndiceCyber(indicesCyber, indiceMax)
           rect(x=x-5 y=y-6 fill='white' width=22 height=12 rx=6 ry=10)
           text(x=x+4 y=y+2 fill='#2F3A43' font-weight='bold')= valeur
         circle(cx=x cy=y r=4 fill='transparent')
-        circle(cx=x cy=y r=2 fill='url(#gradient-lineaire-point)')
+        circle(cx=x cy=y r=2 fill=`url(#gradient-lineaire-point-${idCible})`)
 
-    linearGradient(id="gradient-lineaire-anssi" x1=taille/2 y1="0" x2=taille/2 y2=taille gradientUnits="userSpaceOnUse")
+    linearGradient(id=`gradient-lineaire-anssi-${idCible}` x1=taille/2 y1="0" x2=taille/2 y2=taille gradientUnits="userSpaceOnUse")
       stop(stop-color="#54B8F6")
       stop(offset="1" stop-color="#3479C9")
-    linearGradient(id="gradient-lineaire-point" gradientTransform="rotate(90)")
+    linearGradient(id=`gradient-lineaire-point-${idCible}` gradientTransform="rotate(90)")
       stop(offset="0%" stop-color="#54B8F6")
       stop(offset="100%" stop-color="#3479C9")

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -26,49 +26,55 @@ block header-titre-page
 
 block formulaire
   - const indiceCyber = service.indiceCyber()
+  - const indiceCyberPersonnalise = service.indiceCyberPersonnalise()
   - const noteMax = referentiel.indiceCyberNoteMax()
   - const trancheIndiceCyber = referentiel.trancheIndiceCyber(indiceCyber.total)
   .conteneur-indice-cyber
     .onglets
-      button.onglet.actif(type="button")
+      button.onglet.actif(type="button" data-cible='indice-cyber-ANSSI')
         span Indice cyber ANSSI
         span.note-onglet!= `${indiceCyber.total.toFixed(1)}/${noteMax}`
-    .conteneur-descriptif
-      .disque-indice
-        #conteneur-indice-cyber
-      .contenu-descriptif
-        p
-          | L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures «&nbsp;faites » et «&nbsp;partielles » proposées par #{referentielConcernes} dans MonServiceSécurisé.
-          | Il est un indicateur de la qualité de la démarche de sécurisation du service.
-    .conteneur-plus-details
-      details(open=true)
-        summary(role='button')
-        .contenu-plus-details
-          .conteneur-graphique
-            h4 Répartition par catégorie
-            +radarIndiceCyber([
-              indiceCyber.gouvernance,
-              indiceCyber.resilience,
-              indiceCyber.defense,
-              indiceCyber.protection,
-            ], noteMax)
-          .conteneur-explication-valeur
-            .titre
-              img.icone(src="/statique/assets/images/icone_explication_tranche.svg")
-              h4 Quelle est la valeur de l'indice cyber ?
-            p Face aux risques les plus courants, un indice cyber peut être considéré comme
-            ul.liste-tranches
-              each tranche in referentiel.descriptionsTranchesIndiceCyber(indiceCyber.total)
-                li(class=`${tranche.trancheCourante ? 'tranche-courante' : ''}`)= tranche.description
-    .conteneur-recommandation-anssi
-      img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
-      .titre
-        img.icone(src="/statique/assets/images/icone_recommandation_anssi.svg")
-        h3 Recommandation indicative de l'ANSSI en cas de décision d'homologation
-      .conteneur-duree-recommandee
-        if(trancheIndiceCyber.conseilHomologation)
-          p= trancheIndiceCyber.conseilHomologation
-        if(!trancheIndiceCyber.deconseillee)
-          .separateur
-          p Durée d'homologation conseillée
-          p#duree-recommandee= trancheIndiceCyber.dureeHomologationConseillee
+      button.onglet(type="button" data-cible='indice-cyber-personnalise')
+        span Indice cyber personnalisé
+        span.note-onglet!= `${indiceCyberPersonnalise.total.toFixed(1)}/${noteMax}`
+    #indice-cyber-ANSSI.contenu-global
+      .conteneur-descriptif
+        .disque-indice
+          #conteneur-indice-cyber
+        .contenu-descriptif
+          p
+            | L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures «&nbsp;faites » et «&nbsp;partielles » proposées par #{referentielConcernes} dans MonServiceSécurisé.
+            | Il est un indicateur de la qualité de la démarche de sécurisation du service.
+      .conteneur-plus-details
+        details(open=true)
+          summary(role='button')
+          .contenu-plus-details
+            .conteneur-graphique
+              h4 Répartition par catégorie
+              +radarIndiceCyber([
+                indiceCyber.gouvernance,
+                indiceCyber.resilience,
+                indiceCyber.defense,
+                indiceCyber.protection,
+              ], noteMax)
+            .conteneur-explication-valeur
+              .titre
+                img.icone(src="/statique/assets/images/icone_explication_tranche.svg")
+                h4 Quelle est la valeur de l'indice cyber ?
+              p Face aux risques les plus courants, un indice cyber peut être considéré comme
+              ul.liste-tranches
+                each tranche in referentiel.descriptionsTranchesIndiceCyber(indiceCyber.total)
+                  li(class=`${tranche.trancheCourante ? 'tranche-courante' : ''}`)= tranche.description
+      .conteneur-recommandation-anssi
+        img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
+        .titre
+          img.icone(src="/statique/assets/images/icone_recommandation_anssi.svg")
+          h3 Recommandation indicative de l'ANSSI en cas de décision d'homologation
+        .conteneur-duree-recommandee
+          if(trancheIndiceCyber.conseilHomologation)
+            p= trancheIndiceCyber.conseilHomologation
+          if(!trancheIndiceCyber.deconseillee)
+            .separateur
+            p Durée d'homologation conseillée
+            p#duree-recommandee= trancheIndiceCyber.dureeHomologationConseillee
+    #indice-cyber-personnalise.contenu-global

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -24,6 +24,47 @@ block header-titre-page
   h3
     +texteTronque({ texte: service.nomService() || '' })
 
+mixin contenuIndiceCyber(idCible, titre, donneesIndiceCyber, noteMax, donneesTrancheIndiceCyber, referentiel)
+  .conteneur-descriptif
+    .disque-indice
+      div(id=idCible)
+    .contenu-descriptif
+      h4!= titre
+      if block
+        block
+  .conteneur-plus-details
+    details(open=true)
+      summary(role='button')
+      .contenu-plus-details
+        .conteneur-graphique
+          h4 Répartition par catégorie
+          +radarIndiceCyber([
+            donneesIndiceCyber.gouvernance,
+            donneesIndiceCyber.resilience,
+            donneesIndiceCyber.defense,
+            donneesIndiceCyber.protection,
+          ], noteMax)
+        .conteneur-explication-valeur
+          .titre
+            img.icone(src="/statique/assets/images/icone_explication_tranche.svg")
+            h4 Quelle est la valeur de l'indice cyber ?
+          p Face aux risques les plus courants, un indice cyber peut être considéré comme
+          ul.liste-tranches
+            each tranche in referentiel.descriptionsTranchesIndiceCyber(donneesIndiceCyber.total)
+              li(class=`${tranche.trancheCourante ? 'tranche-courante' : ''}`)= tranche.description
+  .conteneur-recommandation-anssi
+    img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
+    .titre
+      img.icone(src="/statique/assets/images/icone_recommandation_anssi.svg")
+      h3 Recommandation indicative de l'ANSSI en cas de décision d'homologation
+    .conteneur-duree-recommandee
+      if(donneesTrancheIndiceCyber.conseilHomologation)
+        p= donneesTrancheIndiceCyber.conseilHomologation
+      if(!donneesTrancheIndiceCyber.deconseillee)
+        .separateur
+        p Durée d'homologation conseillée
+        p#duree-recommandee= donneesTrancheIndiceCyber.dureeHomologationConseillee
+
 block formulaire
   - const indiceCyber = service.indiceCyber()
   - const indiceCyberPersonnalise = service.indiceCyberPersonnalise()
@@ -38,45 +79,9 @@ block formulaire
         span Indice cyber personnalisé
         span.note-onglet!= `${indiceCyberPersonnalise.total.toFixed(1)}/${noteMax}`
     #indice-cyber-ANSSI.contenu-global
-      .conteneur-descriptif
-        .disque-indice
-          #conteneur-indice-cyber
-        .contenu-descriptif
-          h4 Indice cyber ANSSI
-          p
-            | L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures «&nbsp;faites » et «&nbsp;partielles » proposées par #{referentielConcernes} dans MonServiceSécurisé.
-            | Il est un indicateur de la qualité de la démarche de sécurisation du service.
-          a(href="https://aide.monservicesecurise.cyber.gouv.fr/fr/article/lindice-cyber-que-represente-t-il-et-comment-est-il-calcule-1l94rzd/" target="_blank") Comment est calculé l’indice cyber ANSSI ?
-      .conteneur-plus-details
-        details(open=true)
-          summary(role='button')
-          .contenu-plus-details
-            .conteneur-graphique
-              h4 Répartition par catégorie
-              +radarIndiceCyber([
-                indiceCyber.gouvernance,
-                indiceCyber.resilience,
-                indiceCyber.defense,
-                indiceCyber.protection,
-              ], noteMax)
-            .conteneur-explication-valeur
-              .titre
-                img.icone(src="/statique/assets/images/icone_explication_tranche.svg")
-                h4 Quelle est la valeur de l'indice cyber ?
-              p Face aux risques les plus courants, un indice cyber peut être considéré comme
-              ul.liste-tranches
-                each tranche in referentiel.descriptionsTranchesIndiceCyber(indiceCyber.total)
-                  li(class=`${tranche.trancheCourante ? 'tranche-courante' : ''}`)= tranche.description
-      .conteneur-recommandation-anssi
-        img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
-        .titre
-          img.icone(src="/statique/assets/images/icone_recommandation_anssi.svg")
-          h3 Recommandation indicative de l'ANSSI en cas de décision d'homologation
-        .conteneur-duree-recommandee
-          if(trancheIndiceCyber.conseilHomologation)
-            p= trancheIndiceCyber.conseilHomologation
-          if(!trancheIndiceCyber.deconseillee)
-            .separateur
-            p Durée d'homologation conseillée
-            p#duree-recommandee= trancheIndiceCyber.dureeHomologationConseillee
+      +contenuIndiceCyber('conteneur-indice-cyber', 'Indice cyber ANSSI', indiceCyber, noteMax, trancheIndiceCyber, referentiel)
+        p
+          | L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures «&nbsp;faites » et «&nbsp;partielles » proposées par #{referentielConcernes} dans MonServiceSécurisé.
+          | Il est un indicateur de la qualité de la démarche de sécurisation du service.
+        a(href="https://aide.monservicesecurise.cyber.gouv.fr/fr/article/lindice-cyber-que-represente-t-il-et-comment-est-il-calcule-1l94rzd/" target="_blank") Comment est calculé l’indice cyber ANSSI ?
     #indice-cyber-personnalise.contenu-global

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -29,6 +29,10 @@ block formulaire
   - const noteMax = referentiel.indiceCyberNoteMax()
   - const trancheIndiceCyber = referentiel.trancheIndiceCyber(indiceCyber.total)
   .conteneur-indice-cyber
+    .onglets
+      button.onglet.actif(type="button")
+        span Indice cyber ANSSI
+        span.note-onglet!= `${indiceCyber.total.toFixed(1)}/${noteMax}`
     .conteneur-descriptif
       .disque-indice
         #conteneur-indice-cyber

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -10,9 +10,12 @@ block append styles
 
 block append scripts
   +composantSvelte('indiceCyber.js')
+  +composantSvelte('indiceCyberPersonnalise.js')
   script(type = 'module', src = '/statique/service/indiceCyber.js')
-  script(id = 'indice-cyber', type = 'application/json').
+  script(id = 'donnees-indice-cyber', type = 'application/json').
     !{JSON.stringify({ indiceCyber: service.indiceCyber().total, noteMax: referentiel.indiceCyberNoteMax() })}
+  script(id = 'donnees-indice-cyber-personnalise', type = 'application/json').
+    !{JSON.stringify({ indiceCyberPersonnalise: service.indiceCyberPersonnalise().total })}
 
 block titre
   h1 Sécuriser

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -48,7 +48,7 @@ mixin contenuIndiceCyber(idCible, titre, donneesIndiceCyber, noteMax, donneesTra
             donneesIndiceCyber.resilience,
             donneesIndiceCyber.defense,
             donneesIndiceCyber.protection,
-          ], noteMax)
+          ], noteMax, idCible)
         .conteneur-explication-valeur
           .titre
             img.icone(src="/statique/assets/images/icone_explication_tranche.svg")
@@ -75,6 +75,10 @@ block formulaire
   - const indiceCyberPersonnalise = service.indiceCyberPersonnalise()
   - const noteMax = referentiel.indiceCyberNoteMax()
   - const trancheIndiceCyber = referentiel.trancheIndiceCyber(indiceCyber.total)
+  - const trancheIndiceCyberPersonnalise = referentiel.trancheIndiceCyber(indiceCyberPersonnalise.total)
+  - const nombreMesuresSpecifiques = service.mesuresSpecifiques().nombre()
+  - const nombreMesuresNonFait = service.nombreTotalMesuresNonFait()
+  - const metAuPluriel = (chaine, estAuPluriel) => estAuPluriel ? `${chaine}s` : chaine
   .conteneur-indice-cyber
     .onglets
       button.onglet.actif(type="button" data-cible='indice-cyber-ANSSI')
@@ -90,3 +94,12 @@ block formulaire
           | Il est un indicateur de la qualité de la démarche de sécurisation du service.
         a(href="https://aide.monservicesecurise.cyber.gouv.fr/fr/article/lindice-cyber-que-represente-t-il-et-comment-est-il-calcule-1l94rzd/" target="_blank") Comment est calculé l’indice cyber ANSSI ?
     #indice-cyber-personnalise.contenu-global
+      +contenuIndiceCyber('conteneur-indice-cyber-personnalise', 'Indice cyber personnalisé', indiceCyberPersonnalise, noteMax, trancheIndiceCyberPersonnalise, referentiel)
+        p L'indice cyber personnalisé reprend les même règles de calcul que l'indice cyber ANSSI en intégrant également les mesures spécifiques ajoutées par l'équipe et excluant les mesures de #{referentielConcernes} signalées comme "non prises en compte".
+        p.inclusion-exclusion
+          b Incluant :&nbsp;
+          | #{nombreMesuresSpecifiques} #{metAuPluriel('mesure', nombreMesuresSpecifiques > 1)} #{metAuPluriel('spécifique', nombreMesuresSpecifiques > 1)} #{metAuPluriel('ajoutée', nombreMesuresSpecifiques > 1)}.
+          br
+          b Excluant :&nbsp;
+          | #{nombreMesuresNonFait} #{metAuPluriel('mesure', nombreMesuresNonFait > 1)} #{metAuPluriel('proposée', nombreMesuresNonFait > 1)} par #{referentielConcernes}, "non #{metAuPluriel('prise', nombreMesuresNonFait > 1)} en compte" par l'équipe.
+        a(href="https://aide.monservicesecurise.cyber.gouv.fr/fr/article/lindice-cyber-personnalise-que-represente-t-il-et-comment-est-il-calcule-13ffv4p" target="_blank") Comment est calculé l’indice cyber personnalisé ?

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -18,7 +18,12 @@ block titre
   h1 Sécuriser
 
 block sous-titre
-  h2 Suivez l’indice cyber de votre service
+  h2
+    | Suivez l'
+    b indice cyber ANSSI&nbsp;
+    | et l'
+    b indice cyber personnalisé&nbsp;
+    | de votre service
 
 block header-titre-page
   h3

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -42,9 +42,11 @@ block formulaire
         .disque-indice
           #conteneur-indice-cyber
         .contenu-descriptif
+          h4 Indice cyber ANSSI
           p
             | L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures «&nbsp;faites » et «&nbsp;partielles » proposées par #{referentielConcernes} dans MonServiceSécurisé.
             | Il est un indicateur de la qualité de la démarche de sécurisation du service.
+          a(href="https://aide.monservicesecurise.cyber.gouv.fr/fr/article/lindice-cyber-que-represente-t-il-et-comment-est-il-calcule-1l94rzd/" target="_blank") Comment est calculé l’indice cyber ANSSI ?
       .conteneur-plus-details
         details(open=true)
           summary(role='button')

--- a/svelte/lib/indiceCyberPersonnalise/IndiceCyberPersonnalise.svelte
+++ b/svelte/lib/indiceCyberPersonnalise/IndiceCyberPersonnalise.svelte
@@ -1,1 +1,86 @@
-<h1>Indice cyber personnalisé</h1>
+<script lang="ts">
+  export let indiceCyberPersonnalise: number;
+  export let noteMax: number;
+
+  $: indiceCyberFormatte = Intl.NumberFormat('fr', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(indiceCyberPersonnalise);
+
+  const taille = 200;
+  const nbTraits = 52;
+  const largeurRectangle = 3;
+  const hauteurRectangle = 12;
+  const radius = 0.85 * (taille / 2);
+
+  const avancement = Math.floor((indiceCyberPersonnalise / noteMax) * nbTraits);
+</script>
+
+<svg
+  id="score-indice-cyber-personnalise"
+  viewBox="0 0 {taille} {taille}"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  filter="drop-shadow(0px 4.6857147216796875px 23.428573608398438px rgba(26, 68, 139, 0.2))"
+>
+  <circle cx={taille / 2} cy={taille / 2} r={taille / 2 - 1} fill="white" />
+  <text x="50" y="110" fill="#0079D0" font-size="2.8em" font-weight="bold">
+    {indiceCyberFormatte}
+  </text>
+  <line
+    x1="125"
+    y1="130"
+    x2="137"
+    y2="89"
+    stroke="#0C5C98"
+    stroke-width="2"
+    opacity="0.8"
+  />
+  <text x="135" y="125" fill="#0C5C98" font-size="1.7em" opacity="0.8">
+    {noteMax}
+  </text>
+  <foreignObject x="0" y="0" width={taille} height={taille} mask="url(#masque)">
+    <div class="gradient" xmlns="http://www.w3.org/1999/xhtml"></div>
+  </foreignObject>
+  <mask id="masque">
+    {#each new Array(avancement).fill(0) as _, i}
+      {@const angle = (i / nbTraits) * 2 * Math.PI - Math.PI / 2}
+      {@const x = radius * Math.cos(angle) + taille / 2}
+      {@const y = radius * Math.sin(angle) + taille / 2}
+      {@const angleTrait = ((angle + Math.PI / 2) * 180) / Math.PI}
+      <g
+        transform="translate({x}, {y}) rotate({angleTrait})"
+        filter="url(#ombre)"
+      >
+        <rect
+          x="0"
+          y="0"
+          width={largeurRectangle}
+          height={hauteurRectangle}
+          filter="url(#ombre)"
+          fill="white"
+        />
+      </g>
+    {/each}
+  </mask>
+</svg>
+
+<style>
+  svg {
+    width: 100%;
+  }
+
+  .gradient {
+    width: 100%;
+    height: 100%;
+    background-image: conic-gradient(
+      from 122.78deg at 50% 50%,
+      #54b8f6 -141.68deg,
+      #08416a 103.92deg,
+      #54b8f6 141.72deg,
+      #54b8f6 218.32deg,
+      #08416a 463.92deg
+    );
+    transform: rotate(90deg);
+  }
+</style>

--- a/svelte/lib/indiceCyberPersonnalise/IndiceCyberPersonnalise.svelte
+++ b/svelte/lib/indiceCyberPersonnalise/IndiceCyberPersonnalise.svelte
@@ -1,0 +1,1 @@
+<h1>Indice cyber personnalisé</h1>

--- a/svelte/lib/indiceCyberPersonnalise/indiceCyberPersonnalise.d.ts
+++ b/svelte/lib/indiceCyberPersonnalise/indiceCyberPersonnalise.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  interface HTMLElementEventMap {
+    'svelte-recharge-indice-cyber-personnalise': CustomEvent;
+  }
+}
+
+export type IndiceCyberPersonnaliseProps = {
+  indiceCyberPersonnalise: number;
+  noteMax: number;
+};

--- a/svelte/lib/indiceCyberPersonnalise/indiceCyberPersonnalise.ts
+++ b/svelte/lib/indiceCyberPersonnalise/indiceCyberPersonnalise.ts
@@ -1,0 +1,18 @@
+import IndiceCyberPersonnalise from './IndiceCyberPersonnalise.svelte';
+import type { IndiceCyberPersonnaliseProps } from './indiceCyberPersonnalise.d';
+
+document.body.addEventListener(
+  'svelte-recharge-indice-cyber-personnalise',
+  (e: CustomEvent<IndiceCyberPersonnaliseProps>) => rechargeApp({ ...e.detail })
+);
+
+let app: IndiceCyberPersonnalise;
+const rechargeApp = (props: IndiceCyberPersonnaliseProps) => {
+  app?.$destroy();
+  app = new IndiceCyberPersonnalise({
+    target: document.getElementById('conteneur-indice-cyber-personnalise')!,
+    props: props,
+  });
+};
+
+export default app!;

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -349,4 +349,47 @@ describe('Les mesures liées à un service', () => {
       });
     });
   });
+
+  it('connait le nombre total de mesures "nonFait"', () => {
+    const referentiel = Referentiel.creeReferentiel({
+      categoriesMesures: { C1: 'C1', C2: 'C2' },
+      statutsMesures: {
+        fait: 'Faite',
+        nonFait: 'Non prise en compte',
+      },
+      mesures: {
+        M1: {},
+        M2: {},
+        M3: {},
+      },
+    });
+
+    const mesures = new Mesures(
+      {
+        mesuresGenerales: [
+          { id: 'M1', statut: 'nonFait' },
+          { id: 'M2', statut: 'nonFait' },
+          { id: 'M3', statut: 'fait' },
+        ],
+        mesuresSpecifiques: [
+          {
+            statut: 'nonFait',
+            categorie: 'C1',
+          },
+          {
+            statut: 'fait',
+            categorie: 'C2',
+          },
+        ],
+      },
+      referentiel,
+      {
+        M1: { categorie: 'C1' },
+        M2: { categorie: 'C2' },
+        M3: { categorie: 'C2' },
+      }
+    );
+
+    expect(mesures.nombreTotalNonFait()).to.be(3);
+  });
 });

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -578,6 +578,13 @@ describe('Un service', () => {
     expect(service.indiceCyber()).to.equal(3.7);
   });
 
+  it('connaît son indice cyber personnalisé', () => {
+    const service = unService().construis();
+    service.mesures.indiceCyberPersonnalise = () => 4.8;
+
+    expect(service.indiceCyberPersonnalise()).to.equal(4.8);
+  });
+
   it('délègue aux mesures le calcul du nombre total de mesures générales', () => {
     const service = new Service({ mesuresGenerales: [] });
     service.mesures.nombreTotalMesuresGenerales = () => 42;


### PR DESCRIPTION
On affiche désormais l'indice cyber personnalisé sur la page de l'indice cyber.
Le composant `Svelte` sera réutilisé sur la page SÉCURISER.

![image](https://github.com/user-attachments/assets/de2f09ca-bab8-46d5-aaab-e75eae50ce85)
