### PR TITLE
[CORRECTION] Aligne tout le contenu du tableau de bord à gauche

### DIFF
--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -83,6 +83,7 @@
   :global(#tableau-de-bord) {
     width: 100%;
     padding: 32px 48px;
+    text-align: left;
   }
 
   .conteneur-loader {


### PR DESCRIPTION
... car l'intégralité de MSS est centré par défaut.

Un `text-align: left` avait été introduit par mégarde, et corrigé dans la #1941.

![image](https://github.com/user-attachments/assets/ec51d138-15e8-44b4-85f7-05c4fa3c5c5d)
