### PR TITLE
[CORRECTION] Considère uniquement des `email` en minuscule

### DIFF
--- a/migrations/20241107084938_remplaceMajusculeDansEmailUtilisateur.js
+++ b/migrations/20241107084938_remplaceMajusculeDansEmailUtilisateur.js
@@ -1,0 +1,24 @@
+const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+
+const hache = (email) => hacheSha256(email);
+
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const utilisateurs = await trx('utilisateurs');
+
+    const maj = utilisateurs.map(({ id, donnees }) => {
+      const { email, ...autresDonnees } = donnees;
+      const emailMinuscule = email.toLowerCase();
+      autresDonnees.email = emailMinuscule;
+      const emailHash = hache(emailMinuscule);
+
+      return trx('utilisateurs')
+        .where({ id })
+        .update({ email_hash: emailHash, donnees: autresDonnees });
+    });
+
+    await Promise.all(maj);
+  });
+};
+
+exports.down = async () => {};

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -85,7 +85,8 @@ function fabriquePersistance({
         return dechiffreUtilisateur(donnees);
       },
       celuiAvecEmail: async (email) => {
-        const emailHash = adaptateurChiffrement.hacheSha256(email);
+        const emailMinuscule = email.toLowerCase();
+        const emailHash = adaptateurChiffrement.hacheSha256(emailMinuscule);
         const donnees =
           await adaptateurPersistance.utilisateurAvecEmailHash(emailHash);
         return dechiffreUtilisateur(donnees);

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -438,34 +438,66 @@ describe('Le dépôt de données des utilisateurs', () => {
     });
   });
 
-  it("retourne l'utilisateur associé à un email donné", async () => {
-    const adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur(
-      {
-        utilisateurs: [
-          {
-            id: '123',
-            donnees: {
-              prenom: 'Jean',
-              nom: 'Dupont',
-              email: 'jean.dupont@mail.fr',
-              motDePasse: 'XXX',
+  describe("sur demande d'utilisateur associé à un email", () => {
+    it("retourne l'utilisateur", async () => {
+      const adaptateurPersistance =
+        AdaptateurPersistanceMemoire.nouvelAdaptateur({
+          utilisateurs: [
+            {
+              id: '123',
+              donnees: {
+                prenom: 'Jean',
+                nom: 'Dupont',
+                email: 'jean.dupont@mail.fr',
+                motDePasse: 'XXX',
+              },
+              emailHash: 'jean.dupont@mail.fr-haché256',
             },
-            emailHash: 'jean.dupont@mail.fr-haché256',
-          },
-        ],
-      }
-    );
-    const depot = DepotDonneesUtilisateurs.creeDepot({
-      adaptateurChiffrement,
-      adaptateurJWT,
-      adaptateurPersistance,
+          ],
+        });
+      const depot = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurChiffrement,
+        adaptateurJWT,
+        adaptateurPersistance,
+      });
+
+      const utilisateur = await depot.utilisateurAvecEmail(
+        'jean.dupont@mail.fr'
+      );
+
+      expect(utilisateur).to.be.an(Utilisateur);
+      expect(utilisateur.id).to.equal('123');
+      expect(utilisateur.adaptateurJWT).to.equal(adaptateurJWT);
     });
 
-    const utilisateur = await depot.utilisateurAvecEmail('jean.dupont@mail.fr');
+    it('ne tient pas compte de la casse', async () => {
+      const adaptateurPersistance =
+        AdaptateurPersistanceMemoire.nouvelAdaptateur({
+          utilisateurs: [
+            {
+              id: '123',
+              donnees: {
+                prenom: 'Jean',
+                nom: 'Dupont',
+                email: 'jean.dupont@mail.fr',
+                motDePasse: 'XXX',
+              },
+              emailHash: 'jean.dupont@mail.fr-haché256',
+            },
+          ],
+        });
+      const depot = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurChiffrement,
+        adaptateurJWT,
+        adaptateurPersistance,
+      });
 
-    expect(utilisateur).to.be.an(Utilisateur);
-    expect(utilisateur.id).to.equal('123');
-    expect(utilisateur.adaptateurJWT).to.equal(adaptateurJWT);
+      const utilisateur = await depot.utilisateurAvecEmail(
+        'Jean.Dupont@mail.fr'
+      );
+
+      expect(utilisateur.id).to.equal('123');
+    });
   });
 
   it('retourne tous les utilisateurs enregistrés', async () => {


### PR DESCRIPTION
Suite à une erreur en PROD, on remarque que Agent Connect nous envoi parfois des informations utilisateur contenant des emails avec des majuscules.
Si le compte existe déjà dans MSS en version "minuscule", on ne trouve pas le compte, donc on essaye de le créer, ce qui provoque une erreur côté Brevo.