### PR TITLE
[HISTORIQUE] Recupère les activités des mesures spécifiques

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -112,7 +112,8 @@ const nouvelAdaptateur = (env) => {
         'date',
         'id_acteur as idActeur',
         'id_service as idService',
-        'id_mesure as idMesure'
+        'id_mesure as idMesure',
+        'type_mesure as typeMesure'
       );
 
   const arreteTout = () => knex.destroy();

--- a/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
+++ b/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
@@ -27,7 +27,9 @@ const routesConnecteApiServiceActivitesMesure = ({
         date: a.date.toISOString(),
         idActeur: a.idActeur,
         identifiantNumeriqueMesure:
-          referentiel.mesures()[a.idMesure].identifiantNumerique,
+          a.typeMesure === 'generale'
+            ? referentiel.mesures()[a.idMesure].identifiantNumerique
+            : undefined,
         type: a.type,
         details: a.details,
       }));

--- a/svelte/lib/mesure/contenus/ContenuOngletActivite.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletActivite.svelte
@@ -23,10 +23,12 @@
   };
 
   onMount(async () => {
-    const activites = await recupereActiviteMesure(
-      idService,
-      $store.mesureEditee.metadonnees.idMesure
-    );
+    let id;
+    if ($store.mesureEditee.metadonnees.typeMesure === 'SPECIFIQUE')
+      id = $store.mesureEditee.mesure.id;
+    else id = $store.mesureEditee.metadonnees.idMesure;
+
+    const activites = await recupereActiviteMesure(idService, id);
     storeActivites.charge(activites);
   });
 </script>

--- a/svelte/lib/mesure/contenus/activites/ActiviteAjoutEcheance.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteAjoutEcheance.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ActiviteMesure, DetailsAjoutPropriete } from '../../mesure.d';
   import TagEcheanceMesure from '../../../ui/TagEcheanceMesure.svelte';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   // eslint-disable-next-line svelte/valid-compile
@@ -12,8 +13,7 @@
 
 <div>
   <div>
-    L'échéance de la <b>mesure #{activite.identifiantNumeriqueMesure}</b> a été fixée
-    au
+    L'échéance de la <DesignationMesureActivite {activite} /> a été fixée au
   </div>
   <div>
     <TagEcheanceMesure {echeance} />

--- a/svelte/lib/mesure/contenus/activites/ActiviteAjoutPriorite.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteAjoutPriorite.svelte
@@ -2,6 +2,7 @@
   import type { ActiviteMesure, DetailsAjoutPropriete } from '../../mesure.d';
   import TagPrioriteMesure from '../../../ui/TagPrioriteMesure.svelte';
   import type { PrioriteMesure, ReferentielPriorite } from '../../../ui/types';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   export let priorites: ReferentielPriorite;
@@ -13,6 +14,6 @@
 </script>
 
 <div>
-  La priorité de la <b>mesure #{activite.identifiantNumeriqueMesure}</b> est
+  La priorité de la <DesignationMesureActivite {activite} /> est
   <TagPrioriteMesure {priorites} {priorite} />
 </div>

--- a/svelte/lib/mesure/contenus/activites/ActiviteAjoutResponsable.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteAjoutResponsable.svelte
@@ -4,6 +4,7 @@
     DetailsModificationResponsable,
   } from '../../mesure.d';
   import { contributeurs } from '../../../tableauDesMesures/stores/contributeurs.store';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   // eslint-disable-next-line svelte/valid-compile
@@ -25,5 +26,5 @@
 
 <div>
   <b>{intitule}</b> a été désigné·e responsable de la
-  <b>mesure #{activite.identifiantNumeriqueMesure}</b>
+  <DesignationMesureActivite {activite} />
 </div>

--- a/svelte/lib/mesure/contenus/activites/ActiviteAjoutStatut.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteAjoutStatut.svelte
@@ -3,6 +3,7 @@
   import type { ReferentielStatut } from '../../../ui/types';
   import type { StatutMesure } from '../../../modeles/mesure';
   import TagStatutMesure from '../../../ui/TagStatutMesure.svelte';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   export let statuts: ReferentielStatut;
@@ -14,6 +15,6 @@
 </script>
 
 <div>
-  Le statut de la <b>mesure #{activite.identifiantNumeriqueMesure}</b> est
+  Le statut de la <DesignationMesureActivite {activite} /> est
   <TagStatutMesure referentielStatuts={statuts} {statut} />
 </div>

--- a/svelte/lib/mesure/contenus/activites/ActiviteMiseAJourEcheance.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteMiseAJourEcheance.svelte
@@ -4,6 +4,7 @@
     DetailsMiseAJourPropriete,
   } from '../../mesure.d';
   import TagEcheanceMesure from '../../../ui/TagEcheanceMesure.svelte';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   // eslint-disable-next-line svelte/valid-compile
@@ -16,8 +17,7 @@
 
 <div>
   <div>
-    L'échéance de la <b>mesure #{activite.identifiantNumeriqueMesure}</b> a été modifiée
-    du
+    L'échéance de la <DesignationMesureActivite {activite} /> a été modifiée du
   </div>
   <div>
     <span class="ancienne"

--- a/svelte/lib/mesure/contenus/activites/ActiviteMiseAJourPriorite.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteMiseAJourPriorite.svelte
@@ -5,6 +5,7 @@
   } from '../../mesure.d';
   import TagPrioriteMesure from '../../../ui/TagPrioriteMesure.svelte';
   import type { PrioriteMesure, ReferentielPriorite } from '../../../ui/types';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   export let priorites: ReferentielPriorite;
