### PR TITLE
[INFRASTRUTURE] Utilise un `pool` minimum de 0

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -2,14 +2,14 @@ module.exports = {
   development: {
     client: 'pg',
     connection: process.env.URL_SERVEUR_BASE_DONNEES,
-    pool: { min: 2, max: 10 },
+    pool: { min: 0, max: 10 },
     migrations: { tableName: 'knex_migrations' },
   },
 
   production: {
     client: 'pg',
     connection: process.env.URL_SERVEUR_BASE_DONNEES,
-    pool: { min: 2, max: 10 },
+    pool: { min: 0, max: 10 },
     migrations: { tableName: 'knex_migrations' },
   },
 };


### PR DESCRIPTION
... pour éviter les `stales connexions`, suite à la migration vers CleverCloud.