### PR TITLE
[CORRECTION] Ajoute une espace au dessus des actions du tiroir de sup…

### DIFF
--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -222,6 +222,10 @@
   margin: 0;
 }
 
+#contenu-suppression-dossier-courant .conteneur-actions {
+  margin-top: 24px;
+}
+
 #contenu-suppression .banniere img {
   width: 32px;
 }


### PR DESCRIPTION
…pression du dossier d'homologation.

![image](https://github.com/user-attachments/assets/e5e9857d-da2f-4138-88a2-a67366adbaff)


L'espacement avait dû sauter lors de la modification du tiroir pour inclure la vérification par "phrase".