### PR TITLE
[STATISTIQUES] Cesse d'afficher l'évolution

### DIFF
--- a/src/vues/statistiques.pug
+++ b/src/vues/statistiques.pug
@@ -36,8 +36,7 @@ block main
   .statistiques
     .cartes
       - const chiffres = new Intl.NumberFormat('fr-FR')
-      - const progression = (nombre) => nombre > 0 ? `+${nombre}%` : `${nombre}%`;
-      +uneCarteDeStats('avatar', chiffres.format(utilisateurs.nombre), 'Utilisateurs inscrits', progression(utilisateurs.progression))
-      +uneCarteDeStats('navigateur', chiffres.format(services.nombre), 'Services sécurisés', progression(services.progression))
+      +uneCarteDeStats('avatar', chiffres.format(utilisateurs.nombre), 'Utilisateurs inscrits', '', false)
+      +uneCarteDeStats('navigateur', chiffres.format(services.nombre), 'Services sécurisés', '', false)
       +uneCarteDeStats('data_viz', indiceCyber.nombre, "Progression moyenne de l'indice cyber sur 1 an", "chiffre calculé en décembre 2024", false)
-      +uneCarteDeStats('connexion_perdue', chiffres.format(vulnerabilites.nombre), "Vulnérabilités corrigées", progression(vulnerabilites.progression))
+      +uneCarteDeStats('connexion_perdue', chiffres.format(vulnerabilites.nombre), "Vulnérabilités corrigées", '', false)


### PR DESCRIPTION
… car on ne sait pas la calculer sur les 12 derniers mois 👇 

![image](https://github.com/user-attachments/assets/caad8be6-7949-4278-8fc8-953b06dc4e6d)


Nous sommes au début de l'année, et comme l'évolution est calculée à partir de la fin de l'année dernière, on a des chiffres comme « + 1% » qui sont affichés en PROD.

Autrement dit : on masque le chiffre, car il ne reflète pas la réalité.

Le chantier plus conséquent sera d'afficher de nouveau les statistiques sous forme de courbes.

