### PR TITLE
[CORRECTION] Corrige l'interception des erreurs

### DIFF
--- a/public/scripts/csrf.mjs
+++ b/public/scripts/csrf.mjs
@@ -8,7 +8,10 @@ $(() => {
   axios.interceptors.response.use(
     (response) => response,
     (error) => {
-      if (error.response.data.includes('CSRF token mismatch')) {
+      if (
+        typeof error.response.data === 'string' &&
+        error.response.data.includes('CSRF token mismatch')
+      ) {
         lanceDecompteDeconnexion(0);
       }
       return Promise.reject(error);


### PR DESCRIPTION
...certaines erreurs sont renvoyées depuis l’API dans un objet et l’intercepteur CSRF doit prendre en charge ce cas afin d’éviter une erreur (`includes non trouvé`)