### PR TITLE
[CORRECTION] Centre le contenu du bouton

### DIFF
--- a/svelte/lib/ui/Bouton.svelte
+++ b/svelte/lib/ui/Bouton.svelte
@@ -33,6 +33,7 @@
 
     text-decoration: none;
     user-select: none;
+    justify-content: center;
   }
 
   .suppression:before {


### PR DESCRIPTION
Suite à une régression introduite par l’affichage flex