### PR TITLE
Cache le lien du menu vers la page de changement de mot de passe

### DIFF
--- a/public/entete.js
+++ b/public/entete.js
@@ -12,24 +12,31 @@ $(() => {
 <div class='nom-utilisateur-courant'>${donneesUtilisateur.prenomNom}</div>
   `);
 
-  const creeMenu = () =>
+  const creeMenu = (sourceAuthentification) =>
     $(`
 <div class="menu">
   <a href="/tableauDeBord">Mon tableau de bord</a>
   <a href="/utilisateur/edition">Mettre à jour mon profil</a>
-  <a href="/motDePasse/edition">Changer mon mot de passe</a>  
+  ${
+    sourceAuthentification === 'MSS'
+      ? '<a href="/motDePasse/edition">Changer mon mot de passe</a>'
+      : ''
+  }
 </div>
   `);
 
   const deconnexion = () =>
     '<a class="deconnexion" href="/connexion">Se déconnecter</a>';
 
-  const ajouteUtilisateurCourantDans = (selecteur, donneesUtilisateur) => {
+  const ajouteUtilisateurCourantDans = (
+    selecteur,
+    { utilisateur: donneesUtilisateur, sourceAuthentification }
+  ) => {
     const $conteneur = $(selecteur);
 
     const $identiteUtilisateur =
       creeConteneurUtilisateurCourant(donneesUtilisateur);
-    const $menu = creeMenu();
+    const $menu = creeMenu(sourceAuthentification);
     $menu.toggle();
 
     $conteneur.on('click', () => $menu.toggle());
@@ -49,10 +56,7 @@ $(() => {
   axios
     .get('/api/utilisateurCourant')
     .then((reponse) =>
-      ajouteUtilisateurCourantDans(
-        '.utilisateur-courant',
-        reponse.data.utilisateur
-      )
+      ajouteUtilisateurCourantDans('.utilisateur-courant', reponse.data)
     )
     .catch(() => ajouteBoutonConnexionDans('.utilisateur-courant'));
 });

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -284,6 +284,7 @@ const routesConnecteApi = ({
     if (idUtilisateur) {
       depotDonnees.utilisateur(idUtilisateur).then((utilisateur) => {
         reponse.json({
+          sourceAuthentification: requete.sourceAuthentification,
           utilisateur: {
             prenomNom: utilisateur.prenomNom(),
           },

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -848,6 +848,21 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       expect(utilisateur.prenomNom).to.equal('Marie Jeanne');
     });
 
+    it("renvoie la source d'authentification", async () => {
+      testeur
+        .middleware()
+        .reinitialise({ idUtilisateur: '123', sourceAuth: 'MSS' });
+      const depotDonnees = testeur.depotDonnees();
+      depotDonnees.utilisateur = async () => unUtilisateur().construis();
+
+      const response = await axios.get(
+        'http://localhost:1234/api/utilisateurCourant'
+      );
+
+      const { sourceAuthentification } = response.data;
+      expect(sourceAuthentification).to.equal('MSS');
+    });
+
     it("répond avec un code 401 quand il n'y a pas d'identifiant", (done) => {
       testeur.middleware().reinitialise({ idUtilisateur: '' });
 


### PR DESCRIPTION
 pour les utilisateurs non connectés avec mot de passe (par exemple, via Agent Connect)