### PR TITLE
[TABLEAU DE BORD V2] Ajout du tableau "simple" des services

### DIFF
--- a/public/assets/images/icone_etoile.svg
+++ b/public/assets/images/icone_etoile.svg
@@ -1,0 +1,10 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="star" clip-path="url(#clip0_539_1612)">
+<path id="Ic&#195;&#180;ne" fill-rule="evenodd" clip-rule="evenodd" d="M5.99996 9.13009L2.47346 11.1041L3.26096 7.14009L0.293457 4.39609L4.30696 3.92009L5.99996 0.250092L7.69296 3.92009L11.7065 4.39609L8.73896 7.14009L9.52646 11.1041L5.99996 9.13009Z" fill="#716043"/>
+</g>
+<defs>
+<clipPath id="clip0_539_1612">
+<rect width="12" height="12" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/tableauDeBord-v2.js
+++ b/public/tableauDeBord-v2.js
@@ -1,0 +1,5 @@
+$(() => {
+  document.body.dispatchEvent(
+    new CustomEvent('svelte-recharge-tableau-de-bord')
+  );
+});

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -106,6 +106,15 @@ const routesConnectePage = ({
     }
   );
 
+  routes.get(
+    '/tableauDeBord-v2',
+    middleware.verificationAcceptationCGU,
+    middleware.chargeEtatVisiteGuidee,
+    async (_requete, reponse) => {
+      reponse.render('tableauDeBordv2');
+    }
+  );
+
   routes.get('/deconnexion', middleware.verificationJWT, (requete, reponse) => {
     if (requete.sourceAuthentification === 'MSS') {
       reponse.redirect('/connexion');

--- a/src/vues/tableauDeBordv2.pug
+++ b/src/vues/tableauDeBordv2.pug
@@ -1,0 +1,8 @@
+extends mssConnecte
+
+block append scripts
+  +composantSvelte('tableauDeBord.js')
+  script(type = 'module', src = '/statique/tableauDeBord-v2.js')
+
+block main
+  #tableau-de-bord

--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -11,6 +11,7 @@
   import EtiquetteProprietaire from './elementsDeService/EtiquetteProprietaire.svelte';
   import EtiquetteContributeurs from './elementsDeService/EtiquetteContributeurs.svelte';
   import EtiquetteIndiceCyber from './elementsDeService/EtiquetteIndiceCyber.svelte';
+  import IconeChargementEnCours from '../ui/IconeChargementEnCours.svelte';
 
   let enCoursChargement = false;
 
@@ -77,6 +78,8 @@
                 score={indiceCyberDuService}
                 idService={service.id}
               />
+            {:else}
+              <IconeChargementEnCours />
             {/if}
           </td>
           <td>{service.statutHomologation.libelle}</td>

--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -10,6 +10,7 @@
   import ChargementEnCours from '../ui/ChargementEnCours.svelte';
   import EtiquetteProprietaire from './elementsDeService/EtiquetteProprietaire.svelte';
   import EtiquetteContributeurs from './elementsDeService/EtiquetteContributeurs.svelte';
+  import EtiquetteIndiceCyber from './elementsDeService/EtiquetteIndiceCyber.svelte';
 
   let enCoursChargement = false;
 
@@ -55,7 +56,7 @@
       {#each services as service (service.id)}
         {@const indiceCyberDuService = indicesCybers.find(
           (i) => i.id === service.id
-        )}
+        )?.indiceCyber}
         <tr>
           <td>
             <a class="lien-service" href="/service/{service.id}">
@@ -70,7 +71,14 @@
               nombreContributeurs={service.nombreContributeurs}
             />
           </td>
-          <td>{indiceCyberDuService?.indiceCyber}</td>
+          <td>
+            {#if indiceCyberDuService !== undefined}
+              <EtiquetteIndiceCyber
+                score={indiceCyberDuService}
+                idService={service.id}
+              />
+            {/if}
+          </td>
           <td>{service.statutHomologation.libelle}</td>
         </tr>
       {/each}

--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -1,0 +1,1 @@
+<h1>Mon tableau de bord</h1>

--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -9,6 +9,7 @@
   } from './tableauDeBord.d';
   import ChargementEnCours from '../ui/ChargementEnCours.svelte';
   import EtiquetteProprietaire from './elementsDeService/EtiquetteProprietaire.svelte';
+  import EtiquetteContributeurs from './elementsDeService/EtiquetteContributeurs.svelte';
 
   let enCoursChargement = false;
 
@@ -64,7 +65,11 @@
               <span class="nom-service">{decode(service.nomService)}</span>
             </a>
           </td>
-          <td>{service.nombreContributeurs}</td>
+          <td>
+            <EtiquetteContributeurs
+              nombreContributeurs={service.nombreContributeurs}
+            />
+          </td>
           <td>{indiceCyberDuService?.indiceCyber}</td>
           <td>{service.statutHomologation.libelle}</td>
         </tr>

--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteContributeurs.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteContributeurs.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  export let nombreContributeurs: number;
+</script>
+
+<span>
+  <img
+    src="/statique/assets/images/icone_contributeurs.svg"
+    alt="Icône du nombre de contributeurs"
+  />
+  {nombreContributeurs}
+</span>
+
+<style>
+  span {
+    padding: 0 6px;
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 20px;
+    color: var(--bleu-mise-en-avant);
+    background: var(--cyan-clair);
+    width: fit-content;
+  }
+
+  img {
+    height: 12px;
+  }
+</style>

--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteIndiceCyber.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteIndiceCyber.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  export let score: number;
+  export let idService: string;
+
+  const couleurs = ['rose', 'violet', 'marine', 'bleu', 'turquoise', 'or'];
+  const couleur = couleurs[Math.floor(score)];
+</script>
+
+<a class={couleur} href="/service/{idService}/indiceCyber">
+  <span>{score}</span>
+  <span class="total">/5</span>
+</a>
+
+<style>
+  a {
+    border-radius: 4px;
+    display: flex;
+    padding: 0 6px;
+    justify-content: center;
+    align-items: center;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 20px;
+    width: fit-content;
+    color: white;
+    background: var(--fond);
+    cursor: pointer;
+  }
+
+  a:hover {
+    background: var(--fond-hover);
+  }
+
+  a:active {
+    background: var(--fond-actif);
+  }
+
+  .total {
+    font-weight: 400;
+  }
+
+  .rose {
+    --fond: #9926be;
+    --fond-hover: #84329e;
+    --fond-actif: #6a2880;
+  }
+
+  .violet {
+    --fond: #7025da;
+    --fond-hover: #581aae;
+    --fond-actif: #3e137b;
+  }
+  .marine {
+    --fond: #3352b0;
+    --fond-hover: #1d3fa7;
+    --fond-actif: #042794;
+  }
+  .bleu {
+    --fond: #0079d0;
+    --fond-hover: #026ab5;
+    --fond-actif: #025591;
+  }
+  .turquoise {
+    --fond: #23c8cb;
+    --fond-hover: #19acae;
+    --fond-actif: #169194;
+  }
+
+  .or {
+    --fond: #eac14b;
+    --fond-hover: #d3ae40;
+    --fond-actif: #bc9b3c;
+  }
+</style>

--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteProprietaire.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteProprietaire.svelte
@@ -1,0 +1,31 @@
+<span>
+  <img
+    src="/statique/assets/images/icone_etoile.svg"
+    alt="Icône de propriétaire"
+  />
+  Propriétaire
+</span>
+
+<style>
+  span {
+    text-transform: uppercase;
+    padding: 0 6px;
+    display: flex;
+    gap: 4px;
+    background: #feecc2;
+    color: #716043;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 20px;
+    border-radius: 4px;
+    width: fit-content;
+    align-items: center;
+    justify-content: center;
+  }
+
+  img {
+    width: 12px;
+    height: 12px;
+  }
+</style>

--- a/svelte/lib/tableauDeBord/tableauDeBord.d.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.d.ts
@@ -3,3 +3,51 @@ declare global {
     'svelte-recharge-tableau-de-bord': CustomEvent;
   }
 }
+
+type Contributeur = {
+  id: string;
+  prenomNom: string;
+  initiales: string;
+  poste: string;
+  estUtilisateurCourant: boolean;
+};
+
+export type Service = {
+  id: string;
+  nomService: string;
+  organisationResponsable: string;
+  contributeurs: Contributeur[];
+  statutHomologation: {
+    id: string;
+    enCoursEdition: boolean;
+    libelle: string;
+    ordre: number;
+  };
+  nombreContributeurs: number;
+  estProprietaire: boolean;
+  documentsPdfDisponibles: string[];
+  permissions: {
+    gestionContributeurs: boolean;
+  };
+  aUneSuggestionAction: boolean;
+};
+
+export type ReponseApiServices = {
+  services: Service[];
+  resume: {
+    nombreServices: number;
+    nombreServicesHomologues: number;
+  };
+};
+
+export type IndiceCyber = {
+  id: string;
+  indiceCyber: number;
+};
+
+export type ReponseApiIndicesCyber = {
+  services: IndiceCyber[];
+  resume: {
+    indiceCyberMoyen: number;
+  };
+};

--- a/svelte/lib/tableauDeBord/tableauDeBord.d.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  interface HTMLElementEventMap {
+    'svelte-recharge-tableau-de-bord': CustomEvent;
+  }
+}

