### PR TITLE
[CORRECTION] Corrige le controlleur d'erreur utilisé par MSS

### DIFF
--- a/src/mss.ts
+++ b/src/mss.ts
@@ -174,7 +174,8 @@ const creeServeur = ({
   app.use(adaptateurGestionErreur.controleurErreurs);
 
   if (avecPageErreur) {
-    app.use((_erreur, _requete, reponse) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    app.use((_erreur, _requete, reponse, _suite) => {
       reponse.render('erreur');
     });
   }


### PR DESCRIPTION
...une erreur est lancée au démarrage du middleware mais l’application fonctionnait quand même