### PR TITLE
[AGENT CONNECT] Redirige vers l'url demandée intialement après connexion

### DIFF
--- a/public/apresAuthentification.js
+++ b/public/apresAuthentification.js
@@ -1,3 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  window.location = '/tableauDeBord';
+  const { urlRedirection } = JSON.parse(
+    document.getElementById('url-redirection').innerText
+  );
+  window.location = urlRedirection ?? '/tableauDeBord';
 });

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -19,7 +19,7 @@ const routesNonConnecteOidc = ({
           'AgentConnectInfo',
           { state, nonce },
           {
-            maxAge: 30_000,
+            maxAge: 120_000,
             httpOnly: true,
             sameSite: 'none',
             secure: true,

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const SourceAuthentification = require('../../modeles/sourceAuthentification');
+const { estUrlLegalePourRedirection } = require('../../http/redirection');
 
 const routesNonConnecteOidc = ({
   adaptateurOidc,
@@ -11,13 +12,18 @@ const routesNonConnecteOidc = ({
   routes.get(
     '/connexion',
     middleware.suppressionCookie,
-    async (_requete, reponse, suite) => {
+    async (requete, reponse, suite) => {
       try {
         const { url, state, nonce } =
           await adaptateurOidc.genereDemandeAutorisation();
+
+        const { urlRedirection } = requete.query;
+        const urlValide =
+          urlRedirection && estUrlLegalePourRedirection(urlRedirection);
+
         reponse.cookie(
           'AgentConnectInfo',
-          { state, nonce },
+          { state, nonce, ...(urlValide && { urlRedirection }) },
           {
             maxAge: 120_000,
             httpOnly: true,

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -42,6 +42,7 @@ const routesNonConnecteOidc = ({
     try {
       const { idToken, accessToken } =
         await adaptateurOidc.recupereJeton(requete);
+      const { urlRedirection } = requete.cookies.AgentConnectInfo;
 
       reponse.clearCookie('AgentConnectInfo');
 
@@ -61,7 +62,7 @@ const routesNonConnecteOidc = ({
           utilisateurExistant.id,
           SourceAuthentification.AGENT_CONNECT
         );
-        reponse.render('apresAuthentification');
+        reponse.render('apresAuthentification', { urlRedirection });
       } else {
         const { nom, prenom, email, siret } = informationsUtilisateur;
         const params = new URLSearchParams({

--- a/src/vues/apresAuthentification.pug
+++ b/src/vues/apresAuthentification.pug
@@ -6,3 +6,6 @@ html(lang = 'fr')
     title MonServiceSécurisé | Redirection aprés authentification
 
     script(type = 'module', src = '/statique/apresAuthentification.js')
+
+    script(id = 'url-redirection', type = 'application/json').
+      !{JSON.stringify({urlRedirection: urlRedirection})}

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -53,6 +53,28 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
       expect(cookie).to.contain('unState');
       expect(cookie).to.contain('unNonce');
     });
+
+    it("ajoute l'url de redirection au cookie si elle est présente dans la query", async () => {
+      const reponse = await requeteSansRedirection(
+        'http://localhost:1234/oidc/connexion?urlRedirection=%2FtableauDeBord'
+      );
+
+      const headerCookie = reponse.headers['set-cookie'];
+      const cookie = enObjet(headerCookie[0]).AgentConnectInfo;
+
+      expect(cookie).to.contain('tableauDeBord');
+    });
+
+    it("n'ajoute pas l'url de redirection au cookie si elle est présente dans la query mais illégale (dangereuse)", async () => {
+      const reponse = await requeteSansRedirection(
+        'http://localhost:1234/oidc/connexion?urlRedirection=https%3A%2F%2Funautresite.com'
+      );
+
+      const headerCookie = reponse.headers['set-cookie'];
+      const cookie = enObjet(headerCookie[0]).AgentConnectInfo;
+
+      expect(cookie).not.to.contain('unautresite');
+    });
   });
 
   describe('quand requête GET sur `/oidc/apres-authentification`', () => {

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -91,6 +91,13 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
       testeur.depotDonnees().utilisateurAvecEmail = (email) =>
         email === 'unEmailInconnu' ? undefined : utilisateur;
       testeur.depotDonnees().enregistreNouvelleConnexionUtilisateur = () => {};
+      testeur.middleware().reinitialise({
+        fonctionDeposeCookieAAppeler: (requete) =>
+          (requete.cookies.AgentConnectInfo = {
+            state: 'unState',
+            nonce: 'unNonce',
+          }),
+      });
     });
 
     it('sert une page HTML', async () => {


### PR DESCRIPTION
En ajoutant cette information dans le cookie temporaire d'Agent Connect.
Il faudra penser à mettre l'url demandée en query sur le bouton Agent Connect (elle sera dans l'url de /connexion)