### PR TITLE
[HISTORIQUE] Envoi un événement au bus lorsqu’une mesure spécifique est supprimée

### DIFF
--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -74,6 +74,7 @@ const EvenementMesureServiceModifiee = require('./evenementMesureServiceModifiee
 const {
   consigneActiviteMesure,
 } = require('./abonnements/consigneActiviteMesure');
+const EvenementMesureServiceSupprimee = require('./evenementMesureServiceSupprimee');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -114,6 +115,14 @@ const cableTousLesAbonnes = (
     }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
     consigneActiviteMesure({ depotDonnees }),
+  ]);
+
+  busEvenements.abonnePlusieurs(EvenementMesureServiceSupprimee, [
+    consigneCompletudeDansJournal({
+      adaptateurJournal,
+      adaptateurRechercheEntreprise,
+    }),
+    envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementDescriptionServiceModifiee, [

--- a/src/bus/evenementMesureServiceSupprimee.js
+++ b/src/bus/evenementMesureServiceSupprimee.js
@@ -1,0 +1,14 @@
+class EvenementMesureServiceSupprimee {
+  constructor({ service, utilisateur, idMesure }) {
+    if (!service)
+      throw Error("Impossible d'instancier l'événement sans service");
+    if (!utilisateur)
+      throw Error("Impossible d'instancier l'événement sans utilisateur");
+
+    this.service = service;
+    this.utilisateur = utilisateur;
+    this.idMesure = idMesure;
+  }
+}
+
+module.exports = EvenementMesureServiceSupprimee;

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -96,6 +96,7 @@ const creeDepot = (config = {}) => {
     rechercheContributeurs,
     remplaceRisquesSpecifiquesDuService,
     supprimeService,
+    supprimeMesureSpecifiqueDuService,
     tousLesServices,
   } = depotServices;
 
@@ -190,6 +191,7 @@ const creeDepot = (config = {}) => {
     sauvegardeParcoursUtilisateur,
     sauvegardeNotificationsExpirationHomologation,
     supprimeContributeur,
+    supprimeMesureSpecifiqueDuService,
     supprimeService,
     supprimeIdResetMotDePassePourUtilisateur,
     supprimeNotificationsExpirationHomologation,

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -16,6 +16,7 @@ const EvenementDossierHomologationFinalise = require('../bus/evenementDossierHom
 const EvenementServiceSupprime = require('../bus/evenementServiceSupprime');
 const Entite = require('../modeles/entite');
 const EvenementMesureServiceModifiee = require('../bus/evenementMesureServiceModifiee');
+const EvenementMesureServiceSupprimee = require('../bus/evenementMesureServiceSupprimee');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = async (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -459,6 +460,24 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  const supprimeMesureSpecifiqueDuService = async (
+    idService,
+    idUtilisateur,
+    idMesure
+  ) => {
+    const s = await p.lis.un(idService);
+    s.supprimeMesureSpecifique(idMesure);
+    await metsAJourService(s);
+    const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
+    await busEvenements.publie(
+      new EvenementMesureServiceSupprimee({
+        service: s,
+        utilisateur: u,
+        idMesure,
+      })
+    );
+  };
+
   const supprimeContributeur = async (idService, idUtilisateur) => {
     const unService = await p.lis.un(idService);
 
@@ -516,6 +535,7 @@ const creeDepot = (config = {}) => {
     rechercheContributeurs,
     remplaceRisquesSpecifiquesDuService,
     supprimeContributeur,
+    supprimeMesureSpecifiqueDuService,
     supprimeService,
     tousLesServices,
     trouveIndexDisponible,

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -318,11 +318,14 @@ const routesConnecteApiService = ({
     middleware.verificationAcceptationCGU,
     middleware.trouveService({ [SECURISER]: ECRITURE }),
     async (requete, reponse, _suite) => {
-      const { service } = requete;
+      const { service, idUtilisateurCourant } = requete;
       const { idMesure } = requete.params;
 
-      service.supprimeMesureSpecifique(idMesure);
-      await depotDonnees.metsAJourService(service);
+      await depotDonnees.supprimeMesureSpecifiqueDuService(
+        service.id,
+        idUtilisateurCourant,
+        idMesure
+      );
 
       reponse.sendStatus(200);
     }

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -571,7 +571,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête DELETE sur `api/service/:id/mesuresSpecifiques/:idMesure`', () => {
     beforeEach(() => {
-      testeur.depotDonnees().metsAJourService = async () => {};
+      testeur.depotDonnees().supprimeMesureSpecifiqueDuService = async () => {};
     });
 
     it("vérifie que l'utilisateur est authentifié", (done) => {
@@ -597,7 +597,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it('délègue au dépôt de données et au service la suppression de la mesure spécifique', async () => {
+    it('délègue au dépôt de données la suppression de la mesure spécifique', async () => {
       const serviceARenvoyer = unService(testeur.referentiel())
         .avecId('456')
         .avecMesures(new Mesures({ mesuresSpecifiques: [{ id: 'M1' }] }))
@@ -606,9 +606,17 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: '999',
         serviceARenvoyer,
       });
-      let serviceRecu;
-      testeur.depotDonnees().metsAJourService = async (service) => {
-        serviceRecu = service;
+      let idServiceRecu;
+      let idUtilisateurRecu;
+      let idMesureRecue;
+      testeur.depotDonnees().supprimeMesureSpecifiqueDuService = async (
+        idService,
+        idUtilisateur,
+        idMesure
+      ) => {
+        idServiceRecu = idService;
+        idUtilisateurRecu = idUtilisateur;
+        idMesureRecue = idMesure;
       };
 
       expect(serviceARenvoyer.nombreMesuresSpecifiques()).to.eql(1);
@@ -616,8 +624,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'http://localhost:1234/api/service/456/mesuresSpecifiques/M1'
       );
 
-      expect(serviceRecu).not.to.be(undefined);
-      expect(serviceRecu.nombreMesuresSpecifiques()).to.eql(0);
+      expect(idServiceRecu).to.be('456');
+      expect(idUtilisateurRecu).to.be('999');
+      expect(idMesureRecue).to.be('M1');
     });
   });
 


### PR DESCRIPTION
L’événement est un nouvel événement car on ne veut pas consigner d’activité de suppression d’échéance et de responsables lorsqu’on supprime une mesure spécifique. 