### PR TITLE
[CORRECTION] Ne prend pas en compte les services dont le statut d'homologation est masqué pour un utilisateur dans l'affichage des onglets

### DIFF
--- a/svelte/lib/tableauDeBord/stores/affichageParStatutHomologation.ts
+++ b/svelte/lib/tableauDeBord/stores/affichageParStatutHomologation.ts
@@ -24,13 +24,13 @@ export const affichageParStatutHomologation = derived<
 >([resultatsDeRecherche], ([$resultatsDeRecherche]) => ({
   tous: $resultatsDeRecherche,
   bientotExpiree: $resultatsDeRecherche.filter(
-    (s) => s.statutHomologation.id === 'bientotExpiree'
+    (s) => s.statutHomologation?.id === 'bientotExpiree'
   ),
   expiree: $resultatsDeRecherche.filter(
-    (s) => s.statutHomologation.id === 'expiree'
+    (s) => s.statutHomologation?.id === 'expiree'
   ),
   enCoursEdition: $resultatsDeRecherche.filter(
-    (s) => s.statutHomologation.enCoursEdition
+    (s) => s.statutHomologation?.enCoursEdition
   ),
 }));
 

--- a/svelte/lib/tableauDeBord/stores/affichageTableauVide.ts
+++ b/svelte/lib/tableauDeBord/stores/affichageTableauVide.ts
@@ -38,21 +38,22 @@ export const affichageTableauVide = derived<
       etat = 'aucunResultatDeRecherche' as Etat;
     } else if (
       $affichageParStatutHomologationSelectionne === 'enCoursEdition' &&
-      $resultatsDeRecherche.filter((s) => s.statutHomologation.enCoursEdition)
+      $resultatsDeRecherche.filter((s) => s.statutHomologation?.enCoursEdition)
         .length === 0
     ) {
       etat = 'aucunDossierHomologationEnCours' as Etat;
     } else if (
       $affichageParStatutHomologationSelectionne === 'bientotExpiree' &&
       $resultatsDeRecherche.filter(
-        (s) => s.statutHomologation.id === 'bientotExpiree'
+        (s) => s.statutHomologation?.id === 'bientotExpiree'
       ).length === 0
     ) {
       etat = 'aucunDossierHomologationBientotExpiree' as Etat;
     } else if (
       $affichageParStatutHomologationSelectionne === 'expiree' &&
-      $resultatsDeRecherche.filter((s) => s.statutHomologation.id === 'expiree')
-        .length === 0
+      $resultatsDeRecherche.filter(
+        (s) => s.statutHomologation?.id === 'expiree'
+      ).length === 0
     ) {
       etat = 'aucunDossierHomologationExpiree' as Etat;
     } else {

--- a/svelte/lib/tableauDeBord/tableauDeBord.d.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.d.ts
@@ -23,7 +23,7 @@ export type Service = {
   nomService: string;
   organisationResponsable: string;
   contributeurs: Contributeur[];
-  statutHomologation: {
+  statutHomologation?: {
     id: string;
     enCoursEdition: boolean;
     libelle: string;


### PR DESCRIPTION
... afin de ne pas faire crasher le tableau de bord