### PR TITLE
[CORRECTION] Supprime le sélecteur CSS superflu

### DIFF
--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -936,7 +936,7 @@ p {
   width: 11px;
 }
 
-.synthese-securite .tampon-homologation {
+.tampon-homologation {
   width: calc(288px - 32px);
   margin: -8px;
   padding: 16px;


### PR DESCRIPTION
Il a été rajouté par faute d'inattention, on l'enlève.

Avec le bug, l'encart a un fond transparent. Par exemple ça peut ressembler à 👇 

![image](https://github.com/user-attachments/assets/d1140192-f837-42bc-8a16-9ea9e809125b)

L'attendu est 👇 

![image](https://github.com/user-attachments/assets/e06f48de-cf79-47ff-9c5f-16779f2420f8)
