### PR TITLE
[SOIN] Ne sauvegarde pas les identifiants et date de création dans les données utilisateur

### DIFF
--- a/migrations/20250121162039_enleveIdsDateCreationDeDonneesUtilisateur.js
+++ b/migrations/20250121162039_enleveIdsDateCreationDeDonneesUtilisateur.js
@@ -1,0 +1,21 @@
+exports.up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const utilisateurs = await trx('utilisateurs');
+
+    const maj = utilisateurs.map(({ id, donnees }) => {
+      const {
+        id: _,
+        dateCreation,
+        idResetMotDePasse,
+        ...autresDonnees
+      } = donnees;
+      return trx('utilisateurs')
+        .where({ id })
+        .update({ donnees: autresDonnees });
+    });
+
+    await Promise.all(maj);
+  });
+};
+
+exports.down = async () => {};

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -127,8 +127,10 @@ function fabriquePersistance({
         await dechiffreDonneesUtilisateur(donneesSauvegardees);
       const donneesEnClairAJour = Object.assign(donneesEnClair, deltaDonnees);
       const {
-        emailHash: _,
-        idResetMotDePasse: __,
+        id: _,
+        dateCreation: __,
+        emailHash: ___,
+        idResetMotDePasse: ____,
         ...donneesEnClairASauvegarder
       } = donneesEnClairAJour;
       const donneesChiffreesASauvegarder = await chiffre.donneesUtilisateur(

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -33,8 +33,15 @@ class ConstructeurAdaptateurPersistanceMemoire {
   }
 
   ajouteUnUtilisateur(utilisateur) {
-    const { id, emailHash, idResetMotDePasse, ...donnees } = utilisateur;
-    this.utilisateurs.push({ id, donnees, emailHash, idResetMotDePasse });
+    const { id, emailHash, idResetMotDePasse, dateCreation, ...donnees } =
+      utilisateur;
+    this.utilisateurs.push({
+      id,
+      donnees,
+      emailHash,
+      idResetMotDePasse,
+      dateCreation,
+    });
     return this;
   }
 

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -347,6 +347,19 @@ describe('Le dépôt de données des utilisateurs', () => {
       // Le test passe si aucune exception n'est levée
     });
 
+    it("n'inscris pas les identifiants et la date de création dans l'objet de données", async () => {
+      const utilisateurInitial = unUtilisateur()
+        .avecId('123')
+        .quiSAppelle('Jérôme Dubois').donnees;
+
+      await depot.metsAJourUtilisateur('123', utilisateurInitial);
+
+      const u = await adaptateurPersistance.utilisateur('123');
+      expect(u.donnees.id).to.be(undefined);
+      expect(u.donnees.idResetMotDePasse).to.be(undefined);
+      expect(u.donnees.dateCreation).to.be(undefined);
+    });
+
     it("publie sur le bus d'événements l'utilisateur modifié", async () => {
       await depot.metsAJourUtilisateur(
         '123',


### PR DESCRIPTION
...ces éléments étant stockés dans des colonnes séparées. Depuis la modification sur le chiffrement, ils ont été par erreur re-sauvegardés dans la payload de données utilisateur.

<img width="183" alt="Capture d’écran 2025-01-21 à 16 12 42" src="https://github.com/user-attachments/assets/486ca36c-0a1b-4494-845c-6cfe3e561e35" />
