### PR TITLE
Utilise un séparateur ";" dans les CSV

### DIFF
--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -12,19 +12,20 @@ const avecBOM = (...contenus) => `\uFEFF${contenus.join('')}`;
 const sansRetoursChariots = (texte) => texte.replaceAll('\n', ' ');
 const separesParVirgule = (liste) => liste.join(', ');
 
+const creeWriterDeCsv = (headerDuCsv) =>
+  createObjectCsvStringifier({ header: headerDuCsv, fieldDelimiter: ';' });
+
 const genereCsvServices = (tableauServices) => {
   try {
-    const writer = createObjectCsvStringifier({
+    const writer = creeWriterDeCsv([
       // Les `id` correspondent aux noms des propriétés dans notre modèle
-      header: [
-        { id: 'service', title: 'Nom du service' },
-        { id: 'organisations', title: 'Organisations responsables' },
-        { id: 'nombreContributeurs', title: 'Nombre de contributeurs' },
-        { id: 'estProprietaire', title: 'Est propriétaire ?' },
-        { id: 'indiceCyber', title: 'Indice cyber' },
-        { id: 'statut', title: 'Statut homologation' },
-      ],
-    });
+      { id: 'service', title: 'Nom du service' },
+      { id: 'organisations', title: 'Organisations responsables' },
+      { id: 'nombreContributeurs', title: 'Nombre de contributeurs' },
+      { id: 'estProprietaire', title: 'Est propriétaire ?' },
+      { id: 'indiceCyber', title: 'Indice cyber' },
+      { id: 'statut', title: 'Statut homologation' },
+    ]);
 
     const donnnesCsv = tableauServices.map((s) => ({
       service: decode(s.nomService),
@@ -111,7 +112,7 @@ const genereCsvMesures = async (
       }))
     );
 
-  const writer = createObjectCsvStringifier({ header: colonnes });
+  const writer = creeWriterDeCsv(colonnes);
   const titre = writer.getHeaderString();
   const lignes = writer.stringifyRecords(donneesCsv);
   const csv = avecBOM(titre, lignes);


### PR DESCRIPTION
… pour que le CSV s'ouvre correctement dans les Excel de nos utilisateurs qui sont a priori configurés en français.


Après la correction, un CSV exporté s'ouvre directement avec les colonnes « propres » dans Excel 👇 
![image](https://github.com/user-attachments/assets/9370d4b9-21cb-4594-8c19-47affd9c838c)
