### PR TITLE
Ne loggue pas d'erreur si le cookie AgentConnectInfo n'est pas défini

### DIFF
--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -43,6 +43,10 @@ const routesNonConnecteOidc = ({
   );
 
   routes.get('/apres-authentification', async (requete, reponse) => {
+    if (!requete.cookies.AgentConnectInfo) {
+      reponse.status(401).send("Erreur d'authentification");
+      return;
+    }
     try {
       const { idToken, accessToken } =
         await adaptateurOidc.recupereJeton(requete);


### PR DESCRIPTION
...car il s'agit probablement juste d'un utilisateur qui a mis trop de temps à finir de s'authentifier