### PR TITLE
Corrige la création de l'utilisateur démo en local

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": "10"
   },
   "scripts": {
-    "build": "knex migrate:latest && npm run cree-utilisateur-demo && npx vite build --config svelte/vite.config.mts  && npx tsc",
+    "build": "knex migrate:latest && npx vite build --config svelte/vite.config.mts  && npx tsc && npm run cree-utilisateur-demo",
     "cree-utilisateur-demo": "node dist/creeUtilisateurDemo.js",
     "test": "eslint . && mocha",
     "test:mocha": "mocha",


### PR DESCRIPTION
En développement local, la création de l'utilisateur a besoin que le code ait déjà été compilé or on compilait après la création de cet utilisateur et donc cela échouait sur un environnement vierge sur lequel on n'avait jamais compilé.

On corrige l'ordre de ces instructions pour compiler avant de créer l'utilisateur.