### PR TITLE
[CORRECTION] Vérifie la finalisation de l'inscription pour le parrainage

### DIFF
--- a/src/bus/abonnements/metAJourParrainage.js
+++ b/src/bus/abonnements/metAJourParrainage.js
@@ -1,7 +1,11 @@
 function metAJourParrainage({ depotDonnees }) {
   return async ({ utilisateur }) => {
     const parrainage = await depotDonnees.parrainagePour(utilisateur.id);
-    if (!parrainage || parrainage.compteFilleulEstFinalise()) {
+    if (
+      !parrainage ||
+      parrainage.compteFilleulEstFinalise() ||
+      utilisateur.estUnInvite()
+    ) {
       return;
     }
     parrainage.confirmeFinalisationCompteFilleul();

--- a/test/bus/abonnements/metAJourParrainage.spec.js
+++ b/test/bus/abonnements/metAJourParrainage.spec.js
@@ -80,4 +80,24 @@ describe('L’abonnement qui met à jour les parrainages', () => {
 
     // n'est pas passé dans expect().fail() de metsAJourParrainage
   });
+
+  it('ne fait pas de modification si le compte parrainé est encore un invité', async () => {
+    const depotDonnees = {
+      metsAJourParrainage: async () => {
+        expect().fail("n'aurait pas dû appeler la mise à jour");
+      },
+      parrainagePour: async () =>
+        new Parrainage({
+          idUtilisateurFilleul: 'U1',
+          filleulAFinaliseCompte: false,
+        }),
+    };
+
+    const abonnement = metAJourParrainage({ depotDonnees });
+    await abonnement({
+      utilisateur: unUtilisateur().avecId('U1').quiAEteInvite().construis(),
+    });
+
+    // n'est pas passé dans expect().fail() de metsAJourParrainage
+  });
 });

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -19,7 +19,7 @@ class ConstructeurUtilisateur {
     };
   }
 
-  quiEstInvite() {
+  quiNAPasRempliSonProfil() {
     this.donnees.prenom = '';
     this.donnees.nom = '';
     this.donnees.siret = '';

--- a/test/notifications/centreNotifications.spec.js
+++ b/test/notifications/centreNotifications.spec.js
@@ -422,7 +422,7 @@ describe('Le centre de notifications', () => {
     describe("lorsque l'utilisateur vient d'être invité, donc son profil a plein de champs non renseignés", () => {
       it('renvoie uniquement la notification « globale » de profil à mettre à jour', async () => {
         depotDonnees.utilisateur = async () =>
-          unUtilisateur().quiEstInvite().construis();
+          unUtilisateur().quiNAPasRempliSonProfil().construis();
         referentiel = Referentiel.creeReferentiel({
           tachesCompletudeProfil: [
             { id: 'profil', titre: 'Titre tâche' },


### PR DESCRIPTION
... car sinon, le parrainage était validé avant même que l'utilisateur ne termine le parcours d'inscription.