### PR TITLE
[INDICE CYBER PERSONNALISÉ] Affichage sur la page des dossiers d'homologation

### DIFF
--- a/public/assets/styles/dossiers.css
+++ b/public/assets/styles/dossiers.css
@@ -38,6 +38,12 @@
   border-radius: 4px;
   background: #dbeeff;
   width: fit-content;
+  border: 1px solid transparent;
+}
+
+.homologation .indice-cyber.personnalise {
+  background: white;
+  border: 1px solid var(--liseres-fonce);
 }
 
 .homologation .conteneur-indice-cyber {
@@ -119,6 +125,7 @@
   font-weight: bold;
   color: #2f3a43;
   width: fit-content;
+  height: fit-content;
 }
 
 .homologation .dossier .statut-homologation.bientotActivee {
@@ -280,4 +287,10 @@ dialog.modale-encart-homologation .page img {
   height: 30px;
   margin-right: -4px;
   filter: brightness(0) invert();
+}
+
+.conteneur-statut-indice-cyber .indices-cyber {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -27,6 +27,7 @@ class Dossier extends InformationsService {
         'finalise',
         'archive',
         'indiceCyber',
+        'indiceCyberPersonnalise',
       ],
     });
     this.renseigneProprietes(donneesDossier, referentiel);
@@ -138,7 +139,7 @@ class Dossier extends InformationsService {
     this.decision.enregistre(dateHomologation, dureeHomologation);
   }
 
