### PR TITLE
Limite la création de workflow "déploiement en env de DEV" au déclenchement manuel

### DIFF
--- a/.github/workflows/deploiement-dev.yml
+++ b/.github/workflows/deploiement-dev.yml
@@ -1,8 +1,6 @@
 name: Déploiement vers un environnement de DEV
 
 on:
-  pull_request:
-    branches: [master]
   workflow_dispatch: # Pour activer le déclenchement manuel
 
 jobs:


### PR DESCRIPTION
Plutôt que de créer un workflow par PR