### PR TITLE
[CORRECTION] Ajoute un `nonce` sur la visite guidée de la page SÉCURISER

### DIFF
--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -87,6 +87,7 @@ const routesConnectePage = ({
 
   routes.get(
     '/visiteGuidee/:idEtape',
+    middleware.positionneHeadersAvecNonce,
     middleware.verificationAcceptationCGU,
     middleware.chargePreferencesUtilisateur,
     middleware.chargeEtatVisiteGuidee,


### PR DESCRIPTION
... car la librairie `tiptap` permettant de faire les commentaires à besoin d'un nonce pour fonctionner.