### PR TITLE
[CORRECTION] Retourne les infos du siège si le matching établissements est vide

### DIFF
--- a/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
+++ b/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
@@ -18,8 +18,16 @@ const extraisInfosEtablissement = (terme, resultat) => {
   let { departement, siret } = resultat.siege;
 
   const estUneRechercheParSiret = terme.match('^[0-9 ]+$');
-  if (estUneRechercheParSiret) {
-    if (resultat.matching_etablissements[0].liste_enseignes) {
+
+  const aUnEtablissement =
+    resultat.matching_etablissements &&
+    resultat.matching_etablissements.length > 0;
+
+  if (estUneRechercheParSiret && aUnEtablissement) {
+    const aUneListeEnseigne =
+      resultat.matching_etablissements[0].liste_enseignes &&
+      resultat.matching_etablissements[0].liste_enseignes.length > 0;
+    if (aUneListeEnseigne) {
       // eslint-disable-next-line prefer-destructuring
       nom = resultat.matching_etablissements[0].liste_enseignes[0];
     }

--- a/test/adaptateurs/adaptateurRechercheEntrepriseAPI.spec.js
+++ b/test/adaptateurs/adaptateurRechercheEntrepriseAPI.spec.js
@@ -183,6 +183,30 @@ describe("L'adaptateur recherche entreprise qui utilise l'API Recherche Entrepri
         expect(resultat[0].departement).to.eql('75');
       });
     });
+
+    it("retourne les informations du siège s'il n'y a pas de matching établissement", async () => {
+      const reponseAPI = {
+        nom_complet: 'NOM SIEGE',
+        siege: {
+          departement: 'DEPARTEMENT SIEGE',
+          siret: 'SIRET SIEGE',
+        },
+        matching_etablissements: [],
+      };
+      const fauxAxios = {
+        get: async () => ({ data: { results: [reponseAPI] } }),
+      };
+
+      const resultat = await rechercheOrganisations(
+        '1300 07669 00019',
+        '75',
+        fauxAxios
+      );
+
+      expect(resultat[0].nom).to.eql('NOM SIEGE');
+      expect(resultat[0].siret).to.eql('SIRET SIEGE');
+      expect(resultat[0].departement).to.eql('DEPARTEMENT SIEGE');
+    });
   });
 
   describe("sur demande de détails d'une organisation", () => {


### PR DESCRIPTION
Apparemment, on peut avoir un siège mais une liste d'établissements vide.