### PR TITLE
[CORRECTION] Valide l'acceptation des CGU lors de l'inscription d'un utilisateur

### DIFF
--- a/src/modeles/inscriptionUtilisateur.js
+++ b/src/modeles/inscriptionUtilisateur.js
@@ -38,6 +38,8 @@ function fabriqueInscriptionUtilisateur(config = {}) {
   const inscrisUtilisateur = async (donnees, source) => {
     await creeContactEmail(donnees);
     const utilisateur = await depotDonnees.nouvelUtilisateur(donnees);
+    if (utilisateur.cguAcceptees)
+      await depotDonnees.valideAcceptationCGUPourUtilisateur(utilisateur);
     if (source === SourceAuthentification.MSS) {
       await envoieMessageFinalisationInscription(utilisateur);
     }

--- a/test/modeles/inscriptionUtilisateur.spec.js
+++ b/test/modeles/inscriptionUtilisateur.spec.js
@@ -1,0 +1,38 @@
+const expect = require('expect.js');
+const {
+  fabriqueInscriptionUtilisateur,
+} = require('../../src/modeles/inscriptionUtilisateur');
+const SourceAuthentification = require('../../src/modeles/sourceAuthentification');
+
+describe("Le service d'inscription d'un utilisateur", () => {
+  it("valide l'acceptation des CGU si l'utilisateur les a acceptées", async () => {
+    let validationEffectuee = false;
+    const adaptateurMail = {
+      creeContact: async () => {},
+    };
+    const adaptateurTracking = {
+      envoieTrackingInscription: async () => {},
+    };
+    const depotDonnees = {
+      nouvelUtilisateur: async () => ({
+        email: 'jean.dujardin@beta.gouv.fr',
+        cguAcceptees: true,
+      }),
+      valideAcceptationCGUPourUtilisateur: async () => {
+        validationEffectuee = true;
+      },
+    };
+    const inscriptionUtilisateur = fabriqueInscriptionUtilisateur({
+      adaptateurMail,
+      adaptateurTracking,
+      depotDonnees,
+    });
+
+    await inscriptionUtilisateur.inscrisUtilisateur(
+      {},
+      SourceAuthentification.AGENT_CONNECT
+    );
+
+    expect(validationEffectuee).to.be(true);
+  });
+});


### PR DESCRIPTION
... car sinon on persiste la valeur "true", au lieu de la remplacer par la "dernière version" des CGU. 

On en profite pour ajouter un test unitaire spécifique au service d'inscription d'utilisateur, sinon tous les tests sont réalisés au niveau de l'API.