### PR TITLE
[CORRECTION] Ajoute une confirmation de suppression service

### DIFF
--- a/public/assets/styles/formulaire.css
+++ b/public/assets/styles/formulaire.css
@@ -359,7 +359,7 @@ input[type='checkbox'] + label.label-checkbox {
   background-image: url('/statique/assets/images/icone_cacher_mot_de_passe.svg');
 }
 
-.label-mot-de-passe {
+.label-confirmation {
   margin-bottom: 0.2em !important;
 }
 

--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -408,7 +408,7 @@
   margin-right: -4px;
 }
 
-.label-mot-de-passe {
+.label-confirmation {
   position: relative;
 }
 

--- a/public/modules/tableauDeBord/actions/ActionSuppressionService.mjs
+++ b/public/modules/tableauDeBord/actions/ActionSuppressionService.mjs
@@ -13,24 +13,24 @@ class ActionSuppressionService extends ActionAbstraite {
   initialise({ nomDuService, nbServicesSelectionnes }) {
     super.initialise();
     $('#action-suppression').show();
-    const $msgErreurChallenge = $(
-      '#mot-de-passe-challenge-suppression ~ .message-erreur-specifique'
-    );
-    const $champChallenge = $('#mot-de-passe-challenge-suppression');
-    $msgErreurChallenge.hide();
-    $champChallenge.val('');
-
-    $champChallenge.off('input');
-    $champChallenge.on('input', () => $msgErreurChallenge.hide());
+    const champConfirmation = $('#confirmation-suppression');
+    champConfirmation.val('');
+    champConfirmation.removeClass('touche');
 
     if (nbServicesSelectionnes === 1) {
       $('#nombre-service-suppression').html(
         `le service <strong>${nomDuService}</strong> `
       );
+      $('#intitule-confirmation').html(`<strong>${nomDuService}</strong>`);
+      champConfirmation.attr('pattern', nomDuService);
     } else {
       $('#nombre-service-suppression').html(
         `<strong>les ${nbServicesSelectionnes} services sélectionnés</strong> `
       );
+      $('#intitule-confirmation').html(
+        `<strong>${nbServicesSelectionnes} services</strong>`
+      );
+      champConfirmation.attr('pattern', `${nbServicesSelectionnes} services`);
     }
   }
 
@@ -41,7 +41,6 @@ class ActionSuppressionService extends ActionAbstraite {
 
   execute({ idServices }) {
     const $actionSuppression = $('#action-suppression');
-    const motDePasseChallenge = $('#mot-de-passe-challenge-suppression').val();
 
     if (!this.formulaireEstValide) return Promise.reject();
 
@@ -49,23 +48,10 @@ class ActionSuppressionService extends ActionAbstraite {
     this.basculeLoader(true);
 
     const suppressions = idServices.map((idService) =>
-      axios.delete(`/api/service/${idService}`, {
-        data: { motDePasseChallenge },
-      })
+      axios.delete(`/api/service/${idService}`)
     );
 
-    return Promise.all(suppressions).catch((exc) => {
-      if (exc.response.status === 401) {
-        const $msgErreurChallenge = $(
-          '#mot-de-passe-challenge-suppression ~ .message-erreur-specifique'
-        );
-        $msgErreurChallenge.css('display', 'flex');
-        $actionSuppression.show();
-        this.basculeLoader(false);
-
-        throw exc;
-      }
-    });
+    return Promise.all(suppressions);
   }
 }
 

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -750,7 +750,6 @@ const routesConnecteApiService = ({
   routes.delete(
     '/:id',
     middleware.trouveService({}),
-    middleware.challengeMotDePasse,
     middleware.chargeAutorisationsService,
     (requete, reponse, suite) => {
       const verifiePermissionSuppressionService = () =>

--- a/src/vues/tiroirs/tiroirSuppressionService.pug
+++ b/src/vues/tiroirs/tiroirSuppressionService.pug
@@ -12,11 +12,12 @@
     .banniere.banniere-information
       img(src='/statique/assets/images/icone_information_suppression.svg' alt='')
       .contenu-texte-information
-        p Pour permettre la suppression, veuillez saisir votre mot de passe actuel.
-    label.requis.label-mot-de-passe Mot de passe actuel
-      input(id='mot-de-passe-challenge-suppression', name = 'motDePasseChallengeSuppression', type='password', required)
-      .message-erreur Ce champ est obligatoire. Veuillez le renseigner.
-      .message-erreur-specifique Le mot de passe actuel saisi est incorrect
+        p Pour confirmer la suppression, veuillez saisir l'intitulé "
+          span#intitule-confirmation
+          span " dans le champ ci-dessous
+    label.requis.label-confirmation Confirmation
+      input(id='confirmation-suppression', name = 'confirmationSuppression', type='text', required)
+      .message-erreur La confirmation saisie est incorrecte
     .conteneur-loader
       .icone-chargement
       .titre-loader Suppression en cours…

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -2067,16 +2067,6 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it('utilise le middleware de challenge du mot de passe', (done) => {
-      testeurMSS().middleware().verifieChallengeMotDePasse(
-        {
-          method: 'delete',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
-      );
-    });
-
     it("utilise le middleware de chargement de l'autorisation", (done) => {
       testeur
         .middleware()


### PR DESCRIPTION
Demande confirmation à la suppression de services via un message de confirmation à taper plutôt qu'un challenge mot de passe. En effet, les utilisateurs ProConnect n'ont pas de mot de passe dans MSS.

On demande à l'utilisateur de copier une chaîne pour confirmer qu'il comprend l'action qu'il est en train de faire.