### PR TITLE
Renomme le champ `description` des risques en `intitulé`

### DIFF
--- a/migrations/20240930142255_migreChampsRisquesSpecifiques.js
+++ b/migrations/20240930142255_migreChampsRisquesSpecifiques.js
@@ -1,0 +1,42 @@
+exports.up = (knex) =>
+  knex('services').then((lignes) => {
+    const misesAJour = lignes.map(({ id: idService, donnees }) => {
+      const donneesModifiees = {
+        ...donnees,
+        risquesSpecifiques: donnees.risquesSpecifiques?.map(
+          ({ id, niveauGravite, description, commentaire }) => ({
+            id,
+            niveauGravite,
+            intitule: description,
+            description: '',
+            commentaire,
+          })
+        ),
+      };
+      return knex('services').where({ id: idService }).update({
+        donnees: donneesModifiees,
+      });
+    });
+    return Promise.all(misesAJour);
+  });
+
+exports.down = (knex) =>
+  knex('services').then((lignes) => {
+    const misesAJour = lignes.map(({ id: idService, donnees }) => {
+      const donneesModifiees = {
+        ...donnees,
+        risquesSpecifiques: donnees.risquesSpecifiques?.map(
+          ({ id, intitule, niveauGravite, commentaire }) => ({
+            id,
+            niveauGravite,
+            description: intitule,
+            commentaire,
+          })
+        ),
+      };
+      return knex('services').where({ id: idService }).update({
+        donnees: donneesModifiees,
+      });
+    });
+    return Promise.all(misesAJour);
+  });

