### PR TITLE
[HISTORISATION] Enregistre les modifications d'indice cyber

### DIFF
--- a/migrations/20240916143748_creationTableActivitesIndiceCyber.js
+++ b/migrations/20240916143748_creationTableActivitesIndiceCyber.js
@@ -1,0 +1,10 @@
+exports.up = (knex) =>
+  knex.schema.createTable('evolutions_indice_cyber', (table) => {
+    table.uuid('id_service');
+    table.json('indice_cyber');
+    table.json('indice_cyber_personnalise');
+    table.json('mesures_par_statut');
+    table.datetime('date').defaultTo(knex.fn.now());
+  });
+
+exports.down = (knex) => knex.schema.dropTable('evolutions_indice_cyber');

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -474,6 +474,31 @@ const nouvelAdaptateur = (env) => {
       .update({ date_acquittement: knex.fn.now() });
   };
 
+  const sauvegardeNouvelIndiceCyber = async (
+    idService,
+    indiceCyber,
+    indiceCyberPersonnalise,
+    mesuresParStatut
+  ) =>
+    knex('evolutions_indice_cyber').insert({
+      id_service: idService,
+      indice_cyber: indiceCyber,
+      indice_cyber_personnalise: indiceCyberPersonnalise,
+      mesures_par_statut: mesuresParStatut,
+    });
+
+  const lisDernierIndiceCyber = async (idService) =>
+    knex('evolutions_indice_cyber')
+      .where({ id_service: idService })
+      .select({
+        idService: 'id_service',
+        indiceCyber: 'indice_cyber',
+        indiceCyberPersonnalise: 'indice_cyber_personnalise',
+        mesuresParStatut: 'mesures_par_statut',
+      })
+      .orderBy('date', 'desc')
+      .first();
+
   return {
     activitesMesure,
     ajouteAutorisation,
@@ -490,6 +515,7 @@ const nouvelAdaptateur = (env) => {
     service,
     serviceExisteAvecHashNom,
     services,
+    lisDernierIndiceCyber,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
@@ -503,6 +529,7 @@ const nouvelAdaptateur = (env) => {
     sauvegardeService,
     sauvegardeAutorisation,
     sauvegardeNotificationsExpirationHomologation,
+    sauvegardeNouvelIndiceCyber,
     sauvegardeParcoursUtilisateur,
     suggestionsActionsService,
     supprimeAutorisation,

--- a/src/bus/abonnements/sauvegardeEvolutionIndiceCyber.js
+++ b/src/bus/abonnements/sauvegardeEvolutionIndiceCyber.js
@@ -25,15 +25,17 @@ function sauvegardeEvolutionIndiceCyber({ depotDonnees }) {
       !dernierIndiceCyber ||
       modificationIndiceCyber ||
       modificationIndiceCyberPersonnalise
-    )
+    ) {
+      const avecLesNonPrisesEnCompte =
+        service.statistiquesMesuresGeneralesEtSpecifiques(false);
+
       await depotDonnees.sauvegardeNouvelIndiceCyber({
         idService: service.id,
         indiceCyber,
         indiceCyberPersonnalise,
-        mesuresParStatut: service
-          .statistiquesMesuresGeneralesEtSpecifiques()
-          .totauxParCategorie(),
+        mesuresParStatut: avecLesNonPrisesEnCompte.totauxParCategorie(),
       });
+    }
   };
 }
 

--- a/src/bus/abonnements/sauvegardeEvolutionIndiceCyber.js
+++ b/src/bus/abonnements/sauvegardeEvolutionIndiceCyber.js
@@ -30,7 +30,9 @@ function sauvegardeEvolutionIndiceCyber({ depotDonnees }) {
         idService: service.id,
         indiceCyber,
         indiceCyberPersonnalise,
-        mesuresParStatut: service.statistiquesMesures().totauxParCategorie(),
+        mesuresParStatut: service
+          .statistiquesMesuresGeneralesEtSpecifiques()
+          .totauxParCategorie(),
       });
   };
 }

