### PR TITLE
[CORRECTION] Corrige l'affichage du menu filtres

### DIFF
--- a/svelte/lib/tableauDeBord/BandeauFiltres.svelte
+++ b/svelte/lib/tableauDeBord/BandeauFiltres.svelte
@@ -107,7 +107,7 @@
     padding-bottom: 32px;
     top: 0;
     background-color: white;
-    z-index: 1;
+    z-index: 2;
   }
 
   .recherche {


### PR DESCRIPTION
... qui était sous l'entête de tableau depuis que celui-ci était devenu sticky

<img width="1422" alt="Capture d’écran 2025-01-21 à 12 27 30" src="https://github.com/user-attachments/assets/e3580ca8-7acc-4a1e-af2f-b88c968870e1" />

