### PR TITLE
[SOIN] N'affiche le loader qu'au premier affichage de la page

### DIFF
--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -16,7 +16,7 @@
   export let estSuperviseur: boolean;
   export let modeVisiteGuidee: boolean;
 
-  let enCoursChargement = false;
+  let enCoursChargement = true;
 
   let indicesCybers: IndiceCyber[] = [];
   let nombreServices: number;
@@ -37,7 +37,6 @@
   });
 
   const recupereServices = async () => {
-    enCoursChargement = true;
     const reponse: ReponseApiServices = (await axios.get('/api/services')).data;
     services.reinitialise(reponse.services);
     nombreServices = reponse.resume.nombreServices;


### PR DESCRIPTION
afin de ne pas voir clignoter le tableau de bord v2 à chaque modification