### PR TITLE
[SÉCURISER] Permet d'appliquer la recherche textuelle sur les "précisions" 

### DIFF
--- a/svelte/lib/tableauDesMesures/stores/rechercheTextuelle.store.ts
+++ b/svelte/lib/tableauDesMesures/stores/rechercheTextuelle.store.ts
@@ -12,4 +12,5 @@ export const appliqueFiltreTextuel = (
 ) =>
   contientEnMinuscule(mesure.description, valeur) ||
   contientEnMinuscule((mesure as MesureGenerale).descriptionLongue, valeur) ||
-  contientEnMinuscule(mesure.identifiantNumerique, valeur);
+  contientEnMinuscule(mesure.identifiantNumerique, valeur) ||
+  contientEnMinuscule(mesure.modalites, valeur);


### PR DESCRIPTION
… d'une mesure, appelé "modalités" au sein de l'objet métier.

Cette demande provient de @pgrange qui en aurait besoin dans son utilisation de MSS.