### PR TITLE
[CORRECTION] Corrige l'enregistrement des mesures dans le cas où un problème survient lors de la récupération des activités

### DIFF
--- a/svelte/lib/mesure/mesure.api.ts
+++ b/svelte/lib/mesure/mesure.api.ts
@@ -77,6 +77,9 @@ export const recupereActiviteMesure = async (
   const reponse = await axios.get(
     `/api/service/${idService}/mesures/${idMesure}/activites`
   );
+
+  if (!Array.isArray(reponse.data)) return [];
+
   return reponse.data.map((a: any) => ({ ...a, date: new Date(a.date) }));
 };
 


### PR DESCRIPTION
... suite à un bug remonté en prod par @pgrange.

Il semblerait que ce bug proviennent si la session est terminé, auquel cas la requêtre renverrait un objet dans `data`.