### PR TITLE
Attrape l'erreur lancée par `jwt.verify` afin d'être redirigé vers la page de login

### DIFF
--- a/src/adaptateurs/adaptateurJWT.js
+++ b/src/adaptateurs/adaptateurJWT.js
@@ -1,7 +1,14 @@
 const jwt = require('jsonwebtoken');
 
 const secret = process.env.SECRET_JWT;
-const decode = (token) => (token ? jwt.verify(token, secret) : undefined);
+const decode = (token) => {
+  if (!token) return undefined;
+  try {
+    return jwt.verify(token, secret);
+  } catch (e) {
+    return undefined;
+  }
+};
 
 const signeDonnees = (donnees) => jwt.sign(donnees, secret);
 


### PR DESCRIPTION

... en cas de signature JWT invalide