### PR TITLE
Active le tableau de bord v2

### DIFF
--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -177,7 +177,7 @@ const routesConnectePage = ({
           referentiel,
         });
       } else if (idEtape === 'piloter') {
-        reponse.render('tableauDeBord');
+        reponse.render('tableauDeBordv2');
       }
     }
   );

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -102,18 +102,6 @@ const routesConnectePage = ({
       const estSuperviseur = await depotDonnees.estSuperviseur(
         requete.idUtilisateurCourant
       );
-      reponse.render('tableauDeBord', { estSuperviseur });
-    }
-  );
-
-  routes.get(
-    '/tableauDeBord-v2',
-    middleware.verificationAcceptationCGU,
-    middleware.chargeEtatVisiteGuidee,
-    async (requete, reponse) => {
-      const estSuperviseur = await depotDonnees.estSuperviseur(
-        requete.idUtilisateurCourant
-      );
       reponse.render('tableauDeBordv2', { estSuperviseur });
     }
   );

--- a/svelte/lib/tableauDeBord/BandeauFiltres.svelte
+++ b/svelte/lib/tableauDeBord/BandeauFiltres.svelte
@@ -7,6 +7,7 @@
 <div class="conteneur-filtres">
   <BarreDeRecherche bind:recherche={$rechercheTextuelle} />
   <Lien
+    classe="nouveau-service"
     titre="Ajouter un service"
     type="bouton-primaire"
     icone="plus"

--- a/svelte/lib/tableauDeBord/BandeauFiltres.svelte
+++ b/svelte/lib/tableauDeBord/BandeauFiltres.svelte
@@ -1,18 +1,21 @@
 <script lang="ts">
   import BarreDeRecherche from '../ui/BarreDeRecherche.svelte';
   import { rechercheTextuelle } from './stores/rechercheTextuelle.store';
+  import { services } from './stores/services.store';
   import Lien from '../ui/Lien.svelte';
 </script>
 
 <div class="conteneur-filtres">
   <BarreDeRecherche bind:recherche={$rechercheTextuelle} />
-  <Lien
-    classe="nouveau-service"
-    titre="Ajouter un service"
-    type="bouton-primaire"
-    icone="plus"
-    href="/service/creation"
-  />
+  {#if $services.length > 0}
+    <Lien
+      classe="nouveau-service"
+      titre="Ajouter un service"
+      type="bouton-primaire"
+      icone="plus"
+      href="/service/creation"
+    />
+  {/if}
 </div>
 
 <style>

--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -139,4 +139,18 @@
     background: url('/statique/assets/images/tableauDeBord/icone_graphique.svg')
       no-repeat center;
   }
+
+  .lien-supervision a:hover {
+    background: #f5f5f5;
+  }
+
+  .lien-supervision a:active {
+    background: var(--fond-gris-pale-composant);
+    color: var(--systeme-design-etat-bleu);
+  }
+
+  .lien-supervision a:active::before {
+    filter: brightness(0) invert(8%) sepia(52%) saturate(5373%)
+      hue-rotate(237deg) brightness(125%) contrast(140%);
+  }
 </style>

--- a/svelte/lib/tableauDeBord/TableauDeBord.svelte
+++ b/svelte/lib/tableauDeBord/TableauDeBord.svelte
@@ -33,6 +33,7 @@
         donneesVisiteGuidee.resume.nombreServicesHomologues;
       indicesCybers = donneesVisiteGuidee.indicesCyber;
       indiceCyberMoyen = donneesVisiteGuidee.indiceCyber;
+      enCoursChargement = false;
     } else {
       await rafraichisServices();
     }

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -78,7 +78,7 @@
         </td>
       </tr>
       <tr>
-        <td>
+        <td class="cellule-selection">
           <input
             type="checkbox"
             on:change={basculeSelectionTousServices}
@@ -101,7 +101,7 @@
           (i) => i.id === idService
         )?.indiceCyber}
         <tr class="ligne-service">
-          <td>
+          <td class="cellule-selection">
             <input
               class="selection-service"
               type="checkbox"
@@ -289,5 +289,9 @@
     line-height: 1.5rem;
     color: var(--texte-gris);
     margin: 0 0 8px;
+  }
+
+  .cellule-selection {
+    text-align: center;
   }
 </style>

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -8,12 +8,14 @@
   import ActionRecommandee from './elementsDeService/ActionRecommandee.svelte';
   import type { IndiceCyber } from './tableauDeBord.d';
   import { resultatsDeRecherche } from './stores/resultatDeRecherche.store';
