### PR TITLE
[CORRECTION] N'effectue pas d'appel API pour compléter les informations de l'entité

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -231,7 +231,7 @@ const creeDepot = (config = {}) => {
 
   const metsAJourUtilisateur = async (id, donnees) => {
     delete donnees.motDePasse;
-    if (donnees.entite)
+    if (donnees.entite && donnees.entite.siret)
       donnees.entite = await Entite.completeDonnees(
         donnees.entite,
         adaptateurRechercheEntite

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -228,6 +228,23 @@ describe('Le dépôt de données des utilisateurs', () => {
       expect(utilisateur.entite.nom).to.equal('MonEntite');
     });
 
+    it("ne complète pas les informations de l'entité si le siret est manquant", async () => {
+      let adaptateurAppele = false;
+      adaptateurRechercheEntite.rechercheOrganisations = async () => {
+        adaptateurAppele = true;
+        return [{ nom: 'MonEntite', departement: '75', siret: '12345' }];
+      };
+
+      await depot.metsAJourUtilisateur(
+        '123',
+        unUtilisateur()
+          .avecId('123')
+          .quiTravaillePourUneEntiteAvecSiret(undefined).donnees
+      );
+
+      expect(adaptateurAppele).to.be(false);
+    });
+
     it('ignore les demandes de changement de mot de passe', async () => {
       await depot.metsAJourMotDePasse('123', 'mdp_12345');
       await depot.metsAJourUtilisateur('123', {


### PR DESCRIPTION
… si l'utilisateur se connectant via AgentConnect n'a pas de siret.