@@ -18,8 +19,7 @@
 
 <div>
   <div>
-    La priorité de la <b>mesure #{activite.identifiantNumeriqueMesure}</b> a été
-    modifiée
+    La priorité de la <DesignationMesureActivite {activite} /> a été modifiée
   </div>
   <div class="changements">
     de

--- a/svelte/lib/mesure/contenus/activites/ActiviteMiseAJourStatut.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteMiseAJourStatut.svelte
@@ -6,6 +6,7 @@
   import type { ReferentielStatut } from '../../../ui/types';
   import type { StatutMesure } from '../../../modeles/mesure';
   import TagStatutMesure from '../../../ui/TagStatutMesure.svelte';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   export let statuts: ReferentielStatut;
@@ -19,7 +20,7 @@
 
 <div>
   <div>
-    Le statut de la <b>mesure #{activite.identifiantNumeriqueMesure}</b> a été modifié
+    Le statut de la <DesignationMesureActivite {activite} /> a été modifié
   </div>
   <div class="changements">
     de

--- a/svelte/lib/mesure/contenus/activites/ActiviteSuppressionEcheance.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteSuppressionEcheance.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { ActiviteMesure, DetailsAjoutPropriete } from '../../mesure.d';
-  import TagEcheanceMesure from '../../../ui/TagEcheanceMesure.svelte';
+  import type { ActiviteMesure } from '../../mesure.d';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   // eslint-disable-next-line svelte/valid-compile
@@ -8,5 +8,5 @@
 </script>
 
 <div>
-  L'échéance de la <b>mesure #{activite.identifiantNumeriqueMesure}</b> a été supprimée
+  L'échéance de la <DesignationMesureActivite {activite} /> a été supprimée
 </div>

--- a/svelte/lib/mesure/contenus/activites/ActiviteSuppressionResponsable.svelte
+++ b/svelte/lib/mesure/contenus/activites/ActiviteSuppressionResponsable.svelte
@@ -4,6 +4,7 @@
     DetailsModificationResponsable,
   } from '../../mesure.d';
   import { contributeurs } from '../../../tableauDesMesures/stores/contributeurs.store';
+  import DesignationMesureActivite from './DesignationMesureActivite.svelte';
 
   export let activite: ActiviteMesure;
   // eslint-disable-next-line svelte/valid-compile
@@ -25,5 +26,5 @@
 
 <div>
   <b>{intitule}</b> n'est plus responsable de la
-  <b>mesure #{activite.identifiantNumeriqueMesure}</b>
+  <DesignationMesureActivite {activite} />
 </div>

--- a/svelte/lib/mesure/contenus/activites/DesignationMesureActivite.svelte
+++ b/svelte/lib/mesure/contenus/activites/DesignationMesureActivite.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { ActiviteMesure } from '../../mesure.d';
+
+  export let activite: ActiviteMesure;
+</script>
+
+<b>mesure #{activite.identifiantNumeriqueMesure}</b>

--- a/svelte/lib/mesure/contenus/activites/DesignationMesureActivite.svelte
+++ b/svelte/lib/mesure/contenus/activites/DesignationMesureActivite.svelte
@@ -4,4 +4,8 @@
   export let activite: ActiviteMesure;
 </script>
 
-<b>mesure #{activite.identifiantNumeriqueMesure}</b>
+{#if activite.identifiantNumeriqueMesure}
+  <b>mesure #{activite.identifiantNumeriqueMesure}</b>
+{:else}
+  mesure
+{/if}

--- a/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
+++ b/test/routes/connecte/routesConnecteApiServiceActivitesMesure.spec.js
@@ -52,6 +52,7 @@ describe('Le serveur MSS des routes privées `/api/service/:id/mesures/:id/activ
           idMesure: 'audit',
           type: 'ajoutPriorite',
           details: { nouvelleValeur: 'p3' },
+          typeMesure: 'generale',
         }),
       ];
 
@@ -85,6 +86,25 @@ describe('Le serveur MSS des routes privées `/api/service/:id/mesures/:id/activ
 
       expect(idServiceUtilise).to.be('456');
       expect(idMesureUtilise).to.be('audit');
+    });
+
+    it('fournit un identificant numérique pour les mesures spécifiques', async () => {
+      testeur.depotDonnees().lisActivitesMesure = () => [
+        new ActiviteMesure({
+          idActeur: '9724853e-037c-4bca-9350-0a4b14a85a29',
+          date: new Date('2024-09-29 11:15:02.817 +0200'),
+          idMesure: 'a13ec795-0043-4622-8a36-0670198b6460',
+          type: 'ajoutPriorite',
+          details: { nouvelleValeur: 'p3' },
+          typeMesure: 'specifique',
+        }),
+      ];
+
+      const reponse = await axios.get(
+        'http://localhost:1234/api/service/456/mesures/audit/activites'
+      );
+
+      expect(reponse.data[0].identifiantNumeriqueMesure).to.be(undefined);
     });
   });
 });


### PR DESCRIPTION
Le bon identifiant est envoyé depuis le front au back qui, de son côté, sait construire un identifiant numérique pour les mesures spécifiques. 

Pour l’instant, le (mon) choix est de prendre les 6 premiers caractères de l’UUID de la mesure spécifique. 