### PR TITLE
[CORRECTION] Corrige la valeur de `estUtilisateurCourant`

### DIFF
--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -20,7 +20,7 @@ const donnees = (service, autorisation, referentiel) => {
       prenomNom: c.prenomNom(),
       initiales: c.initiales(),
       poste: c.posteDetaille(),
-      estUtilisateurCourant: autorisation.designeUtilisateur(c.id),
+      estUtilisateurCourant: autorisation.designeUtilisateur(c.idUtilisateur),
     })),
     ...(autorisation.aLesPermissions(DROITS_VOIR_STATUT_HOMOLOGATION) && {
       statutHomologation: {


### PR DESCRIPTION
...qui ne fonctionnait plus suite au renommage `id` vers `idUtilisateur`.

Cela avait pour impact de casser le filtre "Mes mesures"