### PR TITLE
[CORRECTION] N'ouvre que le tiroir demandé sur la page Risques

### DIFF
--- a/svelte/lib/risques/Risques.svelte
+++ b/svelte/lib/risques/Risques.svelte
@@ -67,6 +67,8 @@
 
   const ouvreAjoutRisque = () => {
     tiroirRisqueOuvert = true;
+    tiroirLegendeGraviteOuvert = false;
+    tiroirLegendeVraisemblanceOuvert = false;
     modeAffichageTiroir = 'AJOUT';
     risqueEnEdition = {
       type: 'SPECIFIQUE',
@@ -214,6 +216,8 @@
             icone="information"
             on:click={() => {
               tiroirLegendeGraviteOuvert = true;
+              tiroirLegendeVraisemblanceOuvert = false;
+              tiroirRisqueOuvert = false;
             }}
           />
           <BoutonIcone icone={`tri-${triParGravite}`} on:click={triGravite} />
@@ -226,6 +230,8 @@
             icone="information"
             on:click={() => {
               tiroirLegendeVraisemblanceOuvert = true;
+              tiroirLegendeGraviteOuvert = false;
+              tiroirRisqueOuvert = false;
             }}
           />
           <BoutonIcone

--- a/svelte/lib/risques/TiroirLegende.svelte
+++ b/svelte/lib/risques/TiroirLegende.svelte
@@ -8,7 +8,7 @@
   };
 </script>
 
-<div class="tiroir" class:ouvert>
+<div class="tiroir-legende" class:ouvert>
   <div class="entete-tiroir">
     <div>
       <h2 class="titre-tiroir-legende">{titre}</h2>
@@ -22,7 +22,7 @@
 </div>
 
 <style>
-  .tiroir {
+  .tiroir-legende {
     height: 100%;
     min-width: 650px;
     max-width: 650px;

--- a/svelte/lib/risques/TiroirRisque.svelte
+++ b/svelte/lib/risques/TiroirRisque.svelte
@@ -102,7 +102,7 @@
   $: risque, (afficheConfirmationSuppressionRisque = false);
 </script>
 
-<div class="tiroir {risque?.type}" class:ouvert>
+<div class="tiroir-risque {risque?.type}" class:ouvert>
   {#if risque}
     <div class="entete-tiroir">
       <div>
@@ -249,7 +249,7 @@
 </div>
 
 <style>
-  .tiroir {
+  .tiroir-risque {
     height: 100%;
     min-width: 650px;
     max-width: 650px;


### PR DESCRIPTION
... comme le javascript des anciens tiroirs se basait sur la classe "tiroir" pour ouvrir le tiroir contributeurs/téléchargements, et que les nouveaux tiroirs Svelte avaient aussi cette classe, quatre tiroirs s'ouvraient en même temps sur la page Risques