### PR TITLE
[CORRECTION] Affiche correctement les services du tableau de bord dans le cas de droits personnalisés

### DIFF
--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -99,7 +99,7 @@
         {@const idService = service.id}
         {@const indiceCyberDuService = indicesCybers.find(
           (i) => i.id === idService
-        )?.indiceCyber}
+        )}
         <tr class="ligne-service">
           <td class="cellule-selection">
             <input
@@ -138,17 +138,22 @@
           </td>
           <td>
             {#if indiceCyberDuService !== undefined}
-              <EtiquetteIndiceCyber score={indiceCyberDuService} {idService} />
+              <EtiquetteIndiceCyber
+                score={indiceCyberDuService.indiceCyber}
+                {idService}
+              />
             {:else}
               <IconeChargementEnCours />
             {/if}
           </td>
           <td>
-            <EtiquetteHomologation
-              statutHomologation={service.statutHomologation.id}
-              label={service.statutHomologation.libelle}
-              {idService}
-            />
+            {#if service.statutHomologation}
+              <EtiquetteHomologation
+                statutHomologation={service.statutHomologation.id}
+                label={service.statutHomologation.libelle}
+                {idService}
+              />
+            {/if}
           </td>
           <td>
             <ActionRecommandee action={service.actionRecommandee} {idService} />


### PR DESCRIPTION
... dans le cas d'un utilisateur qui n'aurait pas les droits de lecture sur "SÉCURISER" ou "HOMOLOGUER", le tableau n'affichait rien