--- a/src/bus/abonnements/sauvegardeEvolutionIndiceCyber.js
+++ b/src/bus/abonnements/sauvegardeEvolutionIndiceCyber.js
@@ -1,0 +1,38 @@
+function sauvegardeEvolutionIndiceCyber({ depotDonnees }) {
+  return async ({ service }) => {
+    if (!service)
+      throw new Error(
+        "Impossible de sauvegarder l'indice cyber d'un service sans avoir ce service en paramètre."
+      );
+
+    const dernierIndiceCyber = await depotDonnees.lisDernierIndiceCyber(
+      service.id
+    );
+
+    const indiceCyber = service.indiceCyber();
+    const indiceCyberPersonnalise = service.indiceCyberPersonnalise();
+
+    const modificationIndiceCyber =
+      dernierIndiceCyber &&
+      indiceCyber.total.toFixed(2) !==
+        dernierIndiceCyber.indiceCyber.total.toFixed(2);
+    const modificationIndiceCyberPersonnalise =
+      dernierIndiceCyber &&
+      indiceCyberPersonnalise.total.toFixed(2) !==
+        dernierIndiceCyber.indiceCyberPersonnalise.total.toFixed(2);
+
+    if (
+      !dernierIndiceCyber ||
+      modificationIndiceCyber ||
+      modificationIndiceCyberPersonnalise
+    )
+      await depotDonnees.sauvegardeNouvelIndiceCyber({
+        idService: service.id,
+        indiceCyber,
+        indiceCyberPersonnalise,
+        mesuresParStatut: service.statistiquesMesures().totauxParCategorie(),
+      });
+  };
+}
+
+module.exports = { sauvegardeEvolutionIndiceCyber };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -82,6 +82,9 @@ const {
   consigneConnexionUtilisateurDansJournal,
 } = require('./abonnements/consigneConnexionUtilisateurDansJournal');
 const EvenementNouvelleConnexionUtilisateur = require('./evenementNouvelleConnexionUtilisateur');
+const {
+  sauvegardeEvolutionIndiceCyber,
+} = require('./abonnements/sauvegardeEvolutionIndiceCyber');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -122,6 +125,7 @@ const cableTousLesAbonnes = (
     }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
     consigneActiviteMesure({ depotDonnees }),
