### PR TITLE
[CORRECTION] Renvoi correctement les établissements "secondaires" lors d'une recherche par SIRET

### DIFF
--- a/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
+++ b/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
@@ -70,9 +70,9 @@ const rechercheOrganisations = async (
   }
 };
 
-const recupereDetailsOrganisation = async (siret) => {
+const recupereDetailsOrganisation = async (siret, instanceAxios = axios) => {
   try {
-    const reponse = await axios.get(
+    const reponse = await instanceAxios.get(
       'https://recherche-entreprises.api.gouv.fr/search',
       {
         params: {
@@ -96,6 +96,7 @@ const recupereDetailsOrganisation = async (siret) => {
     }
 
     const [entiteApi] = reponse.data.results;
+    const etablissement = entiteApi.matching_etablissements[0];
 
     return {
       estServicePublic: entiteApi.complements.est_service_public,
@@ -105,13 +106,13 @@ const recupereDetailsOrganisation = async (siret) => {
         entiteApi.complements.est_entrepreneur_individuel,
       estAssociation: entiteApi.complements.est_association,
       categorieEntreprise: entiteApi.categorie_entreprise,
-      activitePrincipale: entiteApi.activite_principale,
-      trancheEffectifSalarie: entiteApi.tranche_effectif_salarie,
+      activitePrincipale: etablissement.activite_principale,
+      trancheEffectifSalarie: etablissement.tranche_effectif_salarie,
       natureJuridique: entiteApi.nature_juridique,
       sectionActivitePrincipale: entiteApi.section_activite_principale,
-      anneeTrancheEffectifSalarie: entiteApi.annee_tranche_effectif_salarie,
-      commune: entiteApi.siege.commune,
-      departement: entiteApi.siege.departement,
+      anneeTrancheEffectifSalarie: etablissement.annee_tranche_effectif_salarie,
+      commune: etablissement.commune,
+      departement: extraisDepartement(etablissement.commune),
     };
   } catch (e) {
     fabriqueAdaptateurGestionErreur().logueErreur(e, {

--- a/test/adaptateurs/adaptateurRechercheEntrepriseAPI.spec.js
+++ b/test/adaptateurs/adaptateurRechercheEntrepriseAPI.spec.js
@@ -1,6 +1,7 @@
 const expect = require('expect.js');
 const {
   rechercheOrganisations,
+  recupereDetailsOrganisation,
 } = require('../../src/adaptateurs/adaptateurRechercheEntrepriseAPI');
 
 describe("L'adaptateur recherche entreprise qui utilise l'API Recherche Entreprise", () => {
@@ -181,6 +182,45 @@ describe("L'adaptateur recherche entreprise qui utilise l'API Recherche Entrepri
         expect(resultat[0].siret).to.eql('SIRET ETABLISSEMENT');
         expect(resultat[0].departement).to.eql('75');
       });
+    });
+  });
+
+  describe("sur demande de détails d'une organisation", () => {
+    it("utilise les données pertinentes de l'enseigne", async () => {
+      const reponseAPI = {
+        activite_principale: 'ACTIVITE SIEGE',
+        annee_tranche_effectif_salarie: 'ANNEE TRANCHE SIEGE',
+        tranche_effectif_salarie: 'TRANCHE SIEGE',
+        complements: {},
+        siege: {
+          commune: 'COMMUNE SIEGE',
+          departement: 'DEPARTEMENT SIEGE',
+        },
+        matching_etablissements: [
+          {
+            activite_principale: 'ACTIVITE ENSEIGNE',
+            annee_tranche_effectif_salarie: 'ANNEE TRANCHE ENSEIGNE',
+            tranche_effectif_salarie: 'TRANCHE ENSEIGNE',
+            commune: '75000',
+          },
+        ],
+      };
+      const fauxAxios = {
+        get: async () => ({ data: { results: [reponseAPI] } }),
+      };
+
+      const resultat = await recupereDetailsOrganisation(
+        '123456789',
+        fauxAxios
+      );
+
+      expect(resultat.activitePrincipale).to.eql('ACTIVITE ENSEIGNE');
+      expect(resultat.trancheEffectifSalarie).to.eql('TRANCHE ENSEIGNE');
+      expect(resultat.anneeTrancheEffectifSalarie).to.eql(
+        'ANNEE TRANCHE ENSEIGNE'
+      );
+      expect(resultat.commune).to.eql('75000');
+      expect(resultat.departement).to.eql('75');
     });
   });
 });


### PR DESCRIPTION
Suite à une remontée des utilisateurs, certains établissement "secondaires" ne figuraient pas dans la liste de proposition des organisations.

C'est dû au fait que ces SIRET ne sont pas les sièges, mais des établissements annexes.
Grâce à l'aide de l'équipe technique responsable de l'API recherche entreprise, nous avons pu correctement extraire les données.

Nous testons EXCEPTIONNELEMENT un adaptateur dans cette Pull Request, car obligatoire pour s'assure que l'on couvre tous les cas d'usage.