### PR TITLE
Mise à jour du lien Calendly pour les rendez-vous de présentation

### DIFF
--- a/src/vues/mssConnecte.pug
+++ b/src/vues/mssConnecte.pug
@@ -28,7 +28,7 @@ block bom-contenu
   p Vous souhaitez :
   ul
     a(href = 'https://aide.monservicesecurise.cyber.gouv.fr/' target='_blank' rel = 'noopener'): li Nous contacter ou donner votre avis
-    a(href = 'https://calendly.com/monservicesecurise-henri/presentation-de-monservicesecurise-anssi-clone' target='_blank' rel = 'noopener'): li Assister à un webinaire de présentation MonServiceSécurisé
+    a(href = 'https://calendly.com/fabien-giraud/presentation-de-monservicesecurise-1' target='_blank' rel = 'noopener'): li Assister à un webinaire de présentation MonServiceSécurisé
     if visiteGuideeActive
       a(id = "lien-reinitialise-visite-guidee"): li Parcourir la visite guidée de MonServiceSécurisé
     a(href = 'https://aide.monservicesecurise.cyber.gouv.fr/' target='_blank' rel = 'noopener'): li Consulter la F.A.Q.


### PR DESCRIPTION
Changement mineur du lien de prise de rendez-vous pour la présentation de MonServiceSécurisé. Le lien de Calendly de Henri a été remplacé par celui de Fabien.