--- a/svelte/lib/tableauDeBord/tableauDeBord.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.ts
@@ -1,0 +1,15 @@
+import TableauDeBord from './TableauDeBord.svelte';
+
+document.body.addEventListener('svelte-recharge-tableau-de-bord', () =>
+  rechargeApp()
+);
+
+let app: TableauDeBord;
+const rechargeApp = () => {
+  app?.$destroy();
+  app = new TableauDeBord({
+    target: document.getElementById('tableau-de-bord')!,
+  });
+};
+
+export default app!;

--- a/svelte/lib/ui/IconeChargementEnCours.svelte
+++ b/svelte/lib/ui/IconeChargementEnCours.svelte
@@ -1,0 +1,23 @@
+<div></div>
+
+<style>
+  div {
+    width: 12px;
+    height: 12px;
+    margin: 0;
+    border-radius: 50%;
+    border: 2px solid;
+    border-color: var(--bleu-mise-en-avant) transparent;
+    animation: rotation 1.2s linear infinite;
+  }
+
+  @keyframes rotation {
+    0% {
+      transform: rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -46,6 +46,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
     '/motDePasse/edition',
     '/profil',
     '/tableauDeBord',
+    '/tableauDeBord-v2',
     '/visiteGuidee/decrire',
     '/visiteGuidee/securiser',
     '/visiteGuidee/homologuer',


### PR DESCRIPTION
... en Svelte.

On crée donc un composant Svelte simple qui va permettre d'afficher le tableau des services "iso-prod" en terme de feature, mais avec le "nouveau look" de la V2 du tableau de bord.

![image](https://github.com/user-attachments/assets/ea0b78a5-75c2-44bc-8e2e-f2d75cc56f55)
