### PR TITLE
Mise à jour de home.pug pour refléter le passage à 6 000 utilisateurs

### DIFF
--- a/src/vues/home.pug
+++ b/src/vues/home.pug
@@ -122,7 +122,7 @@ block main
       .chiffres-cle.petite-marge-basse
         +chiffreCle('+55%', "L'augmentation moyenne de l'indice cyber d'un service en seulement 1 mois.")
         +chiffreCle('5 min', "Le temps nécessaire pour démarrer un projet d'homologation et obtenir une 1ère version de son dossier.")
-        +chiffreCle('+5&nbsp;000', "Plus de 5&nbsp;000 personnes utilisent déjà MonServiceSécurisé.")
+        +chiffreCle('+6&nbsp;000', "Plus de 6&nbsp;000 personnes utilisent déjà MonServiceSécurisé.")
     .bloc-contenu.fond-couleur-principale-attenuee
       h3.alignement-gauche.couleur-principale-foncee.moyenne-marge-basse Ces entités qui nous font confiance
       .conteneur-entites.grande-marge-basse


### PR DESCRIPTION
Modification du texte sur la page d’accueil de MonServiceSécurisé pour indiquer le nouveau cap de 6 000 utilisateurs au lieu des 5 000 précédemment affichés. Ajustement éventuel de la mise en page pour assurer la cohérence. Cette mise à jour garantit l’exactitude des chiffres affichés.