### PR TITLE
[HISTORIQUE] Ajoute les activités pour les changements d’échéance

### DIFF
--- a/migrations/20240829064157_supprimeActivitesMesureSuiteChangementModele.js
+++ b/migrations/20240829064157_supprimeActivitesMesureSuiteChangementModele.js
@@ -1,0 +1,3 @@
+exports.up = (knex) => knex.table('activites_mesure').del();
+
+exports.down = () => {};

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -69,6 +69,12 @@ function consigneActiviteMesure({ depotDonnees }) {
         nouvelleEcheance: nouvelleMesure.echeance,
       });
     }
+
+    if (ancienneMesure?.echeance && !nouvelleMesure.echeance) {
+      await ajouteActivite('suppressionEcheance', {
+        ancienneEcheance: ancienneMesure.echeance,
+      });
+    }
   };
 }
 

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -9,7 +9,7 @@ class ComparateurMesures {
     this.nouvelleMesure = nouvelleMesure;
   }
 
-  valeursÉgales(propriete) {
+  valeursEgales(propriete) {
     if (propriete === 'echeance') {
       return (
         new Date(this.ancienneMesure[propriete]).getTime() ===
@@ -21,7 +21,7 @@ class ComparateurMesures {
 
   aMisAJour = (propriete) =>
     this.ancienneMesure?.[propriete] &&
-    !this.valeursÉgales(propriete) &&
+    !this.valeursEgales(propriete) &&
     this.nouvelleMesure[propriete];
 
   aAjoute = (propriete) =>
@@ -39,13 +39,13 @@ class ComparateurMesures {
   proprietesSupprimees = () => ['echeance'].filter((p) => this.aSupprime(p));
 }
 
-function majuscule(chaine) {
-  return chaine.charAt(0).toUpperCase() + chaine.substring(1);
-}
+const majuscule = (chaine) =>
+  `${chaine.charAt(0).toUpperCase()}${chaine.substring(1)}`;
 
-function consigneActiviteMesure({ depotDonnees }) {
-  return async ({ service, utilisateur, ancienneMesure, nouvelleMesure }) => {
-    async function ajouteActivite(type, details) {
+const consigneActiviteMesure =
+  ({ depotDonnees }) =>
+  async ({ service, utilisateur, ancienneMesure, nouvelleMesure }) => {
+    const consigneActivite = async (type, details) => {
       try {
         const activiteMesure = new ActiviteMesure({
           service,
@@ -61,38 +61,29 @@ function consigneActiviteMesure({ depotDonnees }) {
           e
         );
       }
-    }
+    };
 
-    const ajouteMiseAJour = async (propriete) =>
-      ajouteActivite(`miseAJour${majuscule(propriete)}`, {
+    const consigneMiseAJour = async (propriete) =>
+      consigneActivite(`miseAJour${majuscule(propriete)}`, {
         ancienneValeur: ancienneMesure?.[propriete],
         nouvelleValeur: nouvelleMesure[propriete],
       });
 
-    const ajouteAjout = async (propriete) =>
-      ajouteActivite(`ajout${majuscule(propriete)}`, {
+    const consigneAjout = async (propriete) =>
+      consigneActivite(`ajout${majuscule(propriete)}`, {
         nouvelleValeur: nouvelleMesure[propriete],
       });
 
-    const ajouteSuppression = async (propriete) =>
-      ajouteActivite(`suppression${majuscule(propriete)}`, {
+    const consigneSuppression = async (propriete) =>
+      consigneActivite(`suppression${majuscule(propriete)}`, {
         ancienneValeur: ancienneMesure[propriete],
       });
 
     const comparateur = new ComparateurMesures(ancienneMesure, nouvelleMesure);
 
-    comparateur
-      .proprietesMisesAJour()
-      .forEach((propriete) => ajouteMiseAJour(propriete));
-
-    comparateur
-      .proprietesAjoutees()
-      .forEach((propriete) => ajouteAjout(propriete));
-
-    comparateur
-      .proprietesSupprimees()
-      .forEach((propriete) => ajouteSuppression(propriete));
+    comparateur.proprietesMisesAJour().forEach(consigneMiseAJour);
+    comparateur.proprietesAjoutees().forEach(consigneAjout);
+    comparateur.proprietesSupprimees().forEach(consigneSuppression);
   };
-}
 
 module.exports = { consigneActiviteMesure };

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -48,6 +48,15 @@ function consigneActiviteMesure({ depotDonnees }) {
         });
       }
     }
+
+    if (
+      ancienneMesure?.echeance !== nouvelleMesure.echeance &&
+      nouvelleMesure.echeance
+    ) {
+      await ajouteActivite('ajoutEcheance', {
+        nouvelleEcheance: nouvelleMesure.echeance,
+      });
+    }
   };
 }
 

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -3,6 +3,38 @@ const {
   fabriqueAdaptateurGestionErreur,
 } = require('../../adaptateurs/fabriqueAdaptateurGestionErreur');
 
+class ComparateurMesures {
+  constructor(ancienneMesure, nouvelleMesure) {
+    this.ancienneMesure = ancienneMesure;
+    this.nouvelleMesure = nouvelleMesure;
+  }
+
+  aMisAJour = (propriete) =>
+    this.ancienneMesure?.[propriete] !== this.nouvelleMesure[propriete] &&
+    this.ancienneMesure?.[propriete] &&
+    this.nouvelleMesure[propriete];
+
+  aAjoute = (propriete) =>
+    this.ancienneMesure?.[propriete] !== this.nouvelleMesure[propriete] &&
+    !this.ancienneMesure?.[propriete] &&
+    this.nouvelleMesure[propriete];
+
+  aSupprime = (propriete) =>
+    this.ancienneMesure?.[propriete] && !this.nouvelleMesure[propriete];
+
+  proprietesMisesAJour = () =>
+    ['statut', 'priorite', 'echeance'].filter((p) => this.aMisAJour(p));
+
+  proprietesAjoutees = () =>
+    ['statut', 'priorite', 'echeance'].filter((p) => this.aAjoute(p));
+
+  proprietesSupprimees = () => ['echeance'].filter((p) => this.aSupprime(p));
+}
+
+function majuscule(chaine) {
+  return chaine.charAt(0).toUpperCase() + chaine.substring(1);
+}
+
 function consigneActiviteMesure({ depotDonnees }) {
   return async ({ service, utilisateur, ancienneMesure, nouvelleMesure }) => {
     async function ajouteActivite(type, details) {
@@ -23,58 +55,35 @@ function consigneActiviteMesure({ depotDonnees }) {
       }
     }
 
-    if (ancienneMesure?.statut !== nouvelleMesure.statut) {
-      if (ancienneMesure?.statut) {
-        await ajouteActivite('miseAJourStatut', {
-          ancienStatut: ancienneMesure?.statut,
-          nouveauStatut: nouvelleMesure.statut,
-        });
-      } else {
-        await ajouteActivite('ajoutStatut', {
-          nouveauStatut: nouvelleMesure.statut,
-        });
-      }
-    }
-
-    if (ancienneMesure?.priorite !== nouvelleMesure.priorite) {
-      if (ancienneMesure?.priorite) {
-        await ajouteActivite('miseAJourPriorite', {
-          anciennePriorite: ancienneMesure.priorite,
-          nouvellePriorite: nouvelleMesure.priorite,
-        });
-      } else if (nouvelleMesure.priorite) {
-        await ajouteActivite('ajoutPriorite', {
-          nouvellePriorite: nouvelleMesure.priorite,
-        });
-      }
-    }
-
-    if (
-      ancienneMesure?.echeance !== nouvelleMesure.echeance &&
-      nouvelleMesure.echeance &&
-      !ancienneMesure?.echeance
-    ) {
-      await ajouteActivite('ajoutEcheance', {
-        nouvelleEcheance: nouvelleMesure.echeance,
+    const ajouteMiseAJour = async (propriete) =>
+      ajouteActivite(`miseAJour${majuscule(propriete)}`, {
+        ancienneValeur: ancienneMesure?.[propriete],
+        nouvelleValeur: nouvelleMesure[propriete],
       });
-    }
 
-    if (
-      ancienneMesure?.echeance &&
-      nouvelleMesure.echeance &&
-      ancienneMesure?.echeance !== nouvelleMesure.echeance
-    ) {
-      await ajouteActivite('miseAJourEcheance', {
-        ancienneEcheance: ancienneMesure.echeance,
-        nouvelleEcheance: nouvelleMesure.echeance,
+    const ajouteAjout = async (propriete) =>
+      ajouteActivite(`ajout${majuscule(propriete)}`, {
+        nouvelleValeur: nouvelleMesure[propriete],
       });
-    }
 
-    if (ancienneMesure?.echeance && !nouvelleMesure.echeance) {
-      await ajouteActivite('suppressionEcheance', {
-        ancienneEcheance: ancienneMesure.echeance,
+    const ajouteSuppression = async (propriete) =>
+      ajouteActivite(`suppression${majuscule(propriete)}`, {
+        ancienneValeur: ancienneMesure[propriete],
       });
-    }
+
+    const comparateur = new ComparateurMesures(ancienneMesure, nouvelleMesure);
+
+    comparateur
+      .proprietesMisesAJour()
+      .forEach((propriete) => ajouteMiseAJour(propriete));
+
+    comparateur
+      .proprietesAjoutees()
+      .forEach((propriete) => ajouteAjout(propriete));
+
+    comparateur
+      .proprietesSupprimees()
+      .forEach((propriete) => ajouteSuppression(propriete));
   };
 }
 

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -51,9 +51,21 @@ function consigneActiviteMesure({ depotDonnees }) {
 
     if (
       ancienneMesure?.echeance !== nouvelleMesure.echeance &&
-      nouvelleMesure.echeance
+      nouvelleMesure.echeance &&
+      !ancienneMesure?.echeance
     ) {
       await ajouteActivite('ajoutEcheance', {
+        nouvelleEcheance: nouvelleMesure.echeance,
+      });
+    }
+
+    if (
+      ancienneMesure?.echeance &&
+      nouvelleMesure.echeance &&
+      ancienneMesure?.echeance !== nouvelleMesure.echeance
+    ) {
+      await ajouteActivite('miseAJourEcheance', {
+        ancienneEcheance: ancienneMesure.echeance,
         nouvelleEcheance: nouvelleMesure.echeance,
       });
     }

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -9,15 +9,23 @@ class ComparateurMesures {
     this.nouvelleMesure = nouvelleMesure;
   }
 
+  valeursÉgales(propriete) {
+    if (propriete === 'echeance') {
+      return (
+        new Date(this.ancienneMesure[propriete]).getTime() ===
+        new Date(this.nouvelleMesure[propriete]).getTime()
+      );
+    }
+    return this.ancienneMesure[propriete] === this.nouvelleMesure[propriete];
+  }
+
   aMisAJour = (propriete) =>
-    this.ancienneMesure?.[propriete] !== this.nouvelleMesure[propriete] &&
     this.ancienneMesure?.[propriete] &&
+    !this.valeursÉgales(propriete) &&
     this.nouvelleMesure[propriete];
 
   aAjoute = (propriete) =>
-    this.ancienneMesure?.[propriete] !== this.nouvelleMesure[propriete] &&
-    !this.ancienneMesure?.[propriete] &&
-    this.nouvelleMesure[propriete];
+    !this.ancienneMesure?.[propriete] && this.nouvelleMesure[propriete];
 
   aSupprime = (propriete) =>
     this.ancienneMesure?.[propriete] && !this.nouvelleMesure[propriete];

--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -14,6 +14,7 @@ class MesureGenerale extends Mesure {
 
     this.rendueIndispensable = !!donneesMesure.rendueIndispensable;
     this.referentiel = referentiel;
+    this.echeance = donneesMesure.echeance && new Date(donneesMesure.echeance);
   }
 
   donneesReferentiel() {

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -68,8 +68,8 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     expect(activiteAjoutee.acteur).to.be(evenement.utilisateur);
     expect(activiteAjoutee.type).to.be('miseAJourStatut');
     expect(activiteAjoutee.details).to.eql({
-      ancienStatut: 'nonFait',
-      nouveauStatut: 'fait',
+      ancienneValeur: 'nonFait',
+      nouvelleValeur: 'fait',
     });
   });
 
@@ -83,7 +83,7 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
 
     expect(activiteAjoutee.type).to.be('ajoutStatut');
     expect(activiteAjoutee.details).to.eql({
-      nouveauStatut: 'fait',
+      nouvelleValeur: 'fait',
     });
   });
 
@@ -100,7 +100,7 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     expect(activiteAjoutee.acteur).to.be(evenement.utilisateur);
     expect(activiteAjoutee.type).to.be('ajoutPriorite');
     expect(activiteAjoutee.details).to.eql({
-      nouvellePriorite: 'p2',
+      nouvelleValeur: 'p2',
     });
   });
 
@@ -128,8 +128,8 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     expect(activiteAjoutee).to.be.an(ActiviteMesure);
     expect(activiteAjoutee.type).to.be('miseAJourPriorite');
     expect(activiteAjoutee.details).to.eql({
-      anciennePriorite: 'p3',
-      nouvellePriorite: 'p2',
+      ancienneValeur: 'p3',
+      nouvelleValeur: 'p2',
     });
   });
 
@@ -167,7 +167,7 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
 
     expect(activitesAjoutees.length).to.be(1);
     expect(activiteAjoutee.type).to.be('ajoutEcheance');
-    expect(activiteAjoutee.details).to.eql({ nouvelleEcheance: le28aout });
+    expect(activiteAjoutee.details).to.eql({ nouvelleValeur: le28aout });
   });
 
   it("ne crée pas d'activité lorsque l'ancienne mesure est vide et que l'échéance est vide", async () => {
@@ -195,8 +195,8 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     expect(activitesAjoutees.length).to.be(1);
     expect(activiteAjoutee.type).to.be('miseAJourEcheance');
     expect(activiteAjoutee.details).to.eql({
-      ancienneEcheance: le12septembre,
-      nouvelleEcheance: le28aout,
+      ancienneValeur: le12septembre,
+      nouvelleValeur: le28aout,
     });
   });
 
@@ -213,7 +213,7 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     expect(activitesAjoutees.length).to.be(1);
     expect(activiteAjoutee.type).to.be('suppressionEcheance');
     expect(activiteAjoutee.details).to.eql({
-      ancienneEcheance: le12septembre,
+      ancienneValeur: le12septembre,
     });
   });
 });

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -16,6 +16,8 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
   let activitesAjoutees;
   let ajouteActiviteMesureAppelee;
   let gestionnaire;
+  const le12septembre = new Date(2024, 8, 12);
+  const le28aout = new Date(2024, 7, 28);
 
   beforeEach(() => {
     ajouteActiviteMesureAppelee = false;
@@ -156,7 +158,6 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
   });
 
   it("crée une activité lorsque la date d'échéance est ajoutée", async () => {
-    const le28aout = new Date(2024, 7, 28);
     const evenement = creeEvenement({
       ancienneMesure: uneMesureGenerale().avecEcheance('').construis(),
       nouvelleMesure: uneMesureGenerale().avecEcheance(le28aout).construis(),
@@ -179,5 +180,23 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
 
     expect(activitesAjoutees.length).to.be(1);
     expect(activiteAjoutee.type).to.be('ajoutStatut');
+  });
+
+  it("crée une activité lorsque l'échéance est modifiée", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale()
+        .avecEcheance(le12septembre)
+        .construis(),
+      nouvelleMesure: uneMesureGenerale().avecEcheance(le28aout).construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('miseAJourEcheance');
+    expect(activiteAjoutee.details).to.eql({
+      ancienneEcheance: le12septembre,
+      nouvelleEcheance: le28aout,
+    });
   });
 });

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -199,4 +199,21 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
       nouvelleEcheance: le28aout,
     });
   });
