### PR TITLE
Ajoute un identifiant aux mesures spécifiques qui n'en ont pas

### DIFF
--- a/migrations/20240904080913_ajouteIdentifiantMesuresSpecifiques.js
+++ b/migrations/20240904080913_ajouteIdentifiantMesuresSpecifiques.js
@@ -1,0 +1,32 @@
+const adaptateurUUID = require('../src/adaptateurs/adaptateurUUID');
+
+exports.up = (knex) =>
+  knex('services').then((lignes) => {
+    const misesAJour = lignes.map(({ id, donnees }) => {
+      const donneesModifiees = {
+        ...donnees,
+        mesuresSpecifiques: donnees.mesuresSpecifiques?.map((m) => ({
+          ...m,
+          ...(!m.id && { id: adaptateurUUID.genereUUID() }),
+        })),
+      };
+      return knex('services').where({ id }).update({
+        donnees: donneesModifiees,
+      });
+    });
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) =>
+  knex('services').then((lignes) => {
+    const misesAJour = lignes.map(({ id, donnees }) => {
+      donnees.mesuresSpecifiques = donnees.mesuresSpecifiques?.map((m) => {
+        delete m.id;
+        return m;
+      });
+      return knex('services').where({ id }).update({
+        donnees,
+      });
+    });
+    return Promise.all(misesAJour);
+  });

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -424,6 +424,9 @@ const creeDepot = (config = {}) => {
     idUtilisateur,
     mesures
   ) => {
+    mesures.toutes().forEach((m) => {
+      if (!m.id) m.id = adaptateurUUID.genereUUID();
+    });
     const s = await p.lis.un(idService);
     s.metsAJourMesuresSpecifiques(mesures);
     await metsAJourService(s);

--- a/src/modeles/mesureSpecifique.js
+++ b/src/modeles/mesureSpecifique.js
@@ -39,7 +39,7 @@ class MesureSpecifique extends Mesure {
   }
 
   static proprietesObligatoires() {
-    return ['description', 'categorie', 'statut'];
+    return ['id', 'description', 'categorie', 'statut'];
   }
 
   static valide({ categorie, statut, priorite, echeance }, referentiel) {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1616,6 +1616,34 @@ describe('Le dépôt de données des services', () => {
       );
     });
 
+    it('ajoute un identifiant aux mesures spécifiques', async () => {
+      const mesures = new MesuresSpecifiques({
+        mesuresSpecifiques: [{ description: 'Une mesure spécifique' }],
+      });
+
+      await depot.metsAJourMesuresSpecifiquesDuService('123', '789', mesures);
+
+      const {
+        mesures: { mesuresSpecifiques },
+      } = await depot.service('123');
+      expect(mesuresSpecifiques.item(0).id).to.be('unUUID');
+    });
+
+    it("n'ajoute pas un identifiant aux mesures spécifiques qui en ont déjà un", async () => {
+      const mesures = new MesuresSpecifiques({
+        mesuresSpecifiques: [
+          { description: 'Une mesure spécifique', id: 'truc' },
+        ],
+      });
+
+      await depot.metsAJourMesuresSpecifiquesDuService('123', '789', mesures);
+
+      const {
+        mesures: { mesuresSpecifiques },
+      } = await depot.service('123');
+      expect(mesuresSpecifiques.item(0).id).to.be('truc');
+    });
+
     it("publie un événement de 'Mesures service modifiées'", async () => {
       await depot.metsAJourMesuresSpecifiquesDuService(
         '123',

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -47,6 +47,7 @@ describe('Une mesure spécifique', () => {
 
   elle('connaît ses propriétés obligatoires', () => {
     expect(MesureSpecifique.proprietesObligatoires()).to.eql([
+      'id',
       'description',
       'categorie',
       'statut',
@@ -58,6 +59,7 @@ describe('Une mesure spécifique', () => {
     () => {
       const mesure = new MesureSpecifique(
         {
+          id: 'x',
           description: 'Une mesure spécifique',
           categorie: 'uneCategorie',
           statut: 'fait',

--- a/test/modeles/mesures.spec.js
+++ b/test/modeles/mesures.spec.js
@@ -71,6 +71,7 @@ describe('Les mesures liées à un service', () => {
           mesuresGenerales: [{ id: 'mesure1', statut: 'fait' }],
           mesuresSpecifiques: [
             {
+              id: '1',
               description: 'Faire une étude',
               categorie: 'gouvernance',
               statut: 'fait',


### PR DESCRIPTION
... dans le dépôt de données.

Cela permet de pouvoir ensuite brancher une par une les méthodes PATCH, POST, DELETE tout en conservant le fonctionnement actuel.

On ajoute un `id` à toutes les mesures spécifiques existantes via une migration.