### PR TITLE
Inverse l'ordre d'import des scripts matomo et sentry

### DIFF
--- a/src/vues/base.pug
+++ b/src/vues/base.pug
@@ -15,10 +15,10 @@ html(lang = 'fr', xml:lang = 'fr', xmlns = 'http://www.w3.org/1999/xhtml')
         title MonServiceSécurisé
     block page
 
-    if process.env.SENTRY_DSN
-        script(src='https://browser.sentry-cdn.com/7.102.1/bundle.min.js' crossorigin='anonymous')
-        script(src='/statique/scripts/sentry.js' id='script-sentry' data-environnement=process.env.SENTRY_ENVIRONNEMENT data-dsn=process.env.SENTRY_DSN)
-
     if process.env.ID_MATOMO
         script(src='/statique/scripts/matomo.js', id='script-matomo' data-id-matomo=process.env.ID_MATOMO)
         script(src='/statique/scripts/matomoGestionnaireTag.js')
+
+    if process.env.SENTRY_DSN
+        script(src='https://browser.sentry-cdn.com/7.102.1/bundle.min.js' crossorigin='anonymous')
+        script(src='/statique/scripts/sentry.js' id='script-sentry' data-environnement=process.env.SENTRY_ENVIRONNEMENT data-dsn=process.env.SENTRY_DSN)


### PR DESCRIPTION
...afin d'éviter de recevoir toutes les erreurs liées à matomo. On souhaite se concentrer sur les erreurs MSS