### PR TITLE
[CORRECTION] Remplace le département lors de la sélection d'une organisation

### DIFF
--- a/svelte/lib/inscription/SelectionDepartement.svelte
+++ b/svelte/lib/inscription/SelectionDepartement.svelte
@@ -28,7 +28,7 @@
     suggestionsVisibles = suggestions.length > 0;
   };
 
-  const choisisDepartement = (item: Departement) => {
+  export const choisisDepartement = (item: Departement) => {
     valeur = item;
     saisie = `${valeur.nom} (${valeur.code})`;
     suggestionsVisibles = false;

--- a/svelte/lib/profil/Profil.svelte
+++ b/svelte/lib/profil/Profil.svelte
@@ -38,6 +38,16 @@
       window.location.href = '/tableauDeBord';
     }
   };
+
+  let elementSelectionDepartement: SelectionDepartement;
+  const modifieDepartementApresChoixOrganisation = (
+    e: CustomEvent<Organisation>
+  ) => {
+    const d = departements.find((d) => d.code === e.detail.departement);
+    if (d) {
+      elementSelectionDepartement.choisisDepartement(d);
+    }
+  };
 </script>
 
 <div class="contenu-profil">
@@ -109,7 +119,11 @@
         <label for="departement" class="requis"
           >Département de votre organisation</label
         >
-        <SelectionDepartement bind:valeur={departement} {departements} />
+        <SelectionDepartement
+          bind:valeur={departement}
+          {departements}
+          bind:this={elementSelectionDepartement}
+        />
       </div>
       <div class="champ">
         <label for="nomSiret" class="requis"
@@ -119,6 +133,7 @@
           id="nomSiret"
           bind:valeur={entite}
           filtreDepartement={departement}
+          on:organisationChoisie={modifieDepartementApresChoixOrganisation}
         />
       </div>
     </div>


### PR DESCRIPTION
On utilise ici une mécanique d'export de fonction, pour contourner les problèmes de "race condition" entre la mise à jour des valeurs "bindés" et la mise à jour du DOM.

Cette feature fonctionnait lorsque nous utilisions `selectize`.