### PR TITLE
[CORRECTION] Passe les labels de besoins de sécurité au pluriel

### DIFF
--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -44,9 +44,9 @@
   };
 
   const libellesNiveauSecurite = {
-    niveau1: 'Élémentaire',
-    niveau2: 'Modéré',
-    niveau3: 'Important',
+    niveau1: 'Élémentaires',
+    niveau2: 'Modérés',
+    niveau3: 'Importants',
   };
 </script>
 


### PR DESCRIPTION
...suite à une erreur dans les maquettes.