### PR TITLE
[BLOG] Affiche les filtres de catégories sur l'intégralité de la ligne

### DIFF
--- a/svelte/lib/blog/Blog.svelte
+++ b/svelte/lib/blog/Blog.svelte
@@ -140,7 +140,6 @@
 
   .section {
     flex: 1;
-    max-width: 384px;
     border: 1px solid var(--systeme-design-etat-contour-champs);
     border-bottom: 4px solid var(--bleu-mise-en-avant);
   }


### PR DESCRIPTION
... car on a maintenant plus que 2 "catégories" il faut donc faire en sorte que les filtres s'étendent sur toute la ligne.

![image](https://github.com/user-attachments/assets/8d4d0211-d61a-4774-9121-263bcc8ee498)
