### PR TITLE
[HISTORIQUE] Lis les activités de mesure

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -11,6 +11,7 @@ const nouvelAdaptateur = (
   donnees.notificationsExpirationHomologation ||= [];
   donnees.notifications ||= [];
   donnees.suggestionsActions ||= [];
+  donnees.activitesMesure ||= [];
 
   const supprimeEnregistrement = async (nomTable, id) => {
     donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
@@ -255,7 +256,13 @@ const nouvelAdaptateur = (
 
   const ajouteTacheDeService = async () => {};
 
+  const activitesMesure = async (idService, idMesure) =>
+    donnees.activitesMesure.filter(
+      (a) => a.idService === idService && a.idMesure === idMesure
+    );
+
   return {
+    activitesMesure,
     ajouteAutorisation,
     ajouteSuggestionAction,
     ajouteTacheDeService,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -95,6 +95,18 @@ const nouvelAdaptateur = (env) => {
       details,
     });
 
+  const activitesMesure = async (idService, idMesure) =>
+    knex('activites_mesure')
+      .where({ id_service: idService, id_mesure: idMesure })
+      .select(
+        'type',
+        'details',
+        'date',
+        'id_acteur as idActeur',
+        'id_service as idService',
+        'id_mesure as idMesure'
+      );
+
   const arreteTout = () => knex.destroy();
 
   const service = async (id) =>
@@ -454,6 +466,7 @@ const nouvelAdaptateur = (env) => {
   };
 
   return {
+    activitesMesure,
     ajouteAutorisation,
     ajouteSuggestionAction,
     ajouteTacheDeService,

--- a/src/bus/abonnements/consigneActiviteMesure.js
+++ b/src/bus/abonnements/consigneActiviteMesure.js
@@ -60,11 +60,11 @@ const consigneActiviteMesure =
     const consigneActivite = async (type, details) => {
       try {
         const activiteMesure = new ActiviteMesure({
-          service,
-          acteur: utilisateur,
+          idService: service.id,
+          idActeur: utilisateur.id,
           type,
           details,
-          mesure: nouvelleMesure,
+          idMesure: nouvelleMesure.id,
         });
         await depotDonnees.ajouteActiviteMesure(activiteMesure);
       } catch (e) {

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -146,7 +146,7 @@ const creeDepot = (config = {}) => {
 
   const { acquitteSuggestionAction } = depotSuggestionsActions;
 
-  const { ajouteActiviteMesure } = depotActivitesMesure;
+  const { ajouteActiviteMesure, lisActivitesMesure } = depotActivitesMesure;
 
   return {
     accesAutorise,
@@ -168,6 +168,7 @@ const creeDepot = (config = {}) => {
     services,
     enregistreDossier,
     finaliseDossierCourant,
+    lisActivitesMesure,
     lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
     marqueNouveauteLue,

--- a/src/depots/depotDonneesActivitesMesure.js
+++ b/src/depots/depotDonneesActivitesMesure.js
@@ -15,7 +15,9 @@ const creeDepot = (config = {}) => {
       idService,
       idMesure
     );
-    return activitesMesure.map((a) => ({ ...a, date: new Date(a.date) }));
+    return activitesMesure
+      .map((a) => ({ ...a, date: new Date(a.date) }))
+      .sort((a, b) => b.date - a.date);
   };
 
   return {

--- a/src/depots/depotDonneesActivitesMesure.js
+++ b/src/depots/depotDonneesActivitesMesure.js
@@ -3,9 +3,9 @@ const creeDepot = (config = {}) => {
 
   const ajouteActiviteMesure = (activite) =>
     adaptateurPersistance.ajouteActiviteMesure(
-      activite.idActeur(),
-      activite.idService(),
-      activite.idMesure(),
+      activite.idActeur,
+      activite.idService,
+      activite.idMesure,
       activite.type,
       activite.details
     );

--- a/src/depots/depotDonneesActivitesMesure.js
+++ b/src/depots/depotDonneesActivitesMesure.js
@@ -10,8 +10,17 @@ const creeDepot = (config = {}) => {
       activite.details
     );
 
+  const lisActivitesMesure = async (idService, idMesure) => {
+    const activitesMesure = await adaptateurPersistance.activitesMesure(
+      idService,
+      idMesure
+    );
+    return activitesMesure.map((a) => ({ ...a, date: new Date(a.date) }));
+  };
+
   return {
     ajouteActiviteMesure,
+    lisActivitesMesure,
   };
 };
 module.exports = { creeDepot };

--- a/src/modeles/activiteMesure.js
+++ b/src/modeles/activiteMesure.js
@@ -5,6 +5,7 @@ class ActiviteMesure {
     this.type = donnees.type;
     this.details = donnees.details;
     this.mesure = donnees.mesure;
+    this.date = donnees.date;
   }
 
   idActeur = () => this.acteur.id;

--- a/src/modeles/activiteMesure.js
+++ b/src/modeles/activiteMesure.js
@@ -1,18 +1,12 @@
 class ActiviteMesure {
   constructor(donnees) {
-    this.service = donnees.service;
-    this.acteur = donnees.acteur;
+    this.idService = donnees.idService;
+    this.idActeur = donnees.idActeur;
     this.type = donnees.type;
     this.details = donnees.details;
-    this.mesure = donnees.mesure;
+    this.idMesure = donnees.idMesure;
     this.date = donnees.date;
   }
-
-  idActeur = () => this.acteur.id;
-
-  idService = () => this.service.id;
-
-  idMesure = () => this.mesure.id;
 }
 
 module.exports = ActiviteMesure;

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -39,6 +39,7 @@ const {
 } = require('../../modeles/autorisations/gestionDroits');
 const objetGetMesures = require('../../modeles/objetsApi/objetGetMesures');
 const EvenementRetourUtilisateurMesure = require('../../modeles/journalMSS/evenementRetourUtilisateurMesure');
+const routesConnecteApiServiceActivitesMesure = require('./routesConnecteApiServiceActivitesMesure');
 
 const { ECRITURE, LECTURE } = Permissions;
 const { CONTACTS, SECURISER, RISQUES, HOMOLOGUER, DECRIRE } = Rubriques;
@@ -62,6 +63,10 @@ const routesConnecteApiService = ({
       middleware,
       referentiel,
     })
+  );
+
+  routes.use(
+    routesConnecteApiServiceActivitesMesure({ middleware, depotDonnees })
   );
 
   routes.post(

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -66,7 +66,11 @@ const routesConnecteApiService = ({
   );
 
   routes.use(
-    routesConnecteApiServiceActivitesMesure({ middleware, depotDonnees })
+    routesConnecteApiServiceActivitesMesure({
+      middleware,
+      depotDonnees,
+      referentiel,
+    })
   );
 
   routes.post(

--- a/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
+++ b/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
@@ -10,6 +10,7 @@ const { SECURISER } = Rubriques;
 const routesConnecteApiServiceActivitesMesure = ({
   middleware,
   depotDonnees,
+  referentiel,
 }) => {
   const routes = express.Router();
   routes.get(
@@ -24,9 +25,9 @@ const routesConnecteApiServiceActivitesMesure = ({
 
       const resultat = activites.map((a) => ({
         date: a.date.toISOString(),
-        idActeur: a.idActeur(),
+        idActeur: a.idActeur,
         identifiantNumeriqueMesure:
-          a.mesure.donneesReferentiel().identifiantNumerique,
+          referentiel.mesures()[a.idMesure].identifiantNumerique,
         type: a.type,
         details: a.details,
       }));

--- a/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
+++ b/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
@@ -16,9 +16,9 @@ const routesConnecteApiServiceActivitesMesure = ({
   routes.get(
     '/:id/mesures/:idMesure/activites',
     middleware.trouveService({ [SECURISER]: LECTURE }),
-    (requete, reponse) => {
+    async (requete, reponse) => {
       reponse.status(200);
-      const activites = depotDonnees.litActivitesMesure(
+      const activites = await depotDonnees.lisActivitesMesure(
         requete.service.id,
         requete.params.idMesure
       );

--- a/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
+++ b/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../modeles/autorisations/gestionDroits');
+
+const { LECTURE } = Permissions;
+const { SECURISER } = Rubriques;
+
+const routesConnecteApiServiceActivitesMesure = ({
+  middleware,
+  depotDonnees,
+}) => {
+  const routes = express.Router();
+  routes.get(
+    '/:id/mesures/:idMesure/activites',
+    middleware.trouveService({ [SECURISER]: LECTURE }),
+    (requete, reponse) => {
+      reponse.status(200);
+      const activites = depotDonnees.litActivitesMesure(
+        requete.service.id,
+        requete.params.idMesure
+      );
+
+      const resultat = activites.map((a) => ({
+        date: a.date.toISOString(),
+        idActeur: a.idActeur(),
+        identifiantNumeriqueMesure:
+          a.mesure.donneesReferentiel().identifiantNumerique,
+        type: a.type,
+        details: a.details,
+      }));
+
+      reponse.send(resultat);
+    }
+  );
+  return routes;
+};
+
+module.exports = routesConnecteApiServiceActivitesMesure;

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -2,6 +2,7 @@
   import Formulaire from '../ui/Formulaire.svelte';
   import SuppressionMesureSpecifique from './suppression/SuppressionMesureSpecifique.svelte';
   import type { MesuresExistantes } from './mesure.d';
+  import type { IdService } from '../tableauDesMesures/tableauDesMesures.d';
 
   import { configurationAffichage, store } from './mesure.store';
   import { enregistreMesures, enregistreRetourUtilisateur } from './mesure.api';
@@ -14,7 +15,7 @@
   import { planDActionDisponible } from '../modeles/mesure';
   import ContenuOngletActivite from './contenus/ContenuOngletActivite.svelte';
 
-  export let idService: string;
+  export let idService: IdService;
   export let categories: Record<string, string>;
   export let statuts: ReferentielStatut;
   export let retoursUtilisateur: Record<string, string>;
@@ -118,6 +119,7 @@
         visible={ongletActif === 'activite'}
         {priorites}
         {statuts}
+        {idService}
       />
     </div>
     <div class="conteneur-actions">

--- a/svelte/lib/mesure/contenus/ContenuOngletActivite.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletActivite.svelte
@@ -6,8 +6,10 @@
   import { writable } from 'svelte/store';
   import Activite from './activites/Activite.svelte';
   import type { ReferentielPriorite, ReferentielStatut } from '../../ui/types';
+  import type { IdService } from '../../tableauDesMesures/tableauDesMesures.d';
 
   export let visible: boolean;
+  export let idService: IdService;
   export let priorites: ReferentielPriorite;
   export let statuts: ReferentielStatut;
 
@@ -22,6 +24,7 @@
 
   onMount(async () => {
     const activites = await recupereActiviteMesure(
+      idService,
       $store.mesureEditee.metadonnees.idMesure
     );
     storeActivites.charge(activites);

--- a/svelte/lib/mesure/mesure.api.ts
+++ b/svelte/lib/mesure/mesure.api.ts
@@ -78,5 +78,11 @@ export const enregistreRetourUtilisateur = async (
 };
 
 export const recupereActiviteMesure = async (
+  idService: string,
   idMesure: string | number
-): Promise<ActiviteMesure[]> => [];
+): Promise<ActiviteMesure[]> => {
+  const reponse = await axios.get(
+    `/api/service/${idService}/mesures/${idMesure}/activites`
+  );
+  return reponse.data.map((a: any) => ({ ...a, date: new Date(a.date) }));
+};

--- a/test/bus/abonnements/consigneActiviteMesure.spec.js
+++ b/test/bus/abonnements/consigneActiviteMesure.spec.js
@@ -64,8 +64,8 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     await gestionnaire(evenement);
 
     expect(activiteAjoutee).to.be.an(ActiviteMesure);
-    expect(activiteAjoutee.service).to.be(evenement.service);
-    expect(activiteAjoutee.acteur).to.be(evenement.utilisateur);
+    expect(activiteAjoutee.idService).to.be(evenement.service.id);
+    expect(activiteAjoutee.idActeur).to.be(evenement.utilisateur.id);
     expect(activiteAjoutee.type).to.be('miseAJourStatut');
     expect(activiteAjoutee.details).to.eql({
       ancienneValeur: 'nonFait',
@@ -96,8 +96,8 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
     await gestionnaire(evenement);
 
     expect(activiteAjoutee).to.be.an(ActiviteMesure);
-    expect(activiteAjoutee.service).to.be(evenement.service);
-    expect(activiteAjoutee.acteur).to.be(evenement.utilisateur);
+    expect(activiteAjoutee.idService).to.be(evenement.service.id);
+    expect(activiteAjoutee.idActeur).to.be(evenement.utilisateur.id);
     expect(activiteAjoutee.type).to.be('ajoutPriorite');
     expect(activiteAjoutee.details).to.eql({
       nouvelleValeur: 'p2',
@@ -154,7 +154,7 @@ describe("L'abonnement qui consigne l'activité pour une mesure", () => {
 
     await gestionnaire(evenement);
 
-    expect(activiteAjoutee.mesure).to.be(mesure);
+    expect(activiteAjoutee.idMesure).to.be(mesure.id);
   });
 
   it("crée une activité lorsque la date d'échéance est ajoutée", async () => {

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -8,6 +8,7 @@ class ConstructeurAdaptateurPersistanceMemoire {
     this.utilisateurs = [];
     this.notificationsExpirationHomologation = [];
     this.suggestionsActions = [];
+    this.activitesMesure = [];
     this.adaptateurChiffrement = adaptateurChiffrement;
   }
 
@@ -44,6 +45,11 @@ class ConstructeurAdaptateurPersistanceMemoire {
     return this;
   }
 
+  avecUneActiviteMesure(donneesActivite) {
+    this.activitesMesure.push(donneesActivite);
+    return this;
+  }
+
   construis() {
     return AdaptateurPersistanceMemoire.nouvelAdaptateur({
       autorisations: this.autorisations,
@@ -52,6 +58,7 @@ class ConstructeurAdaptateurPersistanceMemoire {
       notificationsExpirationHomologation:
         this.notificationsExpirationHomologation,
       suggestionsActions: this.suggestionsActions,
+      activitesMesure: this.activitesMesure,
     });
   }
 }

--- a/test/constructeurs/constructeurMesureGenerale.js
+++ b/test/constructeurs/constructeurMesureGenerale.js
@@ -15,6 +15,11 @@ class ConstructeurMesureGenerale {
     return new MesureGenerale(this.donnees, this.referentiel);
   }
 
+  avecId(id) {
+    this.donnees.id = id;
+    return this;
+  }
+
   avecStatut(statut) {
     this.donnees.statut = statut;
     return this;

--- a/test/constructeurs/constructeurMesureGenerale.js
+++ b/test/constructeurs/constructeurMesureGenerale.js
@@ -17,6 +17,9 @@ class ConstructeurMesureGenerale {
 
   avecId(id) {
     this.donnees.id = id;
+    this.referentiel.enrichis({
+      mesures: { [id]: { categorie: 'gouvernance' } },
+    });
     return this;
   }
 

--- a/test/depots/depotDonneesActivitesMesure.spec.js
+++ b/test/depots/depotDonneesActivitesMesure.spec.js
@@ -98,5 +98,27 @@ describe('Le dépôt de données des activités de mesure', () => {
         new Date('2024-08-30T14:17:14.051990Z').getTime()
       );
     });
+
+    it('tri les activités par date', async () => {
+      adaptateurPersistance = unePersistanceMemoire()
+        .avecUneActiviteMesure({
+          idService: 'S1',
+          idMesure: 'm1',
+          date: '2024-09-02 07:30:59.983586 +00:00',
+          type: 'ajoutStatut',
+        })
+        .avecUneActiviteMesure({
+          idService: 'S1',
+          idMesure: 'm1',
+          date: '2024-09-03 07:30:59.983586 +00:00',
+          type: 'ajoutPriorite',
+        })
+        .construis();
+
+      const activites = await depot().lisActivitesMesure('S1', 'm1');
+
+      expect(activites[0].type).to.be('ajoutPriorite');
+      expect(activites[1].type).to.be('ajoutStatut');
+    });
   });
 });

--- a/test/depots/depotDonneesActivitesMesure.spec.js
+++ b/test/depots/depotDonneesActivitesMesure.spec.js
@@ -4,10 +4,6 @@ const {
 } = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
 const DepotDonneesActivitesMesure = require('../../src/depots/depotDonneesActivitesMesure');
 const ActiviteMesure = require('../../src/modeles/activiteMesure');
-const { unService } = require('../constructeurs/constructeurService');
-const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
-const MesureGenerale = require('../../src/modeles/mesureGenerale');
-const Referentiel = require('../../src/referentiel');
 
 describe('Le dépôt de données des activités de mesure', () => {
   describe('sur ajout d’une activité', () => {
@@ -36,17 +32,12 @@ describe('Le dépôt de données des activités de mesure', () => {
       const depot = DepotDonneesActivitesMesure.creeDepot({
         adaptateurPersistance,
       });
-      const referentiel = Referentiel.creeReferentiel({
-        mesures: { audit: { categorie: 'gouvernance' } },
-      });
-      const service = unService().avecId(987).construis();
-      const acteur = unUtilisateur().avecId(654).construis();
       const activite = new ActiviteMesure({
-        service,
-        acteur,
+        idService: 987,
+        idActeur: 654,
         type: 'statutMisAJour',
         details: { nouveauStatut: 'fait' },
-        mesure: new MesureGenerale({ id: 'audit' }, referentiel),
+        idMesure: 'audit',
       });
 
       depot.ajouteActiviteMesure(activite);

--- a/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
+++ b/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
@@ -1,0 +1,101 @@
+const axios = require('axios');
+const expect = require('expect.js');
+const testeurMSS = require('../testeurMSS');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../../src/modeles/autorisations/gestionDroits');
+const Referentiel = require('../../../src/referentiel');
+const {
+  uneMesureGenerale,
+} = require('../../constructeurs/constructeurMesureGenerale');
+const ActiviteMesure = require('../../../src/modeles/activiteMesure');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+
+const { LECTURE } = Permissions;
+const { SECURISER } = Rubriques;
+
+describe('Le serveur MSS des routes privées `/api/service/:id/mesures/:id/activites', () => {
+  const testeur = testeurMSS();
+
+  beforeEach(testeur.initialise);
+
+  afterEach(testeur.arrete);
+
+  describe('quand requête GET sur `/api/service/:id/mesures/:id/activites', () => {
+    beforeEach(() => {
+      testeur.depotDonnees().litActivitesMesure = () => [];
+    });
+
+    it('recherche le service correspondant', (done) => {
+      testeur.middleware().verifieRechercheService(
+        [{ niveau: LECTURE, rubrique: SECURISER }],
+        {
+          method: 'get',
+          url: 'http://localhost:1234/api/service/456/mesures/audit/activites',
+        },
+        done
+      );
+    });
+
+    it('renvoie 200', async () => {
+      const reponse = await axios.get(
+        'http://localhost:1234/api/service/456/mesures/audit/activites'
+      );
+
+      expect(reponse.status).to.be(200);
+    });
+
+    it('renvoie la liste des activités de la mesure', async () => {
+      const avecAudit = Referentiel.creeReferentiel({
+        mesures: { audit: { identifiantNumerique: '0007' } },
+      });
+      const fabriqueMesure = uneMesureGenerale(avecAudit).avecId('audit');
+      const audit = fabriqueMesure.construis();
+      testeur.depotDonnees().litActivitesMesure = () => [
+        new ActiviteMesure({
+          acteur: unUtilisateur()
+            .avecId('9724853e-037c-4bca-9350-0a4b14a85a29')
+            .construis(),
+          date: new Date('2024-09-29 11:15:02.817 +0200'),
+          mesure: audit,
+          type: 'ajoutPriorite',
+          details: { nouvelleValeur: 'p3' },
+        }),
+      ];
+
+      const reponse = await axios.get(
+        'http://localhost:1234/api/service/456/mesures/audit/activites'
+      );
+
+      expect(reponse.data).to.eql([
+        {
+          date: '2024-09-29T09:15:02.817Z',
+          idActeur: '9724853e-037c-4bca-9350-0a4b14a85a29',
+          identifiantNumeriqueMesure: '0007',
+          type: 'ajoutPriorite',
+          details: { nouvelleValeur: 'p3' },
+        },
+      ]);
+    });
+
+    it('retourne uniquement les activités de la mesure et du service', async () => {
+      let idServiceUtilise;
+      let idMesureUtilise;
+      testeur.depotDonnees().litActivitesMesure = (idService, idMesure) => {
+        idServiceUtilise = idService;
+        idMesureUtilise = idMesure;
+        return [];
+      };
+
+      await axios.get(
+        'http://localhost:1234/api/service/456/mesures/audit/activites'
+      );
+
+      expect(idServiceUtilise).to.be('456');
+      expect(idMesureUtilise).to.be('audit');
+    });
+  });
+});

--- a/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
+++ b/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
@@ -5,14 +5,7 @@ const {
   Permissions,
   Rubriques,
 } = require('../../../src/modeles/autorisations/gestionDroits');
-const Referentiel = require('../../../src/referentiel');
-const {
-  uneMesureGenerale,
-} = require('../../constructeurs/constructeurMesureGenerale');
 const ActiviteMesure = require('../../../src/modeles/activiteMesure');
-const {
-  unUtilisateur,
-} = require('../../constructeurs/constructeurUtilisateur');
 
 const { LECTURE } = Permissions;
 const { SECURISER } = Rubriques;
@@ -49,18 +42,14 @@ describe('Le serveur MSS des routes privées `/api/service/:id/mesures/:id/activ
     });
 
     it('renvoie la liste des activités de la mesure', async () => {
-      const avecAudit = Referentiel.creeReferentiel({
+      testeur.referentiel().enrichis({
         mesures: { audit: { identifiantNumerique: '0007' } },
       });
-      const fabriqueMesure = uneMesureGenerale(avecAudit).avecId('audit');
-      const audit = fabriqueMesure.construis();
       testeur.depotDonnees().litActivitesMesure = () => [
         new ActiviteMesure({
-          acteur: unUtilisateur()
-            .avecId('9724853e-037c-4bca-9350-0a4b14a85a29')
-            .construis(),
+          idActeur: '9724853e-037c-4bca-9350-0a4b14a85a29',
           date: new Date('2024-09-29 11:15:02.817 +0200'),
-          mesure: audit,
+          idMesure: 'audit',
           type: 'ajoutPriorite',
           details: { nouvelleValeur: 'p3' },
         }),

--- a/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
+++ b/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
@@ -19,7 +19,7 @@ describe('Le serveur MSS des routes privées `/api/service/:id/mesures/:id/activ
 
   describe('quand requête GET sur `/api/service/:id/mesures/:id/activites', () => {
     beforeEach(() => {
-      testeur.depotDonnees().litActivitesMesure = () => [];
+      testeur.depotDonnees().lisActivitesMesure = () => [];
     });
 
     it('recherche le service correspondant', (done) => {
@@ -45,7 +45,7 @@ describe('Le serveur MSS des routes privées `/api/service/:id/mesures/:id/activ
       testeur.referentiel().enrichis({
         mesures: { audit: { identifiantNumerique: '0007' } },
       });
-      testeur.depotDonnees().litActivitesMesure = () => [
+      testeur.depotDonnees().lisActivitesMesure = () => [
         new ActiviteMesure({
           idActeur: '9724853e-037c-4bca-9350-0a4b14a85a29',
           date: new Date('2024-09-29 11:15:02.817 +0200'),
@@ -73,7 +73,7 @@ describe('Le serveur MSS des routes privées `/api/service/:id/mesures/:id/activ
     it('retourne uniquement les activités de la mesure et du service', async () => {
       let idServiceUtilise;
       let idMesureUtilise;
-      testeur.depotDonnees().litActivitesMesure = (idService, idMesure) => {
+      testeur.depotDonnees().lisActivitesMesure = (idService, idMesure) => {
         idServiceUtilise = idService;
         idMesureUtilise = idMesure;
         return [];


### PR DESCRIPTION
Lis les activités de mesure en base de données et les retourne dans une nouvelle route d'API dans un nouveau routeur dédié aux activités de mesure.