+    sauvegardeEvolutionIndiceCyber({ depotDonnees }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementMesureServiceSupprimee, [

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -10,6 +10,7 @@ const depotDonneesUtilisateurs = require('./depots/depotDonneesUtilisateurs');
 const depotDonneesNotifications = require('./depots/depotDonneesNotifications');
 const depotDonneesSuggestionsActions = require('./depots/depotDonneesSuggestionsActions');
 const depotDonneesActivitesMesure = require('./depots/depotDonneesActivitesMesure');
+const depotDonneesEvolutionsIndiceCyber = require('./depots/depotDonneesEvolutionsIndiceCyber');
 
 const {
   fabriqueAdaptateurChiffrement,
@@ -77,6 +78,11 @@ const creeDepot = (config = {}) => {
   const depotActivitesMesure = depotDonneesActivitesMesure.creeDepot({
     adaptateurPersistance,
   });
+
+  const depotEvolutionsIndiceCyber =
+    depotDonneesEvolutionsIndiceCyber.creeDepot({
+      adaptateurPersistance,
+    });
 
   const {
     ajouteDescriptionService,
@@ -155,6 +161,9 @@ const creeDepot = (config = {}) => {
 
   const { ajouteActiviteMesure, lisActivitesMesure } = depotActivitesMesure;
 
+  const { lisDernierIndiceCyber, sauvegardeNouvelIndiceCyber } =
+    depotEvolutionsIndiceCyber;
+
   return {
     accesAutorise,
     acquitteSuggestionAction,
@@ -177,6 +186,7 @@ const creeDepot = (config = {}) => {
     enregistreDossier,
     finaliseDossierCourant,
     lisActivitesMesure,
+    lisDernierIndiceCyber,
     lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
     marqueNouveauteLue,
@@ -195,6 +205,7 @@ const creeDepot = (config = {}) => {
     remplaceRisquesSpecifiquesDuService,
     sauvegardeAutorisation,
     sauvegardeParcoursUtilisateur,
+    sauvegardeNouvelIndiceCyber,
     enregistreNouvelleConnexionUtilisateur,
     sauvegardeNotificationsExpirationHomologation,
     supprimeContributeur,

--- a/src/depots/depotDonneesEvolutionsIndiceCyber.js
+++ b/src/depots/depotDonneesEvolutionsIndiceCyber.js
@@ -1,0 +1,27 @@
+const fabriqueAdaptateurPersistance = require('../adaptateurs/fabriqueAdaptateurPersistance');
+
+const creeDepot = (config = {}) => {
+  const {
+    adaptateurPersistance = fabriqueAdaptateurPersistance(process.env.NODE_ENV),
+  } = config;
+
+  const sauvegardeNouvelIndiceCyber = async ({
+    idService,
+    indiceCyber,
+    indiceCyberPersonnalise,
+    mesuresParStatut,
+  }) =>
+    adaptateurPersistance.sauvegardeNouvelIndiceCyber(
+      idService,
+      indiceCyber,
+      indiceCyberPersonnalise,
+      mesuresParStatut
+    );
+
+  const lisDernierIndiceCyber = async (idService) =>
+    adaptateurPersistance.lisDernierIndiceCyber(idService);
+
+  return { sauvegardeNouvelIndiceCyber, lisDernierIndiceCyber };
+};
+
+module.exports = { creeDepot };

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -54,7 +54,7 @@ class Mesures extends InformationsService {
 
   indiceCyberPersonnalise() {
     return new IndiceCyber(
-      this.statistiquesMesures().totauxParTypeEtParCategorie(),
+      this.statistiquesMesuresGeneralesEtSpecifiques().totauxParTypeEtParCategorie(),
       this.referentiel
     ).indiceCyber();
   }
@@ -152,7 +152,7 @@ class Mesures extends InformationsService {
     );
   }
 
-  statistiquesMesures() {
+  statistiquesMesuresGeneralesEtSpecifiques() {
     return new StatistiquesMesures(
       {
         mesuresGenerales: this.mesuresGenerales,

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -148,7 +148,8 @@ class Mesures extends InformationsService {
         mesuresGenerales: this.mesuresGenerales,
         mesuresPersonnalisees: this.mesuresPersonnalisees,
       },
-      this.referentiel
+      this.referentiel,
+      false
     );
   }
 

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -2,9 +2,7 @@ const InformationsService = require('./informationsService');
 const MesuresGenerales = require('./mesuresGenerales');
 const MesuresSpecifiques = require('./mesuresSpecifiques');
 const Referentiel = require('../referentiel');
-const {
-  StatistiquesMesuresGenerales,
-} = require('./statistiquesMesuresGenerales');
+const { StatistiquesMesures } = require('./statistiquesMesures');
 const { IndiceCyber } = require('./indiceCyber');
 const { CompletudeMesures } = require('./completudeMesures');
 
@@ -74,7 +72,7 @@ class Mesures extends InformationsService {
   }
 
   nombreTotalNonFait() {
-    const statistiquesAvecNonFait = new StatistiquesMesuresGenerales(
+    const statistiquesAvecNonFait = new StatistiquesMesures(
       {
         mesuresGenerales: this.mesuresGenerales,
         mesuresPersonnalisees: this.mesuresPersonnalisees,
@@ -145,7 +143,7 @@ class Mesures extends InformationsService {
   }
 
   statistiquesMesuresGenerales() {
-    return new StatistiquesMesuresGenerales(
+    return new StatistiquesMesures(
       {
         mesuresGenerales: this.mesuresGenerales,
         mesuresPersonnalisees: this.mesuresPersonnalisees,
@@ -155,7 +153,7 @@ class Mesures extends InformationsService {
   }
 
   statistiquesMesures() {
-    return new StatistiquesMesuresGenerales(
+    return new StatistiquesMesures(
       {
         mesuresGenerales: this.mesuresGenerales,
         mesuresPersonnalisees: this.mesuresPersonnalisees,

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -53,8 +53,11 @@ class Mesures extends InformationsService {
   }
 
   indiceCyberPersonnalise() {
+    const statistiquesSansLesNonPrisesEnCompte =
+      this.statistiquesMesuresGeneralesEtSpecifiques(true);
+
     return new IndiceCyber(
-      this.statistiquesMesuresGeneralesEtSpecifiques().totauxParTypeEtParCategorie(),
+      statistiquesSansLesNonPrisesEnCompte.totauxParTypeEtParCategorie(),
       this.referentiel
     ).indiceCyber();
   }
@@ -153,7 +156,7 @@ class Mesures extends InformationsService {
     );
   }
 
-  statistiquesMesuresGeneralesEtSpecifiques() {
+  statistiquesMesuresGeneralesEtSpecifiques(exclueMesuresNonPrisesEnCompte) {
     return new StatistiquesMesures(
       {
         mesuresGenerales: this.mesuresGenerales,
@@ -161,7 +164,7 @@ class Mesures extends InformationsService {
         mesuresSpecifiques: this.mesuresSpecifiques.items,
       },
       this.referentiel,
-      true
+      exclueMesuresNonPrisesEnCompte
     );
   }
 

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -269,8 +269,8 @@ class Service {
     return this.risques.risquesSpecifiques;
   }
 
-  statistiquesMesures() {
-    return this.mesures.statistiquesMesures();
+  statistiquesMesuresGeneralesEtSpecifiques() {
+    return this.mesures.statistiquesMesuresGeneralesEtSpecifiques();
   }
 
   statistiquesMesuresGenerales() {

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -269,8 +269,10 @@ class Service {
     return this.risques.risquesSpecifiques;
   }
 
-  statistiquesMesuresGeneralesEtSpecifiques() {
-    return this.mesures.statistiquesMesuresGeneralesEtSpecifiques();
+  statistiquesMesuresGeneralesEtSpecifiques(exclueMesuresNonPrisesEnCompte) {
+    return this.mesures.statistiquesMesuresGeneralesEtSpecifiques(
+      exclueMesuresNonPrisesEnCompte
+    );
   }
 
   statistiquesMesuresGenerales() {

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -18,7 +18,7 @@ const initialiseStatsParCategorie = (referentiel, complementaire) =>
     {}
   );
 
-class StatistiquesMesuresGenerales {
+class StatistiquesMesures {
   static valide({ mesuresPersonnalisees }, referentiel) {
     referentiel.verifieCategoriesMesuresSontRepertoriees(
       Object.values(mesuresPersonnalisees).map((m) => m.categorie)
@@ -30,7 +30,7 @@ class StatistiquesMesuresGenerales {
     referentiel,
     ignoreMesuresNonPrisesEnCompte = false
   ) {
-    StatistiquesMesuresGenerales.valide({ mesuresPersonnalisees }, referentiel);
+    StatistiquesMesures.valide({ mesuresPersonnalisees }, referentiel);
 
     this.parCategorie = initialiseStatsParCategorie(referentiel);
     const complementaires = () => ({ total: 0, restant: 0, aRemplir: 0 });
@@ -142,4 +142,4 @@ class StatistiquesMesuresGenerales {
   }
 }
 
-module.exports = { StatistiquesMesuresGenerales };
+module.exports = { StatistiquesMesures };

--- a/src/modeles/statistiquesMesures.js
+++ b/src/modeles/statistiquesMesures.js
@@ -28,7 +28,7 @@ class StatistiquesMesures {
   constructor(
     { mesuresGenerales, mesuresPersonnalisees, mesuresSpecifiques = [] },
     referentiel,
-    ignoreMesuresNonPrisesEnCompte = false
+    exclueMesuresNonPrisesEnCompte
   ) {
     StatistiquesMesures.valide({ mesuresPersonnalisees }, referentiel);
 
@@ -45,7 +45,7 @@ class StatistiquesMesures {
     };
 
     const filtreMesuresNonPriseEnCompte = (mesure) => {
-      if (ignoreMesuresNonPrisesEnCompte) {
+      if (exclueMesuresNonPrisesEnCompte) {
         return mesure.statut !== 'nonFait';
       }
       return true;

--- a/src/modeles/statistiquesMesuresGenerales.js
+++ b/src/modeles/statistiquesMesuresGenerales.js
@@ -136,6 +136,10 @@ class StatistiquesMesuresGenerales {
   totauxParTypeEtParCategorie() {
     return this.parTypeEtParCategorie;
   }
+
+  totauxParCategorie() {
+    return this.toutesCategories;
+  }
 }
 
 module.exports = { StatistiquesMesuresGenerales };

--- a/test/bus/abonnements/sauvegardeEvolutionIndiceCyber.spec.js
+++ b/test/bus/abonnements/sauvegardeEvolutionIndiceCyber.spec.js
@@ -18,7 +18,7 @@ describe("L'abonnement qui sauvegarde (en base de données) l'indice cyber d'un 
     };
     referentiel = Referentiel.creeReferentiel({
       categoriesMesures: { gouvernance: {} },
-      statutsMesures: { fait: {}, enCours: {} },
+      statutsMesures: { fait: {}, enCours: {}, nonFait: {} },
       mesures: { mesureA: {} },
       indiceCyber: { noteMax: 5 },
     });
@@ -58,19 +58,9 @@ describe("L'abonnement qui sauvegarde (en base de données) l'indice cyber d'un 
 
     expect(donneesRecues).to.eql({
       idService: '123',
-      indiceCyber: {
-        gouvernance: 2.5,
-        total: 2.5,
-      },
-      indiceCyberPersonnalise: {
-        gouvernance: 2.5,
-        total: 2.5,
-      },
-      mesuresParStatut: {
-        enCours: 0,
-        fait: 1,
-        sansStatut: 1,
-      },
+      indiceCyber: { gouvernance: 2.5, total: 2.5 },
+      indiceCyberPersonnalise: { gouvernance: 2.5, total: 2.5 },
+      mesuresParStatut: { enCours: 0, fait: 1, sansStatut: 1, nonFait: 0 },
     });
   });
 
@@ -81,12 +71,8 @@ describe("L'abonnement qui sauvegarde (en base de données) l'indice cyber d'un 
       depotDonnees.lisDernierIndiceCyber = async (idService) => {
         idServiceRecu = idService;
         return {
-          indiceCyber: {
-            total: 2.5,
-          },
-          indiceCyberPersonnalise: {
-            total: 2.5,
-          },
+          indiceCyber: { total: 2.5 },
+          indiceCyberPersonnalise: { total: 2.5 },
         };
       };
       depotDonnees.sauvegardeNouvelIndiceCyber = async () => {
@@ -104,12 +90,8 @@ describe("L'abonnement qui sauvegarde (en base de données) l'indice cyber d'un 
     it("enregistre si l'indice cyber est différent", async () => {
       let enregistrementAppele = false;
       depotDonnees.lisDernierIndiceCyber = async () => ({
-        indiceCyber: {
-          total: 2.0,
-        },
-        indiceCyberPersonnalise: {
-          total: 2.5,
-        },
+        indiceCyber: { total: 2.0 },
+        indiceCyberPersonnalise: { total: 2.5 },
       });
       depotDonnees.sauvegardeNouvelIndiceCyber = async () => {
         enregistrementAppele = true;
@@ -125,12 +107,8 @@ describe("L'abonnement qui sauvegarde (en base de données) l'indice cyber d'un 
     it("enregistre si l'indice cyber personnalisé est différent", async () => {
       let enregistrementAppele = false;
       depotDonnees.lisDernierIndiceCyber = async () => ({
-        indiceCyber: {
-          total: 2.5,
-        },
-        indiceCyberPersonnalise: {
-          total: 2.0,
-        },
+        indiceCyber: { total: 2.5 },
+        indiceCyberPersonnalise: { total: 2.0 },
       });
       depotDonnees.sauvegardeNouvelIndiceCyber = async () => {
         enregistrementAppele = true;
@@ -141,6 +119,29 @@ describe("L'abonnement qui sauvegarde (en base de données) l'indice cyber d'un 
       });
 
       expect(enregistrementAppele).to.be(true);
+    });
+
+    it("prend en compte les mesures 'nonFait' dans les statistiques sauvegardées", async () => {
+      // Ce test est rajouté car la première implémentation n'incluait pas les mesures 'nonFait' à tort
+      let statistiquesRecues;
+      depotDonnees.lisDernierIndiceCyber = async () => ({
+        indiceCyber: { total: 2.0 },
+        indiceCyberPersonnalise: { total: 2.5 },
+      });
+      depotDonnees.sauvegardeNouvelIndiceCyber = async (donnees) => {
+        statistiquesRecues = donnees.mesuresParStatut;
+      };
+
+      const uneNonFaite = new Mesures(
+        { mesuresGenerales: [{ id: 'mesureA', statut: 'nonFait' }] },
+        referentiel,
+        { mesureA: { categorie: 'gouvernance' } }
+      );
+      await sauvegardeEvolutionIndiceCyber({ depotDonnees })({
+        service: unService().avecId('123').avecMesures(uneNonFaite).construis(),
+      });
+
+      expect(statistiquesRecues.nonFait).to.be(1);
     });
   });
 });

--- a/test/bus/abonnements/sauvegardeEvolutionIndiceCyber.spec.js
+++ b/test/bus/abonnements/sauvegardeEvolutionIndiceCyber.spec.js
@@ -1,0 +1,146 @@
+const expect = require('expect.js');
+const {
+  sauvegardeEvolutionIndiceCyber,
+} = require('../../../src/bus/abonnements/sauvegardeEvolutionIndiceCyber');
+const { unService } = require('../../constructeurs/constructeurService');
+const Mesures = require('../../../src/modeles/mesures');
+const Referentiel = require('../../../src/referentiel');
+
+describe("L'abonnement qui sauvegarde (en base de données) l'indice cyber d'un service", () => {
+  let depotDonnees;
+  let referentiel;
+  let mesures;
+
+  beforeEach(() => {
+    depotDonnees = {
+      sauvegardeNouvelIndiceCyber: async () => {},
+      lisDernierIndiceCyber: async () => undefined,
+    };
+    referentiel = Referentiel.creeReferentiel({
+      categoriesMesures: { gouvernance: {} },
+      statutsMesures: { fait: {}, enCours: {} },
+      mesures: { mesureA: {} },
+      indiceCyber: { noteMax: 5 },
+    });
+    mesures = new Mesures(
+      { mesuresGenerales: [{ id: 'mesureA', statut: 'fait' }] },
+      referentiel,
+      {
+        mesureA: { categorie: 'gouvernance' },
+        mesureB: { categorie: 'gouvernance' },
+      }
+    );
+  });
+
+  it("lève une exception s'il ne reçoit pas le service", async () => {
+    try {
+      await sauvegardeEvolutionIndiceCyber({
+        depotDonnees,
+      })({ service: undefined });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de sauvegarder l'indice cyber d'un service sans avoir ce service en paramètre."
+      );
+    }
+  });
+
+  it("enregistre l'indice cyber si aucune valeur n'existe", async () => {
+    let donneesRecues = {};
+    depotDonnees.sauvegardeNouvelIndiceCyber = async (donnees) => {
+      donneesRecues = donnees;
+    };
+    depotDonnees.lisDerniereActiviteIndiceCyber = async () => undefined;
+
+    await sauvegardeEvolutionIndiceCyber({ depotDonnees })({
+      service: unService().avecId('123').avecMesures(mesures).construis(),
+    });
+
+    expect(donneesRecues).to.eql({
+      idService: '123',
+      indiceCyber: {
+        gouvernance: 2.5,
+        total: 2.5,
+      },
+      indiceCyberPersonnalise: {
+        gouvernance: 2.5,
+        total: 2.5,
+      },
+      mesuresParStatut: {
+        enCours: 0,
+        fait: 1,
+        sansStatut: 1,
+      },
+    });
+  });
+
+  describe('si une valeur existe déjà', () => {
+    it("n'enregistre pas si l'indice cyber ET l'indice cyber personnalisé sont les mêmes", async () => {
+      let enregistrementAppele = false;
+      let idServiceRecu;
+      depotDonnees.lisDernierIndiceCyber = async (idService) => {
+        idServiceRecu = idService;
+        return {
+          indiceCyber: {
+            total: 2.5,
+          },
+          indiceCyberPersonnalise: {
+            total: 2.5,
+          },
+        };
+      };
+      depotDonnees.sauvegardeNouvelIndiceCyber = async () => {
+        enregistrementAppele = true;
+      };
+
+      await sauvegardeEvolutionIndiceCyber({ depotDonnees })({
+        service: unService().avecId('123').avecMesures(mesures).construis(),
+      });
+
+      expect(idServiceRecu).to.be('123');
+      expect(enregistrementAppele).to.be(false);
+    });
+
+    it("enregistre si l'indice cyber est différent", async () => {
+      let enregistrementAppele = false;
+      depotDonnees.lisDernierIndiceCyber = async () => ({
+        indiceCyber: {
+          total: 2.0,
+        },
+        indiceCyberPersonnalise: {
+          total: 2.5,
+        },
+      });
+      depotDonnees.sauvegardeNouvelIndiceCyber = async () => {
+        enregistrementAppele = true;
+      };
+
+      await sauvegardeEvolutionIndiceCyber({ depotDonnees })({
+        service: unService().avecId('123').avecMesures(mesures).construis(),
+      });
+
+      expect(enregistrementAppele).to.be(true);
+    });
+
+    it("enregistre si l'indice cyber personnalisé est différent", async () => {
+      let enregistrementAppele = false;
+      depotDonnees.lisDernierIndiceCyber = async () => ({
+        indiceCyber: {
+          total: 2.5,
+        },
+        indiceCyberPersonnalise: {
+          total: 2.0,
+        },
+      });
+      depotDonnees.sauvegardeNouvelIndiceCyber = async () => {
+        enregistrementAppele = true;
+      };
+
+      await sauvegardeEvolutionIndiceCyber({ depotDonnees })({
+        service: unService().avecId('123').avecMesures(mesures).construis(),
+      });
+
+      expect(enregistrementAppele).to.be(true);
+    });
+  });
+});

--- a/test/constructeurs/constructeurStatistiquesMesures.js
+++ b/test/constructeurs/constructeurStatistiquesMesures.js
@@ -1,9 +1,9 @@
 const {
-  StatistiquesMesuresGenerales,
-} = require('../../src/modeles/statistiquesMesuresGenerales');
+  StatistiquesMesures,
+} = require('../../src/modeles/statistiquesMesures');
 const MesuresGenerales = require('../../src/modeles/mesuresGenerales');
 
-class ConstructeurStatistiquesMesuresGenerales {
+class ConstructeurStatistiquesMesures {
   constructor(referentiel) {
     this.donnees = {
       mesuresGenerales: [],
@@ -35,7 +35,7 @@ class ConstructeurStatistiquesMesuresGenerales {
   }
 
   construis() {
-    return new StatistiquesMesuresGenerales(
+    return new StatistiquesMesures(
       {
         mesuresGenerales: new MesuresGenerales(
           { mesuresGenerales: this.donnees.mesuresGenerales },
@@ -51,6 +51,6 @@ class ConstructeurStatistiquesMesuresGenerales {
 }
 
 const desStatistiques = (referentiel) =>
-  new ConstructeurStatistiquesMesuresGenerales(referentiel);
+  new ConstructeurStatistiquesMesures(referentiel);
 
 module.exports = { desStatistiques };

--- a/test/depots/depotDonneesEvolutionsIndiceCyber.spec.js
+++ b/test/depots/depotDonneesEvolutionsIndiceCyber.spec.js
@@ -1,0 +1,59 @@
+const expect = require('expect.js');
+const {
+  creeDepot,
+} = require('../../src/depots/depotDonneesEvolutionsIndiceCyber');
+
+describe("Le dépôt de données des évolutions d'indice cyber", () => {
+  let depotActivitesIndiceCyber;
+  let adaptateurPersistance;
+
+  beforeEach(() => {
+    adaptateurPersistance = {
+      lisDernierIndiceCyber: async () => {},
+      sauvegardeNouvelIndiceCyber: async () => {},
+    };
+    depotActivitesIndiceCyber = creeDepot({
+      adaptateurPersistance,
+    });
+  });
+
+  it("délègue à l'adaptateur persistance la lecture de la dernière activité d'indice cyber d'un service", async () => {
+    let idRecu;
+    adaptateurPersistance.lisDernierIndiceCyber = async (idService) => {
+      idRecu = idService;
+    };
+
+    await depotActivitesIndiceCyber.lisDernierIndiceCyber('S1');
+
+    expect(idRecu).to.be('S1');
+  });
+
+  it("délègue à l'adaptateur persistance la sauvegarde d'une activité d'indice cyber d'un service", async () => {
+    let donneesRecues;
+    adaptateurPersistance.sauvegardeNouvelIndiceCyber = async (
+      idService,
+      indiceCyber,
+      indiceCyberPersonnalise,
+      mesuresParStatut
+    ) => {
+      donneesRecues = {
+        idService,
+        indiceCyber,
+        indiceCyberPersonnalise,
+        mesuresParStatut,
+      };
+    };
+
+    await depotActivitesIndiceCyber.sauvegardeNouvelIndiceCyber({
+      idService: '123',
+      indiceCyber: { total: 1.0 },
+      indiceCyberPersonnalise: { total: 2.0 },
+      mesuresParStatut: { fait: 2 },
+    });
+
+    expect(donneesRecues.idService).to.be('123');
+    expect(donneesRecues.indiceCyber.total).to.be(1.0);
+    expect(donneesRecues.indiceCyberPersonnalise.total).to.be(2.0);
+    expect(donneesRecues.mesuresParStatut).to.eql({ fait: 2 });
+  });
+});

--- a/test/modeles/completudeMesures.spec.js
+++ b/test/modeles/completudeMesures.spec.js
@@ -2,7 +2,7 @@ const expect = require('expect.js');
 const { CompletudeMesures } = require('../../src/modeles/completudeMesures');
 const {
   desStatistiques,
-} = require('../constructeurs/constructeurStatistiquesMesuresGenerales');
+} = require('../constructeurs/constructeurStatistiquesMesures');
 const Referentiel = require('../../src/referentiel');
 const MesuresSpecifiques = require('../../src/modeles/mesuresSpecifiques');
 

--- a/test/modeles/indiceCyber.spec.js
+++ b/test/modeles/indiceCyber.spec.js
@@ -3,7 +3,7 @@ const expect = require('expect.js');
 const Referentiel = require('../../src/referentiel');
 const {
   desStatistiques,
-} = require('../constructeurs/constructeurStatistiquesMesuresGenerales');
+} = require('../constructeurs/constructeurStatistiquesMesures');
 const { IndiceCyber } = require('../../src/modeles/indiceCyber');
 
 describe("L'indice cyber", () => {

--- a/test/modeles/statistiquesMesuresGenerales.spec.js
+++ b/test/modeles/statistiquesMesuresGenerales.spec.js
@@ -4,7 +4,7 @@ const Referentiel = require('../../src/referentiel');
 const { ErreurCategorieInconnue } = require('../../src/erreurs');
 const {
   desStatistiques,
-} = require('../constructeurs/constructeurStatistiquesMesuresGenerales');
+} = require('../constructeurs/constructeurStatistiquesMesures');
 
 describe('Les statistiques des mesures générales', () => {
   it('vérifient que les catégories sont présentes dans le référentiel', () => {


### PR DESCRIPTION
Afin de préparer l'ajout d'un graphique du suivi de l'évolution de l'indice cyber, on souhaite commencer à historiser les modifications.

Ces modifications interviennent sur l'**indice cyber** et l'**indice cyber personnalisé**.
La comparaison est faite "2 chiffres après la virgule"