### PR TITLE
[CORRECTION] Empêche l'etiquette du statut d'homologation de se propager sur plusieurs lignes

### DIFF
--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteHomologation.svelte
@@ -17,6 +17,7 @@
     line-height: 20px;
     background: var(--fond);
     color: var(--texte-fonce);
+    white-space: nowrap;
   }
 
   a:hover {


### PR DESCRIPTION
… afin d'éviter un affichage incorrect.

![image](https://github.com/user-attachments/assets/7b8097f3-22a9-476d-b7d1-41aebcc36491)
