### PR TITLE
[CORRECTION] Télécharge les PDF avec une query string empêchant la mise en cache

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionTelechargement.mjs
+++ b/public/modules/tableauDeBord/actions/ActionTelechargement.mjs
@@ -20,12 +20,17 @@ class ActionTelechargement extends ActionAbstraite {
       return;
     }
 
-    const urlBase = `/api/service/${idService}/pdf/`;
+    const lienSansMiseEnCache = (idLien, document) => {
+      $(idLien).attr(
+        'href',
+        `/api/service/${idService}/pdf/${document}?timestamp=${Date.now()}`
+      );
+    };
 
-    $('#lien-synthese').attr('href', `${urlBase}syntheseSecurite.pdf`);
-    $('#lien-annexes').attr('href', `${urlBase}annexes.pdf`);
-    $('#lien-decision').attr('href', `${urlBase}dossierDecision.pdf`);
-    $('#lien-archive').attr('href', `${urlBase}documentsHomologation.zip`);
+    lienSansMiseEnCache('#lien-synthese', 'syntheseSecurite.pdf');
+    lienSansMiseEnCache('#lien-annexes', 'annexes.pdf');
+    lienSansMiseEnCache('#lien-decision', 'dossierDecision.pdf');
+    lienSansMiseEnCache('#lien-archive', 'documentsHomologation.zip');
 
     const domDocuments = {
       dossierDecision: 'decision',


### PR DESCRIPTION
Sans cette query string dynamique, nos PDF sont mis en cache.
Ce qui empêche les utilisateurs d'avoir des PDF tout le temps à jour.

Par exemple :
 - je génère un PDF
 - je change le statut de 4 mesures
 - je re-génère le PDF. Ici je récupère le PDF mis en cache à l'étape 1.

On passe par une query string plutôt que par une configuration du cache, car c'est beaucoup plus explicite et visible.

Le code modifié est évalué à chaque ouverture du tiroir. 
Donc ça fait bien des liens uniques à chaque ouverture 👇 
![image](https://github.com/user-attachments/assets/daedfeb5-24dc-459f-8bb5-0c83f19b8cf3)
