### PR TITLE
[CORRECTION] Empêche le cache sur la route `/api/sante`

### DIFF
--- a/src/routes/nonConnecte/routesNonConnecteApi.js
+++ b/src/routes/nonConnecte/routesNonConnecteApi.js
@@ -195,6 +195,12 @@ const routesNonConnecteApi = ({
     async (_requete, reponse) => {
       try {
         await depotDonnees.santeDuDepot();
+        reponse.setHeader('Surrogate-Control', 'no-store');
+        reponse.setHeader(
+          'Cache-Control',
+          'no-store, no-cache, must-revalidate, proxy-revalidate'
+        );
+        reponse.setHeader('Expires', '0');
         reponse.sendStatus(200);
       } catch (e) {
         adaptateurGestionErreur.logueErreur(

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -713,5 +713,17 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         );
       }
     });
+
+    it('empêche le cache', async () => {
+      testeur.depotDonnees().santeDuDepot = () => {};
+
+      const reponse = await axios.get('http://localhost:1234/api/sante');
+
+      expect(reponse.headers['surrogate-control']).to.be('no-store');
+      expect(reponse.headers['cache-control']).to.be(
+        'no-store, no-cache, must-revalidate, proxy-revalidate'
+      );
+      expect(reponse.headers.expires).to.be('0');
+    });
   });
 });


### PR DESCRIPTION
... car sinon le robot de contrôle de santé reçoit des codes '302'.