### PR TITLE
[CORRECTION] Applique la police "Marianne" sur la liste déroulante

### DIFF
--- a/svelte/lib/ui/ListeDeroulante.svelte
+++ b/svelte/lib/ui/ListeDeroulante.svelte
@@ -97,6 +97,7 @@
     background: var(--fond-gris-pale-composant);
     background-size: 1.11em 1.11em;
     min-width: 288px;
+    font-family: 'Marianne';
   }
 
   select:hover {


### PR DESCRIPTION
... car par défaut, le `select` ne prend pas la police du `body`