### PR TITLE
[CORRECTION] Extrais correctement la `dateCreation` de l'adaptateur Persistance

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -40,6 +40,7 @@ function fabriquePersistance({
       ...donneesEnClair,
       id: donneesUtilisateur.id,
       idResetMotDePasse: donneesUtilisateur.idResetMotDePasse,
+      dateCreation: donneesUtilisateur.dateCreation,
     };
   };
 

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -469,8 +469,8 @@ describe('Le dépôt de données des utilisateurs', () => {
               nom: 'Dupont',
               email: 'jean.dupont@mail.fr',
               motDePasse: 'XXX',
-              dateCreation: date,
             },
+            dateCreation: date,
           },
         ],
       }


### PR DESCRIPTION
... afin de la provisionner au modèle `Utilisateur`.
Cet oubli date sûrement de la mise en place du chiffrement.