### PR TITLE
[CORRECTION] Cible correctement le fichier du tampon d'homologation

### DIFF
--- a/src/adaptateurs/adaptateurPdf.js
+++ b/src/adaptateurs/adaptateurPdf.js
@@ -205,7 +205,10 @@ const genereTamponHomologation = async (donnees) => {
     });
 
     const imageTamponHomologation = await readFile(
-      resolve(__dirname, '../../public/assets/images/tampon_homologation.png')
+      resolve(
+        __dirname,
+        '../../../public/assets/images/tampon_homologation.png'
+      )
     );
     fichiers.push({
       nom: 'tamponHomologation.png',


### PR DESCRIPTION
... car désormais, le code est exécuté depuis `/dist`, depuis le passage en Typescript