--- a/public/modules/elementsDom/saisieRisqueSpecifique.js
+++ b/public/modules/elementsDom/saisieRisqueSpecifique.js
@@ -72,7 +72,11 @@ const $saisieRisqueSpecifique = (
   donnees = {},
   lectureSeule = false
 ) => {
-  const { description = '', niveauGravite = '', commentaire = '' } = donnees;
+  const {
+    intitule: description = '',
+    niveauGravite = '',
+    commentaire = '',
+  } = donnees;
 
   const $conteneur = $(
     '<div class="saisie-risque-specifique"><div class="synthese"></div></div>'

--- a/src/modeles/risqueGeneral.js
+++ b/src/modeles/risqueGeneral.js
@@ -14,14 +14,14 @@ class RisqueGeneral extends Risque {
     this.referentiel = referentiel;
   }
 
-  descriptionRisque() {
+  intituleRisque() {
     return this.referentiel.descriptionRisque(this.id);
   }
 
   toJSON() {
     return {
       ...super.toJSON(),
-      description: this.descriptionRisque(),
+      intitule: this.intituleRisque(),
     };
   }
 

--- a/src/modeles/risqueSpecifique.js
+++ b/src/modeles/risqueSpecifique.js
@@ -4,12 +4,13 @@ class RisqueSpecifique extends Risque {
   constructor(donneesRisque, referentiel) {
     super(donneesRisque, referentiel);
 
-    this.proprietesAtomiquesRequises.push('description');
+    this.proprietesAtomiquesRequises.push('intitule');
+    this.proprietesAtomiquesFacultatives.push('description');
     this.renseigneProprietes(donneesRisque);
   }
 
-  descriptionRisque() {
-    return this.description;
+  intituleRisque() {
+    return this.intitule;
   }
 }
 

--- a/src/pdf/modeles/annexeRisques.pug
+++ b/src/pdf/modeles/annexeRisques.pug
@@ -19,7 +19,7 @@ block page
                 +niveau-criticite(niveau.identifiant)
                 p.niveau= niveau.description
               .contenu-risque
-                p.description!= risque.description
+                p.description!= risque.intitule
                 if referentiel.definitionRisque(risque.id)
                   p.definition= referentiel.definitionRisque(risque.id)
                 if risque.commentaire

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -473,12 +473,19 @@ const routesConnecteApiService = ({
 
         ajouts
           .then(() => {
-            const aPersister = risquesSpecifiques.filter(
+            const ceuxAPersister = risquesSpecifiques.filter(
               (r) => r?.description || r?.commentaire || r?.niveauGravite
+            );
+            const donneesRisquesSpecifiques = ceuxAPersister.map(
+              ({ description, commentaire, niveauGravite }) => ({
+                intitule: description,
+                commentaire,
+                niveauGravite,
+              })
             );
             const listeRisquesSpecifiques = new RisquesSpecifiques(
               {
-                risquesSpecifiques: aPersister,
+                risquesSpecifiques: donneesRisquesSpecifiques,
               },
               referentiel
             );

--- a/test/modeles/objetsPDF/objetPDFAnnexeRisques.spec.js
+++ b/test/modeles/objetsPDF/objetPDFAnnexeRisques.spec.js
@@ -101,7 +101,7 @@ describe("L'objet PDF des descriptions des risques", () => {
     expect(donnees).to.have.key('risquesParNiveauGravite');
     expect(donnees.risquesParNiveauGravite).to.have.key('grave');
     expect(donnees.risquesParNiveauGravite.grave.length).to.equal(1);
-    expect(donnees.risquesParNiveauGravite.grave[0].description).to.equal(
+    expect(donnees.risquesParNiveauGravite.grave[0].intitule).to.equal(
       'Une description'
     );
   });

--- a/test/modeles/risqueGeneral.spec.js
+++ b/test/modeles/risqueGeneral.spec.js
@@ -17,7 +17,7 @@ describe('Un risque général', () => {
 
   it('retourne un JSON avec incluant la description du risque', () => {
     const risque = new RisqueGeneral({ id: 'unRisque' }, referentiel);
-    expect(risque.toJSON().description).to.equal('Une description');
+    expect(risque.toJSON().intitule).to.equal('Une description');
   });
 
   it('sait se décrire', () => {
@@ -36,24 +36,24 @@ describe('Un risque général', () => {
     expect(risque.toJSON()).to.eql({
       id: 'unRisque',
       commentaire: 'Un commentaire',
-      description: 'Une description',
+      intitule: 'Une description',
       niveauGravite: 'unNiveau',
     });
   });
 
-  it('connaît sa description', () => {
+  it('connaît son intitulé', () => {
     referentiel.recharge({
       risques: { unRisque: { description: 'Une description' } },
     });
     const risque = new RisqueGeneral({ id: 'unRisque' }, referentiel);
-    expect(risque.descriptionRisque()).to.equal('Une description');
+    expect(risque.intituleRisque()).to.equal('Une description');
   });
 
   it('retourne un JSON partiel si certaines informations sont inexistantes', () => {
     const risque = new RisqueGeneral({ id: 'unRisque' }, referentiel);
     expect(risque.toJSON()).to.eql({
       id: 'unRisque',
-      description: 'Une description',
+      intitule: 'Une description',
     });
   });
 

--- a/test/modeles/risqueSpecifique.spec.js
+++ b/test/modeles/risqueSpecifique.spec.js
@@ -17,6 +17,7 @@ describe('Un risque spécifique', () => {
   it('sait se décrire', () => {
     const risque = new RisqueSpecifique(
       {
+        intitule: 'Un intitulé',
         description: 'Un risque',
         commentaire: 'Un commentaire',
         niveauGravite: 'unNiveau',
@@ -24,14 +25,15 @@ describe('Un risque spécifique', () => {
       referentiel
     );
 
+    expect(risque.intitule).to.equal('Un intitulé');
     expect(risque.description).to.equal('Un risque');
     expect(risque.commentaire).to.equal('Un commentaire');
     expect(risque.niveauGravite).to.equal('unNiveau');
   });
 
-  it("expose sa description en cohérence avec l'API des classes sœurs", () => {
-    const risque = new RisqueSpecifique({ description: 'Un risque' });
-    expect(risque.descriptionRisque()).to.equal('Un risque');
+  it("expose son intitulé en cohérence avec l'API des classes sœurs", () => {
+    const risque = new RisqueSpecifique({ intitule: 'Un risque' });
+    expect(risque.intituleRisque()).to.equal('Un risque');
   });
 
   it('vérifie que le niveau de gravité est bien répertorié', (done) => {

--- a/test/modeles/risques.spec.js
+++ b/test/modeles/risques.spec.js
@@ -36,7 +36,7 @@ describe('Les risques liés à un service', () => {
             risquesSpecifiques: [
               {
                 id: 'RS1',
-                description: 'Un risque spécifique',
+                intitule: 'Un risque spécifique',
                 niveauGravite: 'grave',
               },
             ],

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -1168,17 +1168,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       expect(reponse.data).to.eql({ idService: '456' });
     });
 
-    it("demande au dépôt d'associer les risques spécifiques au service", async () => {
-      let risquesRemplaces = false;
+    it("[TEMPORAIRE migration vers risques v2] demande au dépôt d'associer les risques spécifiques au service en positionnant la valeur reçue en description comme intitule", async () => {
+      let risquesRecus;
+      let idServiceRecu;
       testeur.depotDonnees().remplaceRisquesSpecifiquesDuService = async (
         idService,
         risques
       ) => {
-        expect(idService).to.equal('456');
-        expect(risques.nombre()).to.equal(1);
-        expect(risques.item(0).description).to.equal('Un risque spécifique');
-        expect(risques.item(0).commentaire).to.equal('Un commentaire');
-        risquesRemplaces = true;
+        idServiceRecu = idService;
+        risquesRecus = risques;
       };
 
       await axios.post('http://localhost:1234/api/service/456/risques', {
@@ -1190,7 +1188,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         ],
       });
 
-      expect(risquesRemplaces).to.be(true);
+      expect(idServiceRecu).to.equal('456');
+      expect(risquesRecus.nombre()).to.equal(1);
+      expect(risquesRecus.item(0).intitule).to.equal('Un risque spécifique');
+      expect(risquesRecus.item(0).commentaire).to.equal('Un commentaire');
     });
 
     it('filtre les risques spécifiques vides', async () => {


### PR DESCRIPTION
en gardant la route actuelle iso (elle disparaîtra au profit de la nouvelle page)