### PR TITLE
[CORRECTION] Utilise un `pool` minimum de 0 pour le journal

### DIFF
--- a/src/adaptateurs/adaptateurJournalMSSPostgres.js
+++ b/src/adaptateurs/adaptateurJournalMSSPostgres.js
@@ -4,7 +4,7 @@ const uuid = require('uuid');
 const config = {
   client: 'pg',
   connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
-  pool: { min: 2, max: 10 },
+  pool: { min: 0, max: 10 },
 };
 
 const nouvelAdaptateur = () => {


### PR DESCRIPTION
... pour éviter les `stales connexions`, suite à la migration vers CleverCloud.
Le journal avait été oublié lors de la précédente PR.