### PR TITLE
[SOIN] Extrais la configuration du tiroir dans les composant

### DIFF
--- a/svelte/lib/tableauDeBord/ActionsDesServices.svelte
+++ b/svelte/lib/tableauDeBord/ActionsDesServices.svelte
@@ -35,16 +35,9 @@
       type="lien"
       actif={actionsDisponibles && estProprietaireDesServicesSelectionnes}
       on:click={() =>
-        tiroirStore.afficheContenu(
-          TiroirGestionContributeurs,
-          { services: selection },
-          {
-            titre: 'Gérer les contributeurs',
-            sousTitre: selectionUnique
-              ? 'Gérer la liste des personnes invitées à contribuer au service.'
-              : 'Gérer la liste des personnes invitées à contribuer aux services.',
-          }
-        )}
+        tiroirStore.afficheContenu(TiroirGestionContributeurs, {
+          services: selection,
+        })}
     />
     <Bouton
       titre="Télécharger PDFs"
@@ -53,15 +46,9 @@
       type="lien"
       actif={actionsDisponibles && selectionUnique && ontDesDocuments}
       on:click={() =>
-        tiroirStore.afficheContenu(
-          TiroirTelechargementDocumentsService,
-          { service: selection[0] },
-          {
-            titre: 'Télécharger les PDF',
-            sousTitre:
-              "Obtenir les documents utiles à la sécurisation et à l'homologation du service sélectionné.",
-          }
-        )}
+        tiroirStore.afficheContenu(TiroirTelechargementDocumentsService, {
+          service: selection[0],
+        })}
     />
     <Bouton
       titre="Exporter la sélection"
@@ -70,16 +57,9 @@
       type="lien"
       actif={actionsDisponibles}
       on:click={() =>
-        tiroirStore.afficheContenu(
-          TiroirExportServices,
-          { services: selection },
-          {
-            titre: 'Exporter la sélection',
-            sousTitre: selectionUnique
-              ? 'Télécharger les données du service sélectionné dans le tableau de bord.'
-              : 'Télécharger la liste des services sélectionnés dans le tableau de bord.',
-          }
-        )}
+        tiroirStore.afficheContenu(TiroirExportServices, {
+          services: selection,
+        })}
     />
     <Bouton
       titre="Dupliquer"
@@ -90,15 +70,9 @@
         selectionUnique &&
         estProprietaireDesServicesSelectionnes}
       on:click={() =>
-        tiroirStore.afficheContenu(
-          TiroirDuplication,
-          { service: selection[0] },
-          {
-            titre: 'Dupliquer',
-            sousTitre:
-              "Créer une ou plusieurs copies du services sélectionné. Cette copie n'inclut pas les données concernant son homologation.",
-          }
-        )}
+        tiroirStore.afficheContenu(TiroirDuplication, {
+          service: selection[0],
+        })}
     />
     <Bouton
       titre="Supprimer"
@@ -107,16 +81,7 @@
       type="lien"
       actif={actionsDisponibles && estProprietaireDesServicesSelectionnes}
       on:click={() =>
-        tiroirStore.afficheContenu(
-          TiroirSuppression,
-          { services: selection },
-          {
-            titre: 'Supprimer',
-            sousTitre: selectionUnique
-              ? 'Effacer toutes les données du service sélectionné.'
-              : 'Effacer toutes les données des services sélectionnés.',
-          }
-        )}
+        tiroirStore.afficheContenu(TiroirSuppression, { services: selection })}
     />
   </div>
 </div>

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -140,15 +140,9 @@
             <EtiquetteContributeurs
               nombreContributeurs={service.nombreContributeurs}
               on:click={() =>
-                tiroirStore.afficheContenu(
-                  TiroirGestionContributeurs,
-                  { services: [service] },
-                  {
-                    titre: 'Gérer les contributeurs',
-                    sousTitre:
-                      'Gérer la liste des personnes invitées à contribuer au service.',
-                  }
-                )}
+                tiroirStore.afficheContenu(TiroirGestionContributeurs, {
+                  services: [service],
+                })}
             />
           </td>
           <td>

--- a/svelte/lib/tableauDeBord/elementsDeService/ActionRecommandee.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/ActionRecommandee.svelte
@@ -81,14 +81,8 @@
     icone="inviter"
     classe="inviterContributeur"
     on:click={() =>
-      tiroirStore.afficheContenu(
-        TiroirGestionContributeurs,
-        { services: [service] },
-        {
-          titre: 'Gérer les contributeurs',
-          sousTitre:
-            'Gérer la liste des personnes invitées à contribuer au service.',
-        }
-      )}
+      tiroirStore.afficheContenu(TiroirGestionContributeurs, {
+        services: [service],
+      })}
   />
 {/if}

--- a/svelte/lib/tiroir/Tiroir.svelte
+++ b/svelte/lib/tiroir/Tiroir.svelte
@@ -1,5 +1,10 @@
-<script>
-  import { tiroirStore } from '../ui/stores/tiroir.store';
+<script lang="ts">
+  import {
+    type ConfigurationTiroir,
+    tiroirStore,
+  } from '../ui/stores/tiroir.store';
+
+  let composant: ConfigurationTiroir;
 </script>
 
 <div id="tiroir" class:ouvert={$tiroirStore.ouvert}>
@@ -9,13 +14,14 @@
         <button class="fermeture-tiroir" on:click={() => tiroirStore.ferme()}>
           ✕
         </button>
