### PR TITLE
[CORRECTION] Corrige un bug sur mise à jour d'une mesure spécifique avec responsable

### DIFF
--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -363,7 +363,7 @@ class Service {
   }
 
   metsAJourMesureSpecifique(mesure) {
-    const idContributeurs = this.contributeurs.map((u) => u.id);
+    const idContributeurs = this.contributeurs.map((u) => u.idUtilisateur);
     if (mesure.responsables.some((r) => !idContributeurs.includes(r))) {
       throw new ErreurResponsablesMesureInvalides(
         "Les responsables d'une mesure spécifique doivent être des contributeurs du service."

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -1062,5 +1062,29 @@ describe('Un service', () => {
 
       expect(donneesRecues.id).to.be('M1');
     });
+
+    it('peut ajouter un responsable', async () => {
+      const service = unService()
+        .ajouteUnContributeur(
+          unUtilisateur().avecId('id-utilisateur').construis()
+        )
+        .construis();
+      let donneesRecues;
+      service.mesures.mesuresSpecifiques.metsAJourMesure = (mesureRecu) => {
+        donneesRecues = mesureRecu;
+      };
+      const mesure = new MesureSpecifique(
+        {
+          id: 'M1',
+          statut: 'fait',
+          responsables: ['id-utilisateur'],
+        },
+        referentiel
+      );
+
+      await service.metsAJourMesureSpecifique(mesure);
+
+      expect(donneesRecues.responsables).to.eql(['id-utilisateur']);
+    });
   });
 });


### PR DESCRIPTION
 Ce bug provient de la séparation des contributeurs et utilisateurs et du renommage de id vers idUtilisateur de l'identifiant de l'utilisateur