### PR TITLE
[SUPERVISION] Liaison entre superviseur et service à la création d'un service

### DIFF
--- a/migrations/20241105100212_creationTableSuperviseurs.js
+++ b/migrations/20241105100212_creationTableSuperviseurs.js
@@ -1,0 +1,8 @@
+exports.up = (knex) =>
+  knex.schema.createTable('superviseurs', (table) => {
+    table.uuid('id_superviseur');
+    table.text('siret_supervise');
+    table.primary(['id_superviseur', 'siret_supervise']);
+  });
+
+exports.down = (knex) => knex.schema.dropTable('superviseurs');

--- a/server.js
+++ b/server.js
@@ -36,6 +36,7 @@ const {
 const {
   fabriqueInscriptionUtilisateur,
 } = require('./src/modeles/inscriptionUtilisateur');
+const fabriqueAdaptateurSupervision = require('./src/adaptateurs/fabriqueAdaptateurSupervision');
 const adaptateurStatistiques = require('./src/adaptateurs/adaptateurStatistiquesMetabase');
 const { fabriqueServiceCgu } = require('./src/serviceCgu');
 
@@ -44,6 +45,7 @@ const adaptateurTracking = fabriqueAdaptateurTracking();
 const adaptateurJournal = fabriqueAdaptateurJournalMSS();
 const adaptateurChiffrement = fabriqueAdaptateurChiffrement();
 const adaptateurOidc = fabriqueAdaptateurOidc();
+const adaptateurSupervision = fabriqueAdaptateurSupervision();
 const busEvenements = new BusEvenements({ adaptateurGestionErreur });
 const port = process.env.PORT || 3000;
 
@@ -70,6 +72,7 @@ cableTousLesAbonnes(busEvenements, {
   adaptateurJournal,
   adaptateurRechercheEntreprise: adaptateurRechercheEntrepriseAPI,
   adaptateurMail,
+  adaptateurSupervision,
   depotDonnees,
   referentiel,
 });

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -12,6 +12,7 @@ const nouvelAdaptateur = (
   donnees.notifications ||= [];
   donnees.suggestionsActions ||= [];
   donnees.activitesMesure ||= [];
+  donnees.superviseurs ||= [];
 
   const supprimeEnregistrement = async (nomTable, id) => {
     donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
@@ -278,6 +279,11 @@ const nouvelAdaptateur = (
       details,
     });
 
+  const lisSuperviseursConcernes = async (siret) =>
+    donnees.superviseurs
+      .filter(({ siretSupervise }) => siretSupervise === siret)
+      .map(({ idSuperviseur }) => idSuperviseur);
+
   return {
     activitesMesure,
     ajouteActiviteMesure,
@@ -296,6 +302,7 @@ const nouvelAdaptateur = (
     services,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
+    lisSuperviseursConcernes,
     marqueNouveauteLue,
     marqueSuggestionActionFaiteMaintenant,
     marqueTacheDeServiceLue,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -501,6 +501,13 @@ const nouvelAdaptateur = (env) => {
 
   const sante = async () => knex.raw('SELECT 1 + 1;');
 
+  const lisSuperviseursConcernes = async (siret) =>
+    (
+      await knex('superviseurs')
+        .where({ siret_supervise: siret })
+        .select({ idSuperviseur: 'id_superviseur' })
+    ).map(({ idSuperviseur }) => idSuperviseur);
+
   return {
     activitesMesure,
     ajouteAutorisation,
@@ -520,6 +527,7 @@ const nouvelAdaptateur = (env) => {
     lisDernierIndiceCyber,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
+    lisSuperviseursConcernes,
     marqueNouveauteLue,
     marqueSuggestionActionFaiteMaintenant,
     marqueTacheDeServiceLue,

--- a/src/adaptateurs/adaptateurSupervision.js
+++ b/src/adaptateurs/adaptateurSupervision.js
@@ -1,0 +1,29 @@
+const Knex = require('knex');
+
+const adaptateurSupervision = ({ adaptateurChiffrement }) => {
+  const config = {
+    client: 'pg',
+    connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
+    pool: { min: 0, max: 10 },
+  };
+
+  const knex = Knex(config);
+
+  return {
+    relieSuperviseursAService: async (idService, idSuperviseurs) => {
+      const idServiceHash = adaptateurChiffrement.hacheSha256(idService);
+      const idSuperviseursHash = idSuperviseurs.map(
+        adaptateurChiffrement.hacheSha256
+      );
+
+      await knex('journal_mss.superviseurs').insert(
+        idSuperviseursHash.map((idSuperviseur) => ({
+          id_superviseur: idSuperviseur,
+          id_service: idServiceHash,
+        }))
+      );
+    },
+  };
+};
+
+module.exports = adaptateurSupervision;

--- a/src/adaptateurs/adaptateurSupervision.js
+++ b/src/adaptateurs/adaptateurSupervision.js
@@ -10,8 +10,11 @@ const adaptateurSupervision = ({ adaptateurChiffrement }) => {
   const knex = Knex(config);
 
   return {
-    relieSuperviseursAService: async (idService, idSuperviseurs) => {
-      const idServiceHash = adaptateurChiffrement.hacheSha256(idService);
+    relieSuperviseursAService: async (service, idSuperviseurs) => {
+      const idServiceHash = adaptateurChiffrement.hacheSha256(service.id);
+      const siretServiceHash = adaptateurChiffrement.hacheSha256(
+        service.siretDeOrganisation()
+      );
       const idSuperviseursHash = idSuperviseurs.map(
         adaptateurChiffrement.hacheSha256
       );
@@ -20,6 +23,7 @@ const adaptateurSupervision = ({ adaptateurChiffrement }) => {
         idSuperviseursHash.map((idSuperviseur) => ({
           id_superviseur: idSuperviseur,
           id_service: idServiceHash,
+          siret_service: siretServiceHash,
         }))
       );
     },

--- a/src/adaptateurs/fabriqueAdaptateurSupervision.js
+++ b/src/adaptateurs/fabriqueAdaptateurSupervision.js
@@ -1,0 +1,11 @@
+const adaptateurSupervision = require('./adaptateurSupervision');
+const {
+  fabriqueAdaptateurChiffrement,
+} = require('./fabriqueAdaptateurChiffrement');
+
+const fabriqueAdaptateurSupervision = () =>
+  adaptateurSupervision({
+    adaptateurChiffrement: fabriqueAdaptateurChiffrement(),
+  });
+
+module.exports = fabriqueAdaptateurSupervision;

--- a/src/bus/abonnements/relieServiceEtSuperviseurs.js
+++ b/src/bus/abonnements/relieServiceEtSuperviseurs.js
@@ -1,0 +1,13 @@
+function relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision }) {
+  return async ({ service }) => {
+    const superviseurs = await depotDonnees.lisSuperviseurs(
+      service.siretDeOrganisation()
+    );
+    await adaptateurSupervision.relieSuperviseursAService(
+      service.id,
+      superviseurs
+    );
+  };
+}
+
+module.exports = { relieServiceEtSuperviseurs };

--- a/src/bus/abonnements/relieServiceEtSuperviseurs.js
+++ b/src/bus/abonnements/relieServiceEtSuperviseurs.js
@@ -3,6 +3,9 @@ function relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision }) {
     const superviseurs = await depotDonnees.lisSuperviseurs(
       service.siretDeOrganisation()
     );
+
+    if (!superviseurs.length) return;
+
     await adaptateurSupervision.relieSuperviseursAService(
       service.id,
       superviseurs

--- a/src/bus/abonnements/relieServiceEtSuperviseurs.js
+++ b/src/bus/abonnements/relieServiceEtSuperviseurs.js
@@ -7,7 +7,7 @@ function relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision }) {
     if (!superviseurs.length) return;
 
     await adaptateurSupervision.relieSuperviseursAService(
-      service.id,
+      service,
       superviseurs
     );
   };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -89,6 +89,9 @@ const EvenementRisqueServiceModifie = require('./evenementRisqueServiceModifie')
 const {
   consigneRisquesDansJournal,
 } = require('./abonnements/consigneRisquesDansJournal');
+const {
+  relieServiceEtSuperviseurs,
+} = require('./abonnements/relieServiceEtSuperviseurs');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -98,6 +101,7 @@ const cableTousLesAbonnes = (
     adaptateurJournal,
     adaptateurRechercheEntreprise,
     adaptateurMail,
+    adaptateurSupervision,
     depotDonnees,
     referentiel,
   }
@@ -120,6 +124,7 @@ const cableTousLesAbonnes = (
       crmBrevo,
       depotDonnees,
     }),
+    relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementMesureServiceModifiee, [

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -11,6 +11,7 @@ const depotDonneesNotifications = require('./depots/depotDonneesNotifications');
 const depotDonneesSuggestionsActions = require('./depots/depotDonneesSuggestionsActions');
 const depotDonneesActivitesMesure = require('./depots/depotDonneesActivitesMesure');
 const depotDonneesEvolutionsIndiceCyber = require('./depots/depotDonneesEvolutionsIndiceCyber');
+const depotDonneesSuperviseurs = require('./depots/depotDonneesSuperviseurs');
 
 const {
   fabriqueAdaptateurChiffrement,
@@ -87,6 +88,10 @@ const creeDepot = (config = {}) => {
     depotDonneesEvolutionsIndiceCyber.creeDepot({
       adaptateurPersistance,
     });
+
+  const depotSuperviseurs = depotDonneesSuperviseurs.creeDepot({
+    adaptateurPersistance,
+  });
 
   const {
     ajouteDescriptionService,
@@ -170,6 +175,8 @@ const creeDepot = (config = {}) => {
   const { lisDernierIndiceCyber, sauvegardeNouvelIndiceCyber } =
     depotEvolutionsIndiceCyber;
 
+  const { lisSuperviseurs } = depotSuperviseurs;
+
   const santeDuDepot = async () => {
     await adaptateurPersistance.sante();
   };
@@ -200,6 +207,7 @@ const creeDepot = (config = {}) => {
     lisDernierIndiceCyber,
     lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
+    lisSuperviseurs,
     marqueNouveauteLue,
     marqueTacheDeServiceLue,
     metsAJourMotDePasse,

--- a/src/depots/depotDonneesSuperviseurs.js
+++ b/src/depots/depotDonneesSuperviseurs.js
@@ -1,0 +1,8 @@
+const creeDepot = ({ adaptateurPersistance }) => {
+  const lisSuperviseurs = async (siret) =>
+    adaptateurPersistance.lisSuperviseursConcernes(siret);
+
+  return { lisSuperviseurs };
+};
+
+module.exports = { creeDepot };

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -274,6 +274,10 @@ class Service {
     return this.risques.risquesSpecifiques;
   }
 
+  siretDeOrganisation() {
+    return this.descriptionService.organisationResponsable.siret;
+  }
+
   statistiquesMesuresGeneralesEtSpecifiques(exclueMesuresNonPrisesEnCompte) {
     return this.mesures.statistiquesMesuresGeneralesEtSpecifiques(
       exclueMesuresNonPrisesEnCompte

--- a/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
+++ b/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
@@ -1,0 +1,59 @@
+const expect = require('expect.js');
+const { unService } = require('../../constructeurs/constructeurService');
+const {
+  relieServiceEtSuperviseurs,
+} = require('../../../src/bus/abonnements/relieServiceEtSuperviseurs');
+
+describe("L'abonné en charge de relier un nouveau service à ses superviseurs", () => {
+  let adaptateurSupervision;
+  let depotDonnees;
+
+  beforeEach(() => {
+    adaptateurSupervision = {
+      relieSuperviseursAService: async () => {},
+    };
+    depotDonnees = {
+      lisSuperviseurs: async () => {},
+    };
+  });
+
+  it('délègue au dépôt la lecture des superviseurs concernés', async () => {
+    let siretRecu;
+    depotDonnees.lisSuperviseurs = async (siret) => {
+      siretRecu = siret;
+      return [];
+    };
+    const service = unService()
+      .avecOrganisationResponsable({ siret: '12345' })
+      .construis();
+
+    await relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision })({
+      service,
+    });
+
+    expect(siretRecu).to.be('12345');
+  });
+
+  it('délègue à la supervision la création du lien entre les superviseurs et le service', async () => {
+    let idsSuperviseurRecus;
+    let idServiceRecu;
+    adaptateurSupervision.relieSuperviseursAService = async (
+      idService,
+      idsSuperviseurs
+    ) => {
+      idsSuperviseurRecus = idsSuperviseurs;
+      idServiceRecu = idService;
+    };
+
+    depotDonnees.lisSuperviseurs = async () => ['US1'];
+
+    const service = unService().avecId('S1').construis();
+
+    await relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision })({
+      service,
+    });
+
+    expect(idsSuperviseurRecus).to.eql(['US1']);
+    expect(idServiceRecu).to.be('S1');
+  });
+});

--- a/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
+++ b/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
@@ -56,4 +56,21 @@ describe("L'abonné en charge de relier un nouveau service à ses superviseurs",
     expect(idsSuperviseurRecus).to.eql(['US1']);
     expect(idServiceRecu).to.be('S1');
   });
+
+  it("n'appelle pas la supervision si aucun superviseur n'est concerné par le service", async () => {
+    let supervisionAppelee = false;
+    adaptateurSupervision.relieSuperviseursAService = async () => {
+      supervisionAppelee = true;
+    };
+
+    depotDonnees.lisSuperviseurs = async () => [];
+
+    const service = unService().construis();
+
+    await relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision })({
+      service,
+    });
+
+    expect(supervisionAppelee).to.be(false);
+  });
 });

--- a/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
+++ b/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
@@ -36,25 +36,28 @@ describe("L'abonné en charge de relier un nouveau service à ses superviseurs",
 
   it('délègue à la supervision la création du lien entre les superviseurs et le service', async () => {
     let idsSuperviseurRecus;
-    let idServiceRecu;
+    let serviceRecu;
     adaptateurSupervision.relieSuperviseursAService = async (
-      idService,
+      service,
       idsSuperviseurs
     ) => {
       idsSuperviseurRecus = idsSuperviseurs;
-      idServiceRecu = idService;
+      serviceRecu = service;
     };
 
     depotDonnees.lisSuperviseurs = async () => ['US1'];
 
-    const service = unService().avecId('S1').construis();
+    const service = unService()
+      .avecOrganisationResponsable({ siret: '12345' })
+      .avecId('S1')
+      .construis();
 
     await relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision })({
       service,
     });
 
     expect(idsSuperviseurRecus).to.eql(['US1']);
-    expect(idServiceRecu).to.be('S1');
+    expect(serviceRecu).to.be(service);
   });
 
   it("n'appelle pas la supervision si aucun superviseur n'est concerné par le service", async () => {

--- a/test/depots/depotDonneesSuperviseurs.spec.js
+++ b/test/depots/depotDonneesSuperviseurs.spec.js
@@ -1,0 +1,26 @@
+const expect = require('expect.js');
+const depotDonneesSuperviseurs = require('../../src/depots/depotDonneesSuperviseurs');
+const {
+  unePersistanceMemoire,
+} = require('../constructeurs/constructeurAdaptateurPersistanceMemoire');
+
+describe('Le dépôt de données des superviseurs', () => {
+  let depot;
+  let adaptateurPersistance;
+
+  beforeEach(() => {
+    adaptateurPersistance = unePersistanceMemoire().construis();
+    depot = depotDonneesSuperviseurs.creeDepot({ adaptateurPersistance });
+  });
+
+  it('délègue à la persistance la lecture des superviseurs concernés par un siret', async () => {
+    let siretRecu;
+    adaptateurPersistance.lisSuperviseursConcernes = async (siret) => {
+      siretRecu = siret;
+    };
+
+    await depot.lisSuperviseurs('SIRET');
+
+    expect(siretRecu).to.eql('SIRET');
+  });
+});


### PR DESCRIPTION
Afin de proposer un dashboard de "Supervision" aux utilisateurs concernés, MonServiceSécurisé va tenir dans son Journal une liste à jour des liens entre superviseur et service.

Cette PR permet de relier un service à un superviseur lors de sa création.