### PR TITLE
[AGENT CONNECT] Supprime l'utilisateur authentifié au début du parcours de connexion

### DIFF
--- a/src/mss.js
+++ b/src/mss.js
@@ -116,6 +116,7 @@ const creeServeur = (
     routesNonConnecteOidc({
       adaptateurOidc,
       depotDonnees,
+      middleware,
     })
   );
   app.use(

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -1,28 +1,36 @@
 const express = require('express');
 const SourceAuthentification = require('../../modeles/sourceAuthentification');
 
-const routesNonConnecteOidc = ({ adaptateurOidc, depotDonnees }) => {
+const routesNonConnecteOidc = ({
+  adaptateurOidc,
+  depotDonnees,
+  middleware,
+}) => {
   const routes = express.Router();
 
-  routes.get('/connexion', async (_requete, reponse, suite) => {
-    try {
-      const { url, state, nonce } =
-        await adaptateurOidc.genereDemandeAutorisation();
-      reponse.cookie(
-        'AgentConnectInfo',
-        { state, nonce },
-        {
-          maxAge: 30_000,
-          httpOnly: true,
-          sameSite: 'none',
-          secure: true,
-        }
-      );
-      reponse.redirect(url);
-    } catch (e) {
-      suite(e);
+  routes.get(
+    '/connexion',
+    middleware.suppressionCookie,
+    async (_requete, reponse, suite) => {
+      try {
+        const { url, state, nonce } =
+          await adaptateurOidc.genereDemandeAutorisation();
+        reponse.cookie(
+          'AgentConnectInfo',
+          { state, nonce },
+          {
+            maxAge: 30_000,
+            httpOnly: true,
+            sameSite: 'none',
+            secure: true,
+          }
+        );
+        reponse.redirect(url);
+      } catch (e) {
+        suite(e);
+      }
     }
-  });
+  );
 
   routes.get('/apres-authentification', async (requete, reponse) => {
     try {

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -30,6 +30,15 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
       });
     });
 
+    it("déconnecte l'utilisateur courant", (done) => {
+      testeur
+        .middleware()
+        .verifieRequeteExigeSuppressionCookie(
+          'http://localhost:1234/oidc/connexion',
+          done
+        );
+    });
+
     it('redirige vers la page d’autorisation', async () => {
       const reponse = await requeteSansRedirection(
         'http://localhost:1234/oidc/connexion'


### PR DESCRIPTION
pour éviter de se retrouver à s'inscrire avec un utilisateur Agent Connect en étant connecté avec un autre utilisateur (cas rare, mais possible pour plusieurs utilisateurs sur un même ordinateur).