### PR TITLE
[CORRECTION] Publie sur le bus *après* la mise à jour du service

### DIFF
--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -211,10 +211,9 @@ const creeDepot = (config = {}) => {
   };
 
   const ajouteRisqueGeneralAService = async (unService, risque) => {
-    await busEvenements.publie(
-      new EvenementRisqueServiceModifie({ service: unService })
-    );
-    return ajouteAItemsDuService('risquesGeneraux', unService.id, risque);
+    await ajouteAItemsDuService('risquesGeneraux', unService.id, risque);
+    const s = await p.lis.un(unService.id);
+    busEvenements.publie(new EvenementRisqueServiceModifie({ service: s }));
   };
 
   const serviceExiste = async (idUtilisateur, nomService, idServiceMisAJour) =>

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -504,7 +504,7 @@ describe('Le dépôt de données des services', () => {
       expect(risques.risquesGeneraux.item(0).id).to.equal('R1');
     });
 
-    it("publie un événement de 'Risques service modifiés'", async () => {
+    it("publie un événement de 'Risques service modifiés' avec le service à jour", async () => {
       const risque = new RisqueGeneral({ id: 'R1' });
       await depot.ajouteRisqueGeneralAService(service, risque);
 
@@ -516,6 +516,7 @@ describe('Le dépôt de données des services', () => {
       );
       expect(evenement.service).not.to.be(undefined);
       expect(evenement.service.id).to.be('S1');
+      expect(evenement.service.risques.risquesGeneraux.nombre()).to.equal(1);
     });
   });
 


### PR DESCRIPTION
Si on publie avant, le service embarqué dans l'événement ne contient pas le nouveau risque.