+
+  it("crée une activité lorsque l'échéance est supprimée", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale()
+        .avecEcheance(le12septembre)
+        .construis(),
+      nouvelleMesure: uneMesureGenerale().avecEcheance('').construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('suppressionEcheance');
+    expect(activiteAjoutee.details).to.eql({
+      ancienneEcheance: le12septembre,
+    });
+  });
 });

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -170,7 +170,7 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     expect(activiteAjoutee.details).to.eql({ nouvelleValeur: le28aout });
   });
 
-  it("ne crée pas d'activité lorsque l'ancienne mesure est vide et que l'échéance est vide", async () => {
+  it("ne crée pas d'activité concernant l'échéance lorsque l'ancienne mesure est vide et que l'échéance est vide", async () => {
     const evenement = creeEvenement({
       ancienneMesure: undefined,
       nouvelleMesure: uneMesureGenerale().avecEcheance('').construis(),

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -194,4 +194,51 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
 
     expect(activiteAjoutee.mesure).to.be(mesure);
   });
+
+  it("crée une activité lorsque la date d'échéance est ajoutée", async () => {
+    const le28aout = new Date(2024, 7, 28);
+    const evenement = creeEvenement({
+      ancienneMesure: new MesureGenerale(
+        {
+          id: 'audit',
+          statut: 'fait',
+          echeance: '',
+        },
+        referentiel
+      ),
+      nouvelleMesure: new MesureGenerale(
+        {
+          id: 'audit',
+          statut: 'fait',
+          echeance: le28aout,
+        },
+        referentiel
+      ),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('ajoutEcheance');
+    expect(activiteAjoutee.details).to.eql({ nouvelleEcheance: le28aout });
+  });
+
+  it("ne crée pas d'activité lorsque l'ancienne mesure est vide et que l'échéance est vide", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: undefined,
+      nouvelleMesure: new MesureGenerale(
+        {
+          id: 'audit',
+          statut: 'fait',
+          echeance: '',
+        },
+        referentiel
+      ),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('ajoutStatut');
+  });
 });

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -216,4 +216,19 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
       ancienneValeur: le12septembre,
     });
   });
