### PR TITLE
Ajoute une ellipse et un tooltip sur les cases de la cartographie

### DIFF
--- a/svelte/lib/risques/MatriceRisques.svelte
+++ b/svelte/lib/risques/MatriceRisques.svelte
@@ -45,6 +45,14 @@
   const niveauRisqueCellule = (colonne: number, ligne: number) => {
     return matriceNiveauxRisque[colonne + 1][4 - ligne];
   };
+
+  const avecEllipse = (risques: Risque[]) =>
+    risques.length > 6
+      ? `${risques
+          .slice(0, 6)
+          .map((r) => r.identifiantNumerique)
+          .join(', ')}&hellip;`
+      : risques.map((r) => r.identifiantNumerique).join(', ');
 </script>
 
 <div class="matrice">
@@ -68,10 +76,14 @@
       {@const y = Math.floor(index / 4)}
       {@const classe = niveauRisqueCellule(x, y)}
       {@const risquesPresent = grille[y][x]}
-      <div class="cellule-matrice {classe} {index}">
-        {risquesPresent
-          ? risquesPresent.map((r) => r.identifiantNumerique).join(', ')
-          : ''}
+      {@const titreCellule = risquesPresent
+        ? risquesPresent.map((r) => r.identifiantNumerique).join(', ')
+        : 'Aucun risque à ce niveau'}
+      {@const titreCelluleAvecEllipse = risquesPresent
+        ? avecEllipse(risquesPresent)
+        : ''}
+      <div class="cellule-matrice {classe} {index}" title={titreCellule}>
+        {@html titreCelluleAvecEllipse}
       </div>
     {/each}
   </div>


### PR DESCRIPTION
... pour n'afficher que les premiers risques de la case sans débordement
![Capture d’écran 2024-10-28 à 16 11 05](https://github.com/user-attachments/assets/ec0cab9f-35a4-40b5-8fe6-f5778ca26006)
