### PR TITLE
[SUPERVISION] Modification du lien des superviseurs lors d'un changement de SIRET

### DIFF
--- a/src/bus/abonnements/delieServiceEtSuperviseurs.js
+++ b/src/bus/abonnements/delieServiceEtSuperviseurs.js
@@ -1,6 +1,6 @@
-function delieServiceEtSuperviseurs({ adaptateurSupervision }) {
+function delieServiceEtSuperviseurs({ serviceSupervision }) {
   return async ({ idService }) => {
-    await adaptateurSupervision.delieServiceDesSuperviseurs(idService);
+    await serviceSupervision.delieServiceEtSuperviseurs(idService);
   };
 }
 

--- a/src/bus/abonnements/modifieLienServiceEtSuperviseurs.js
+++ b/src/bus/abonnements/modifieLienServiceEtSuperviseurs.js
@@ -1,0 +1,12 @@
+function modifieLienServiceEtSuperviseurs({ serviceSupervision }) {
+  return async ({ service, ancienneDescription }) => {
+    if (
+      service.siretDeOrganisation() ===
+      ancienneDescription.organisationResponsable.siret
+    )
+      return;
+    await serviceSupervision.modifieLienServiceEtSuperviseurs(service);
+  };
+}
+
+module.exports = { modifieLienServiceEtSuperviseurs };

--- a/src/bus/abonnements/relieServiceEtSuperviseurs.js
+++ b/src/bus/abonnements/relieServiceEtSuperviseurs.js
@@ -1,15 +1,6 @@
-function relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision }) {
+function relieServiceEtSuperviseurs({ serviceSupervision }) {
   return async ({ service }) => {
-    const superviseurs = await depotDonnees.lisSuperviseurs(
-      service.siretDeOrganisation()
-    );
-
-    if (!superviseurs.length) return;
-
-    await adaptateurSupervision.relieSuperviseursAService(
-      service,
-      superviseurs
-    );
+    await serviceSupervision.relieServiceEtSuperviseurs(service);
   };
 }
 

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -96,6 +96,9 @@ const {
   delieServiceEtSuperviseurs,
 } = require('./abonnements/delieServiceEtSuperviseurs');
 const ServiceSupervision = require('../supervision/serviceSupervision');
+const {
+  modifieLienServiceEtSuperviseurs,
+} = require('./abonnements/modifieLienServiceEtSuperviseurs');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -165,6 +168,7 @@ const cableTousLesAbonnes = (
       adaptateurRechercheEntreprise,
     }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
+    modifieLienServiceEtSuperviseurs({ serviceSupervision }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementAutorisationsServiceModifiees, [

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -95,6 +95,7 @@ const {
 const {
   delieServiceEtSuperviseurs,
 } = require('./abonnements/delieServiceEtSuperviseurs');
+const ServiceSupervision = require('../supervision/serviceSupervision');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -113,6 +114,10 @@ const cableTousLesAbonnes = (
     adaptateurRechercheEntreprise,
     adaptateurMail,
   });
+  const serviceSupervision = new ServiceSupervision({
+    adaptateurSupervision,
+    depotDonnees,
+  });
 
   busEvenements.abonnePlusieurs(EvenementNouveauServiceCree, [
     consigneNouveauServiceDansJournal({ adaptateurJournal }),
@@ -127,7 +132,7 @@ const cableTousLesAbonnes = (
       crmBrevo,
       depotDonnees,
     }),
-    relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision }),
+    relieServiceEtSuperviseurs({ serviceSupervision }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementMesureServiceModifiee, [
@@ -209,7 +214,7 @@ const cableTousLesAbonnes = (
     consigneServiceSupprimeDansJournal({ adaptateurJournal }),
     supprimeNotificationsExpirationHomologation({ depotDonnees }),
     metAJourContactsBrevoDesContributeurs({ crmBrevo, depotDonnees }),
-    delieServiceEtSuperviseurs({ adaptateurSupervision }),
+    delieServiceEtSuperviseurs({ serviceSupervision }),
   ]);
 };
 

--- a/src/bus/evenementDescriptionServiceModifiee.js
+++ b/src/bus/evenementDescriptionServiceModifiee.js
@@ -1,12 +1,17 @@
 class EvenementDescriptionServiceModifiee {
-  constructor({ service, utilisateur }) {
+  constructor({ service, utilisateur, ancienneDescription }) {
     if (!service)
       throw Error("Impossible d'instancier l'événement sans service");
     if (!utilisateur)
       throw Error("Impossible d'instancier l'événement sans utilisateur");
+    if (!ancienneDescription)
+      throw Error(
+        "Impossible d'instancier l'événement sans l'ancienne description"
+      );
 
     this.service = service;
     this.utilisateur = utilisateur;
+    this.ancienneDescription = ancienneDescription;
   }
 }
 

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -279,7 +279,11 @@ const creeDepot = (config = {}) => {
     const s = await p.lis.un(idService);
     const u = await depotDonneesUtilisateurs.utilisateur(idUtilisateur);
     await busEvenements.publie(
-      new EvenementDescriptionServiceModifiee({ service: s, utilisateur: u })
+      new EvenementDescriptionServiceModifiee({
+        service: s,
+        utilisateur: u,
+        ancienneDescription: existant.descriptionService,
+      })
     );
   };
 

--- a/src/supervision/serviceSupervision.js
+++ b/src/supervision/serviceSupervision.js
@@ -25,6 +25,11 @@ class ServiceSupervision {
       superviseurs
     );
   }
+
+  async modifieLienServiceEtSuperviseurs(service) {
+    await this.delieServiceEtSuperviseurs(service.id);
+    await this.relieServiceEtSuperviseurs(service);
+  }
 }
 
 module.exports = ServiceSupervision;

--- a/src/supervision/serviceSupervision.js
+++ b/src/supervision/serviceSupervision.js
@@ -1,0 +1,30 @@
+class ServiceSupervision {
+  constructor({ depotDonnees, adaptateurSupervision }) {
+    if (!depotDonnees || !adaptateurSupervision) {
+      throw new Error(
+        "Impossible d'instancier le service de supervision sans ses dépendances"
+      );
+    }
+    this.depotDonnees = depotDonnees;
+    this.adaptateurSupervision = adaptateurSupervision;
+  }
+
+  async delieServiceEtSuperviseurs(idService) {
+    await this.adaptateurSupervision.delieServiceDesSuperviseurs(idService);
+  }
+
+  async relieServiceEtSuperviseurs(service) {
+    const superviseurs = await this.depotDonnees.lisSuperviseurs(
+      service.siretDeOrganisation()
+    );
+
+    if (!superviseurs.length) return;
+
+    await this.adaptateurSupervision.relieSuperviseursAService(
+      service,
+      superviseurs
+    );
+  }
+}
+
+module.exports = ServiceSupervision;

--- a/test/bus/abonnements/delieServiceEtSuperviseurs.spec.js
+++ b/test/bus/abonnements/delieServiceEtSuperviseurs.spec.js
@@ -4,15 +4,15 @@ const {
 } = require('../../../src/bus/abonnements/delieServiceEtSuperviseurs');
 
 describe("L'abonné en charge de délier un service supprimé à ses superviseurs", () => {
-  it('délègue à la supervision la suppression du lien entre les superviseurs et le service', async () => {
+  it('délègue la suppression du lien au service de supervision', async () => {
     let idServiceRecu;
-    const adaptateurSupervision = {
-      delieServiceDesSuperviseurs: async (idService) => {
+    const serviceSupervision = {
+      delieServiceEtSuperviseurs: async (idService) => {
         idServiceRecu = idService;
       },
     };
 
-    await delieServiceEtSuperviseurs({ adaptateurSupervision })({
+    await delieServiceEtSuperviseurs({ serviceSupervision })({
       idService: 'S1',
     });
 

--- a/test/bus/abonnements/modifieLienServiceEtSuperviseurs.spec.js
+++ b/test/bus/abonnements/modifieLienServiceEtSuperviseurs.spec.js
@@ -1,0 +1,69 @@
+const expect = require('expect.js');
+const { unService } = require('../../constructeurs/constructeurService');
+const {
+  modifieLienServiceEtSuperviseurs,
+} = require('../../../src/bus/abonnements/modifieLienServiceEtSuperviseurs');
+const uneDescriptionValide = require('../../constructeurs/constructeurDescriptionService');
+
+describe("L'abonné en charge de modifier le lien entre un service modifié et ses superviseurs", () => {
+  let serviceSupervision;
+
+  beforeEach(() => {
+    serviceSupervision = {
+      modifieLienServiceEtSuperviseurs: async () => {},
+    };
+  });
+
+  it("ne fait rien si le SIRET n'a pas changé", async () => {
+    let serviceAppele = false;
+
+    serviceSupervision.modifieLienServiceEtSuperviseurs = async () => {
+      serviceAppele = true;
+    };
+
+    const service = unService()
+      .avecOrganisationResponsable({
+        siret: 'unSIRET',
+      })
+      .construis();
+    const ancienneDescription = uneDescriptionValide()
+      .deLOrganisation({ siret: 'unSIRET' })
+      .construis();
+
+    await modifieLienServiceEtSuperviseurs({
+      serviceSupervision,
+    })({
+      service,
+      ancienneDescription,
+    });
+
+    expect(serviceAppele).to.be(false);
+  });
+
+  it('délègue au service de supervision la modification du lien si le SIRET a changé', async () => {
+    let serviceRecu;
+
+    serviceSupervision.modifieLienServiceEtSuperviseurs = async (service) => {
+      serviceRecu = service;
+    };
+
+    const service = unService()
+      .avecId('S1')
+      .avecOrganisationResponsable({
+        siret: 'unSIRET',
+      })
+      .construis();
+    const ancienneDescription = uneDescriptionValide()
+      .deLOrganisation({ siret: 'unAutreSIRET' })
+      .construis();
+
+    await modifieLienServiceEtSuperviseurs({
+      serviceSupervision,
+    })({
+      service,
+      ancienneDescription,
+    });
+
+    expect(serviceRecu.id).to.be('S1');
+  });
+});

--- a/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
+++ b/test/bus/abonnements/relieServiceEtSuperviseurs.spec.js
@@ -5,75 +5,20 @@ const {
 } = require('../../../src/bus/abonnements/relieServiceEtSuperviseurs');
 
 describe("L'abonné en charge de relier un nouveau service à ses superviseurs", () => {
-  let adaptateurSupervision;
-  let depotDonnees;
-
-  beforeEach(() => {
-    adaptateurSupervision = {
-      relieSuperviseursAService: async () => {},
-    };
-    depotDonnees = {
-      lisSuperviseurs: async () => {},
-    };
-  });
-
-  it('délègue au dépôt la lecture des superviseurs concernés', async () => {
-    let siretRecu;
-    depotDonnees.lisSuperviseurs = async (siret) => {
-      siretRecu = siret;
-      return [];
-    };
-    const service = unService()
-      .avecOrganisationResponsable({ siret: '12345' })
-      .construis();
-
-    await relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision })({
-      service,
-    });
-
-    expect(siretRecu).to.be('12345');
-  });
-
-  it('délègue à la supervision la création du lien entre les superviseurs et le service', async () => {
-    let idsSuperviseurRecus;
+  it('délègue la création du lien au service de supervision', async () => {
     let serviceRecu;
-    adaptateurSupervision.relieSuperviseursAService = async (
-      service,
-      idsSuperviseurs
-    ) => {
-      idsSuperviseurRecus = idsSuperviseurs;
-      serviceRecu = service;
+    const serviceSupervision = {
+      relieServiceEtSuperviseurs: async (service) => {
+        serviceRecu = service;
+      },
     };
 
-    depotDonnees.lisSuperviseurs = async () => ['US1'];
+    const service = unService().avecId('S1').construis();
 
-    const service = unService()
-      .avecOrganisationResponsable({ siret: '12345' })
-      .avecId('S1')
-      .construis();
-
-    await relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision })({
+    await relieServiceEtSuperviseurs({ serviceSupervision })({
       service,
     });
 
-    expect(idsSuperviseurRecus).to.eql(['US1']);
-    expect(serviceRecu).to.be(service);
-  });
-
-  it("n'appelle pas la supervision si aucun superviseur n'est concerné par le service", async () => {
-    let supervisionAppelee = false;
-    adaptateurSupervision.relieSuperviseursAService = async () => {
-      supervisionAppelee = true;
-    };
-
-    depotDonnees.lisSuperviseurs = async () => [];
-
-    const service = unService().construis();
-
-    await relieServiceEtSuperviseurs({ depotDonnees, adaptateurSupervision })({
-      service,
-    });
-
-    expect(supervisionAppelee).to.be(false);
+    expect(serviceRecu.id).to.eql('S1');
   });
 });

--- a/test/bus/evenementDescriptionServiceModifiee.spec.js
+++ b/test/bus/evenementDescriptionServiceModifiee.spec.js
@@ -12,6 +12,7 @@ describe("L'événement `descriptionServiceModifiee", () => {
         new EvenementDescriptionServiceModifiee({
           service: null,
           utilisateur: unUtilisateur().construis(),
+          ancienneDescription: { nomService: 'Service 1' },
         })
     ).to.throwError();
   });
@@ -22,6 +23,18 @@ describe("L'événement `descriptionServiceModifiee", () => {
         new EvenementDescriptionServiceModifiee({
           service: unService().construis(),
           utilisateur: null,
+          ancienneDescription: { nomService: 'Service 1' },
+        })
+    ).to.throwError();
+  });
+
+  it("lève une exception s'il est instancié sans l'ancienne description", () => {
+    expect(
+      () =>
+        new EvenementDescriptionServiceModifiee({
+          service: unService().construis(),
+          utilisateur: unUtilisateur().construis(),
+          ancienneDescription: null,
         })
     ).to.throwError();
   });

--- a/test/constructeurs/constructeurDescriptionService.js
+++ b/test/constructeurs/constructeurDescriptionService.js
@@ -1,7 +1,8 @@
 const DescriptionService = require('../../src/modeles/descriptionService');
+const Referentiel = require('../../src/referentiel');
 
 class ConstructeurDescriptionService {
-  constructor(referentiel) {
+  constructor(referentiel = Referentiel.creeReferentiel()) {
     this.referentiel = referentiel;
     this.referentiel.enrichis({
       statutsDeploiement: { unStatutDeploiement: {} },

--- a/test/supervision/serviceSupervision.spec.js
+++ b/test/supervision/serviceSupervision.spec.js
@@ -1,0 +1,100 @@
+const expect = require('expect.js');
+const ServiceSupervision = require('../../src/supervision/serviceSupervision');
+const { unService } = require('../constructeurs/constructeurService');
+
+describe('Le service de supervision', () => {
+  let adaptateurSupervision;
+  let depotDonnees;
+  let serviceSupervision;
+
+  beforeEach(() => {
+    adaptateurSupervision = {
+      relieSuperviseursAService: async () => {},
+      delieServiceDesSuperviseurs: async () => {},
+    };
+    depotDonnees = {
+      lisSuperviseurs: async () => {},
+    };
+    serviceSupervision = new ServiceSupervision({
+      depotDonnees,
+      adaptateurSupervision,
+    });
+  });
+
+  it("jette une erreur s'il n'est pas instancié avec les bons adaptateurs", () => {
+    expect(() => new ServiceSupervision({})).to.throwError((e) => {
+      expect(e.message).to.be(
+        "Impossible d'instancier le service de supervision sans ses dépendances"
+      );
+    });
+  });
+
+  describe('sur demande de liaison entre un service et des superviseurs', () => {
+    it('délègue au dépôt la lecture des superviseurs concernés', async () => {
+      let siretRecu;
+      depotDonnees.lisSuperviseurs = async (siret) => {
+        siretRecu = siret;
+        return [];
+      };
+      const service = unService()
+        .avecOrganisationResponsable({ siret: '12345' })
+        .construis();
+
+      await serviceSupervision.relieServiceEtSuperviseurs(service);
+
+      expect(siretRecu).to.be('12345');
+    });
+
+    it("délègue à l'adaptateur la création du lien", async () => {
+      let idsSuperviseurRecus;
+      let serviceRecu;
+      adaptateurSupervision.relieSuperviseursAService = async (
+        service,
+        idsSuperviseurs
+      ) => {
+        idsSuperviseurRecus = idsSuperviseurs;
+        serviceRecu = service;
+      };
+
+      depotDonnees.lisSuperviseurs = async () => ['US1'];
+
+      const service = unService()
+        .avecOrganisationResponsable({ siret: '12345' })
+        .avecId('S1')
+        .construis();
+
+      await serviceSupervision.relieServiceEtSuperviseurs(service);
+
+      expect(idsSuperviseurRecus).to.eql(['US1']);
+      expect(serviceRecu).to.be(service);
+    });
+
+    it("n'appelle pas l'adaptateur si aucun superviseur n'est concerné par le service", async () => {
+      let supervisionAppelee = false;
+      adaptateurSupervision.relieSuperviseursAService = async () => {
+        supervisionAppelee = true;
+      };
+
+      depotDonnees.lisSuperviseurs = async () => [];
+
+      const service = unService().construis();
+
+      await serviceSupervision.relieServiceEtSuperviseurs(service);
+
+      expect(supervisionAppelee).to.be(false);
+    });
+  });
+
+  describe('sur demande de suppression du lien entre un service et des superviseurs', () => {
+    it("délègue à l'adaptateur la suppression du lien", async () => {
+      let idServiceRecu;
+      adaptateurSupervision.delieServiceDesSuperviseurs = async (idService) => {
+        idServiceRecu = idService;
+      };
+
+      await serviceSupervision.delieServiceEtSuperviseurs('S1');
+
+      expect(idServiceRecu).to.be('S1');
+    });
+  });
+});

--- a/test/supervision/serviceSupervision.spec.js
+++ b/test/supervision/serviceSupervision.spec.js
@@ -97,4 +97,24 @@ describe('Le service de supervision', () => {
       expect(idServiceRecu).to.be('S1');
     });
   });
+
+  describe('sur demande de modification du lien entre un service et des superviseurs', () => {
+    it("appele successivement les méthodes de suppression et d'ajout de lien", async () => {
+      let idServiceRecuParSuppression;
+      let serviceRecuParAjout;
+      serviceSupervision.delieServiceEtSuperviseurs = async (idService) => {
+        idServiceRecuParSuppression = idService;
+      };
+      serviceSupervision.relieServiceEtSuperviseurs = async (service) => {
+        serviceRecuParAjout = service;
+      };
+
+      const service = unService().avecId('S1').construis();
+
+      await serviceSupervision.modifieLienServiceEtSuperviseurs(service);
+
+      expect(idServiceRecuParSuppression).to.be('S1');
+      expect(serviceRecuParAjout.id).to.be('S1');
+    });
+  });
 });


### PR DESCRIPTION
Cet abonné ne fait finalement qu'une suppression suivi d'un ajout dans le cas d'une modification de SIRET.

On en profite pour extraire un `ServiceSupervision` qui permet d'orchestrer ces actions.