### PR TITLE
[JOURNAL] Ajoute la source de connexion aux évènements CONNEXION_UTILISATEUR

### DIFF
--- a/src/bus/evenementNouvelleConnexionUtilisateur.js
+++ b/src/bus/evenementNouvelleConnexionUtilisateur.js
@@ -1,5 +1,5 @@
 class EvenementNouvelleConnexionUtilisateur {
-  constructor({ idUtilisateur, dateDerniereConnexion }) {
+  constructor({ idUtilisateur, dateDerniereConnexion, source }) {
     if (!idUtilisateur)
       throw Error("Impossible d'instancier l'événement sans id utilisateur");
     if (!dateDerniereConnexion)
@@ -13,6 +13,7 @@ class EvenementNouvelleConnexionUtilisateur {
 
     this.idUtilisateur = idUtilisateur;
     this.dateDerniereConnexion = dateDerniereConnexion;
+    this.source = source;
   }
 }
 

--- a/src/depots/depotDonneesParcoursUtilisateur.js
+++ b/src/depots/depotDonneesParcoursUtilisateur.js
@@ -19,7 +19,10 @@ const creeDepot = (config = {}) => {
     );
   };
 
-  const enregistreNouvelleConnexionUtilisateur = async (idUtilisateur) => {
+  const enregistreNouvelleConnexionUtilisateur = async (
+    idUtilisateur,
+    source
+  ) => {
     const parcoursUtilisateur = await lisParcoursUtilisateur(idUtilisateur);
 
     parcoursUtilisateur.enregistreDerniereConnexionMaintenant();
@@ -29,6 +32,7 @@ const creeDepot = (config = {}) => {
       new EvenementNouvelleConnexionUtilisateur({
         idUtilisateur,
         dateDerniereConnexion: parcoursUtilisateur.dateDerniereConnexion,
+        source,
       })
     );
   };

--- a/src/routes/nonConnecte/routesNonConnecteApi.js
+++ b/src/routes/nonConnecte/routesNonConnecteApi.js
@@ -141,7 +141,8 @@ const routesNonConnecteApi = ({
         requete.session.token = token;
 
         await depotDonnees.enregistreNouvelleConnexionUtilisateur(
-          utilisateur.id
+          utilisateur.id,
+          'MSS'
         );
 
         reponse.sendStatus(200);

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -41,6 +41,9 @@ const routesNonConnecteOidc = ({ adaptateurOidc, depotDonnees }) => {
 
       if (utilisateurExistant) {
         requete.session.token = utilisateurExistant.genereToken();
+        await depotDonnees.enregistreNouvelleConnexionUtilisateur(
+          utilisateurExistant.id
+        );
         reponse.render('apresAuthentification');
       } else {
         reponse.status(401).send("Erreur d'authentification");

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -42,7 +42,8 @@ const routesNonConnecteOidc = ({ adaptateurOidc, depotDonnees }) => {
       if (utilisateurExistant) {
         requete.session.token = utilisateurExistant.genereToken();
         await depotDonnees.enregistreNouvelleConnexionUtilisateur(
-          utilisateurExistant.id
+          utilisateurExistant.id,
+          'AGENT_CONNECT'
         );
         reponse.render('apresAuthentification');
       } else {

--- a/test/depots/depotDonneesParcoursUtilisateur.spec.js
+++ b/test/depots/depotDonneesParcoursUtilisateur.spec.js
@@ -40,7 +40,7 @@ describe('Le dépôt de données Parcours utilisateur', () => {
     });
 
     it("publie un événement de 'Nouvelle connexion utilisateur'", async () => {
-      await depot.enregistreNouvelleConnexionUtilisateur('123');
+      await depot.enregistreNouvelleConnexionUtilisateur('123', 'MSS');
 
       expect(
         busEvenements.aRecuUnEvenement(EvenementNouvelleConnexionUtilisateur)
@@ -50,6 +50,7 @@ describe('Le dépôt de données Parcours utilisateur', () => {
       );
       expect(evenement.idUtilisateur).to.be('123');
       expect(evenement.dateDerniereConnexion).not.to.be(undefined);
+      expect(evenement.source).to.be('MSS');
     });
   });
 

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -448,10 +448,13 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
 
       it("délègue au dépôt de données l'enregistrement de la dernière connexion utilisateur'", async () => {
         let idUtilisateurPasse = {};
+        let sourcePassee;
         testeur.depotDonnees().enregistreNouvelleConnexionUtilisateur = async (
-          idUtilisateur
+          idUtilisateur,
+          source
         ) => {
           idUtilisateurPasse = idUtilisateur;
+          sourcePassee = source;
         };
 
         await axios.post('http://localhost:1234/api/token', {
@@ -459,7 +462,8 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
           motDePasse: 'mdp_12345',
         });
 
-        expect(idUtilisateurPasse).to.eql('456');
+        expect(idUtilisateurPasse).to.be('456');
+        expect(sourcePassee).to.be('MSS');
       });
     });
 

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -71,6 +71,7 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
       });
       testeur.depotDonnees().utilisateurAvecEmail = (email) =>
         email === 'unEmailInconnu' ? undefined : utilisateur;
+      testeur.depotDonnees().enregistreNouvelleConnexionUtilisateur = () => {};
     });
 
     it('sert une page HTML', async () => {
@@ -142,6 +143,26 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
 
       const tokenDecode = decodeTokenDuCookie(reponse, 1);
       expect(tokenDecode.token).to.be('unJetonJWT');
+    });
+
+    it("délègue au dépôt de données l'enregistrement de la dernière connexion utilisateur'", async () => {
+      let idUtilisateurPasse = {};
+      testeur.depotDonnees().enregistreNouvelleConnexionUtilisateur = async (
+        idUtilisateur
+      ) => {
+        idUtilisateurPasse = idUtilisateur;
+      };
+
+      const utilisateurAuthentifie = unUtilisateur().avecId('456').construis();
+      utilisateurAuthentifie.genereToken = () => 'unJetonJWT';
+      testeur.depotDonnees().utilisateurAvecEmail = async () =>
+        utilisateurAuthentifie;
+
+      await requeteSansRedirection(
+        'http://localhost:1234/oidc/apres-authentification'
+      );
+
+      expect(idUtilisateurPasse).to.eql('456');
     });
   });
 });

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -147,10 +147,13 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
 
     it("délègue au dépôt de données l'enregistrement de la dernière connexion utilisateur'", async () => {
       let idUtilisateurPasse = {};
+      let sourcePassee;
       testeur.depotDonnees().enregistreNouvelleConnexionUtilisateur = async (
-        idUtilisateur
+        idUtilisateur,
+        source
       ) => {
         idUtilisateurPasse = idUtilisateur;
+        sourcePassee = source;
       };
 
       const utilisateurAuthentifie = unUtilisateur().avecId('456').construis();
@@ -162,7 +165,8 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
         'http://localhost:1234/oidc/apres-authentification'
       );
 
-      expect(idUtilisateurPasse).to.eql('456');
+      expect(idUtilisateurPasse).to.be('456');
+      expect(sourcePassee).to.be('AGENT_CONNECT');
     });
   });
 });


### PR DESCRIPTION
Afin de distinguer les utilisateurs MSS (email/mdp) et Agent Connect