### PR TITLE
Création de la classe `Contributeur`

### DIFF
--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -339,7 +339,9 @@ const creeDepot = (config = {}) => {
     await busEvenements.publie(
       new EvenementServiceSupprime({
         idService,
-        autorisations: avantSuppression.map((u) => ({ idUtilisateur: u.id })),
+        autorisations: avantSuppression.map((u) => ({
+          idUtilisateur: u.idUtilisateur,
+        })),
       })
     );
   };

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -47,16 +47,19 @@ const fabriquePersistance = (
   };
 
   const enrichisService = async (service) => {
+    const serviceEnClair = await dechiffreDonneesService(service);
+
     const donneesContributeurs =
       await adaptateurPersistance.contributeursService(service.id);
-    const serviceEnClair = await dechiffreDonneesService(service);
     serviceEnClair.contributeurs = await Promise.all(
       donneesContributeurs.map((d) =>
         depotDonneesUtilisateurs.dechiffreUtilisateur(d)
       )
     );
+
     serviceEnClair.suggestionsActions =
       await adaptateurPersistance.suggestionsActionsService(service.id);
+
     return new Service(serviceEnClair, referentiel);
   };
 

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -46,8 +46,10 @@ function fabriquePersistance({
 
   const dechiffreUtilisateur = async (donneesUtilisateur) => {
     if (!donneesUtilisateur) return undefined;
+
     const donneesDechiffrees =
       await dechiffreDonneesUtilisateur(donneesUtilisateur);
+
     return new Utilisateur(donneesDechiffrees, { adaptateurJWT });
   };
 

--- a/src/modeles/contributeur.js
+++ b/src/modeles/contributeur.js
@@ -1,9 +1,9 @@
 const { Identite } = require('./identite');
 
 class Contributeur {
-  constructor(donnees) {
-    const { id, email, prenom, nom, postes } = donnees;
-    this.id = id;
+  constructor(donneesUtilisateur) {
+    const { id, email, prenom, nom, postes } = donneesUtilisateur;
+    this.idUtilisateur = id;
     this.identite = new Identite({ email, prenom, nom, postes });
   }
 

--- a/src/modeles/contributeur.js
+++ b/src/modeles/contributeur.js
@@ -2,9 +2,9 @@ const { Identite } = require('./identite');
 
 class Contributeur {
   constructor(donnees) {
-    const { id, prenom, nom, postes } = donnees;
+    const { id, email, prenom, nom, postes } = donnees;
     this.id = id;
-    this.identite = new Identite({ prenom, nom, postes });
+    this.identite = new Identite({ email, prenom, nom, postes });
   }
 
   prenomNom() {

--- a/src/modeles/contributeur.js
+++ b/src/modeles/contributeur.js
@@ -1,31 +1,22 @@
-const { formatteListeFr } = require('../utilitaires/liste');
+const { Identite } = require('./identite');
 
 class Contributeur {
   constructor(donnees) {
     const { id, prenom, nom, postes } = donnees;
     this.id = id;
-    this.prenom = prenom;
-    this.nom = nom;
-    this.postes = postes;
+    this.identite = new Identite({ prenom, nom, postes });
   }
 
   prenomNom() {
-    return `${this.prenom} ${this.nom}`;
+    return this.identite.prenomNom();
   }
 
   initiales() {
-    const premiereLettreMajuscule = (s) =>
-      typeof s === 'string' ? s.charAt(0).toUpperCase() : '';
-
-    return (
-      `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(
-        this.nom
-      )}` || ''
-    );
+    return this.identite.initiales();
   }
 
   posteDetaille() {
-    return formatteListeFr(this.postes);
+    return this.identite.posteDetaille();
   }
 }
 

--- a/src/modeles/contributeur.js
+++ b/src/modeles/contributeur.js
@@ -1,0 +1,32 @@
+const { formatteListeFr } = require('../utilitaires/liste');
+
+class Contributeur {
+  constructor(donnees) {
+    const { id, prenom, nom, postes } = donnees;
+    this.id = id;
+    this.prenom = prenom;
+    this.nom = nom;
+    this.postes = postes;
+  }
+
+  prenomNom() {
+    return `${this.prenom} ${this.nom}`;
+  }
+
+  initiales() {
+    const premiereLettreMajuscule = (s) =>
+      typeof s === 'string' ? s.charAt(0).toUpperCase() : '';
+
+    return (
+      `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(
+        this.nom
+      )}` || ''
+    );
+  }
+
+  posteDetaille() {
+    return formatteListeFr(this.postes);
+  }
+}
+
+module.exports = { Contributeur };

--- a/src/modeles/identite.js
+++ b/src/modeles/identite.js
@@ -1,0 +1,32 @@
+const { formatteListeFr } = require('../utilitaires/liste');
+
+class Identite {
+  constructor(donnees) {
+    const { prenom, nom, email, postes } = donnees;
+    this.prenom = prenom;
+    this.nom = nom;
+    this.email = email;
+    this.postes = postes;
+  }
+
+  initiales() {
+    const premiereLettreMajuscule = (s) =>
+      typeof s === 'string' ? s.charAt(0).toUpperCase() : '';
+
+    return (
+      `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(
+        this.nom
+      )}` || ''
+    );
+  }
+
+  prenomNom() {
+    return [this.prenom, this.nom].join(' ').trim() || this.email;
+  }
+
+  posteDetaille() {
+    return formatteListeFr(this.postes);
+  }
+}
+
+module.exports = { Identite };

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -16,7 +16,7 @@ const donnees = (service, autorisation, referentiel) => {
     organisationResponsable:
       service.descriptionService.organisationResponsable.nom ?? '',
     contributeurs: service.contributeurs.map((c) => ({
-      id: c.id,
+      id: c.idUtilisateur,
       prenomNom: c.prenomNom(),
       initiales: c.initiales(),
       poste: c.posteDetaille(),

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -217,8 +217,8 @@ class Service {
   }
 
   metsAJourMesureGenerale(mesure) {
-    const idContributeurs = this.contributeurs.map((u) => u.id);
-    if (mesure.responsables.some((r) => !idContributeurs.includes(r))) {
+    const idUtilisateurs = this.contributeurs.map((u) => u.idUtilisateur);
+    if (mesure.responsables.some((r) => !idUtilisateurs.includes(r))) {
       throw new ErreurResponsablesMesureInvalides(
         "Les responsables d'une mesure générale doivent être des contributeurs du service."
       );

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -8,7 +8,6 @@ const Mesures = require('./mesures');
 const ObjetPersistanceService = require('./objetsPersistance/objetPersistanceService');
 const Risques = require('./risques');
 const RolesResponsabilites = require('./rolesResponsabilites');
-const Utilisateur = require('./utilisateur');
 const ObjetPDFAnnexeDescription = require('./objetsPDF/objetPDFAnnexeDescription');
 const ObjetPDFAnnexeMesures = require('./objetsPDF/objetPDFAnnexeMesures');
 const ObjetPDFAnnexeRisques = require('./objetsPDF/objetPDFAnnexeRisques');
@@ -16,6 +15,7 @@ const Autorisation = require('./autorisations/autorisation');
 const SuggestionAction = require('./suggestionAction');
 const { ErreurResponsablesMesureInvalides } = require('../erreurs');
 const { dateEnIso } = require('../utilitaires/date');
+const { Contributeur } = require('./contributeur');
 
 const NIVEAUX = {
   NIVEAU_SECURITE_BON: 'bon',
@@ -46,7 +46,7 @@ class Service {
     this.id = id;
     this.prochainIdNumeriqueDeRisqueSpecifique =
       prochainIdNumeriqueDeRisqueSpecifique;
-    this.contributeurs = contributeurs.map((c) => new Utilisateur(c));
+    this.contributeurs = contributeurs.map((c) => new Contributeur(c));
     this.descriptionService = new DescriptionService(
       descriptionService,
       referentiel

--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -3,8 +3,8 @@ const {
   ErreurEmailManquant,
   ErreurDonneesObligatoiresManquantes,
 } = require('../erreurs');
-const { formatteListeFr } = require('../utilitaires/liste');
 const Entite = require('./entite');
+const { Identite } = require('./identite');
 
 const valide = (donnees) => {
   const { email } = donnees;
@@ -34,6 +34,7 @@ class Utilisateur extends Base {
     this.entite = new Entite(donnees.entite);
     this.renseigneProprietes(donnees);
     this.adaptateurJWT = adaptateurJWT;
+    this.identite = new Identite(donnees);
   }
 
   static valideDonnees(donnees = {}, utilisateurExistant = false) {
@@ -127,22 +128,15 @@ class Utilisateur extends Base {
   }
 
   initiales() {
-    const premiereLettreMajuscule = (s) =>
-      typeof s === 'string' ? s.charAt(0).toUpperCase() : '';
-
-    return (
-      `${premiereLettreMajuscule(this.prenom)}${premiereLettreMajuscule(
-        this.nom
-      )}` || ''
-    );
+    return this.identite.initiales();
   }
 
   posteDetaille() {
-    return formatteListeFr(this.postes);
+    return this.identite.posteDetaille();
   }
 
   prenomNom() {
-    return [this.prenom, this.nom].join(' ').trim() || this.email;
+    return this.identite.prenomNom();
   }
 
   completudeProfil() {

--- a/src/routes/connecte/routesConnectePageService.js
+++ b/src/routes/connecte/routesConnectePageService.js
@@ -132,7 +132,7 @@ const routesConnectePageService = ({
 
       try {
         const contributeurs = Object.fromEntries(
-          service.contributeurs.map((c) => [c.id, c.prenomNom()])
+          service.contributeurs.map((c) => [c.idUtilisateur, c.prenomNom()])
         );
         const bufferCsv = await adaptateurCsv.genereCsvMesures(
           service.mesures.enrichiesAvecDonneesPersonnalisees(),

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -209,8 +209,8 @@ describe('Le dépôt de données des services', () => {
 
     const { contributeurs } = service;
     expect(contributeurs.length).to.equal(2);
-    expect(contributeurs[0].id).to.equal('U1');
-    expect(contributeurs[1].id).to.equal('U2');
+    expect(contributeurs[0].idUtilisateur).to.equal('U1');
+    expect(contributeurs[1].idUtilisateur).to.equal('U2');
   });
 
   it("délègue au dépôt d'utilisateurs de déchiffrer les contributeurs", async () => {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -242,8 +242,8 @@ describe('Le dépôt de données des services', () => {
 
     const service = await depot.service('S1');
 
-    expect(service.contributeurs[0].nom).to.equal('U1-déchiffré');
-    expect(service.contributeurs[1].nom).to.equal('U2-déchiffré');
+    expect(service.contributeurs[0].prenomNom()).to.equal('U1-déchiffré');
+    expect(service.contributeurs[1].prenomNom()).to.equal('U2-déchiffré');
   });
 
   it('associe ses suggestions d’actions au service', async () => {

--- a/test/modeles/contributeur.spec.js
+++ b/test/modeles/contributeur.spec.js
@@ -1,0 +1,30 @@
+const expect = require('expect.js');
+const { Contributeur } = require('../../src/modeles/contributeur');
+
+describe('Un contributeur', () => {
+  it('connaît son identifiant', () => {
+    const contributeur = new Contributeur({ id: 'C-1' });
+
+    expect(contributeur.id).to.be('C-1');
+  });
+
+  it('connaît son « prénom / nom »', () => {
+    const contributeur = new Contributeur({ prenom: 'Jean', nom: 'Dujardin' });
+
+    expect(contributeur.prenomNom()).to.be('Jean Dujardin');
+  });
+
+  it('connaît ses initiales', () => {
+    const contributeur = new Contributeur({ prenom: 'Jean', nom: 'Dujardin' });
+
+    expect(contributeur.initiales()).to.be('JD');
+  });
+
+  it("connaît les détails du poste qu'il occupe", () => {
+    const contributeur = new Contributeur({
+      postes: ['RSSI', 'DPO', 'Maire'],
+    });
+
+    expect(contributeur.posteDetaille()).to.eql('RSSI, DPO et Maire');
+  });
+});

--- a/test/modeles/contributeur.spec.js
+++ b/test/modeles/contributeur.spec.js
@@ -2,10 +2,10 @@ const expect = require('expect.js');
 const { Contributeur } = require('../../src/modeles/contributeur');
 
 describe('Un contributeur', () => {
-  it('connaît son identifiant', () => {
+  it("connaît l'identifiant de l'utilisateur qu'il représente", () => {
     const contributeur = new Contributeur({ id: 'C-1' });
 
-    expect(contributeur.id).to.be('C-1');
+    expect(contributeur.idUtilisateur).to.be('C-1');
   });
 
   it('connaît son « prénom / nom »', () => {

--- a/test/modeles/identite.spec.js
+++ b/test/modeles/identite.spec.js
@@ -1,0 +1,52 @@
+const expect = require('expect.js');
+const { Identite } = require('../../src/modeles/identite');
+
+describe('Une identité', () => {
+  describe('sur demande de ses initiales', () => {
+    it('renvoie les initiales du prénom et du nom', () => {
+      const jean = new Identite({
+        prenom: 'Jean',
+        nom: 'Dupont',
+        email: 'jean.dupont@mail.fr',
+      });
+      expect(jean.initiales()).to.equal('JD');
+    });
+
+    it('reste robuste en cas de prénom ou de nom absent', () => {
+      const jean = new Identite({ email: 'jean.dupont@mail.fr' });
+      expect(jean.initiales()).to.equal('');
+    });
+  });
+
+  describe('sur demande du « prénom / nom »', () => {
+    it('reste robuste si le nom est absent', () => {
+      const jean = new Identite({
+        prenom: 'Jean',
+        email: 'jean.dupont@mail.fr',
+      });
+      expect(jean.prenomNom()).to.equal('Jean');
+    });
+
+    it('reste robuste si le prénom est absent', () => {
+      const jean = new Identite({
+        nom: 'Dupont',
+        email: 'jean.dupont@mail.fr',
+      });
+      expect(jean.prenomNom()).to.equal('Dupont');
+    });
+
+    it("retourne l'email si le prénom et le nom sont absents", () => {
+      const jean = new Identite({ email: 'jean.dupont@mail.fr' });
+      expect(jean.prenomNom()).to.equal('jean.dupont@mail.fr');
+    });
+  });
+
+  it('combine toutes les informations de postes sur demande de son poste détaillé', () => {
+    const plusieursPostes = new Identite({
+      email: 'jean.dupont@mail.fr',
+      postes: ['RSSI', 'DPO', 'Maire'],
+    });
+
+    expect(plusieursPostes.posteDetaille()).to.eql('RSSI, DPO et Maire');
+  });
+});

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -53,7 +53,7 @@ describe('Un service', () => {
 
     const contributeur = contributeurs[0];
     expect(contributeur).to.be.a(Contributeur);
-    expect(contributeur.id).to.equal('456');
+    expect(contributeur.idUtilisateur).to.equal('456');
   });
 
   describe("concernant les suggestions d'actions", () => {

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -7,7 +7,6 @@ const Referentiel = require('../../src/referentiel');
 const InformationsService = require('../../src/modeles/informationsService');
 const Service = require('../../src/modeles/service');
 const MesureGenerale = require('../../src/modeles/mesureGenerale');
-const Utilisateur = require('../../src/modeles/utilisateur');
 const VueAnnexePDFDescription = require('../../src/modeles/objetsPDF/objetPDFAnnexeDescription');
 const VueAnnexePDFMesures = require('../../src/modeles/objetsPDF/objetPDFAnnexeMesures');
 const VueAnnexePDFRisques = require('../../src/modeles/objetsPDF/objetPDFAnnexeRisques');
@@ -25,6 +24,7 @@ const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
 const Mesures = require('../../src/modeles/mesures');
 const { ErreurResponsablesMesureInvalides } = require('../../src/erreurs');
 const MesureSpecifique = require('../../src/modeles/mesureSpecifique');
+const { Contributeur } = require('../../src/modeles/contributeur');
 
 describe('Un service', () => {
   it('connaît son nom', () => {
@@ -52,7 +52,7 @@ describe('Un service', () => {
     expect(contributeurs.length).to.equal(1);
 
     const contributeur = contributeurs[0];
-    expect(contributeur).to.be.an(Utilisateur);
+    expect(contributeur).to.be.a(Contributeur);
     expect(contributeur.id).to.equal('456');
   });
 

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -59,43 +59,22 @@ describe('Un utilisateur', () => {
     });
   });
 
-  describe('sur demande de ses initiales', () => {
-    it('renvoie les initiales du prénom et du nom', () => {
-      const utilisateur = new Utilisateur({
-        prenom: 'Jean',
-        nom: 'Dupont',
-        email: 'jean.dupont@mail.fr',
-      });
-      expect(utilisateur.initiales()).to.equal('JD');
+  it('connaît ses initiales', () => {
+    const jeanDupont = new Utilisateur({
+      prenom: 'Jean',
+      nom: 'Dupont',
+      email: 'jean.dupont@mail.fr',
     });
-
-    it('reste robuste en cas de prénom ou de nom absent', () => {
-      const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
-      expect(utilisateur.initiales()).to.equal('');
-    });
+    expect(jeanDupont.initiales()).to.equal('JD');
   });
 
-  describe('sur demande du « prénom / nom »', () => {
-    it('reste robuste si le nom est absent', () => {
-      const utilisateur = new Utilisateur({
-        prenom: 'Jean',
-        email: 'jean.dupont@mail.fr',
-      });
-      expect(utilisateur.prenomNom()).to.equal('Jean');
+  it('connaît son « prénom / nom »', () => {
+    const jeanDupont = new Utilisateur({
+      prenom: 'Jean',
+      nom: 'Dupont',
+      email: 'jean.dupont@mail.fr',
     });
-
-    it('reste robuste si le prénom est absent', () => {
-      const utilisateur = new Utilisateur({
-        nom: 'Dupont',
-        email: 'jean.dupont@mail.fr',
-      });
-      expect(utilisateur.prenomNom()).to.equal('Dupont');
-    });
-
-    it("retourne l'email si le prénom et le nom sont absents", () => {
-      const utilisateur = new Utilisateur({ email: 'jean.dupont@mail.fr' });
-      expect(utilisateur.prenomNom()).to.equal('jean.dupont@mail.fr');
-    });
+    expect(jeanDupont.prenomNom()).to.equal('Jean Dupont');
   });
 
   it('combine toutes les informations de postes sur demande de son poste détaillé', () => {


### PR DESCRIPTION
Cette PR vise à casser la dépendance entre `Service` et `Utilisateur`.

Pour le chantier de versionning des CGU acceptées par chaque `Utilisateur`, on va devoir modifier la classe `Utilisateur`.
La dépendance entre `Service` et `Utilisateur` nous gêne… car elle nous forcerait à modifier `Service` si on touche `Utilisateur`.

Pour résoudre le problème, cette PR extrait `Contributeur` qui est une version allégée d'un `Utilisateur`.
Par composition on évite la duplication de code en utilisant `Identite`.