### PR TITLE
[SUPERVISION] Ajoute le `hash` des SIRETs de service

### DIFF
--- a/migrations/20241107100038_ajouteColonneSiretHash.js
+++ b/migrations/20241107100038_ajouteColonneSiretHash.js
@@ -1,0 +1,10 @@
+const services = 'services';
+const nouvelleColonne = 'siret_hash';
+
+exports.up = (knex) =>
+  knex.schema.alterTable(services, (table) => table.string(nouvelleColonne));
+
+exports.down = (knex) =>
+  knex.schema.alterTable(services, (table) =>
+    table.dropColumn(nouvelleColonne)
+  );

--- a/migrations/20241107100049_insereSiretHash.js
+++ b/migrations/20241107100049_insereSiretHash.js
@@ -1,0 +1,24 @@
+const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+
+const hache = (nom) => hacheSha256(nom);
+
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const services = await trx('services');
+
+    const maj = services.map(({ id, donnees }) => {
+      const siret = donnees.descriptionService?.organisationResponsable?.siret;
+      const siretHash = siret ? hache(siret) : null;
+
+      return trx('services').where({ id }).update({ siret_hash: siretHash });
+    });
+
+    await Promise.all(maj);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.transaction(async (trx) =>
+    trx('services').update({ siret_hash: null })
+  );
+};

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -18,8 +18,18 @@ const nouvelAdaptateur = (
     donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
   };
 
