### PR TITLE
Mets à jours les statuts d'homologation

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -255,7 +255,7 @@ module.exports = {
 
   statutsHomologation: {
     expiree: { libelle: 'Expirée', ordre: 0 },
-    bientotExpiree: { libelle: 'Bientôt expirée', ordre: 1 },
+    bientotExpiree: { libelle: 'Expire le ', ordre: 1 },
     nonRealisee: { libelle: 'Aucune', ordre: 3 },
     bientotActivee: { libelle: 'Bientôt activée', ordre: 4 },
     activee: { libelle: 'Active', ordre: 5 },

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -258,7 +258,7 @@ module.exports = {
     bientotExpiree: { libelle: 'Expire le ', ordre: 1 },
     nonRealisee: { libelle: 'Aucune', ordre: 3 },
     bientotActivee: { libelle: 'Bientôt activée', ordre: 4 },
-    activee: { libelle: 'Active', ordre: 5 },
+    activee: { libelle: 'Réalisée', ordre: 5 },
   },
 
   typesService: {

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -256,8 +256,8 @@ module.exports = {
   statutsHomologation: {
     expiree: { libelle: 'Expirée', ordre: 0 },
     bientotExpiree: { libelle: 'Expire le ', ordre: 1 },
-    nonRealisee: { libelle: 'Aucune', ordre: 3 },
-    activee: { libelle: 'Réalisée', ordre: 5 },
+    nonRealisee: { libelle: 'Aucune', ordre: 2 },
+    activee: { libelle: 'Réalisée', ordre: 3 },
   },
 
   typesService: {

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -256,7 +256,7 @@ module.exports = {
   statutsHomologation: {
     expiree: { libelle: 'Expirée', ordre: 0 },
     bientotExpiree: { libelle: 'Bientôt expirée', ordre: 1 },
-    nonRealisee: { libelle: 'Non réalisée', ordre: 3 },
+    nonRealisee: { libelle: 'Aucune', ordre: 3 },
     bientotActivee: { libelle: 'Bientôt activée', ordre: 4 },
     activee: { libelle: 'Active', ordre: 5 },
   },

--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -257,7 +257,6 @@ module.exports = {
     expiree: { libelle: 'Expirée', ordre: 0 },
     bientotExpiree: { libelle: 'Expire le ', ordre: 1 },
     nonRealisee: { libelle: 'Aucune', ordre: 3 },
-    bientotActivee: { libelle: 'Bientôt activée', ordre: 4 },
     activee: { libelle: 'Réalisée', ordre: 5 },
   },
 

--- a/public/assets/styles/carteInformations.css
+++ b/public/assets/styles/carteInformations.css
@@ -139,10 +139,6 @@
   background: #dbeeff;
 }
 
-.carte .statut-homologation.bientotActivee {
-  background: #e7f8d7;
-}
-
 .carte .statut-homologation.activee {
   background: #d4f4db;
 }

--- a/public/assets/styles/dossiers.css
+++ b/public/assets/styles/dossiers.css
@@ -131,10 +131,6 @@
   height: fit-content;
 }
 
-.homologation .dossier .statut-homologation.bientotActivee {
-  background: #e7f8d7;
-}
-
 .homologation .dossier .statut-homologation.activee {
   background: #d4f4db;
 }

--- a/public/assets/styles/tableauDeBord.css
+++ b/public/assets/styles/tableauDeBord.css
@@ -515,10 +515,6 @@ label[for='recherche-service'] {
   background: #dbeeff;
 }
 
-.tableau-services td .statut-homologation.statut-bientotActivee {
-  background: #e7f8d7;
-}
-
 .tableau-services td .statut-homologation.statut-activee {
   background: #d4f4db;
 }

--- a/src/modeles/dossier.js
+++ b/src/modeles/dossier.js
@@ -190,14 +190,14 @@ class Dossier extends InformationsService {
   statutHomologation() {
     if (!this.finalise) return 'nonRealisee';
 
+    if (this.estBientotExpire()) return 'bientotExpiree';
+
     const activeDansLeFutur =
       new Date(this.decision.dateHomologation) >
       this.adaptateurHorloge.maintenant();
-    if (activeDansLeFutur) return 'bientotActivee';
 
-    if (this.estBientotExpire()) return 'bientotExpiree';
-
-    if (this.decision.periodeHomologationEstEnCours()) return 'activee';
+    if (activeDansLeFutur || this.decision.periodeHomologationEstEnCours())
+      return 'activee';
 
     if (this.estExpire()) return 'expiree';
 

--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -6,6 +6,7 @@ const {
   ErreurDossierCourantInexistant,
 } = require('../erreurs');
 const Referentiel = require('../referentiel');
+const { dateEnFrancais } = require('../utilitaires/date');
 
 const STATUTS_HOMOLOGATION = {
   NON_REALISEE: 'nonRealisee',
@@ -41,6 +42,13 @@ class Dossiers extends ElementsConstructibles {
     if (!dossierActif) return false;
     const statut = dossierActif.statutHomologation();
     return statut === Dossiers.ACTIVEE || statut === Dossiers.BIENTOT_EXPIREE;
+  }
+
+  dateExpiration() {
+    if (!this.dossierActif()) {
+      return undefined;
+    }
+    return dateEnFrancais(this.dossierActif().dateProchaineHomologation());
   }
 
   dossierCourant() {

--- a/src/modeles/dossiers.js
+++ b/src/modeles/dossiers.js
@@ -11,7 +11,6 @@ const { dateEnFrancais } = require('../utilitaires/date');
 const STATUTS_HOMOLOGATION = {
   NON_REALISEE: 'nonRealisee',
   ACTIVEE: 'activee',
-  BIENTOT_ACTIVEE: 'bientotActivee',
   EXPIREE: 'expiree',
   BIENTOT_EXPIREE: 'bientotExpiree',
 };

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -1,6 +1,5 @@
 const Dossiers = require('../dossiers');
 const Autorisation = require('../autorisations/autorisation');
-const { dateEnFrancais } = require('../../utilitaires/date');
 
 const { DROITS_VOIR_STATUT_HOMOLOGATION } = Autorisation;
 

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -1,5 +1,6 @@
 const Dossiers = require('../dossiers');
 const Autorisation = require('../autorisations/autorisation');
+const { dateEnFrancais } = require('../../utilitaires/date');
 
 const { DROITS_VOIR_STATUT_HOMOLOGATION } = Autorisation;
 
@@ -10,6 +11,7 @@ const donnees = (service, autorisation, referentiel) => {
     service.dossiers.dossierCourant()?.etapeCourante(),
     autorisation.peutHomologuer()
   );
+  const dateExpiration = service.dossiers.dateExpiration();
   return {
     id: service.id,
     nomService: service.nomService(),
@@ -26,6 +28,7 @@ const donnees = (service, autorisation, referentiel) => {
       statutHomologation: {
         id: service.dossiers.statutHomologation(),
         enCoursEdition,
+        ...(dateExpiration && { dateExpiration }),
         ...(enCoursEdition && { etapeCourante: etapeCouranteAutorisee }),
         ...referentiel.statutHomologation(
           service.dossiers.statutHomologation()

--- a/src/vues/service/dossiers.pug
+++ b/src/vues/service/dossiers.pug
@@ -13,6 +13,7 @@ mixin dossier({ statut, dossier, service, indiceCyber, indiceCyberPersonnalise, 
       if (resultat.length < longueurInitiale) resultat += '…';
       return resultat
     }
+    const dateExpiration = service.dossiers.dateExpiration();
 
   .dossier(class=classeCss)
     div
@@ -24,6 +25,8 @@ mixin dossier({ statut, dossier, service, indiceCyber, indiceCyberPersonnalise, 
               - const statutHomologation = dossier.statutHomologation()
               .statut-homologation(class=statutHomologation)
                 span!= referentiel.statutHomologation(statutHomologation).libelle
+                  if dateExpiration && statutHomologation === 'bientotExpiree'
+                    span!= dateExpiration
             .indices-cyber
               if indiceCyber !== undefined
                 .indice-cyber
@@ -59,7 +62,7 @@ mixin dossier({ statut, dossier, service, indiceCyber, indiceCyberPersonnalise, 
 
 mixin dossierFinalise({ dossier, service, afficheStatutHomologation, afficheTamponHomologation })
   - const dateDecision = new Intl.DateTimeFormat('fr-FR').format(new Date(dossier.decision.dateHomologation))
-  +dossier({ statut: `Décision d'homologation du ${dateDecision}`, dossier, afficheStatutHomologation, afficheTamponHomologation, indiceCyber: dossier.indiceCyber, indiceCyberPersonnalise: dossier.indiceCyberPersonnalise })
+  +dossier({ statut: `Décision d'homologation du ${dateDecision}`, dossier, service, afficheStatutHomologation, afficheTamponHomologation, indiceCyber: dossier.indiceCyber, indiceCyberPersonnalise: dossier.indiceCyberPersonnalise })
 
 mixin dossierCourant({ dossier, idService, service })
   +dossier({ statut: "Projet d'homologation", dossier, service, indiceCyber: service.indiceCyber().total, indiceCyberPersonnalise: service.indiceCyberPersonnalise().total, afficheActions: true, classeCss: "dossier-courant"})
@@ -102,7 +105,7 @@ block contenu-etape
     if dossiersPasses.length
       h3.titre-section Homologations passées
       each dossier in dossiersPasses
-        +dossierFinalise({ dossier, afficheStatutHomologation: false })
+        +dossierFinalise({ dossier, service, afficheStatutHomologation: false })
 
     if aucunDossier
       .aucun-projets

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -151,6 +151,7 @@
               <EtiquetteHomologation
                 statutHomologation={service.statutHomologation.id}
                 label={service.statutHomologation.libelle}
+                dateExpiration={service.statutHomologation.dateExpiration}
                 {idService}
               />
             {/if}

--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
@@ -2,10 +2,14 @@
   export let statutHomologation: string;
   export let label: string;
   export let idService: string;
+  export let dateExpiration: string = '';
 </script>
 
 <a class={statutHomologation} href="/service/{idService}/dossiers">
   {label}
+  {#if statutHomologation === 'bientotExpiree'}
+    {dateExpiration}
+  {/if}
 </a>
 
 <style>

--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
@@ -49,12 +49,6 @@
     --fond-actif: #dadfe6;
   }
 
-  .bientotActivee {
-    --fond: #eaf5ff;
-    --fond-hover: #b6cffb;
-    --fond-actif: #7badef;
-  }
-
   .activee {
     --fond: #defbe5;
     --fond-hover: #c0edcb;

--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
@@ -40,9 +40,9 @@
   }
 
   .nonRealisee {
-    --fond: #e9ddff;
-    --fond-hover: #d4bcff;
-    --fond-actif: #c19eff;
+    --fond: #e6ebf1;
+    --fond-hover: #e6ebf1;
+    --fond-actif: #dadfe6;
   }
 
   .bientotActivee {

--- a/svelte/lib/tableauDeBord/tableauDeBord.d.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.d.ts
@@ -28,6 +28,7 @@ export type Service = {
     enCoursEdition: boolean;
     libelle: string;
     ordre: number;
+    dateExpiration?: string;
   };
   nombreContributeurs: number;
   estProprietaire: boolean;

--- a/test/modeles/dossier.spec.js
+++ b/test/modeles/dossier.spec.js
@@ -269,7 +269,7 @@ describe("Un dossier d'homologation", () => {
       expect(nonFinalise.statutHomologation()).to.be('nonRealisee');
     });
 
-    it('est « Bientôt activée » si le dossier est finalisé avec une date de début dans le futur', () => {
+    it('est « Réalisée » même si le dossier est finalisé avec une date de début dans le futur', () => {
       const maintenantPremierJuin = {
         maintenant: () => new Date('2023-06-01'),
       };
@@ -278,7 +278,7 @@ describe("Un dossier d'homologation", () => {
         .avecDateHomologation(new Date('2023-06-02'))
         .construit();
 
-      expect(actifLeDeuxJuin.statutHomologation()).to.be('bientotActivee');
+      expect(actifLeDeuxJuin.statutHomologation()).to.be('activee');
     });
 
     it('est « Bientôt expirée » si le dossier est finalisé avec une date de fin qui est proche', () => {


### PR DESCRIPTION
Expirée : ancien et nouveau statut iso
Non réalisée devient Aucune
BIentôt expiré devient le "expire + date"
Active devient "realisée"
Bientôt activée disparait, toute homologation qui n'est pas expirée est "réalisée"