### PR TITLE
Règle un problème des erreurs CSRF

### DIFF
--- a/public/mssConnecte.js
+++ b/public/mssConnecte.js
@@ -32,10 +32,9 @@ $(() => {
   axios
     .get('/api/dureeSession')
     .then((reponse) => {
-      const duree = parseInt(reponse.data.dureeSession, 10);
-      if (!duree) {
-        return Promise.reject();
-      }
+      const duree = reponse.data.dureeSession
+        ? parseInt(reponse.data.dureeSession, 10)
+        : 0;
       return lanceDecompteDeconnexion(duree);
     })
     /* eslint-disable no-console */


### PR DESCRIPTION
Cette modification permet d’afficher la modale de reconnexion lorsque le DOM est remonté suite à un redémarrage du navigateur. La requête "dureeSession" retournait la page de connexion, ce qui était ignoré jusqu’à présent et la modale n’était pas affichée.