### PR TITLE
[SOIN] Enrichis les erreurs loguées par le bus

### DIFF
--- a/src/bus/busEvenements.js
+++ b/src/bus/busEvenements.js
@@ -1,3 +1,5 @@
+const { ErreurBusEvenements } = require('../erreurs');
+
 class BusEvenements {
   constructor({ adaptateurGestionErreur }) {
     this.handlers = {};
@@ -18,7 +20,9 @@ class BusEvenements {
     // Dans un souci de performance : on ne veut pas attendre les exécutions.
     this.handlers[evenement.constructor.name]?.forEach((handler) => {
       handler(evenement).catch((e) => {
-        this.adaptateurGestionErreur.logueErreur(e);
+        this.adaptateurGestionErreur.logueErreur(
+          new ErreurBusEvenements(evenement.constructor.name, e)
+        );
       });
     });
   }

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -3,6 +3,12 @@ class EchecEnvoiMessage extends Error {}
 class ErreurApiBrevo extends Error {}
 class ErreurDroitsIncoherents extends Error {}
 class ErreurChainageMiddleware extends Error {}
+class ErreurBusEvenements extends Error {
+  constructor(typeEvenement, erreurDeAbonne) {
+    const details = { cause: erreurDeAbonne };
+    super(`Erreur dans un abonné à [${typeEvenement}]`, details);
+  }
+}
 class ErreurModele extends Error {}
 class ErreurArticleCrispIntrouvable extends ErreurModele {}
 class ErreurAutorisationExisteDeja extends ErreurModele {}
@@ -70,6 +76,7 @@ module.exports = {
   ErreurAutorisationExisteDeja,
   ErreurAutorisationInexistante,
   ErreurAvisInvalide,
+  ErreurBusEvenements,
   ErreurCategoriesRisqueManquantes,
   ErreurCategorieRisqueInconnue,
   ErreurCategorieInconnue,


### PR DESCRIPTION
… pour avoir davantage d'infos sur le contexte lorsqu'une erreur part vers Sentry.

En renseignant la propriété `cause` de `Error`, Sentry est capable de faire un affichage 👇 

- _En (1) on voit que le `bus` logue maintenant le type d'événement ayant causé un crash dans l'abonné_
- _En (2) on voit l'imbrication des exceptions 🎉_ 
![image](https://github.com/user-attachments/assets/893a248e-1ded-4957-939f-31cdde574edb)


Cette PR pourrait être le début d'une gestion réfléchie des erreurs au niveau du bus : les abonnés `throw` et le bus logue en prenant soin de renseigner la propriété `cause` de l'erreur.

⚠️ Là… on ne sait pas encore précisément QUEL abonné a crashé. Réfléchissons à comment on s'y prend…

#### 💡 `try catch` dans chaque abonné
On pourrait imaginer un `try catch` dans chaque abonné, qui `throw new ErreurDansAbonne("Impossible de xyz", {cause: e})`, comme ça on aurait tout le temps 3 étages dans Sentry : l'exception du bus > l'exception de l'abonnée > l'exception système.
Mais ça veut dire modifier tous les abonnés, et se souvenir de le faire pour chaque abonné

#### 💡 `catch` dans le `bus`
On pourrait catcher dans le `bus`, mais la seule solution à laquelle je suis parvenu pour avoir le nom de l'abonné est de changer la signature de `abonne()` et `abonnePlusieurs()`. Pour passer, en + de la fonction abonnée, le nom de celui-ci.
Mais alors on n'aurait peut-être pas dans Sentry l'endroit exact du code où ça a crashé dans l'abonné… 