### PR TITLE
[HISTORIQUE] Enregistre les changements de statut des mesures

### DIFF
--- a/migrations/20240827134814_creationTableActivitesMesure.js
+++ b/migrations/20240827134814_creationTableActivitesMesure.js
@@ -1,0 +1,10 @@
+exports.up = (knex) =>
+  knex.schema.createTable('activites_mesure', (table) => {
+    table.uuid('id_acteur');
+    table.uuid('id_service');
+    table.string('type');
+    table.datetime('date').defaultTo(knex.fn.now());
+    table.json('details');
+  });
+
+exports.down = (knex) => knex.schema.dropTable('activites_mesure');

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -86,7 +86,13 @@ const nouvelAdaptateur = (env) => {
       email_hash: emailHash,
     });
 
-  const ajouteActiviteMesure = (idActeur, idService, type, details) => {};
+  const ajouteActiviteMesure = (idActeur, idService, type, details) =>
+    knex('activites_mesure').insert({
+      id_acteur: idActeur,
+      id_service: idService,
+      type,
+      details,
+    });
 
   const arreteTout = () => knex.destroy();
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -86,6 +86,8 @@ const nouvelAdaptateur = (env) => {
       email_hash: emailHash,
     });
 
+  const ajouteActiviteMesure = (idActeur, idService, type, details) => {};
+
   const arreteTout = () => knex.destroy();
 
   const service = async (id) =>