+
+  it("ne crée pas d'activité si les deux dates des échéances sont égales", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale()
+        .avecEcheance(new Date(le12septembre))
+        .construis(),
+      nouvelleMesure: uneMesureGenerale()
+        .avecEcheance(new Date(le12septembre))
+        .construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(0);
+  });
 });

--- a/test/constructeurs/constructeurMesureGenerale.js
+++ b/test/constructeurs/constructeurMesureGenerale.js
@@ -1,0 +1,44 @@
+const Referentiel = require('../../src/referentiel');
+const MesureGenerale = require('../../src/modeles/mesureGenerale');
+
+class ConstructeurMesureGenerale {
+  constructor(referentiel) {
+    this.donnees = {
+      id: 'audit',
+      statut: 'fait',
+    };
+    this.referentiel = referentiel;
+  }
+
+  construis() {
+    return new MesureGenerale(this.donnees, this.referentiel);
+  }
+
+  avecStatut(statut) {
+    this.donnees.statut = statut;
+    return this;
+  }
+
+  sansPriorite() {
+    return this.avecPriorite(undefined);
+  }
+
+  avecPriorite(priorite) {
+    this.donnees.priorite = priorite;
+    return this;
+  }
+
+  avecEcheance(echeance) {
+    this.donnees.echeance = echeance;
+    return this;
+  }
+}
+
+const uneMesureGenerale = (
+  referentiel = Referentiel.creeReferentiel({
+    mesures: { audit: { categorie: 'gouvernance' } },
+    prioritesMesures: { p1: {}, p2: {}, p3: {} },
+  })
+) => new ConstructeurMesureGenerale(referentiel);
+
+module.exports = { uneMesureGenerale };

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -44,7 +44,7 @@ describe('Une mesure de sécurité', () => {
     expect(mesure.statut).to.equal(MesureGenerale.STATUT_FAIT);
     expect(mesure.modalites).to.equal("Des modalités d'application");
     expect(mesure.priorite).to.equal('p3');
-    expect(mesure.echeance).to.equal('01/01/2023');
+    expect(mesure.echeance).to.eql(new Date('01/01/2023'));
     expect(mesure.responsables).to.eql([
       'unIdUtilisateur',
       'unAutreIdUtilisateur',
@@ -54,7 +54,7 @@ describe('Une mesure de sécurité', () => {
       statut: MesureGenerale.STATUT_FAIT,
       modalites: "Des modalités d'application",
       priorite: 'p3',
-      echeance: '01/01/2023',
+      echeance: new Date('01/01/2023'),
       responsables: ['unIdUtilisateur', 'unAutreIdUtilisateur'],
     });
   });
@@ -203,5 +203,18 @@ describe('Une mesure de sécurité', () => {
     const persistance = avecEcheance.donneesSerialisees();
 
     expect(persistance.echeance).to.be('2024-01-23T10:00:00.000Z');
+  });
+
+  it('conserve une echeance vide', () => {
+    const mesure = new MesureGenerale(
+      {
+        id: 'identifiantMesure',
+        statut: MesureGenerale.STATUT_FAIT,
+        echeance: '',
+      },
+      referentiel
+    );
+
+    expect(mesure.echeance).to.be('');
   });
 });

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -815,7 +815,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         mesureGenerale
       );
 
-      expect(donneesRecues.echeance).to.equal('01/01/2024');
+      expect(donneesRecues.echeance.getTime()).to.equal(
+        new Date('01/01/2024').getTime()
+      );
     });
   });
 


### PR DESCRIPTION
La date d’échéance des mesures peut être :
- ajoutée
- modifiée
- supprimée

Un refactoring au niveau de la comparaison des mesures a également été fait.