### PR TITLE
[SOIN] Supprime le passage des mesures existantes au tiroir

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionMesure.mjs
+++ b/public/modules/tableauDeBord/actions/ActionMesure.mjs
@@ -13,7 +13,6 @@ class ActionMesure extends ActionAbstraite {
     priorites,
     retoursUtilisateur,
     estLectureSeule,
-    mesuresExistantes,
     mesureAEditer,
     modeVisiteGuidee,
   }) {
@@ -27,7 +26,6 @@ class ActionMesure extends ActionAbstraite {
           priorites,
           retoursUtilisateur,
           estLectureSeule,
-          mesuresExistantes,
           mesureAEditer,
           modeVisiteGuidee,
         },

--- a/public/service/mesures.js
+++ b/public/service/mesures.js
@@ -55,7 +55,6 @@ $(() => {
       retoursUtilisateur,
       estLectureSeule,
       modeVisiteGuidee: enVisiteGuidee(),
-      mesuresExistantes: e.detail.mesuresExistantes,
       mesureAEditer: e.detail.mesureAEditer,
     };
     actionMesure = new ActionMesure(e.detail.titreTiroir);

--- a/svelte/lib/mesure/Mesure.svelte
+++ b/svelte/lib/mesure/Mesure.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import Formulaire from '../ui/Formulaire.svelte';
   import SuppressionMesureSpecifique from './suppression/SuppressionMesureSpecifique.svelte';
-  import type { MesuresExistantes } from './mesure.d';
   import type { IdService } from '../tableauDesMesures/tableauDesMesures.d';
 
   import { configurationAffichage, store } from './mesure.store';
@@ -19,7 +18,6 @@
   export let categories: Record<string, string>;
   export let statuts: ReferentielStatut;
   export let retoursUtilisateur: Record<string, string>;
-  export let mesuresExistantes: MesuresExistantes;
   export let estLectureSeule: boolean;
   export let priorites: ReferentielPriorite;
   export let modeVisiteGuidee: boolean;
@@ -29,7 +27,7 @@
   let enCoursEnvoi = false;
   const enregistreMesure = async () => {
     enCoursEnvoi = true;
-    const promesses = [enregistreMesures(idService, mesuresExistantes, $store)];
+    const promesses = [enregistreMesures(idService, $store)];
     if (
       $configurationAffichage.doitAfficherRetourUtilisateur &&
       retourUtilisateur
@@ -68,7 +66,7 @@
 </script>
 
 {#if $store.etape === 'SuppressionSpecifique'}
-  <SuppressionMesureSpecifique {idService} {mesuresExistantes} />
+  <SuppressionMesureSpecifique {idService} />
 {:else}
   {#if featureFlags.planAction()}
     <div class="conteneur-onglet">

--- a/svelte/lib/mesure/contenus/ContenuOngletActivite.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletActivite.svelte
@@ -30,6 +30,8 @@
         ? activitesVisiteGuidee
         : recupereActiviteMesure(idService, idMesure);
 
+    if ($store.etape === 'Creation') return;
+
     let id;
     if ($store.mesureEditee.metadonnees.typeMesure === 'SPECIFIQUE')
       id = $store.mesureEditee.mesure.id;

--- a/svelte/lib/mesure/mesure.api.ts
+++ b/svelte/lib/mesure/mesure.api.ts
@@ -1,11 +1,10 @@
-import type { ActiviteMesure, MesuresExistantes } from './mesure.d';
+import type { ActiviteMesure } from './mesure.d';
 import type { MesureStore } from './mesure.store';
 
 const formatteurDate = new Intl.DateTimeFormat('en-EN');
 
 export const enregistreMesures = async (
   idService: string,
-  mesuresExistantes: MesuresExistantes,
   $store: MesureStore
 ) => {
   async function enregistreMesureGenerale() {
@@ -14,12 +13,6 @@ export const enregistreMesures = async (
       $store.mesureEditee.mesure;
     let { echeance } = $store.mesureEditee.mesure;
     if (echeance) echeance = formatteurDate.format(new Date(echeance));
-
-    mesuresExistantes.mesuresGenerales[idMesure] = {
-      modalites,
-      statut,
-      id: idMesure,
-    };
 
     await axios.put(`/api/service/${idService}/mesures/${idMesure}`, {
       modalites,
@@ -57,11 +50,8 @@ export const enregistreMesures = async (
 
 export const supprimeMesureSpecifique = async (
   idService: string,
-  mesuresExistantes: MesuresExistantes,
-  indexMesureSpecifique: number
+  idMesure: string
 ) => {
-  const idMesure =
-    mesuresExistantes.mesuresSpecifiques[indexMesureSpecifique].id;
   await axios.delete(
     `/api/service/${idService}/mesuresSpecifiques/${idMesure}`
   );

--- a/svelte/lib/mesure/mesure.d.ts
+++ b/svelte/lib/mesure/mesure.d.ts
@@ -13,13 +13,7 @@ export type MesureProps = {
   statuts: Record<StatutMesure, string>;
   retoursUtilisateur: Record<string, string>;
   estLectureSeule: boolean;
-  mesuresExistantes: MesuresExistantes;
   mesureAEditer?: MesureEditee;
-};
-
-export type MesuresExistantes = {
-  mesuresGenerales: Record<string, MesureGenerale>;
-  mesuresSpecifiques: MesureSpecifique[];
 };
 
 type IdUtilisateur = string;

--- a/svelte/lib/mesure/suppression/SuppressionMesureSpecifique.svelte
+++ b/svelte/lib/mesure/suppression/SuppressionMesureSpecifique.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
   import { store } from '../mesure.store';
   import { supprimeMesureSpecifique } from '../mesure.api';
-  import type { MesuresExistantes } from '../mesure.d';
 
   export let idService: string;
-  export let mesuresExistantes: MesuresExistantes;
 
   let enCoursEnvoi = false;
   const supprimeMesure = async () => {
     enCoursEnvoi = true;
-    await supprimeMesureSpecifique(
-      idService,
-      mesuresExistantes,
-      $store.mesureEditee.metadonnees.idMesure as number
-    );
+    await supprimeMesureSpecifique(idService, $store.mesureEditee.mesure.id);
     enCoursEnvoi = false;
     document.body.dispatchEvent(
       new CustomEvent('mesure-modifiee', {
@@ -38,8 +32,9 @@
 <div class="conteneur-actions">
   <button
     class="bouton bouton-secondaire"
-    on:click={store.afficheEtapeEditionSpecifique}>Annuler</button
-  >
+    on:click={store.afficheEtapeEditionSpecifique}
+    >Annuler
+  </button>
   <button
     class="bouton"
     class:en-cours-chargement={enCoursEnvoi}

--- a/svelte/lib/tableauDesMesures/actionsTiroir.ts
+++ b/svelte/lib/tableauDesMesures/actionsTiroir.ts
@@ -15,7 +15,6 @@ export const afficheTiroirEditeMesure = (mesureAEditer: MesureAEditer) => {
   document.body.dispatchEvent(
     new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
       detail: {
-        mesuresExistantes: metEnFormeMesures(get(mesures)),
         titreTiroir:
           mesureAEditer.metadonnees.typeMesure === 'GENERALE'
             ? mesureAEditer.mesure.description
@@ -30,7 +29,6 @@ export const afficheTiroirCreeMesure = () => {
   document.body.dispatchEvent(
     new CustomEvent('svelte-affiche-tiroir-ajout-mesure-specifique', {
       detail: {
-        mesuresExistantes: metEnFormeMesures(get(mesures)),
         titreTiroir: 'Ajouter une mesure',
       },
     })


### PR DESCRIPTION
Ce n’est plus nécessaire depuis qu’on travaille avec des méthodes unitaires pour les mesures générales et les mesures spécifiques. 
Au passage, on supprime une erreur 404 qui se produisait en mode création quand on essayait de charger les activités d’une mesure. 