### PR TITLE
Vérifie une hypothèse sur les erreurs CSRF

### DIFF
--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -302,7 +302,10 @@ const routesConnecteApi = ({
   });
 
   routes.get('/dureeSession', (_requete, reponse) => {
-    reponse.send({ dureeSession: DUREE_SESSION });
+    const MARGE_DE_SECURITE_CSRF_MISMATCH = 2 * 60_000;
+    reponse.send({
+      dureeSession: DUREE_SESSION - MARGE_DE_SECURITE_CSRF_MISMATCH,
+    });
   });
 
   routes.post(

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -921,7 +921,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           expect(reponse.status).to.equal(200);
 
           const { dureeSession } = reponse.data;
-          expect(dureeSession).to.equal(3600000);
+          expect(dureeSession).to.equal(58 * 60_000);
           done();
         })
         .catch((e) => done(e.response?.data || e));


### PR DESCRIPTION
Le cookie de session n'est mis à jour qu'une fois toutes les minutes.

La date d'affichage de la modale de déconnexion est mis à jour à chaque requête.

Il peut exister un battement de presque une minute pendant lequel l'utilisateur ne voit pas la modale mais le cookie est expiré. Dans ce cas, toute action provoque une erreur CSRF sur le serveur. Exmple :

* Bob se connecte à 12:00:00
  * le cookie expire à 13:00:00
  * la modale s'affichera à 13:00:00
* Bob effectue une action à 12:00:59
  * le cookie expire à 13:00:00 (pas mis à jour car moins d'une minute)
  * la modale s'affichera à 13:00:59
* Bob prend une pause et effectue une action à 13:00:01 (elle échoue)
  * le cookie est expiré depuis 13:00:00 et donc n'est pas envoyé au serveur
  * la modale ne s'est pas encore affiché car il n'est pas encore 13:00:59
  * une erreur CSRF mismatch se produit sur le serveur

On réduit l'intervalle de temps d'affichage de la modale pour passer de 1h à 58 minutes. On suppose que les erreurs CSRF qu'on observe ne se produiront plus.