+  import { services } from './stores/services.store';
   import ActionsDesServices from './ActionsDesServices.svelte';
   import { tiroirStore } from '../ui/stores/tiroir.store';
   import TiroirGestionContributeurs from '../ui/tiroirs/TiroirGestionContributeurs.svelte';
   import Bouton from '../ui/Bouton.svelte';
   import { rechercheTextuelle } from './stores/rechercheTextuelle.store';
   import { selectionIdsServices } from './stores/selectionService.store';
+  import Lien from '../ui/Lien.svelte';
 
   export let indicesCybers: IndiceCyber[] = [];
 
@@ -40,7 +42,21 @@
 </script>
 
 <table>
-  {#if $resultatsDeRecherche.length === 0}
+  {#if $services.length === 0}
+    <div class="aucun-service">
+      <h4>Laissez vous guider !</h4>
+      <p>
+        Nous vous accompagnons sur toutes les étapes de sécurisation de votre
+        service numérique.
+      </p>
+      <Lien
+        titre="Ajouter votre premier service"
+        type="bouton-primaire"
+        icone="plus"
+        href="/service/creation"
+      />
+    </div>
+  {:else if $resultatsDeRecherche.length === 0}
     <div class="aucun-resultat">
       <img
         src="/statique/assets/images/illustration_recherche_vide.svg"
@@ -248,5 +264,30 @@
 
   .aucun-resultat img {
     max-width: 128px;
+  }
+
+  .aucun-service {
+    margin: 59px auto 47px;
+    text-align: center;
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    width: 389px;
+    flex-direction: column;
+  }
+
+  .aucun-service h4 {
+    margin: 0;
+    padding: 0;
+    font-size: 1.5rem;
+    line-height: 2rem;
+    font-weight: bold;
+  }
+
+  .aucun-service p {
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+    color: var(--texte-gris);
+    margin: 0 0 8px;
   }
 </style>

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -78,22 +78,23 @@
         <th>Actions recommandées</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody class="contenu-tableau-services">
       {#each $resultatsDeRecherche as service (service.id)}
         {@const idService = service.id}
         {@const indiceCyberDuService = indicesCybers.find(
           (i) => i.id === idService
         )?.indiceCyber}
-        <tr>
+        <tr class="ligne-service">
           <td>
             <input
+              class="selection-service"
               type="checkbox"
               bind:group={$selectionIdsServices}
               value={idService}
               title="Sélection du service {service.nomService}"
             />
           </td>
-          <td>
+          <td class="cellule-noms">
             <a class="lien-service" href="/service/{idService}">
               {#if service.estProprietaire}
                 <EtiquetteProprietaire />

--- a/svelte/lib/ui/Bouton.svelte
+++ b/svelte/lib/ui/Bouton.svelte
@@ -114,10 +114,25 @@
     color: #fff;
   }
 
-  button.lien:disabled {
+  button.lien:disabled,
+  button.lien:disabled:hover {
     background: none;
     border: none;
     color: #929292;
+  }
+
+  button.lien:hover {
+    background: #f5f5f5;
+  }
+
+  button.lien:active {
+    background: var(--fond-gris-pale-composant);
+    color: var(--systeme-design-etat-bleu);
+  }
+
+  button.lien.avecIcone:active::before {
+    filter: brightness(0) invert(8%) sepia(52%) saturate(5373%)
+      hue-rotate(237deg) brightness(125%) contrast(140%);
   }
 
   button.lien.avecIcone:disabled:before {

--- a/svelte/lib/ui/Lien.svelte
+++ b/svelte/lib/ui/Lien.svelte
@@ -10,13 +10,14 @@
   }
   export let titre: string;
   export let href: string;
+  export let classe: string | undefined = undefined;
   export let icone: 'plus' | 'attention' | undefined = undefined;
   export let type: 'bouton-primaire' | 'bouton-secondaire' = 'bouton-primaire';
   export let taille: 'petit' | 'moyen' = 'moyen';
 </script>
 
 <a
-  class="{type} {icone} {taille}"
+  class="{type} {icone} {taille} {classe || ''}"
   class:avecIcone={!!icone}
   {href}
   rel={$$restProps.rel || 'noopener'}

--- a/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
+++ b/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
@@ -14,23 +14,8 @@
     document.getElementsByClassName(classe)[0]! as HTMLElement;
 
   onMount(() => {
-    // On utilise ici un mutation observer pour attendre que l'appel API
-    // du tableau des services ait ajouté au DOM les éléments de ligne service
-    const observateur = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach((noeud) => {
-          if (noeud.classList.contains('ligne-service')) {
-            cibleNomService = elementDeClasse('cellule-noms');
-            cibleLignePremierService = elementDeClasse('ligne-service');
-          }
-        });
-      });
-    });
-    observateur.observe(elementDeClasse('contenu-tableau-services'), {
-      childList: true,
-      subtree: false,
-    });
-
+    cibleNomService = elementDeClasse('cellule-noms');
+    cibleLignePremierService = elementDeClasse('ligne-service');
     cibleCentreNotifications = elementDeClasse('centre-notifications');
     cibleBOM = elementDeClasse('bom-modale');
     cibleNouveauService = elementDeClasse('nouveau-service');
@@ -60,7 +45,7 @@
     }
     return {
       cible: cibleLignePremierService,
-      positionnementModale: 'BasMilieu',
+      positionnementModale: 'HautMilieu',
       callbackInitialeCible: (cible) => {
         cible.inert = true;
       },
@@ -77,10 +62,10 @@
     sousEtapes={[
       {
         cible: cibleNomService,
-        positionnementModale: 'MilieuDroite',
+        positionnementModale: 'BasDroite',
         callbackInitialeCible: () => {
           document
-            .getElementsByClassName('conteneur-noms')[0]
+            .getElementsByClassName('lien-service')[0]
             .removeAttribute('href');
           document.getElementsByClassName(
             'selection-service'

--- a/svelte/lib/visiteGuidee/kit/ModaleSousEtape.d.ts
+++ b/svelte/lib/visiteGuidee/kit/ModaleSousEtape.d.ts
@@ -6,6 +6,7 @@ export type PositionModale =
   | 'HautGauche'
   | 'BasGauche'
   | 'BasMilieu'
+  | 'HautMilieu'
   | 'DeuxTiersCentre';
 
 export type SousEtape = {
@@ -22,4 +23,9 @@ export type SousEtape = {
   texteBoutonDerniereEtape?: string;
 };
 
-export type PositionRond = 'Droite' | 'Gauche' | 'Bas' | 'DeuxTiersCentre';
+export type PositionRond =
+  | 'Droite'
+  | 'Gauche'
+  | 'Bas'
+  | 'Haut'
+  | 'DeuxTiersCentre';

--- a/svelte/lib/visiteGuidee/kit/ModaleSousEtape.svelte
+++ b/svelte/lib/visiteGuidee/kit/ModaleSousEtape.svelte
@@ -121,6 +121,16 @@
             leftPointe: '50%',
           };
           break;
+        case 'HautMilieu':
+          positionModale = {
+            top: `${positionCible.top - 7}px`,
+            left: `${positionCible.right - positionCible.width / 2}px`,
+            transformY: '100%',
+            transformX: '-50%',
+            positionRond: 'Haut',
+            leftPointe: '50%',
+          };
+          break;
       }
     }
   }
@@ -189,6 +199,12 @@
         case 'Bas':
           decallageRond = {
             top: positionCible.bottom - 9,
+            left: positionCible.left + positionCible.width / 2 - 9,
+          };
+          break;
+        case 'Haut':
+          decallageRond = {
+            top: positionCible.top - 9,
             left: positionCible.left + positionCible.width / 2 - 9,
           };
           break;

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -46,7 +46,6 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
     '/motDePasse/edition',
     '/profil',
     '/tableauDeBord',
-    '/tableauDeBord-v2',
     '/visiteGuidee/decrire',
     '/visiteGuidee/securiser',
     '/visiteGuidee/homologuer',
@@ -173,26 +172,10 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
   });
 
   describe('quand GET sur /tableauDeBord', () => {
-    it("affiche l'encart de superviseur si l'utilisateur en est un", async () => {
-      testeur.depotDonnees().estSuperviseur = async () => true;
-      const reponse = await axios.get(`http://localhost:1234/tableauDeBord`);
-
-      expect(reponse.data).to.contain('Voir le tableau');
-    });
-
-    it("n'affiche pas l'encart de superviseur si l'utilisateur n'en est pas un", async () => {
-      testeur.depotDonnees().estSuperviseur = async () => false;
-      const reponse = await axios.get(`http://localhost:1234/tableauDeBord`);
-
-      expect(reponse.data).not.to.contain('Voir le tableau');
-    });
-  });
-
-  describe('quand GET sur /tableauDeBord-v2', () => {
     it("ajoute la donnée partagée indiquant si l'utilisateur est superviseur", async () => {
       testeur.depotDonnees().estSuperviseur = async () => true;
 
-      const reponse = await axios.get(`http://localhost:1234/tableauDeBord-v2`);
+      const reponse = await axios.get(`http://localhost:1234/tableauDeBord`);
 
       const donnees = donneesPartagees(reponse.data, 'utilisateur-superviseur');
       expect(donnees).to.eql({ estSuperviseur: true });


### PR DESCRIPTION
Corrige les deux petits retours de recette.
Ajoute un encart quand l'utilisateur n'a aucun service.
Active le tableau de bord v2 sur l'url `/tableauDeBord`. 
Corrige la visite guidée pour qu'elle s'affiche correctement avec le nouveau tableau de bord.