### PR TITLE
[INDICE CYBER PERSONNALISÉ] Derniers correctifs UI/UX

### DIFF
--- a/public/assets/styles/homologation/mesures.css
+++ b/public/assets/styles/homologation/mesures.css
@@ -17,7 +17,6 @@
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  gap: 1em;
   position: sticky;
   top: 0;
   right: 0;
@@ -46,6 +45,7 @@
   gap: 0;
   align-items: center;
   margin-top: -14px;
+  margin-left: -16px;
 }
 
 .conteneur-indice-cyber svg {

--- a/public/service/indiceCyber.js
+++ b/public/service/indiceCyber.js
@@ -23,6 +23,22 @@ $(() => {
     $onglets.on('click', basculeOnglets);
   };
 
+  const brancheNavigationOngletDepuisURL = () => {
+    const $onglets = $('.conteneur-indice-cyber .onglets .onglet');
+    const $tousContenus = $('.contenu-global');
+
+    const recherche = new URLSearchParams(window.location.search);
+    if (recherche.has('onglet')) {
+      const cible = recherche.get('onglet');
+
+      $onglets.removeClass('actif');
+      $(`.onglet[data-cible=${cible}]`).addClass('actif');
+
+      $tousContenus.hide();
+      $(`#${cible}`).show();
+    }
+  };
+
   document.body.dispatchEvent(
     new CustomEvent('svelte-recharge-indice-cyber', {
       detail: { indiceCyber, noteMax, idService },
@@ -34,4 +50,5 @@ $(() => {
     })
   );
   brancheOnglets();
+  brancheNavigationOngletDepuisURL();
 });

--- a/src/vues/service/indiceCyber.pug
+++ b/src/vues/service/indiceCyber.pug
@@ -32,7 +32,7 @@ block header-titre-page
   h3
     +texteTronque({ texte: service.nomService() || '' })
 
-mixin contenuIndiceCyber(idCible, titre, donneesIndiceCyber, noteMax, donneesTrancheIndiceCyber, referentiel)
+mixin contenuIndiceCyber(idCible, titre, donneesIndiceCyber, noteMax, donneesTrancheIndiceCyber, referentiel, avecRecommandationANSSI)
   .conteneur-descriptif
     .disque-indice
       div(id=idCible)
@@ -60,18 +60,19 @@ mixin contenuIndiceCyber(idCible, titre, donneesIndiceCyber, noteMax, donneesTra
           ul.liste-tranches
             each tranche in referentiel.descriptionsTranchesIndiceCyber(donneesIndiceCyber.total)
               li(class=`${tranche.trancheCourante ? 'tranche-courante' : ''}`)= tranche.description
-  .conteneur-recommandation-anssi
-    img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
-    .titre
-      img.icone(src="/statique/assets/images/icone_recommandation_anssi.svg")
-      h3 Recommandation indicative de l'ANSSI en cas de décision d'homologation
-    .conteneur-duree-recommandee
-      if(donneesTrancheIndiceCyber.conseilHomologation)
-        p= donneesTrancheIndiceCyber.conseilHomologation
-      if(!donneesTrancheIndiceCyber.deconseillee)
-        .separateur
-        p Durée d'homologation conseillée
-        p#duree-recommandee= donneesTrancheIndiceCyber.dureeHomologationConseillee
+  if avecRecommandationANSSI
+    .conteneur-recommandation-anssi
+      img.fond(src="/statique/assets/images/fond_recommandation_anssi.svg")
+      .titre
+        img.icone(src="/statique/assets/images/icone_recommandation_anssi.svg")
+        h3 Recommandation indicative de l'ANSSI en cas de décision d'homologation
+      .conteneur-duree-recommandee
+        if(donneesTrancheIndiceCyber.conseilHomologation)
+          p= donneesTrancheIndiceCyber.conseilHomologation
+        if(!donneesTrancheIndiceCyber.deconseillee)
+          .separateur
+          p Durée d'homologation conseillée
+          p#duree-recommandee= donneesTrancheIndiceCyber.dureeHomologationConseillee
 
 block formulaire
   - const indiceCyber = service.indiceCyber()
@@ -91,7 +92,7 @@ block formulaire
         span Indice cyber personnalisé
         span.note-onglet!= `${indiceCyberPersonnalise.total.toFixed(1)}/${noteMax}`
     #indice-cyber-ANSSI.contenu-global
-      +contenuIndiceCyber('conteneur-indice-cyber', 'Indice cyber ANSSI', indiceCyber, noteMax, trancheIndiceCyber, referentiel)
+      +contenuIndiceCyber('conteneur-indice-cyber', 'Indice cyber ANSSI', indiceCyber, noteMax, trancheIndiceCyber, referentiel, true)
         p
           | L'indice cyber est une évaluation indicative du niveau de sécurisation du service, calculé à partir des mesures «&nbsp;faites » et «&nbsp;partielles » proposées par #{referentielConcernes} dans MonServiceSécurisé.
           | Il est un indicateur de la qualité de la démarche de sécurisation du service.

--- a/src/vues/service/mesures.pug
+++ b/src/vues/service/mesures.pug
@@ -47,7 +47,7 @@ block formulaire
           span
             b ANSSI&nbsp;&nbsp;
           br
-          a.lien-indice-cyber(href="indiceCyber") Voir le détail
+          a.lien-indice-cyber(href="indiceCyber?onglet=indice-cyber-ANSSI") Voir le détail
         #conteneur-indice-cyber
       .conteneur-indice-cyber.personnalise
         .cartouche-indice-cyber.personnalise
@@ -55,5 +55,5 @@ block formulaire
           span
             b personnalisé&nbsp;&nbsp;
           br
-          a.lien-indice-cyber(href="indiceCyber") Voir le détail
+          a.lien-indice-cyber(href="indiceCyber?onglet=indice-cyber-personnalise") Voir le détail
         #conteneur-indice-cyber-personnalise


### PR DESCRIPTION
Au menu dans cette PR :
- On supprime le cartouche de recommandation ANSSI dans le cas de l'indice cyber personnalisé, sur la page Indice Cyber
- On permet de naviguer directement sur un onglet de la page Indice Cyber via un `query param`
- On réduit l'espacement entre les indices cybers sur la page SÉCURISER afin de les afficher correctement sur des petits écrans