-        <h2 class="titre-tiroir">{$tiroirStore.contenu.configuration.titre}</h2>
+        <h2 class="titre-tiroir">{composant?.titre}</h2>
         <p class="texte-tiroir">
-          {$tiroirStore.contenu.configuration.sousTitre}
+          {composant?.sousTitre}
         </p>
       </div>
       <svelte:component
         this={$tiroirStore.contenu.composant}
+        bind:this={composant}
         {...$tiroirStore.contenu.props}
       />
     {/if}

--- a/svelte/lib/ui/stores/tiroir.store.ts
+++ b/svelte/lib/ui/stores/tiroir.store.ts
@@ -1,16 +1,15 @@
 import { writable } from 'svelte/store';
 import type { ComponentProps, ComponentType, SvelteComponent } from 'svelte';
 
-type ConfigurationTiroir = {
+export type ConfigurationTiroir = SvelteComponent & {
   titre: string;
   sousTitre: string;
 };
 
 type TiroirStoreProps = {
   contenu?: {
-    composant: ComponentType;
-    props: any;
-    configuration: ConfigurationTiroir;
+    composant: ComponentType<ConfigurationTiroir>;
+    props: ComponentProps<ConfigurationTiroir>;
   };
   ouvert: boolean;
 };
@@ -19,10 +18,9 @@ const { set, subscribe } = writable<TiroirStoreProps>({ ouvert: false });
 
 export const tiroirStore = {
   subscribe,
-  afficheContenu: <T extends SvelteComponent>(
+  afficheContenu: <T extends ConfigurationTiroir>(
     composant: ComponentType<T>,
-    props: ComponentProps<T>,
-    configuration: ConfigurationTiroir
-  ) => set({ contenu: { composant, props, configuration }, ouvert: true }),
+    props: ComponentProps<T>
+  ) => set({ contenu: { composant, props }, ouvert: true }),
   ferme: () => set({ ouvert: false }),
 };

--- a/svelte/lib/ui/tiroirs/TiroirDuplication.svelte
+++ b/svelte/lib/ui/tiroirs/TiroirDuplication.svelte
@@ -9,6 +9,9 @@
   import type { Service } from '../../tableauDeBord/tableauDeBord.d';
 
   export let service: Service;
+  export const titre = 'Dupliquer';
+  export const sousTitre =
+    "Créer une ou plusieurs copies du services sélectionné. Cette copie n'inclut pas les données concernant son homologation.";
 
   let nombreCopies: number = 1;
   let enCoursEnvoi = false;

--- a/svelte/lib/ui/tiroirs/TiroirExportServices.svelte
+++ b/svelte/lib/ui/tiroirs/TiroirExportServices.svelte
@@ -4,6 +4,11 @@
   import type { Service } from '../../tableauDeBord/tableauDeBord.d';
 
   export let services: Service[];
+  export const titre = 'Exporter la sélection';
+  export const sousTitre =
+    services.length > 1
+      ? 'Télécharger la liste des services sélectionnés dans le tableau de bord.'
+      : 'Télécharger les données du service sélectionné dans le tableau de bord.';
 
   const queryString = new URLSearchParams();
   services.forEach((service) => queryString.append('idsServices', service.id));

--- a/svelte/lib/ui/tiroirs/TiroirGestionContributeurs.svelte
+++ b/svelte/lib/ui/tiroirs/TiroirGestionContributeurs.svelte
@@ -5,6 +5,11 @@
   import { store } from '../../gestionContributeurs/gestionContributeurs.store';
 
   export let services: Service[];
+  export const titre: string = 'Gérer les contributeurs';
+  export const sousTitre: string =
+    services.length > 1
+      ? 'Gérer la liste des personnes invitées à contribuer aux services.'
+      : 'Gérer la liste des personnes invitées à contribuer au service.';
 
   store.reinitialise(services);
 </script>

--- a/svelte/lib/ui/tiroirs/TiroirSuppression.svelte
+++ b/svelte/lib/ui/tiroirs/TiroirSuppression.svelte
@@ -11,6 +11,11 @@
   import ChampTexte from '../ChampTexte.svelte';
 
   export let services: Service[];
+  export const titre = 'Supprimer';
+  export const sousTitre =
+    services.length > 1
+      ? 'Effacer toutes les données des services sélectionnés.'
+      : 'Effacer toutes les données du service sélectionné.';
 
   const confirmationSuppression =
     services.length > 1

--- a/svelte/lib/ui/tiroirs/TiroirTelechargementDocumentsService.svelte
+++ b/svelte/lib/ui/tiroirs/TiroirTelechargementDocumentsService.svelte
@@ -6,6 +6,10 @@
   export let service: Service;
   export let modeVisiteGuidee: boolean = false;
 
+  export const titre = 'Télécharger les PDF';
+  export const sousTitre =
+    "Obtenir les documents utiles à la sécurisation et à l'homologation du service sélectionné.";
+
   const idService = service.id;
   const nbPdfDisponibles = service.documentsPdfDisponibles.length;
 


### PR DESCRIPTION
... afin de rendre le code plus propre.

Aujourd'hui, chaque appel d'affichage d'un contenu de tiroir devait configurer le titre et le sous-titre à afficher. Or, cette configuration est liée au contenu de tiroir lui-même.
On créer donc des `props` : `titre`, `sous-titre` dans chaque tiroir, et on assigne un type de "ConfigurationTiroir" au store `tiroir.store`.

On utilise le [ComponentType](https://svelte.dev/docs/svelte/typescript#The-Component-type) de Svelte pour typer correctement ce store et ces composants.