### PR TITLE
Affiche une alerte pour les risques specifiques à mettre à jour

### DIFF
--- a/svelte/lib/risques/LigneRisque.svelte
+++ b/svelte/lib/risques/LigneRisque.svelte
@@ -9,7 +9,7 @@
   import { Referentiel } from '../ui/types.d';
   import { createEventDispatcher } from 'svelte';
   import SelectionGravite from './SelectionGravite.svelte';
-  import { intituleRisque } from './risques';
+  import { intituleRisque, risqueAMettreAJour } from './risques';
   import SelectionVraisemblance from './SelectionVraisemblance.svelte';
 
   export let categories: ReferentielCategories;
@@ -19,8 +19,7 @@
 
   export let risque: Risque;
 
-  $: estSpecifiqueAMettreAJour =
-    risque.type === 'SPECIFIQUE' && !risque.categories.length;
+  $: estSpecifiqueAMettreAJour = risqueAMettreAJour(risque);
 
   const emet = createEventDispatcher<{
     metAJourRisque: null;

--- a/svelte/lib/risques/LigneRisque.svelte
+++ b/svelte/lib/risques/LigneRisque.svelte
@@ -31,7 +31,7 @@
   };
 </script>
 
-<tr class:estSpecifiqueAMettreAJour>
+<tr>
   <td>
     <span class="identifiant-numerique">{risque.identifiantNumerique}</span>
   </td>
@@ -40,7 +40,7 @@
       class="intitule-risques"
       title={estSpecifiqueAMettreAJour ? 'Ce risque doit être mis à jour' : ''}
     >
-      {estSpecifiqueAMettreAJour ? '⚠️ ' : ''}{intituleRisque(risque)}
+      {intituleRisque(risque)}
     </p>
     <p class="cartouches-intitule">
       <CartoucheReferentiel
@@ -52,6 +52,9 @@
         <span class="cartouche-categorie">{categories[categorie]}</span>
       {/each}
     </p>
+    {#if estSpecifiqueAMettreAJour}
+      <span class="a-mettre-a-jour">⚠️ Risque à mettre à jour</span>
+    {/if}
   </td>
   <td>
     <SelectionGravite
@@ -139,7 +142,8 @@
     line-height: 16px;
   }
 
-  .estSpecifiqueAMettreAJour {
-    background: var(--fond-ocre-pale);
+  .a-mettre-a-jour {
+    font-size: 12px;
+    line-height: 20px;
   }
 </style>

--- a/svelte/lib/risques/Risques.svelte
+++ b/svelte/lib/risques/Risques.svelte
@@ -12,6 +12,7 @@
   import LigneRisque from './LigneRisque.svelte';
   import { enregistreRisque } from './risque.api';
   import Bouton from '../ui/Bouton.svelte';
+  import Avertissement from '../ui/Avertissement.svelte';
 
   export let idService: string;
   export let estLectureSeule: boolean;
@@ -60,6 +61,10 @@
       description: '',
     };
   };
+
+  $: doitAfficherAvertissement = risques.some(
+    (risque) => risque.type === 'SPECIFIQUE' && !risque.categories.length
+  );
 </script>
 
 <div class="entete-tableau-risques">
@@ -72,6 +77,19 @@
     on:click={ouvreAjoutRisque}
   />
 </div>
+{#if doitAfficherAvertissement}
+  <Avertissement
+    niveau="avertissement"
+    classeSupplementaire="avertissement-risques-specifiques"
+  >
+    <strong>Risques spécifiques à mettre à jour.</strong>
+    <span
+      >Suite à l'ajout de l'échelle de vraisemblance et de la catégorie sur les
+      risques, nous vous invitons à mettre à jour les risques spécifiques que
+      vous avez ajoutés afin de compléter les informations manquantes</span
+    >
+  </Avertissement>
+{/if}
 <table>
   <thead>
     <tr>
@@ -114,6 +132,7 @@
 <style>
   h3 {
     text-align: left;
+    margin: 0;
   }
 
   table {
@@ -149,5 +168,11 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    margin-bottom: 19px;
+  }
+
+  :global(.avertissement-risques-specifiques) {
+    margin-top: 0;
+    margin-bottom: 19px !important;
   }
 </style>

--- a/svelte/lib/risques/Risques.svelte
+++ b/svelte/lib/risques/Risques.svelte
@@ -13,6 +13,7 @@
   import { enregistreRisque } from './risque.api';
   import Bouton from '../ui/Bouton.svelte';
   import Avertissement from '../ui/Avertissement.svelte';
+  import { risqueAMettreAJour } from './risques';
 
   export let idService: string;
   export let estLectureSeule: boolean;
@@ -62,9 +63,7 @@
     };
   };
 
-  $: doitAfficherAvertissement = risques.some(
-    (risque) => risque.type === 'SPECIFIQUE' && !risque.categories.length
-  );
+  $: doitAfficherAvertissement = risques.some(risqueAMettreAJour);
 </script>
 
 <div class="entete-tableau-risques">

--- a/svelte/lib/risques/risques.ts
+++ b/svelte/lib/risques/risques.ts
@@ -55,4 +55,7 @@ const ellipse = (chaine: string, n: number) => {
 export const intituleRisque = (risque: Risque) =>
   risque.type === 'GENERAL' ? risque.intitule : ellipse(risque.intitule, 100);
 
+export const risqueAMettreAJour = (risque: Risque) =>
+  risque.type === 'SPECIFIQUE' && !risque.categories.length;
+
 export default app!;

--- a/svelte/lib/ui/Avertissement.svelte
+++ b/svelte/lib/ui/Avertissement.svelte
@@ -6,11 +6,12 @@
   export let niveau: 'info' | 'avertissement' = 'info';
   export let avecBoutonFermeture: boolean = false;
   export let id: string | undefined = undefined;
+  export let classeSupplementaire: string = '';
 </script>
 
 <div
   {id}
-  class="cadre {niveau}"
+  class="cadre {niveau} {classeSupplementaire}"
   out:glisse|global={{ depuis: 'right', duree: avecBoutonFermeture ? 500 : 0 }}
 >
   {#if avecBoutonFermeture}


### PR DESCRIPTION
S’il y a des risques spécifiques qui n’ont pas de catégorie, on affiche une alerte au dessus du tableau des risques :
![image](https://github.com/user-attachments/assets/8cadbbb4-037d-4eaf-ba09-eb0d9e04aa13)

Chaque risque est affiché avec une alerte :
![image](https://github.com/user-attachments/assets/1e097bc0-0417-411a-ac0d-9a343a3a46ab)

