### PR TITLE
[MonProfilAnssi] Inscris les invités à MonProfilAnssi

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -253,6 +253,10 @@ const creeDepot = (config = {}) => {
 
   const metsAJourUtilisateur = async (id, donnees) => {
     delete donnees.motDePasse;
+
+    let u = await p.lis.un(id);
+    const etaitUnInvite = u.estUnInvite();
+
     if (donnees.entite && donnees.entite.siret)
       donnees.entite = await Entite.completeDonnees(
         donnees.entite,
@@ -261,10 +265,16 @@ const creeDepot = (config = {}) => {
 
     await p.sauvegarde(id, donnees);
 
-    const u = await p.lis.un(id);
+    u = await p.lis.un(id);
+
+    if (etaitUnInvite) {
+      await adaptateurProfilAnssi.inscris(u);
+    }
+
     await busEvenements.publie(
       new EvenementUtilisateurModifie({ utilisateur: u })
     );
+
     return u;
   };
 

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -206,7 +206,9 @@ const creeDepot = (config = {}) => {
     await p.idResetMotDePasse.sauvegarde(id, idResetMotDePasse);
     u = await p.lis.un(id);
 
-    adaptateurProfilAnssi.inscris(u);
+    if (!u.estUnInvite()) {
+      await adaptateurProfilAnssi.inscris(u);
+    }
 
     await busEvenements.publie(
       new EvenementUtilisateurInscrit({ utilisateur: u })

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -810,7 +810,7 @@ describe('Le dépôt de données des utilisateurs', () => {
         expect(utilisateur.donnees.motDePasse).to.be(undefined);
       });
 
-      it("inscris l'utilisateur dans MonProfilAnssi", async () => {
+      it("inscris l'utilisateur avec un compte complet dans MonProfilAnssi", async () => {
         let profilAnssiEnvoyeAAdaptateur;
         adaptateurProfilAnssi.inscris = (utilisateur) =>
           (profilAnssiEnvoyeAAdaptateur = utilisateur);
@@ -823,6 +823,19 @@ describe('Le dépôt de données des utilisateurs', () => {
 
         const utilisateur = await depot.utilisateur('1');
         expect(profilAnssiEnvoyeAAdaptateur).to.eql(utilisateur);
+      });
+
+      it("n'inscris pas l'utilisateur invité dans MonProfilAnssi", async () => {
+        let profilAnssiEnvoyeAAdaptateur;
+        adaptateurProfilAnssi.inscris = (utilisateur) =>
+          (profilAnssiEnvoyeAAdaptateur = utilisateur);
+
+        await depot.nouvelUtilisateur(
+          unUtilisateur().avecEmail('jean.dupont@mail.fr').quiAEteInvite()
+            .donnees
+        );
+
+        expect(profilAnssiEnvoyeAAdaptateur).to.eql(undefined);
       });
     });
 


### PR DESCRIPTION
Lors de la création de compte utilisateur, on ne doit pas envoyer les invités à MPA.
Lors de la mise à jour d'un compte utilisateur, on ne doit envoyer que les invités confirmant leur inscription MSS.