### PR TITLE
[CORRECTION] Affiche correctement la visite guidée sur le tableau de bord v2

### DIFF
--- a/public/tableauDeBord-v2.js
+++ b/public/tableauDeBord-v2.js
@@ -1,6 +1,6 @@
 $(() => {
   const { estSuperviseur } = JSON.parse($('#utilisateur-superviseur').text());
-  const { etatVisiteGuidee } = JSON.parse($('#etat-visite-guidee').text());
+  const etatVisiteGuidee = JSON.parse($('#etat-visite-guidee').text());
   const visiteGuideeActive =
     etatVisiteGuidee.dejaTerminee === false && !etatVisiteGuidee.enPause;
   const modeVisiteGuidee =

--- a/src/vues/tableauDeBordv2.pug
+++ b/src/vues/tableauDeBordv2.pug
@@ -3,7 +3,6 @@ extends mssConnecte
 block append scripts
   +composantSvelte('tableauDeBord.js')
   +donneesPartagees('utilisateur-superviseur', {estSuperviseur})
-  +donneesPartagees('etat-visite-guidee', {etatVisiteGuidee})
   script(type = 'module', src = '/statique/tableauDeBord-v2.js')
 
 block main


### PR DESCRIPTION
... l'état de la visite guidée était ajouté à deux endroits, le deuxième l'ajoutant avec un niveau d'objet supplémentaire, ce qui cassait le fonctionnement du composant visite guidée