-  enregistreFinalisation(indiceCyber) {
+  enregistreFinalisation(indiceCyber, indiceCyberPersonnalise) {
     if (!this.estComplet()) {
       const etapesIncompletes = Dossier.etapesObligatoires().filter(
         (etape) => !this[etape].estComplete()
@@ -151,6 +152,7 @@ class Dossier extends InformationsService {
 
     this.finalise = true;
     this.indiceCyber = indiceCyber;
+    this.indiceCyberPersonnalise = indiceCyberPersonnalise;
   }
 
   estComplet() {

--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -55,7 +55,7 @@ class Dossiers extends ElementsConstructibles {
     return this.items.find((dossier) => dossier.estActif());
   }
 
-  finaliseDossierCourant(indiceCyber) {
+  finaliseDossierCourant(indiceCyber, indiceCyberPersonnalise) {
     if (!this.dossierCourant())
       throw new ErreurDossierNonFinalisable(
         'Aucun dossier courant à finaliser'
@@ -64,7 +64,10 @@ class Dossiers extends ElementsConstructibles {
     this.items.forEach((dossier) => {
       if (dossier !== this.dossierCourant()) dossier.enregistreArchivage();
     });
-    this.dossierCourant().enregistreFinalisation(indiceCyber);
+    this.dossierCourant().enregistreFinalisation(
+      indiceCyber,
+      indiceCyberPersonnalise
+    );
   }
 
   finalises() {

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -181,7 +181,10 @@ class Service {
   }
 
   finaliseDossierCourant() {
-    this.dossiers.finaliseDossierCourant(this.indiceCyber().total);
+    this.dossiers.finaliseDossierCourant(
+      this.indiceCyber().total,
+      this.indiceCyberPersonnalise().total
+    );
   }
 
   fonctionAutoriteHomologation() {

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -1,6 +1,6 @@
 extends ./formulaireEtapier
 
-mixin dossier({ statut, dossier, service, indiceCyber, afficheStatutHomologation, afficheActions, afficheTamponHomologation, classeCss })
+mixin dossier({ statut, dossier, service, indiceCyber, indiceCyberPersonnalise, afficheStatutHomologation, afficheActions, afficheTamponHomologation, classeCss })
   -
     const etapeCourante = referentiel.etapeDossierAutorisee(dossier.etapeCourante(), autorisationsService.peutHomologuer)
     const numeroDerniereEtapeCompletee = referentiel.numeroEtape(etapeCourante)
@@ -24,11 +24,17 @@ mixin dossier({ statut, dossier, service, indiceCyber, afficheStatutHomologation
               - const statutHomologation = dossier.statutHomologation()
               .statut-homologation(class=statutHomologation)
                 span!= referentiel.statutHomologation(statutHomologation).libelle
-            if indiceCyber !== undefined
-              .indice-cyber
-                b Indice cyber&nbsp;
-                span.conteneur-indice-cyber
-                  span.note-indice-cyber!= `${indiceCyber.toFixed(1)}/${referentiel.indiceCyberNoteMax()}`
+            .indices-cyber
+              if indiceCyber !== undefined
+                .indice-cyber
+                  b Indice cyber&nbsp;
+                  span.conteneur-indice-cyber
+                    span.note-indice-cyber!= `${indiceCyber.toFixed(1)}/${referentiel.indiceCyberNoteMax()}`
+              if indiceCyberPersonnalise !== undefined
+                .indice-cyber.personnalise
+                  b Indice cyber Personnalisé&nbsp;
+                  span.conteneur-indice-cyber
+                    span.note-indice-cyber!= `${indiceCyberPersonnalise.toFixed(1)}/${referentiel.indiceCyberNoteMax()}`
         .contenu-details
           .details
             if dossier.finalise
@@ -53,10 +59,10 @@ mixin dossier({ statut, dossier, service, indiceCyber, afficheStatutHomologation
 
 mixin dossierFinalise({ dossier, service, afficheStatutHomologation, afficheTamponHomologation })
   - const dateDecision = new Intl.DateTimeFormat('fr-FR').format(new Date(dossier.decision.dateHomologation))
-  +dossier({ statut: `Décision d'homologation du ${dateDecision}`, dossier, afficheStatutHomologation, afficheTamponHomologation, indiceCyber: dossier.indiceCyber })
+  +dossier({ statut: `Décision d'homologation du ${dateDecision}`, dossier, afficheStatutHomologation, afficheTamponHomologation, indiceCyber: dossier.indiceCyber, indiceCyberPersonnalise: dossier.indiceCyberPersonnalise })
 
 mixin dossierCourant({ dossier, idService, service })
-  +dossier({ statut: "Projet d'homologation", dossier, service, indiceCyber: service.indiceCyber().total, afficheActions: true, classeCss: "dossier-courant"})
+  +dossier({ statut: "Projet d'homologation", dossier, service, indiceCyber: service.indiceCyber().total, indiceCyberPersonnalise: service.indiceCyberPersonnalise().total, afficheActions: true, classeCss: "dossier-courant"})
 
 block append styles
   link(href='/statique/assets/styles/dossiers.css', rel='stylesheet')

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -42,6 +42,7 @@ describe("Un dossier d'homologation", () => {
         finalise: true,
         archive: true,
         indiceCyber: 3.5,
+        indiceCyberPersonnalise: 4.5,
       },
       referentiel
     );
@@ -64,6 +65,7 @@ describe("Un dossier d'homologation", () => {
       finalise: true,
       archive: true,
       indiceCyber: 3.5,
+      indiceCyberPersonnalise: 4.5,
     });
   });
 
@@ -378,9 +380,10 @@ describe("Un dossier d'homologation", () => {
         .quiEstNonFinalise()
         .construit();
 
-      dossierComplet.enregistreFinalisation(3.5);
+      dossierComplet.enregistreFinalisation(3.5, 4.5);
       expect(dossierComplet.finalise).to.be(true);
       expect(dossierComplet.indiceCyber).to.be(3.5);
+      expect(dossierComplet.indiceCyberPersonnalise).to.be(4.5);
     });
   });
 

--- a/test/modeles/dossiers.spec.js
+++ b/test/modeles/dossiers.spec.js
@@ -185,7 +185,7 @@ describe('Les dossiers liés à un service', () => {
         referentiel
       );
 
-      deuxDossiers.finaliseDossierCourant(3.5);
+      deuxDossiers.finaliseDossierCourant(3.5, 4.5);
 
       const [dossierAArchiver, dossierAFinaliser] = deuxDossiers.items;
       expect(dossierAArchiver.id).to.equal('dossier à archiver');
@@ -194,6 +194,7 @@ describe('Les dossiers liés à un service', () => {
       expect(dossierAFinaliser.archive).to.be(undefined);
       expect(dossierAFinaliser.finalise).to.be(true);
       expect(dossierAFinaliser.indiceCyber).to.be(3.5);
+      expect(dossierAFinaliser.indiceCyberPersonnalise).to.be(4.5);
     });
 
     it("jette une erreur si aucun dossier courant n'existe", () => {


### PR DESCRIPTION
On affiche désormais l'indice cyber personnalisé sur la page de résumé des dossiers d'homologation.
On doit enregistrer cet indice cyber au moment de la finalisation d'un dossier afin de garder une trace de sa valeur "à l'instant T".

![image](https://github.com/user-attachments/assets/03579188-8060-4b9b-b384-33e7bb30af79)
