### PR TITLE
[CORRECTION] Demande confirmation à la suppression d'un projet d'homologation

### DIFF
--- a/public/modules/tableauDeBord/actions/ActionSuppressionDossierCourant.mjs
+++ b/public/modules/tableauDeBord/actions/ActionSuppressionDossierCourant.mjs
@@ -13,50 +13,21 @@ class ActionSuppressionDossierCourant extends ActionAbstraite {
   initialise() {
     super.initialise();
     $('#action-suppression-dossier-courant').show();
-    const $msgErreurChallenge = $(
-      '#mot-de-passe-challenge-suppression-dossier-courant ~ .message-erreur-specifique'
-    );
-    const $champChallenge = $(
-      '#mot-de-passe-challenge-suppression-dossier-courant'
-    );
-    $msgErreurChallenge.hide();
-    $champChallenge.val('');
-
-    $champChallenge.off('input');
-    $champChallenge.on('input', () => $msgErreurChallenge.hide());
+    const champConfirmation = $('#confirmation-suppression');
+    champConfirmation.val('');
+    champConfirmation.removeClass('touche');
   }
 
   // eslint-disable-next-line consistent-return
   async execute({ idService }) {
     const $actionSuppression = $('#action-suppression-dossier-courant');
-    const motDePasseChallenge = $(
-      '#mot-de-passe-challenge-suppression-dossier-courant'
-    ).val();
 
     if (!this.formulaireEstValide) return Promise.reject();
 
     $actionSuppression.hide();
     this.basculeLoader(true);
 
-    try {
-      await axios.delete(
-        `/api/service/${idService}/homologation/dossierCourant`,
-        {
-          data: { motDePasseChallenge },
-        }
-      );
-    } catch (e) {
-      if (e.response.status === 401) {
-        const $msgErreurChallenge = $(
-          '#mot-de-passe-challenge-suppression-dossier-courant ~ .message-erreur-specifique'
-        );
-        $msgErreurChallenge.css('display', 'flex');
-        $actionSuppression.show();
-        this.basculeLoader(false);
-
-        throw e;
-      }
-    }
+    await axios.delete(`/api/service/${idService}/homologation/dossierCourant`);
   }
 }
 

--- a/src/vues/tiroirs/tiroirSuppressionDossierCourant.pug
+++ b/src/vues/tiroirs/tiroirSuppressionDossierCourant.pug
@@ -11,11 +11,12 @@
     .banniere.banniere-information
       img(src='/statique/assets/images/icone_information_suppression.svg' alt='')
       .contenu-texte-information
-        p Pour permettre la suppression, veuillez saisir votre mot de passe actuel.
-    label.requis Mot de passe actuel
-      input(id='mot-de-passe-challenge-suppression-dossier-courant', name = 'motDePasseChallengeSuppression', type='password', required)
-      .message-erreur Ce champ est obligatoire. Veuillez le renseigner.
-      .message-erreur-specifique Le mot de passe actuel saisi est incorrect
+        p Pour confirmer la suppression du projet d'homologation, veuillez saisir l'intitulé "
+          strong projet d'homologation
+          span " dans le champ ci-dessous
+    label.requis.label-confirmation Confirmation
+      input(id='confirmation-suppression', name = 'confirmationSuppression', type='text', required, pattern="projet d'homologation")
+      .message-erreur La confirmation saisie est incorrecte
     .conteneur-loader
       .icone-chargement
       .titre-loader Suppression en cours…


### PR DESCRIPTION
...via un message de confirmation à taper plutôt qu'un challenge mot de passe. En effet, les utilisateurs ProConnect n'ont pas de mot de passe dans MSS. On demande à l'utilisateur de copier une chaîne pour confirmer qu'il comprend l'action qu'il est en train de faire.