@@ -449,6 +451,7 @@ const nouvelAdaptateur = (env) => {
     ajouteSuggestionAction,
     ajouteTacheDeService,
     ajouteUtilisateur,
+    ajouteActiviteMesure,
     arreteTout,
     autorisation,
     autorisationPour,

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -5,17 +5,20 @@ function consigneActiviteMesure({ depotDonnees }) {
     if (ancienneMesure?.statut === nouvelleMesure.statut) {
       return;
     }
-
-    const activiteMesure = new ActiviteMesure({
-      service,
-      acteur: utilisateur,
-      type: 'miseAJourStatut',
-      details: {
-        ancienStatut: ancienneMesure?.statut,
-        nouveauStatut: nouvelleMesure.statut,
-      },
-    });
-    depotDonnees.ajouteActiviteMesure(activiteMesure);
+    try {
+      const activiteMesure = new ActiviteMesure({
+        service,
+        acteur: utilisateur,
+        type: 'miseAJourStatut',
+        details: {
+          ancienStatut: ancienneMesure?.statut,
+          nouveauStatut: nouvelleMesure.statut,
+        },
+      });
+      await depotDonnees.ajouteActiviteMesure(activiteMesure);
+    } catch (e) {
+      console.error("Erreur d'ajout d'activité", e);
+    }
   };
 }
 

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -2,6 +2,10 @@ const ActiviteMesure = require('../../modeles/activiteMesure');
 
 function consigneActiviteMesure({ depotDonnees }) {
   return async ({ service, utilisateur, ancienneMesure, nouvelleMesure }) => {
+    if (ancienneMesure?.statut === nouvelleMesure.statut) {
+      return;
+    }
+
     const activiteMesure = new ActiviteMesure({
       service,
       acteur: utilisateur,

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -1,4 +1,7 @@
 const ActiviteMesure = require('../../modeles/activiteMesure');
+const {
+  fabriqueAdaptateurGestionErreur,
+} = require('../../adaptateurs/fabriqueAdaptateurGestionErreur');
 
 function consigneActiviteMesure({ depotDonnees }) {
   return async ({ service, utilisateur, ancienneMesure, nouvelleMesure }) => {
@@ -17,7 +20,10 @@ function consigneActiviteMesure({ depotDonnees }) {
       });
       await depotDonnees.ajouteActiviteMesure(activiteMesure);
     } catch (e) {
-      console.error("Erreur d'ajout d'activité", e);
+      fabriqueAdaptateurGestionErreur().logueErreur(
+        "Erreur d'ajout d'activité",
+        e
+      );
     }
   };
 }

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -1,0 +1,18 @@
+const ActiviteMesure = require('../../modeles/activiteMesure');
+
+function consigneActiviteMesure({ depotDonnees }) {
+  return async ({ service, utilisateur, ancienneMesure, nouvelleMesure }) => {
+    const activiteMesure = new ActiviteMesure({
+      service,
+      acteur: utilisateur,
+      type: 'miseAJourStatut',
+      details: {
+        ancienStatut: ancienneMesure?.statut,
+        nouveauStatut: nouvelleMesure.statut,
+      },
+    });
+    depotDonnees.ajouteActiviteMesure(activiteMesure);
+  };
+}
+
+module.exports = { consigneActiviteMesure };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -72,6 +72,9 @@ const {
   supprimeSuggestionsSurDesChampsObligatoires,
 } = require('./abonnements/supprimeSuggestionsSurDesChampsObligatoires');
 const EvenementMesureServiceModifiee = require('./evenementMesureServiceModifiee');
+const {
+  consigneActiviteMesure,
+} = require('./abonnements/consigneActiviteMesure');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -119,6 +122,7 @@ const cableTousLesAbonnes = (
       adaptateurRechercheEntreprise,
     }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
+    consigneActiviteMesure({ depotDonnees }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementDescriptionServiceModifiee, [

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -71,6 +71,7 @@ const {
 const {
   supprimeSuggestionsSurDesChampsObligatoires,
 } = require('./abonnements/supprimeSuggestionsSurDesChampsObligatoires');
+const EvenementMesureServiceModifiee = require('./evenementMesureServiceModifiee');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -105,6 +106,14 @@ const cableTousLesAbonnes = (
   ]);
 
   busEvenements.abonnePlusieurs(EvenementMesuresServiceModifiees, [
+    consigneCompletudeDansJournal({
+      adaptateurJournal,
+      adaptateurRechercheEntreprise,
+    }),
+    envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
+  ]);
+
+  busEvenements.abonnePlusieurs(EvenementMesureServiceModifiee, [
     consigneCompletudeDansJournal({
       adaptateurJournal,
       adaptateurRechercheEntreprise,

--- a/src/bus/evenementMesureServiceModifiee.js
+++ b/src/bus/evenementMesureServiceModifiee.js
@@ -1,5 +1,5 @@
 class EvenementMesureServiceModifiee {
-  constructor({ service, utilisateur }) {
+  constructor({ service, utilisateur, ancienneMesure, nouvelleMesure }) {
     if (!service)
       throw Error("Impossible d'instancier l'événement sans service");
     if (!utilisateur)
@@ -7,6 +7,8 @@ class EvenementMesureServiceModifiee {
 
     this.service = service;
     this.utilisateur = utilisateur;
+    this.ancienneMesure = ancienneMesure;
+    this.nouvelleMesure = nouvelleMesure;
   }
 }
 

--- a/src/bus/evenementMesureServiceModifiee.js
+++ b/src/bus/evenementMesureServiceModifiee.js
@@ -1,0 +1,13 @@
+class EvenementMesureServiceModifiee {
+  constructor({ service, utilisateur }) {
+    if (!service)
+      throw Error("Impossible d'instancier l'événement sans service");
+    if (!utilisateur)
+      throw Error("Impossible d'instancier l'événement sans utilisateur");
+
+    this.service = service;
+    this.utilisateur = utilisateur;
+  }
+}
+
+module.exports = EvenementMesureServiceModifiee;

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -9,6 +9,8 @@ const depotDonneesParcoursUtilisateurs = require('./depots/depotDonneesParcoursU
 const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 const depotDonneesNotifications = require('./depots/depotDonneesNotifications');
 const depotDonneesSuggestionsActions = require('./depots/depotDonneesSuggestionsActions');
+const depotDonneesActivitesMesure = require('./depots/depotDonneesActivitesMesure');
+
 const {
   fabriqueAdaptateurChiffrement,
 } = require('./adaptateurs/fabriqueAdaptateurChiffrement');
@@ -68,6 +70,10 @@ const creeDepot = (config = {}) => {
   });
 
   const depotSuggestionsActions = depotDonneesSuggestionsActions.creeDepot({
+    adaptateurPersistance,
+  });
+
+  const depotActivitesMesure = depotDonneesActivitesMesure.creeDepot({
     adaptateurPersistance,
   });
 
@@ -140,9 +146,12 @@ const creeDepot = (config = {}) => {
 
   const { acquitteSuggestionAction } = depotSuggestionsActions;
 
+  const { ajouteActiviteMesure } = depotActivitesMesure;
+
   return {
     accesAutorise,
     acquitteSuggestionAction,
+    ajouteActiviteMesure,
     ajouteContributeurAuService,
     ajouteDescriptionService,
     ajouteDossierCourantSiNecessaire,

--- a/src/depots/depotDonneesActivitesMesure.js
+++ b/src/depots/depotDonneesActivitesMesure.js
@@ -1,0 +1,17 @@
+const creeDepot = (config = {}) => {
+  const { adaptateurPersistance } = config;
+
+  const ajouteActiviteMesure = (activite) => {
+    adaptateurPersistance.ajouteActiviteMesure(
+      activite.acteurId(),
+      activite.serviceId(),
+      activite.type,
+      activite.details
+    );
+  };
+
+  return {
+    ajouteActiviteMesure,
+  };
+};
+module.exports = { creeDepot };

--- a/src/depots/depotDonneesActivitesMesure.js
+++ b/src/depots/depotDonneesActivitesMesure.js
@@ -1,14 +1,13 @@
 const creeDepot = (config = {}) => {
   const { adaptateurPersistance } = config;
 
-  const ajouteActiviteMesure = (activite) => {
+  const ajouteActiviteMesure = (activite) =>
     adaptateurPersistance.ajouteActiviteMesure(
-      activite.acteurId(),
-      activite.serviceId(),
+      activite.idActeur(),
+      activite.idService(),
       activite.type,
       activite.details
     );
-  };
 
   return {
     ajouteActiviteMesure,

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -16,6 +16,7 @@ const {
 const EvenementDossierHomologationFinalise = require('../bus/evenementDossierHomologationFinalise');
 const EvenementServiceSupprime = require('../bus/evenementServiceSupprime');
 const Entite = require('../modeles/entite');
+const EvenementMesureServiceModifiee = require('../bus/evenementMesureServiceModifiee');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = async (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -408,7 +409,7 @@ const creeDepot = (config = {}) => {
     await metsAJourService(s);
     const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
     await busEvenements.publie(
-      new EvenementMesuresServiceModifiees({ service: s, utilisateur: u })
+      new EvenementMesureServiceModifiee({ service: s, utilisateur: u })
     );
   };
 

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -405,11 +405,17 @@ const creeDepot = (config = {}) => {
     mesure
   ) => {
     const s = await p.lis.un(idService);
+    const ancienneMesure = s.mesuresGenerales().avecId(mesure.id);
     s.metsAJourMesureGenerale(mesure);
     await metsAJourService(s);
     const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
     await busEvenements.publie(
-      new EvenementMesureServiceModifiee({ service: s, utilisateur: u })
+      new EvenementMesureServiceModifiee({
+        service: s,
+        utilisateur: u,
+        ancienneMesure,
+        nouvelleMesure: mesure,
+      })
     );
   };
 

--- a/src/modeles/activiteMesure.js
+++ b/src/modeles/activiteMesure.js
@@ -1,0 +1,10 @@
+class ActiviteMesure {
+  constructor(donnees) {
+    this.service = donnees.service;
+    this.acteur = donnees.acteur;
+    this.type = donnees.type;
+    this.details = donnees.details;
+  }
+}
+
+module.exports = ActiviteMesure;

--- a/src/modeles/activiteMesure.js
+++ b/src/modeles/activiteMesure.js
@@ -6,9 +6,9 @@ class ActiviteMesure {
     this.details = donnees.details;
   }
 
-  acteurId = () => this.acteur.id;
+  idActeur = () => this.acteur.id;
 
-  serviceId = () => this.service.id;
+  idService = () => this.service.id;
 }
 
 module.exports = ActiviteMesure;

--- a/src/modeles/activiteMesure.js
+++ b/src/modeles/activiteMesure.js
@@ -5,6 +5,10 @@ class ActiviteMesure {
     this.type = donnees.type;
     this.details = donnees.details;
   }
+
+  acteurId = () => this.acteur.id;
+
+  serviceId = () => this.service.id;
 }
 
 module.exports = ActiviteMesure;

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -1,0 +1,82 @@
+const expect = require('expect.js');
+const {
+  consigneActiviteMesure,
+} = require('../../../src/bus/abonnements/consigneActiviteMesure');
+const ActiviteMesure = require('../../../src/modeles/activiteMesure');
+const MesureGenerale = require('../../../src/modeles/mesureGenerale');
+const { unService } = require('../../constructeurs/constructeurService');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+const Referentiel = require('../../../src/referentiel');
+
+describe("L'abonnement qui consigne l'activité pour une mesure", () => {
+  let activiteAjoutee;
+  let gestionnaire;
+  const referentiel = Referentiel.creeReferentiel({
+    mesures: { audit: { categorie: 'gouvernance' } },
+  });
+
+  beforeEach(() => {
+    const depotDonnees = {
+      ajouteActiviteMesure: (activite) => {
+        activiteAjoutee = activite;
+      },
+    };
+    gestionnaire = consigneActiviteMesure({ depotDonnees });
+  });
+
+  it('renvoie une fonction', () => {
+    expect(typeof gestionnaire).to.be('function');
+  });
+
+  it('delegue au depôt de données la creation de l’activité', async () => {
+    await gestionnaire({ nouvelleMesure: {} });
+
+    expect(activiteAjoutee).to.be.an(ActiviteMesure);
+  });
+
+  it('crée une activité de mise à jour de statut', async () => {
+    const service = unService().construis();
+    const utilisateur = unUtilisateur().construis();
+    const evenement = {
+      service,
+      utilisateur,
+      ancienneMesure: new MesureGenerale(
+        { id: 'audit', statut: 'nonFait' },
+        referentiel
+      ),
+      nouvelleMesure: new MesureGenerale(
+        { id: 'audit', statut: 'fait' },
+        referentiel
+      ),
+    };
+
+    await gestionnaire(evenement);
+
+    expect(activiteAjoutee.service).to.be(service);
+    expect(activiteAjoutee.acteur).to.be(utilisateur);
+    expect(activiteAjoutee.type).to.be('miseAJourStatut');
+    expect(activiteAjoutee.details).to.eql({
+      ancienStatut: 'nonFait',
+      nouveauStatut: 'fait',
+    });
+  });
+
+  it("considère l'ancien statut comme non défini si l'ancienne mesure est indéfinie", async () => {
+    const evenement = {
+      ancienneMesure: undefined,
+      nouvelleMesure: new MesureGenerale(
+        { id: 'audit', statut: 'fait' },
+        referentiel
+      ),
+    };
+
+    await gestionnaire(evenement);
+
+    expect(activiteAjoutee.details).to.eql({
+      ancienStatut: undefined,
+      nouveauStatut: 'fait',
+    });
+  });
+});

--- a/test/bus/evenementMesureServiceModifiee.spec.js
+++ b/test/bus/evenementMesureServiceModifiee.spec.js
@@ -1,0 +1,26 @@
+const expect = require('expect.js');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+const { unService } = require('../constructeurs/constructeurService');
+const EvenementMesureServiceModifiee = require('../../src/bus/evenementMesureServiceModifiee');
+
+describe("L'événement `mesureServiceModifiee", () => {
+  it("lève une exception s'il est instancié sans service", () => {
+    expect(
+      () =>
+        new EvenementMesureServiceModifiee({
+          service: null,
+          utilisateur: unUtilisateur().construis(),
+        })
+    ).to.throwError();
+  });
+
+  it("lève une exception s'il est instancié sans utilisateur", () => {
+    expect(
+      () =>
+        new EvenementMesureServiceModifiee({
+          service: unService().construis(),
+          utilisateur: null,
+        })
+    ).to.throwError();
+  });
+});

--- a/test/depots/depotDonneesActivitesMesure.spec.js
+++ b/test/depots/depotDonneesActivitesMesure.spec.js
@@ -1,0 +1,52 @@
+const expect = require('expect.js');
+const {
+  unePersistanceMemoire,
+} = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
+const DepotDonneesActivitesMesure = require('../../src/depots/depotDonneesActivitesMesure');
+const ActiviteMesure = require('../../src/modeles/activiteMesure');
+const { unService } = require('../constructeurs/constructeurService');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+
+describe('Le dépôt de données des activités de mesure', () => {
+  describe('sur ajout d’une activité', () => {
+    it("ajoute l'activité", () => {
+      const adaptateurPersistance = unePersistanceMemoire().construis();
+      let activiteAjouteeAPersistance = false;
+      let idServiceActivite;
+      let idActeurActivite;
+      let typeActivite;
+      let detailsActivite;
+      adaptateurPersistance.ajouteActiviteMesure = (
+        idActeur,
+        idService,
+        type,
+        details
+      ) => {
+        activiteAjouteeAPersistance = true;
+        idServiceActivite = idService;
+        idActeurActivite = idActeur;
+        typeActivite = type;
+        detailsActivite = details;
+      };
+      const depot = DepotDonneesActivitesMesure.creeDepot({
+        adaptateurPersistance,
+      });
+      const service = unService().avecId(987).construis();
+      const acteur = unUtilisateur().avecId(654).construis();
+      const activite = new ActiviteMesure({
+        service,
+        acteur,
+        type: 'statutMisAJour',
+        details: { nouveauStatut: 'fait' },
+      });
+
+      depot.ajouteActiviteMesure(activite);
+
+      expect(activiteAjouteeAPersistance).to.be(true);
+      expect(idServiceActivite).to.be(987);
+      expect(idActeurActivite).to.be(654);
+      expect(typeActivite).to.be('statutMisAJour');
+      expect(detailsActivite).to.eql({ nouveauStatut: 'fait' });
+    });
+  });
+});

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -61,6 +61,7 @@ const Entite = require('../../src/modeles/entite');
 const Utilisateur = require('../../src/modeles/utilisateur');
 const DepotDonneesUtilisateurs = require('../../src/depots/depotDonneesUtilisateurs');
 const { creeReferentielVide } = require('../../src/referentiel');
+const EvenementMesureServiceModifiee = require('../../src/bus/evenementMesureServiceModifiee');
 
 const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 const { ECRITURE } = Permissions;
@@ -1679,7 +1680,7 @@ describe('Le dépôt de données des services', () => {
       await depot.metsAJourMesureGeneraleDuService('123', '789', mesure);
 
       expect(
-        busEvenements.aRecuUnEvenement(EvenementMesuresServiceModifiees)
+        busEvenements.aRecuUnEvenement(EvenementMesureServiceModifiee)
       ).to.be(true);
     });
   });


### PR DESCRIPTION
Les activités liées aux changements de statut des mesures générales des services sont enregistrées dans une nouvelle table `activites_mesure`