### PR TITLE
[TDB V2] Désactive les actions recommandées si elles ne sont pas autorisées

### DIFF
--- a/src/modeles/autorisations/autorisation.js
+++ b/src/modeles/autorisations/autorisation.js
@@ -108,8 +108,16 @@ class Autorisation extends Base {
     [SECURISER]: LECTURE,
   };
 
+  static DROITS_EDITER_MESURES = {
+    [SECURISER]: ECRITURE,
+  };
+
   static DROITS_VOIR_STATUT_HOMOLOGATION = {
     [HOMOLOGUER]: LECTURE,
+  };
+
+  static DROITS_EDITER_HOMOLOGATION = {
+    [HOMOLOGUER]: ECRITURE,
   };
 
   static DROITS_ANNEXES_PDF = {
@@ -132,6 +140,12 @@ class Autorisation extends Base {
     [DECRIRE]: LECTURE,
   };
 
+  static DROIT_INVITER_CONTRIBUTEUR = 'peutInviterContributeur';
+
+  static DROITS_EDITER_DESCRIPTION = {
+    [DECRIRE]: ECRITURE,
+  };
+
   appliqueDroits(nouveauxDroits) {
     if (nouveauxDroits.estProprietaire) {
       this.estProprietaire = true;
@@ -141,6 +155,16 @@ class Autorisation extends Base {
 
     this.estProprietaire = false;
     this.droits = { ...this.droits, ...nouveauxDroits };
+  }
+
+  peutFaireActionRecommandee(actionRecommandee) {
+    if (
+      actionRecommandee.droitsNecessaires ===
+      Autorisation.DROIT_INVITER_CONTRIBUTEUR
+    )
+      return this.peutGererContributeurs();
+
+    return this.aLesPermissions(actionRecommandee.droitsNecessaires);
   }
 }
 

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -12,6 +12,7 @@ const donnees = (service, autorisation, referentiel) => {
   );
   const dateExpiration = service.dossiers.dateExpiration();
   const completude = service.completudeMesures();
+  const actionRecommandee = service.actionRecommandee();
   return {
     id: service.id,
     nomService: service.nomService(),
@@ -42,7 +43,12 @@ const donnees = (service, autorisation, referentiel) => {
       gestionContributeurs: autorisation.peutGererContributeurs(),
     },
     aUneSuggestionAction: !!service.aUneSuggestionDAction(),
-    actionRecommandee: service.actionRecommandee(),
+    ...(actionRecommandee && {
+      actionRecommandee: {
+        id: actionRecommandee.id,
+        autorisee: autorisation.peutFaireActionRecommandee(actionRecommandee),
+      },
+    }),
     niveauSecurite: service.descriptionService.niveauSecurite,
     pourcentageCompletude:
       completude.nombreMesuresCompletes / completude.nombreTotalMesures || 0,

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -420,13 +420,34 @@ class Service {
   }
 
   static ACTIONS_RECOMMANDEES = {
-    METTRE_A_JOUR: 'mettreAJour',
-    CONTINUER_HOMOLOGATION: 'continuerHomologation',
-    AUGMENTER_INDICE_CYBER: 'augmenterIndiceCyber',
-    TELECHARGER_ENCART_HOMOLOGATION: 'telechargerEncartHomologation',
-    HOMOLOGUER_A_NOUVEAU: 'homologuerANouveau',
-    HOMOLOGUER_SERVICE: 'homologuerService',
-    INVITER_CONTRIBUTEUR: 'inviterContributeur',
+    METTRE_A_JOUR: {
+      id: 'mettreAJour',
+      droitsNecessaires: Autorisation.DROITS_EDITER_DESCRIPTION,
+    },
+    CONTINUER_HOMOLOGATION: {
+      id: 'continuerHomologation',
+      droitsNecessaires: Autorisation.DROITS_EDITER_HOMOLOGATION,
+    },
+    AUGMENTER_INDICE_CYBER: {
+      id: 'augmenterIndiceCyber',
+      droitsNecessaires: Autorisation.DROITS_EDITER_MESURES,
+    },
+    TELECHARGER_ENCART_HOMOLOGATION: {
+      id: 'telechargerEncartHomologation',
+      droitsNecessaires: Autorisation.DROITS_VOIR_STATUT_HOMOLOGATION,
+    },
+    HOMOLOGUER_A_NOUVEAU: {
+      id: 'homologuerANouveau',
+      droitsNecessaires: Autorisation.DROITS_EDITER_HOMOLOGATION,
+    },
+    HOMOLOGUER_SERVICE: {
+      id: 'homologuerService',
+      droitsNecessaires: Autorisation.DROITS_EDITER_HOMOLOGATION,
+    },
+    INVITER_CONTRIBUTEUR: {
+      id: 'inviterContributeur',
+      droitsNecessaires: Autorisation.DROIT_INVITER_CONTRIBUTEUR,
+    },
   };
 }
 

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -24,16 +24,6 @@ const NIVEAUX = {
   NIVEAU_SECURITE_INSUFFISANT: 'insuffisant',
 };
 
-const ACTIONS_RECOMMANDEES = {
-  METTRE_A_JOUR: 'mettreAJour',
-  CONTINUER_HOMOLOGATION: 'continuerHomologation',
-  AUGMENTER_INDICE_CYBER: 'augmenterIndiceCyber',
-  TELECHARGER_ENCART_HOMOLOGATION: 'telechargerEncartHomologation',
-  HOMOLOGUER_A_NOUVEAU: 'homologuerANouveau',
-  HOMOLOGUER_SERVICE: 'homologuerService',
-  INVITER_CONTRIBUTEUR: 'inviterContributeur',
-};
-
 class Service {
   constructor(
     donnees,
@@ -337,33 +327,34 @@ class Service {
   }
 
   actionRecommandee() {
-    if (this.aUneSuggestionDAction()) return ACTIONS_RECOMMANDEES.METTRE_A_JOUR;
+    if (this.aUneSuggestionDAction())
+      return Service.ACTIONS_RECOMMANDEES.METTRE_A_JOUR;
 
     const indiceCyber = this.indiceCyber().total;
     if (this.dossierCourant() && indiceCyber >= 4)
-      return ACTIONS_RECOMMANDEES.CONTINUER_HOMOLOGATION;
+      return Service.ACTIONS_RECOMMANDEES.CONTINUER_HOMOLOGATION;
 
     if (this.dossierCourant() && indiceCyber < 4)
-      return ACTIONS_RECOMMANDEES.AUGMENTER_INDICE_CYBER;
+      return Service.ACTIONS_RECOMMANDEES.AUGMENTER_INDICE_CYBER;
 
     if (this.dossiers.aUnDossierEnCoursDeValidite())
-      return ACTIONS_RECOMMANDEES.TELECHARGER_ENCART_HOMOLOGATION;
+      return Service.ACTIONS_RECOMMANDEES.TELECHARGER_ENCART_HOMOLOGATION;
 
     if (this.dossiers.dossierActif()?.statutHomologation() === 'expiree')
-      return ACTIONS_RECOMMANDEES.HOMOLOGUER_A_NOUVEAU;
+      return Service.ACTIONS_RECOMMANDEES.HOMOLOGUER_A_NOUVEAU;
 
     const completude = this.completudeMesures();
     const pourcentageCompletude =
       completude.nombreMesuresCompletes / completude.nombreTotalMesures || 0;
     const nbContributeurs = this.contributeurs.length;
     if (nbContributeurs === 1 && pourcentageCompletude < 0.8 && indiceCyber < 4)
-      return ACTIONS_RECOMMANDEES.INVITER_CONTRIBUTEUR;
+      return Service.ACTIONS_RECOMMANDEES.INVITER_CONTRIBUTEUR;
 
     if (nbContributeurs > 1 && pourcentageCompletude < 0.8 && indiceCyber < 4)
-      return ACTIONS_RECOMMANDEES.AUGMENTER_INDICE_CYBER;
+      return Service.ACTIONS_RECOMMANDEES.AUGMENTER_INDICE_CYBER;
 
     if (pourcentageCompletude >= 0.8 && indiceCyber >= 4)
-      return ACTIONS_RECOMMANDEES.HOMOLOGUER_SERVICE;
+      return Service.ACTIONS_RECOMMANDEES.HOMOLOGUER_SERVICE;
 
     return undefined;
   }
@@ -427,6 +418,16 @@ class Service {
 
     return new Service(donneesService);
   }
+
+  static ACTIONS_RECOMMANDEES = {
+    METTRE_A_JOUR: 'mettreAJour',
+    CONTINUER_HOMOLOGATION: 'continuerHomologation',
+    AUGMENTER_INDICE_CYBER: 'augmenterIndiceCyber',
+    TELECHARGER_ENCART_HOMOLOGATION: 'telechargerEncartHomologation',
+    HOMOLOGUER_A_NOUVEAU: 'homologuerANouveau',
+    HOMOLOGUER_SERVICE: 'homologuerService',
+    INVITER_CONTRIBUTEUR: 'inviterContributeur',
+  };
 }
 
 Object.assign(Service, NIVEAUX);

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -177,7 +177,9 @@
             {/if}
           </td>
           <td>
-            <ActionRecommandee action={service.actionRecommandee} {service} />
+            {#if service.actionRecommandee}
+              <ActionRecommandee action={service.actionRecommandee} {service} />
+            {/if}
           </td>
         </tr>
       {/each}

--- a/svelte/lib/tableauDeBord/elementsDeService/ActionRecommandee.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/ActionRecommandee.svelte
@@ -12,8 +12,9 @@
   const idService = service.id;
 </script>
 
-{#if action === 'mettreAJour'}
+{#if action.id === 'mettreAJour'}
   <Lien
+    inactif={!action.autorisee}
     titre="Mettre à jour les informations"
     type="bouton-secondaire"
     href="/service/{idService}"
@@ -21,8 +22,9 @@
     icone="attention"
     classe="mettreAJour"
   />
-{:else if action === 'continuerHomologation'}
+{:else if action.id === 'continuerHomologation'}
   <Lien
+    inactif={!action.autorisee}
     titre="Continuer l'homologation"
     type="bouton-secondaire"
     href="/service/{idService}/homologation/edition/etape/recapitulatif"
@@ -30,8 +32,9 @@
     icone="homologation"
     classe="continuerHomologation"
   />
-{:else if action === 'augmenterIndiceCyber'}
+{:else if action.id === 'augmenterIndiceCyber'}
   <Lien
+    inactif={!action.autorisee}
     titre="Augmenter l’indice cyber"
     type="bouton-secondaire"
     href="/service/{idService}/mesures"
@@ -39,8 +42,9 @@
     icone="indiceCyber"
     classe="augmenterIndiceCyber"
   />
-{:else if action === 'telechargerEncartHomologation'}
+{:else if action.id === 'telechargerEncartHomologation'}
   <Lien
+    inactif={!action.autorisee}
     titre="Télécharger l'encart"
     type="bouton-secondaire"
     href="/service/{idService}/dossiers?succesHomologation"
@@ -48,8 +52,9 @@
     icone="telecharger"
     classe="telechargerEncartHomologation"
   />
-{:else if action === 'homologuerANouveau'}
+{:else if action.id === 'homologuerANouveau'}
   <Lien
+    inactif={!action.autorisee}
     titre="Homologuer à nouveau"
     type="bouton-secondaire"
     href="/service/{idService}/dossiers"
@@ -57,8 +62,9 @@
     icone="medaille"
     classe="homologuerANouveau"
   />
-{:else if action === 'homologuerService'}
+{:else if action.id === 'homologuerService'}
   <Lien
+    inactif={!action.autorisee}
     titre="Homologuer le service"
     type="bouton-secondaire"
     href="/service/{idService}/dossiers"
@@ -66,8 +72,9 @@
     icone="medaille"
     classe="homologuerService"
   />
-{:else if action === 'inviterContributeur'}
+{:else if action.id === 'inviterContributeur'}
   <Bouton
+    actif={action.autorisee}
     titre="Inviter un contributeur"
     type="secondaire"
     taille="petit"

--- a/svelte/lib/tableauDeBord/tableauDeBord.d.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.d.ts
@@ -39,7 +39,7 @@ export type Service = {
     gestionContributeurs: boolean;
   };
   aUneSuggestionAction: boolean;
-  actionRecommandee: ActionRecommandee;
+  actionRecommandee?: ActionRecommandee;
   niveauSecurite: NiveauSecuriteService;
   pourcentageCompletude: number;
 };
@@ -69,12 +69,16 @@ export type ReponseApiIndicesCyber = {
   };
 };
 
-export type ActionRecommandee =
+export type IdActionRecommandee =
   | 'mettreAJour'
   | 'continuerHomologation'
   | 'augmenterIndiceCyber'
   | 'telechargerEncartHomologation'
   | 'homologuerANouveau'
   | 'homologuerService'
-  | 'inviterContributeur'
-  | undefined;
+  | 'inviterContributeur';
+
+export type ActionRecommandee = {
+  id: IdActionRecommandee;
+  autorisee: boolean;
+};

--- a/svelte/lib/ui/Bouton.svelte
+++ b/svelte/lib/ui/Bouton.svelte
@@ -124,10 +124,23 @@
     border: none;
   }
 
-  button:disabled {
-    background-color: var(--gris-inactif);
-    border-color: var(--gris-inactif);
-    color: #fff;
+  button.primaire:disabled,
+  button.primaire:disabled:hover,
+  button.secondaire:disabled,
+  button.secondaire:disabled:hover {
+    cursor: not-allowed;
+    border-color: var(--fond-gris-fonce);
+    color: var(--gris-inactif);
+  }
+
+  button.primaire:disabled,
+  button.primaire:disabled:hover {
+    background-color: var(--fond-gris-fonce);
+  }
+
+  button.secondaire:disabled,
+  button.secondaire:disabled:hover {
+    background-color: white;
   }
 
   button.lien:disabled,
@@ -151,9 +164,11 @@
       hue-rotate(237deg) brightness(125%) contrast(140%);
   }
 
-  button.lien.avecIcone:disabled:before {
-    filter: brightness(0) invert(71%) sepia(13%) saturate(0%) hue-rotate(190deg)
-      brightness(80%) contrast(86%);
+  button.lien.avecIcone:disabled::before,
+  button.primaire.avecIcone:disabled::before,
+  button.secondaire.avecIcone:disabled::before {
+    filter: invert(65%) sepia(1%) saturate(0%) hue-rotate(358deg)
+      brightness(90%) contrast(84%);
   }
 
   button.secondaire.avecIcone::before {

--- a/svelte/lib/ui/Lien.svelte
+++ b/svelte/lib/ui/Lien.svelte
@@ -15,6 +15,7 @@
     taille?: 'petit' | 'moyen';
     classe?: string;
     href: string;
+    inactif?: boolean;
   }
   export let titre: string;
   export let href: string;
@@ -29,12 +30,14 @@
     | undefined = undefined;
   export let type: 'bouton-primaire' | 'bouton-secondaire' = 'bouton-primaire';
   export let taille: 'petit' | 'moyen' = 'moyen';
+  export let inactif: boolean = false;
 </script>
 
 <a
   class="{type} {icone} {taille} {classe || ''}"
   class:avecIcone={!!icone}
-  {href}
+  class:inactif
+  href={inactif ? '#' : href}
   rel={$$restProps.rel || 'noopener'}
   {...$$restProps}
 >
@@ -141,5 +144,29 @@
   .bouton-secondaire:focus-visible {
     outline: 2px solid var(--bleu-mise-en-avant);
     outline-offset: 2px;
+  }
+
+  .bouton-primaire.inactif,
+  .bouton-primaire.inactif:hover,
+  .bouton-secondaire.inactif,
+  .bouton-secondaire.inactif:hover {
+    color: var(--gris-inactif);
+    cursor: not-allowed;
+    border-color: var(--fond-gris-fonce);
+  }
+
+  .bouton-primaire.inactif,
+  .bouton-primaire.inactif:hover {
+    background-color: var(--fond-gris-fonce);
+  }
+
+  .bouton-secondaire.inactif,
+  .bouton-secondaire.inactif:hover {
+    background-color: white;
+  }
+
+  .bouton-secondaire.avecIcone.inactif::before {
+    filter: invert(65%) sepia(1%) saturate(0%) hue-rotate(358deg)
+      brightness(90%) contrast(84%);
   }
 </style>

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -6,8 +6,8 @@ const {
   uneAutorisation,
 } = require('../../constructeurs/constructeurAutorisation');
 const {
-  Rubriques: { HOMOLOGUER },
-  Permissions: { LECTURE },
+  Rubriques: { HOMOLOGUER, DECRIRE },
+  Permissions: { LECTURE, ECRITURE },
 } = require('../../../src/modeles/autorisations/gestionDroits');
 const { unService } = require('../../constructeurs/constructeurService');
 const {
@@ -43,8 +43,8 @@ describe("L'objet d'API de `GET /service`", () => {
     statutsMesures: { fait: {}, enCours: {}, nonFait: {} },
     mesures: { mesureA: {} },
   });
-  const lectureSurHomologuer = uneAutorisation()
-    .avecDroits({ [HOMOLOGUER]: LECTURE })
+  const autorisation = uneAutorisation()
+    .avecDroits({ [HOMOLOGUER]: LECTURE, [DECRIRE]: ECRITURE })
     .construis();
 
   const service = unService(referentiel)
@@ -82,9 +82,7 @@ describe("L'objet d'API de `GET /service`", () => {
     .construis();
 
   it('fournit les données nécessaires', () => {
-    expect(
-      objetGetService.donnees(service, lectureSurHomologuer, referentiel)
-    ).to.eql({
+    expect(objetGetService.donnees(service, autorisation, referentiel)).to.eql({
       id: '123',
       nomService: 'Un service',
       organisationResponsable: 'Une organisation',
@@ -116,7 +114,7 @@ describe("L'objet d'API de `GET /service`", () => {
       documentsPdfDisponibles: [],
       permissions: { gestionContributeurs: false },
       aUneSuggestionAction: true,
-      actionRecommandee: 'mettreAJour',
+      actionRecommandee: { id: 'mettreAJour', autorisee: true },
       niveauSecurite: 'niveau1',
       pourcentageCompletude: 0.5,
     });
@@ -131,7 +129,7 @@ describe("L'objet d'API de `GET /service`", () => {
 
     const donnees = objetGetService.donnees(
       unServiceAvecDossierBientotExpire,
-      lectureSurHomologuer,
+      autorisation,
       referentiel
     );
 
@@ -182,7 +180,7 @@ describe("L'objet d'API de `GET /service`", () => {
 
     const donnees = objetGetService.donnees(
       serviceAvecDossierFinalise,
-      lectureSurHomologuer,
+      autorisation,
       referentielDeuxEtapes
     );
     expect(donnees.statutHomologation.etapeCourante).to.be('autorite');
@@ -220,7 +218,7 @@ describe("L'objet d'API de `GET /service`", () => {
       expect(
         objetGetService.donnees(
           unServiceDontAestCreateur,
-          lectureSurHomologuer,
+          autorisation,
           referentiel
         ).permissions
       ).to.eql({ gestionContributeurs: false });

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -1127,7 +1127,7 @@ describe('Un service', () => {
         .avecSuggestionAction({ nature: 'siret-a-renseigner' })
         .construis();
 
-      expect(service.actionRecommandee()).to.be('mettreAJour');
+      expect(service.actionRecommandee().id).to.be('mettreAJour');
     });
 
     it("retourne 'continuerHomologation' si le service a un un dossier d'homologation en cours et un indice cyber supérieur à 4", () => {
@@ -1138,7 +1138,7 @@ describe('Un service', () => {
         .avecMesures(mesuresToutesFaites)
         .construis();
 
-      expect(service.actionRecommandee()).to.be('continuerHomologation');
+      expect(service.actionRecommandee().id).to.be('continuerHomologation');
     });
 
     it("retourne 'augmenterIndiceCyber' si le service a un un dossier d'homologation en cours et un indice cyber inférieur à 4", () => {
@@ -1149,7 +1149,7 @@ describe('Un service', () => {
         .avecMesures(mesuresNonFaites)
         .construis();
 
-      expect(service.actionRecommandee()).to.be('augmenterIndiceCyber');
+      expect(service.actionRecommandee().id).to.be('augmenterIndiceCyber');
     });
 
     it("retourne 'telechargerEncartHomologation' si le service a un un dossier d'homologation actif et en cours de validité", () => {
@@ -1159,7 +1159,7 @@ describe('Un service', () => {
         ])
         .construis();
 
-      expect(service.actionRecommandee()).to.be(
+      expect(service.actionRecommandee().id).to.be(
         'telechargerEncartHomologation'
       );
     });
@@ -1171,7 +1171,7 @@ describe('Un service', () => {
         ])
         .construis();
 
-      expect(service.actionRecommandee()).to.be('homologuerANouveau');
+      expect(service.actionRecommandee().id).to.be('homologuerANouveau');
     });
 
     it("retourne 'inviterContributeur' si le service n'a qu'un contributeur, un taux de complétion inférieur à 80% et indice cyber inférieur à 4", () => {
@@ -1180,7 +1180,7 @@ describe('Un service', () => {
         .avecMesures(mesuresNonRemplies)
         .construis();
 
-      expect(service.actionRecommandee()).to.be('inviterContributeur');
+      expect(service.actionRecommandee().id).to.be('inviterContributeur');
     });
 
     it("retourne 'augmenterIndiceCyber' si le service a plus d'un contributeur, un taux de complétion inférieur à 80% et indice cyber inférieur à 4", () => {
@@ -1189,7 +1189,7 @@ describe('Un service', () => {
         .avecMesures(mesuresNonRemplies)
         .construis();
 
-      expect(service.actionRecommandee()).to.be('augmenterIndiceCyber');
+      expect(service.actionRecommandee().id).to.be('augmenterIndiceCyber');
     });
 
     it("retourne 'homologuerService' si le service a un taux de complétion supérieur à 80% et indice cyber supérieur à 4", () => {
@@ -1197,7 +1197,7 @@ describe('Un service', () => {
         .avecMesures(mesuresToutesFaites)
         .construis();
 
-      expect(service.actionRecommandee()).to.be('homologuerService');
+      expect(service.actionRecommandee().id).to.be('homologuerService');
     });
 
     it("retourne 'undefined' si aucune action recommandée", () => {


### PR DESCRIPTION
L'action recommandée dépend du service et non de l'utilisateur qui navigue. C'est pourquoi parfois l'utilisateur n'a pas le droit d'exécuter l'action recommandée. Dans ce cas, on désactive le bouton.