### PR TITLE
[SOIN] Utilise un 'objet' pour instancier le serveur

### DIFF
--- a/server.js
+++ b/server.js
@@ -103,7 +103,7 @@ const serviceSupervision = new ServiceSupervision({
   adaptateurSupervision,
 });
 
-const serveur = MSS.creeServeur(
+const serveur = MSS.creeServeur({
   depotDonnees,
   middleware,
   referentiel,
@@ -126,8 +126,8 @@ const serveur = MSS.creeServeur(
   serviceSupervision,
   serviceCgu,
   procedures,
-  inscriptionUtilisateur
-);
+  inscriptionUtilisateur,
+});
 
 serveur.ecoute(port, () => {
   /* eslint-disable no-console */

--- a/src/mss.js
+++ b/src/mss.js
@@ -20,7 +20,7 @@ const routesConnecteOidc = require('./routes/connecte/routesConnecteOidc');
 
 require('dotenv').config();
 
-const creeServeur = (
+const creeServeur = ({
   depotDonnees,
   middleware,
   referentiel,
@@ -35,18 +35,18 @@ const creeServeur = (
   adaptateurZip,
   adaptateurTracking,
   adaptateurProtection,
-  adaptateurJournalMSS,
+  adaptateurJournal,
   adaptateurOidc,
   adaptateurEnvironnement,
   adaptateurStatistiques,
   adaptateurJWT,
   serviceSupervision,
-  serviceCGU,
+  serviceCgu,
   procedures,
   inscriptionUtilisateur,
   avecCookieSecurise = process.env.NODE_ENV === 'production',
-  avecPageErreur = process.env.NODE_ENV === 'production'
-) => {
+  avecPageErreur = process.env.NODE_ENV === 'production',
+}) => {
   let serveur;
 
   const app = express();
@@ -121,7 +121,7 @@ const creeServeur = (
       adaptateurGestionErreur,
       adaptateurMail,
       inscriptionUtilisateur,
-      serviceCGU,
+      serviceCgu,
     })
   );
   app.use(
@@ -153,11 +153,11 @@ const creeServeur = (
       adaptateurPdf,
       adaptateurCsv,
       adaptateurZip,
-      adaptateurJournalMSS,
+      adaptateurJournal,
       procedures,
       serviceAnnuaire,
       serviceSupervision,
-      serviceCGU,
+      serviceCgu,
     })
   );
   app.use('/bibliotheques', routesNonConnecteApiBibliotheques());

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -41,11 +41,11 @@ const routesConnecteApi = ({
   adaptateurPdf,
   adaptateurCsv,
   adaptateurZip,
-  adaptateurJournalMSS,
+  adaptateurJournal,
   procedures,
   serviceAnnuaire,
   serviceSupervision,
-  serviceCGU,
+  serviceCgu,
 }) => {
   const routes = express.Router();
 
@@ -151,7 +151,7 @@ const routesConnecteApi = ({
       adaptateurHorloge,
       adaptateurPdf,
       adaptateurZip,
-      adaptateurJournalMSS,
+      adaptateurJournal,
     })
   );
 
@@ -256,7 +256,7 @@ const routesConnecteApi = ({
       const idUtilisateur = requete.idUtilisateurCourant;
       const donnees = obtentionDonneesDeBaseUtilisateur(
         requete.body,
-        serviceCGU
+        serviceCgu
       );
       const { donneesInvalides, messageErreur } =
         messageErreurDonneesUtilisateur(donnees, true);

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -56,7 +56,7 @@ const routesConnecteApiService = ({
   adaptateurHorloge,
   adaptateurPdf,
   adaptateurZip,
-  adaptateurJournalMSS,
+  adaptateurJournal,
 }) => {
   const routes = express.Router();
 
@@ -926,7 +926,7 @@ const routesConnecteApiService = ({
         return;
       }
 
-      await adaptateurJournalMSS.consigneEvenement(
+      await adaptateurJournal.consigneEvenement(
         new EvenementRetourUtilisateurMesure({
           idService: service.id,
           idUtilisateur: idUtilisateurCourant,

--- a/src/routes/nonConnecte/routesNonConnecteApi.js
+++ b/src/routes/nonConnecte/routesNonConnecteApi.js
@@ -19,7 +19,7 @@ const routesNonConnecteApi = ({
   adaptateurMail,
   inscriptionUtilisateur,
   adaptateurGestionErreur,
-  serviceCGU,
+  serviceCgu,
 }) => {
   const routes = express.Router();
 
@@ -30,7 +30,7 @@ const routesNonConnecteApi = ({
     async (requete, reponse, suite) => {
       const donnees = obtentionDonneesDeBaseUtilisateur(
         requete.body,
-        serviceCGU
+        serviceCgu
       );
       donnees.email = requete.body.email?.toLowerCase();
       const { donneesInvalides, messageErreur } =

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -18,7 +18,7 @@ const { fabriqueServiceCgu } = require('../../src/serviceCgu');
 const testeurMss = () => {
   let serviceAnnuaire;
   let serviceSupervision;
-  let serviceCGU;
+  let serviceCgu;
   let adaptateurHorloge;
   let adaptateurCmsCrisp;
   let adaptateurMail;
@@ -28,7 +28,7 @@ const testeurMss = () => {
   let adaptateurZip;
   let adaptateurTracking;
   let adaptateurProtection;
-  let adaptateurJournalMSS;
+  let adaptateurJournal;
   let adaptateurOidc;
   let adaptateurEnvironnement;
   let adaptateurStatistiques;
@@ -106,7 +106,7 @@ const testeurMss = () => {
         () => (_requete, _reponse, suite) =>
           suite(),
     };
-    adaptateurJournalMSS = {
+    adaptateurJournal = {
       consigneEvenement: async () => {},
     };
     adaptateurOidc = {};
@@ -121,7 +121,7 @@ const testeurMss = () => {
       adaptateurMail,
       adaptateurTracking,
     });
-    serviceCGU = fabriqueServiceCgu({ referentiel });
+    serviceCgu = fabriqueServiceCgu({ referentiel });
 
     moteurRegles = new MoteurRegles(referentiel);
     depotVide()
@@ -132,7 +132,7 @@ const testeurMss = () => {
           adaptateurTracking,
           depotDonnees,
         });
-        serveur = MSS.creeServeur(
+        serveur = MSS.creeServeur({
           depotDonnees,
           middleware,
           referentiel,
@@ -147,18 +147,18 @@ const testeurMss = () => {
           adaptateurZip,
           adaptateurTracking,
           adaptateurProtection,
-          adaptateurJournalMSS,
+          adaptateurJournal,
           adaptateurOidc,
           adaptateurEnvironnement,
           adaptateurStatistiques,
           adaptateurJWT,
           serviceSupervision,
-          serviceCGU,
+          serviceCgu,
           procedures,
           inscriptionUtilisateur,
-          false,
-          false
-        );
+          avecCookieSecurise: false,
+          avecPageErreur: false,
+        });
         serveur.ecoute(1234, done);
       })
       .catch(done);
@@ -176,7 +176,7 @@ const testeurMss = () => {
     adaptateurCsv: () => adaptateurCsv,
     adaptateurZip: () => adaptateurZip,
     adaptateurTracking: () => adaptateurTracking,
-    adaptateurJournalMSS: () => adaptateurJournalMSS,
+    adaptateurJournalMSS: () => adaptateurJournal,
     adaptateurCmsCrisp: () => adaptateurCmsCrisp,
     adaptateurOidc: () => adaptateurOidc,
     adaptateurStatistiques: () => adaptateurStatistiques,


### PR DESCRIPTION
... plutôt que de se reposer sur des paramètres positionnels. Cela permet de s'affranchir des problèmes d'ordre de passage des dépendances.