### PR TITLE
[HISTORIQUE] Ajoute les activités pour les ajouts/suppressions de responsables

### DIFF
--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -37,6 +37,18 @@ class ComparateurMesures {
     ['statut', 'priorite', 'echeance'].filter((p) => this.aAjoute(p));
 
   proprietesSupprimees = () => ['echeance'].filter((p) => this.aSupprime(p));
+
+  responsablesDeLancienneMesure = () => this.ancienneMesure?.responsables || [];
+
+  responsablesAjoutes = () =>
+    this.nouvelleMesure.responsables.filter(
+      (r) => !this.responsablesDeLancienneMesure().includes(r)
+    );
+
+  responsablesRetires = () =>
+    this.responsablesDeLancienneMesure().filter(
+      (r) => !this.nouvelleMesure.responsables.includes(r)
+    );
 }
 
 const majuscule = (chaine) =>
@@ -84,17 +96,14 @@ const consigneActiviteMesure =
     comparateur.proprietesMisesAJour().forEach(consigneMiseAJour);
     comparateur.proprietesAjoutees().forEach(consigneAjout);
     comparateur.proprietesSupprimees().forEach(consigneSuppression);
-
-    const responsablesDeLancienneMesure = ancienneMesure?.responsables || [];
-
-    const responsablesAjoutes = nouvelleMesure.responsables.filter(
-      (r) => !responsablesDeLancienneMesure.includes(r)
-    );
-    responsablesAjoutes.forEach((r) =>
-      consigneActivite('ajoutResponsable', {
-        valeur: r,
-      })
-    );
+    comparateur
+      .responsablesAjoutes()
+      .forEach((valeur) => consigneActivite('ajoutResponsable', { valeur }));
+    comparateur
+      .responsablesRetires()
+      .forEach((valeur) =>
+        consigneActivite('suppressionResponsable', { valeur })
+      );
   };
 
 module.exports = { consigneActiviteMesure };

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -84,6 +84,17 @@ const consigneActiviteMesure =
     comparateur.proprietesMisesAJour().forEach(consigneMiseAJour);
     comparateur.proprietesAjoutees().forEach(consigneAjout);
     comparateur.proprietesSupprimees().forEach(consigneSuppression);
+
+    const responsablesDeLancienneMesure = ancienneMesure?.responsables || [];
+
+    const responsablesAjoutes = nouvelleMesure.responsables.filter(
+      (r) => !responsablesDeLancienneMesure.includes(r)
+    );
+    responsablesAjoutes.forEach((r) =>
+      consigneActivite('ajoutResponsable', {
+        valeur: r,
+      })
+    );
   };
 
 module.exports = { consigneActiviteMesure };

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -302,4 +302,45 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     expect(activitesAjoutees[1].type).to.be('ajoutResponsable');
     expect(activitesAjoutees[1].details).to.eql({ valeur: 'idUtilisateur' });
   });
+
+  it("crée une activité lorsqu'un responsable est supprimé", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale()
+        .avecResponsable('idUtilisateur')
+        .construis(),
+      nouvelleMesure: uneMesureGenerale().sansResponsable().construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('suppressionResponsable');
+    expect(activiteAjoutee.details).to.eql({ valeur: 'idUtilisateur' });
+  });
+
+  it('crée une activité lorsque les responsables changent', async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale()
+        .avecResponsable('U1')
+        .avecResponsable('U2')
+        .construis(),
+      nouvelleMesure: uneMesureGenerale()
+        .avecResponsable('U3')
+        .avecResponsable('U4')
+        .construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    const activiteAEteAjoutee = (type, valeur) =>
+      activitesAjoutees.some(
+        (a) => a.type === type && a.details.valeur === valeur
+      );
+
+    expect(activitesAjoutees.length).to.be(4);
+    expect(activiteAEteAjoutee('suppressionResponsable', 'U1')).to.be(true);
+    expect(activiteAEteAjoutee('suppressionResponsable', 'U2')).to.be(true);
+    expect(activiteAEteAjoutee('ajoutResponsable', 'U3')).to.be(true);
+    expect(activiteAEteAjoutee('ajoutResponsable', 'U4')).to.be(true);
+  });
 });

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -231,4 +231,75 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
 
     expect(activitesAjoutees.length).to.be(0);
   });
+
+  it("crée une activité lorsqu'un responsable est ajouté", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale().sansResponsable().construis(),
+      nouvelleMesure: uneMesureGenerale()
+        .avecResponsable('idUtilisateur')
+        .construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('ajoutResponsable');
+    expect(activiteAjoutee.details).to.eql({ valeur: 'idUtilisateur' });
+  });
+
+  it("crée une activité lorsqu'un second responsable est ajouté", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale()
+        .avecResponsable('idUtilisateur')
+        .construis(),
+      nouvelleMesure: uneMesureGenerale()
+        .avecResponsable('idUtilisateur')
+        .avecResponsable('secondIdUtilisateur')
+        .construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('ajoutResponsable');
+    expect(activiteAjoutee.details).to.eql({ valeur: 'secondIdUtilisateur' });
+  });
+
+  it("crée une activité lorsqu'un second responsable est ajouté en première position", async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale()
+        .avecResponsable('idUtilisateur')
+        .construis(),
+      nouvelleMesure: uneMesureGenerale()
+        .avecResponsable('secondIdUtilisateur')
+        .avecResponsable('idUtilisateur')
+        .construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(1);
+    expect(activiteAjoutee.type).to.be('ajoutResponsable');
+    expect(activiteAjoutee.details).to.eql({ valeur: 'secondIdUtilisateur' });
+  });
+
+  it('crée une activité lorsque plusieurs responsables sont ajoutés', async () => {
+    const evenement = creeEvenement({
+      ancienneMesure: uneMesureGenerale().sansResponsable().construis(),
+      nouvelleMesure: uneMesureGenerale()
+        .avecResponsable('secondIdUtilisateur')
+        .avecResponsable('idUtilisateur')
+        .construis(),
+    });
+
+    await gestionnaire(evenement);
+
+    expect(activitesAjoutees.length).to.be(2);
+    expect(activitesAjoutees[0].type).to.be('ajoutResponsable');
+    expect(activitesAjoutees[0].details).to.eql({
+      valeur: 'secondIdUtilisateur',
+    });
+    expect(activitesAjoutees[1].type).to.be('ajoutResponsable');
+    expect(activitesAjoutees[1].details).to.eql({ valeur: 'idUtilisateur' });
+  });
 });

--- a/test/constructeurs/constructeurMesureGenerale.js
+++ b/test/constructeurs/constructeurMesureGenerale.js
@@ -6,6 +6,7 @@ class ConstructeurMesureGenerale {
     this.donnees = {
       id: 'audit',
       statut: 'fait',
+      responsables: [],
     };
     this.referentiel = referentiel;
   }
@@ -30,6 +31,16 @@ class ConstructeurMesureGenerale {
 
   avecEcheance(echeance) {
     this.donnees.echeance = echeance;
+    return this;
+  }
+
+  sansResponsable() {
+    this.donnees.responsables = [];
+    return this;
+  }
+
+  avecResponsable(idUtilisateur) {
+    this.donnees.responsables.push(idUtilisateur);
     return this;
   }
 }


### PR DESCRIPTION
On sauvegarde les "ajouts" et les "suppressions" unitaires et pas des "modifications" (de la liste) avec ancienne/nouvelle valeur.