-  const ajouteService = async (id, donneesService, nomServiceHash) => {
-    donnees.services.push({ id, donnees: donneesService, nomServiceHash });
+  const ajouteService = async (
+    id,
+    donneesService,
+    nomServiceHash,
+    siretHash
+  ) => {
+    donnees.services.push({
+      id,
+      donnees: donneesService,
+      nomServiceHash,
+      siretHash,
+    });
   };
 
   const ajouteUtilisateur = async (id, donneesUtilisateur, emailHash) => {
@@ -72,9 +82,14 @@ const nouvelAdaptateur = (
     );
   };
 
-  const metsAJourService = async (id, donneesService, nomServiceHash) => {
+  const metsAJourService = async (
+    id,
+    donneesService,
+    nomServiceHash,
+    siretHash
+  ) => {
     const s = await service(id);
-    Object.assign(s, { nomServiceHash, donnees: donneesService });
+    Object.assign(s, { nomServiceHash, siretHash, donnees: donneesService });
   };
 
   const sauvegardeAutorisation = async (id, donneesAutorisation) => {
@@ -84,11 +99,11 @@ const nouvelAdaptateur = (
     else Object.assign(dejaConnue, { ...donneesAutorisation });
   };
 
-  const sauvegardeService = (id, donneesService, nomServiceHash) => {
+  const sauvegardeService = (id, donneesService, nomServiceHash, siretHash) => {
     const dejaConnu = donnees.services.find((s) => s.id === id) !== undefined;
     return dejaConnu
-      ? metsAJourService(id, donneesService, nomServiceHash)
-      : ajouteService(id, donneesService, nomServiceHash);
+      ? metsAJourService(id, donneesService, nomServiceHash, siretHash)
+      : ajouteService(id, donneesService, nomServiceHash, siretHash);
   };
 
   const supprimeService = (...params) =>

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -76,8 +76,13 @@ const nouvelAdaptateur = (env) => {
   const supprimeEnregistrement = (nomTable, id) =>
     knex(nomTable).where({ id }).del();
 
-  const ajouteService = async (id, donnees, nomServiceHash) =>
-    knex('services').insert({ id, donnees, nom_service_hash: nomServiceHash });
+  const ajouteService = async (id, donnees, nomServiceHash, siretHash) =>
+    knex('services').insert({
+      id,
+      donnees,
+      nom_service_hash: nomServiceHash,
+      siret_hash: siretHash,
+    });
 
   const ajouteUtilisateur = (id, donnees, emailHash) =>
     knex('utilisateurs').insert({
@@ -177,7 +182,7 @@ const nouvelAdaptateur = (env) => {
     return avecPMapPourChaqueElement(Promise.resolve(ids), service);
   };
 
-  const metsAJourService = (id, donnees, nomServiceHash) =>
+  const metsAJourService = (id, donnees, nomServiceHash, siretHash) =>
     knex('services')
       .where({ id })
       .first()
@@ -185,6 +190,7 @@ const nouvelAdaptateur = (env) => {
         knex('services').where({ id }).update({
           donnees,
           nom_service_hash: nomServiceHash,
+          siret_hash: siretHash,
         })
       );
 
@@ -278,7 +284,7 @@ const nouvelAdaptateur = (env) => {
       .whereRaw("(donnees->>'estProprietaire')::boolean=true")
       .then(([{ count }]) => parseInt(count, 10));
 
-  const sauvegardeService = (id, donneesService, nomServiceHash) => {
+  const sauvegardeService = (id, donneesService, nomServiceHash, siretHash) => {
     const testExistence = knex('services')
       .where('id', id)
       .select({ id: 'id' })
@@ -287,8 +293,8 @@ const nouvelAdaptateur = (env) => {
 
     return testExistence.then((dejaConnu) =>
       dejaConnu
-        ? metsAJourService(id, donneesService, nomServiceHash)
-        : ajouteService(id, donneesService, nomServiceHash)
+        ? metsAJourService(id, donneesService, nomServiceHash, siretHash)
+        : ajouteService(id, donneesService, nomServiceHash, siretHash)
     );
   };
 

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -114,10 +114,15 @@ const fabriquePersistance = (
         donneesService.descriptionService.nomService
       );
 
+      const siret =
+        donneesService.descriptionService?.organisationResponsable?.siret;
+      const siretHash = siret ? adaptateurChiffrement.hacheSha256(siret) : null;
+
       return adaptateurPersistance.sauvegardeService(
         id,
         donneesChiffrees,
-        nomServiceHash
+        nomServiceHash,
+        siretHash
       );
     },
     supprime: async (idService) => {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -351,6 +351,17 @@ describe('Le dépôt de données des services', () => {
       expect(donnees.nomServiceHash).to.be('Nouveau Nom-haché256');
     });
 
+    it('met à jour le SHA-256 du SIRET du service', async () => {
+      const description = uneDescriptionValide(referentiel)
+        .deLOrganisation({ siret: 'unSIRET' })
+        .construis();
+
+      await depot.ajouteDescriptionService('U1', 'S1', description);
+
+      const donnees = await adaptateurPersistance.service('S1');
+      expect(donnees.siretHash).to.be('unSIRET-haché256');
+    });
+
     it('lève une exception si des propriétés obligatoires ne sont pas renseignées', async () => {
       const descriptionIncomplete = uneDescriptionValide(referentiel)
         .avecNomService('')
@@ -829,6 +840,20 @@ describe('Le dépôt de données des services', () => {
 
       const donnees = await adaptateurPersistance.service(idNouveau);
       expect(donnees.nomServiceHash).to.be('Super Service-haché256');
+    });
+
+    it('stocke le SHA-256 du SIRET du service', async () => {
+      const descriptionService = uneDescriptionValide(referentiel)
+        .deLOrganisation({ siret: 'unSIRET' })
+        .construis()
+        .donneesSerialisees();
+
+      const idNouveau = await depot.nouveauService('123', {
+        descriptionService,
+      });
+
+      const donnees = await adaptateurPersistance.service(idNouveau);
+      expect(donnees.siretHash).to.be('unSIRET-haché256');
     });
 
     it("déclare un accès en écriture entre l'utilisateur et le service", async () => {


### PR DESCRIPTION
... en base de données, afin de pouvoir plus facilement rechercher tous les services d'un SIRET.

On sort cette données dans une colonne dédiée afin de garantir le fonctionnement de nos méthodes lorsque les données seront chiffrées.