### PR TITLE
Corrige l’affichage de la flèche sur la sélection du domaine

### DIFF
--- a/svelte/lib/inscription/SelectionDomaineSpecialite.svelte
+++ b/svelte/lib/inscription/SelectionDomaineSpecialite.svelte
@@ -55,7 +55,7 @@
     parDessusDeclencheur={true}
     classePersonnalisee="selection-domaine"
   >
-    <div slot="declencheur">
+    <div slot="declencheur" class="avec-fleche">
       <input
         type="text"
         role="button"
@@ -122,7 +122,7 @@
     color: black;
   }
 
-  .bouton::after {
+  .avec-fleche::after {
     content: '';
     display: inline-block;
 


### PR DESCRIPTION
... car elle avait disparu lorsque nous avons transformé le bouton en champ texte. Un input ne peut en effet pas avoir de `::after` en CSS. 