### PR TITLE
Ajout d'un bandeau d'avertissement de maintenance

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -89,3 +89,4 @@ CRISP_ID_CATEGORIE_BLOG= # L'identifiant de la catégorie `blog` des articles
 
 # Maintenance
 MODE_MAINTENANCE= # 'true' pour activer le mode maintenance. Renvoi une erreur 503 et affiche une page dédiée pour toutes les requêtes
+PREPARATION_MODE_MAINTENANCE = # Permet d'activer un bandeau annonçant une maintenance ce jour. Au format "Jour complet - Xh à Xh". ex: "Jeudi 5 septembre 2024 - 17h à 19h"

--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -161,3 +161,15 @@ section:last-of-type {
   bottom: 64px;
   left: 50px;
 }
+
+.banniere-maintenance {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--role-proprietaire);
+  border-top: 1px solid var(--role-proprietaire-texte);
+  border-bottom: 1px solid var(--role-proprietaire-texte);
+  font-size: 12px;
+  font-weight: 500;
+  gap: 12px;
+}

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -60,7 +60,11 @@ const versionDeBuild = () => {
   return versionCommit.substring(0, 8);
 };
 
-const modeMaintenance = () => process.env.MODE_MAINTENANCE === 'true';
+const modeMaintenance = () => ({
+  actif: () => process.env.MODE_MAINTENANCE === 'true',
+  enPreparation: () => !!process.env.PREPARATION_MODE_MAINTENANCE,
+  detailsPreparation: () => process.env.PREPARATION_MODE_MAINTENANCE,
+});
 
 module.exports = {
   chiffrement,

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -314,7 +314,13 @@ const middleware = (configuration = {}) => {
   };
 
   const verificationModeMaintenance = (_requete, reponse, suite) => {
-    const modeMaintenanceActif = adaptateurEnvironnement.modeMaintenance();
+    const modeMaintenance = adaptateurEnvironnement.modeMaintenance();
+    const modeMaintenanceEnPreparation = modeMaintenance.enPreparation();
+    if (modeMaintenanceEnPreparation) {
+      const [jour, heure] = modeMaintenance.detailsPreparation().split(' - ');
+      reponse.locals.avertissementMaintenance = { jour, heure };
+    }
+    const modeMaintenanceActif = modeMaintenance.actif();
     if (modeMaintenanceActif) {
       reponse.status(503).render('maintenance');
     } else {

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -36,6 +36,15 @@ block page
           nav
             .bouton-fermer Fermer
             block navigation
+    if avertissementMaintenance
+      .banniere-maintenance
+        img(src="/statique/assets/images/icone_danger.svg" alt="")
+        p
+          span Une maintenance est prévue aujourd'hui (#{avertissementMaintenance.jour}) sur MonServiceSécurisé, de #{avertissementMaintenance.heure}.
+          br
+          span La plateforme sera inaccessible. Nous nous excusons pour la gêne occasionée.
+
+
 
   block session
     include csrf.pug


### PR DESCRIPTION
... afin de signaler aux utilisateurs d'une maintenance proche.

> [!IMPORTANT]  
> Afin de signaler la maintenance du jour, il faut rajouter la variable d'environnement `PREPARATION_MODE_MAINTENANCE=Jeudi 5 septembre 2024 - 17h à 19h`

<img src="https://github.com/user-attachments/assets/14dab1e4-555e-444d-83e5-1cdf23c62c93" width=600 />