### PR TITLE
[HISTORIQUE] Enregistre les changements de priorité des mesures

### DIFF
--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -5,25 +5,29 @@ const {
 
 function consigneActiviteMesure({ depotDonnees }) {
   return async ({ service, utilisateur, ancienneMesure, nouvelleMesure }) => {
-    if (ancienneMesure?.statut === nouvelleMesure.statut) {
-      return;
+    async function ajouteActivite(type, details) {
+      try {
+        const activiteMesure = new ActiviteMesure({
+          service,
+          acteur: utilisateur,
+          type,
+          details,
+        });
+        await depotDonnees.ajouteActiviteMesure(activiteMesure);
+      } catch (e) {
+        fabriqueAdaptateurGestionErreur().logueErreur("Erreur d'ajout d'activité", e);
+      }
     }
-    try {
-      const activiteMesure = new ActiviteMesure({
-        service,
-        acteur: utilisateur,
-        type: 'miseAJourStatut',
-        details: {
-          ancienStatut: ancienneMesure?.statut,
-          nouveauStatut: nouvelleMesure.statut,
-        },
+
+    if (ancienneMesure?.statut !== nouvelleMesure.statut) {
+      await ajouteActivite('miseAJourStatut', {
+        ancienStatut: ancienneMesure?.statut,
+        nouveauStatut: nouvelleMesure.statut,
       });
-      await depotDonnees.ajouteActiviteMesure(activiteMesure);
-    } catch (e) {
-      fabriqueAdaptateurGestionErreur().logueErreur(
-        "Erreur d'ajout d'activité",
-        e
-      );
+    } else if (ancienneMesure.priorite !== nouvelleMesure.priorite) {
+      await ajouteActivite('ajoutPriorite', {
+        nouvellePriorite: nouvelleMesure.priorite,
+      });
     }
   };
 }

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -15,7 +15,10 @@ function consigneActiviteMesure({ depotDonnees }) {
         });
         await depotDonnees.ajouteActiviteMesure(activiteMesure);
       } catch (e) {
-        fabriqueAdaptateurGestionErreur().logueErreur("Erreur d'ajout d'activité", e);
+        fabriqueAdaptateurGestionErreur().logueErreur(
+          "Erreur d'ajout d'activité",
+          e
+        );
       }
     }
 
@@ -32,7 +35,7 @@ function consigneActiviteMesure({ depotDonnees }) {
           anciennePriorite: ancienneMesure.priorite,
           nouvellePriorite: nouvelleMesure.priorite,
         });
-      } else {
+      } else if (nouvelleMesure.priorite) {
         await ajouteActivite('ajoutPriorite', {
           nouvellePriorite: nouvelleMesure.priorite,
         });

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -24,10 +24,19 @@ function consigneActiviteMesure({ depotDonnees }) {
         ancienStatut: ancienneMesure?.statut,
         nouveauStatut: nouvelleMesure.statut,
       });
-    } else if (ancienneMesure.priorite !== nouvelleMesure.priorite) {
-      await ajouteActivite('ajoutPriorite', {
-        nouvellePriorite: nouvelleMesure.priorite,
-      });
+    }
+
+    if (ancienneMesure?.priorite !== nouvelleMesure.priorite) {
+      if (ancienneMesure?.priorite) {
+        await ajouteActivite('miseAJourPriorite', {
+          anciennePriorite: ancienneMesure.priorite,
+          nouvellePriorite: nouvelleMesure.priorite,
+        });
+      } else {
+        await ajouteActivite('ajoutPriorite', {
+          nouvellePriorite: nouvelleMesure.priorite,
+        });
+      }
     }
   };
 }


### PR DESCRIPTION
Les activités de mesure sont créées lorsque :
- une priorité est définie alors qu’il n’y en avait pas
- une priorité est modifiée

De plus, il est possible de changer un statut **ET** de définir/changer une priorité. 
