### PR TITLE
Manipule directement `X-Forwarded-For` pour extraire les adresses IP

### DIFF
--- a/src/adaptateurs/adaptateurGestionErreurSentry.js
+++ b/src/adaptateurs/adaptateurGestionErreurSentry.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 const { IpDeniedError } = require('express-ipfilter');
 const adaptateurEnvironnement = require('./adaptateurEnvironnement');
+const { extraisIp } = require('../http/requeteHttp');
 
 const logueErreur = (erreur, infosDeContexte = {}) => {
   Sentry.withScope(() => {
@@ -33,11 +34,13 @@ const initialise = (applicationExpress) => {
 const controleurErreurs = (erreur, requete, reponse, suite) => {
   const estErreurDeFiltrageIp = erreur instanceof IpDeniedError;
   if (estErreurDeFiltrageIp) {
+    const ipDuClient = extraisIp(requete.headers).client;
+
     logueErreur(
       new Error(
         'Une IP non autorisée a été bloquée. Aucune page ne lui a été servie.'
       ),
-      { 'IP de la requete': requete.headers['x-real-ip']?.replaceAll('.', '*') }
+      { 'IP du client': ipDuClient?.replaceAll('.', '*') }
     );
     reponse.end();
     return suite();

--- a/src/adaptateurs/adaptateurProtection.js
+++ b/src/adaptateurs/adaptateurProtection.js
@@ -3,12 +3,14 @@ const rateLimit = require('express-rate-limit');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
+const { extraisIp } = require('../http/requeteHttp');
 
 const uneMinute = 60 * 1000;
 const parametresCommuns = (typeRequete, doitFermerConnexion = false) => ({
   windowMs: uneMinute,
+  keyGenerator: (requete, _reponse) => extraisIp(requete.headers).client,
   handler: (requete, reponse) => {
-    const attaque = requete.ip.replaceAll('.', '*');
+    const attaque = extraisIp(requete.headers).client?.replaceAll('.', '*');
 
     if (typeRequete === 'Navigation')
       // eslint-disable-next-line no-console

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -14,6 +14,7 @@ const {
   ErreurChainageMiddleware,
 } = require('../erreurs');
 const { ajouteLaRedirectionPostConnexion } = require('./redirection');
+const { extraisIp } = require('./requeteHttp');
 
 const middleware = (configuration = {}) => {
   const {
@@ -301,8 +302,8 @@ const middleware = (configuration = {}) => {
     }
 
     return ipfilter(config.ipAutorisees(), {
-      // Utilise l'IP d'origine : https://doc.scalingo.com/platform/internals/routing
-      detectIp: (requete) => requete.headers['x-real-ip'],
+      // Seules les IP du WAF doivent être autorisées si jamais le filtrage IP est activé.
+      detectIp: (requete) => extraisIp(requete.headers).waf,
       mode: 'allow',
       log: false,
     });

--- a/src/http/requeteHttp.js
+++ b/src/http/requeteHttp.js
@@ -1,0 +1,9 @@
+function extraisIp(headersExpress) {
+  const ips = headersExpress['x-forwarded-for']?.split(', ');
+
+  if (!ips) return {};
+
+  return { client: ips[0], waf: ips[ips.length - 1] };
+}
+
+module.exports = { extraisIp };

--- a/test/http/requeteHttp.spec.js
+++ b/test/http/requeteHttp.spec.js
@@ -1,0 +1,40 @@
+const expect = require('expect.js');
+const { extraisIp } = require('../../src/http/requeteHttp');
+
+describe('Les fonctions sur les requêtes HTTP', () => {
+  describe("concernant l'extraction des IP", () => {
+    it('sait extraire l\'IP du client depuis le header "X-Forwarded-For"', () => {
+      const forwardedFor = '1.1.1.1, 2.2.2.2';
+
+      const ips = extraisIp({ 'x-forwarded-for': forwardedFor });
+
+      expect(ips.client).to.be('1.1.1.1');
+    });
+
+    it('sait extraire l\'IP du WAF depuis le header "X-Forwarded-For"', () => {
+      const forwardedFor = '1.1.1.1, 2.2.2.2';
+
+      const ips = extraisIp({ 'x-forwarded-for': forwardedFor });
+
+      expect(ips.waf).to.be('2.2.2.2');
+    });
+
+    it('fonctionne même quand il y a plusieurs nœuds au milieu du "X-Forwarded-For"', () => {
+      const forwardedFor = '1.1.1.1, 8.8.8.8, 9.9.9.9, 2.2.2.2';
+
+      const ips = extraisIp({ 'x-forwarded-for': forwardedFor });
+
+      expect(ips.client).to.be('1.1.1.1');
+      expect(ips.waf).to.be('2.2.2.2');
+    });
+
+    it('reste robuste si le header est introuvable (cas du dev en local par exemple)', () => {
+      const sansForwardedFor = {};
+
+      const ips = extraisIp(sansForwardedFor);
+
+      expect(ips.client).to.be(undefined);
+      expect(ips.waf).to.be(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Passer par ce header bas-niveau est plus fiable : il fonctionne de la même façon chez Scalingo et chez Clever.

Alors que `X-Real-Ip` était du spécifique Scalingo.