### PR TITLE
Empêche que l'appui sur `Entrée` dans la sélection de mention publie le commentaire

### DIFF
--- a/svelte/lib/mesure/commentaire/CommentaireMesure.svelte
+++ b/svelte/lib/mesure/commentaire/CommentaireMesure.svelte
@@ -25,6 +25,7 @@
         handleKeyDown: (vue, evenement) => {
           if (
             evenement.key === 'Enter' &&
+            !vue.state.mention$.active &&
             !evenement.shiftKey &&
             !evenement.altKey &&
             !evenement.ctrlKey


### PR DESCRIPTION
(commit oublié sur la précédente branche)