### PR TITLE
Ajout d'un ID à la balise vidéo pour un lien direct

### DIFF
--- a/src/vues/home.pug
+++ b/src/vues/home.pug
@@ -85,7 +85,7 @@ block main
     .bloc-contenu
       h3.alignement-gauche.moyenne-marge-basse.couleur-principale-foncee Découvrez MonServiceSécurisé en vidéo
       .conteneur-video
-        video(src="https://monservicesecurise-ressources.cellar-c2.services.clever-cloud.com/Video_MonServiceSecurise_Thumbnail.mp4" controls)
+        video#video-presentation(src="https://monservicesecurise-ressources.cellar-c2.services.clever-cloud.com/Video_MonServiceSecurise_Thumbnail.mp4" controls)
     .bloc-contenu.bloc-etroit.fond-couleur-principale
       .conteneur-flex-photos-equipe
         .conteneur-photos-equipe.petite-marge-basse


### PR DESCRIPTION
Cette modification ajoute l'ID "video-presentation" à la balise <video> dans le fichier home.pug. Cela permet de créer un lien qui dirige directement les utilisateurs vers la vidéo de présentation sur la page d'accueil.