### PR TITLE
Augmentation des infos transmises à Sentry

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -85,6 +85,7 @@ const middleware = Middleware({
   adaptateurEnvironnement,
   adaptateurJWT,
   adaptateurProtection,
+  adaptateurGestionErreur,
   depotDonnees,
 });
 

--- a/src/adaptateurs/adaptateurGestionErreurSentry.js
+++ b/src/adaptateurs/adaptateurGestionErreurSentry.js
@@ -53,8 +53,16 @@ const controleurErreurs = (erreur, requete, reponse, suite) => {
   return Sentry.Handlers.errorHandler()(erreur, requete, reponse, suite);
 };
 
+const identifieUtilisateur = (idUtilisateur, timestampTokenJwt) => {
+  Sentry.setUser({
+    id: idUtilisateur,
+    'Connexion UTC': new Date(timestampTokenJwt * 1_000),
+  });
+};
+
 module.exports = {
   initialise,
+  identifieUtilisateur,
   controleurErreurs,
   logueErreur,
 };

--- a/src/adaptateurs/adaptateurGestionErreurVide.js
+++ b/src/adaptateurs/adaptateurGestionErreurVide.js
@@ -1,4 +1,5 @@
 const initialise = () => {};
+const identifieUtilisateur = () => {};
 const controleurErreurs = (erreur, _requete, _reponse, suite) => suite(erreur);
 const logueErreur = (_erreur) => {};
 
@@ -6,4 +7,5 @@ module.exports = {
   initialise,
   controleurErreurs,
   logueErreur,
+  identifieUtilisateur,
 };

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -24,6 +24,7 @@ const middleware = (configuration = {}) => {
     adaptateurEnvironnement = adaptateurEnvironnementParDefaut,
     adaptateurJWT,
     adaptateurProtection,
+    adaptateurGestionErreur,
   } = configuration;
 
   const positionneHeaders = (requete, reponse, suite) => {
@@ -91,6 +92,11 @@ const middleware = (configuration = {}) => {
       token.idUtilisateur
     );
     if (!utilisateurExiste) return reponse.redirect('/connexion');
+
+    adaptateurGestionErreur.identifieUtilisateur(
+      token.idUtilisateur,
+      token.iat
+    );
 
     requete.idUtilisateurCourant = token.idUtilisateur;
     requete.cguAcceptees = token.cguAcceptees;


### PR DESCRIPTION
Pour augmenter nos compréhensions des erreurs, cette PR [utilise le `setUser` de Sentry](https://docs.sentry.io/platforms/javascript/enriching-events/identify-user/) dans notre middleware de vérification de JWT.

Ça commence par une PR de soin, pour faciliter l'ajout de `adaptateurGestionErreur` dans le middleware.

Côté Sentry, le résultat est 👇 
![image](https://github.com/user-attachments/assets/5e2700a3-a985-4d6f-bc95-461f49aeba3b)

Dans ce qu'on log chez Sentry, si on met `token` ou `JWT`  le nom de dans le clé, la donnée se fait `[Filtered]`.
Donc j'ai choisi `Connexion UTC`.

Cette PR met l'ID de l'utilisateur… et pas l'email.
À voir si on veut l'email… car le dépôt, pour vérifier si l'utilisateur existe, le récupère en BDD. Donc ça ne serait pas plus cher…