### PR TITLE
[COMMENTAIRES] Ajoute une route permettant de sauvegarder une activité de mesure `ajoutCommentaire`

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -261,8 +261,26 @@ const nouvelAdaptateur = (
       (a) => a.idService === idService && a.idMesure === idMesure
     );
 
+  const ajouteActiviteMesure = (
+    idActeur,
+    idService,
+    idMesure,
+    type,
+    typeMesure,
+    details
+  ) =>
+    donnees.activitesMesure.push({
+      idActeur,
+      idService,
+      idMesure,
+      type,
+      typeMesure,
+      details,
+    });
+
   return {
     activitesMesure,
+    ajouteActiviteMesure,
     ajouteAutorisation,
     ajouteSuggestionAction,
     ajouteTacheDeService,


### PR DESCRIPTION
On représente les commentaires de mesure sous la forme d'un type d'activité de mesure.