### PR TITLE
Redirige vers le tableau de bord après la création du compte

### DIFF
--- a/svelte/lib/inscription/Inscription.svelte
+++ b/svelte/lib/inscription/Inscription.svelte
@@ -38,9 +38,10 @@
       etapeCourante++;
     }
   };
-  const valide = () => {
+  const valide = async () => {
     if (formulaireCourant.estValide()) {
-      axios.post('/api/utilisateur', formulaireInscription);
+      await axios.post('/api/utilisateur', formulaireInscription);
+      window.location.href = '/tableauDeBord';
     }
   };
 


### PR DESCRIPTION
Il n’est plus utile de demander une activation du compte, ni une saisie de mot de passe. On arrive donc directement sur le tableau de bord. 