### PR TITLE
Renomme le cookie de session en `session`

### DIFF
--- a/src/mss.ts
+++ b/src/mss.ts
@@ -63,7 +63,7 @@ const creeServeur = ({
   app.use(
     cookieSession({
       maxAge: DUREE_SESSION,
-      name: 'token',
+      name: 'session',
       sameSite: true,
       secret: process.env.SECRET_COOKIE,
       secure: avecCookieSecurise,

--- a/test/aides/cookie.js
+++ b/test/aides/cookie.js
@@ -7,7 +7,7 @@ const enObjet = (cookie) =>
     return acc;
   }, {});
 
-const decodeTokenDuCookie = (reponse, indiceHeader) => {
+const decodeSessionDuCookie = (reponse, indiceHeader) => {
   try {
     const headerCookie = reponse.headers['set-cookie'];
     const cookieSession = enObjet(headerCookie[indiceHeader]);
@@ -24,15 +24,15 @@ const expectContenuSessionValide = (
   estInvite,
   indiceDuHeader = 0
 ) => {
-  expect(decodeTokenDuCookie(reponse, indiceDuHeader).token).to.be(
+  expect(decodeSessionDuCookie(reponse, indiceDuHeader).token).to.be(
     `un token de source ${source}`
   );
-  expect(decodeTokenDuCookie(reponse, indiceDuHeader).cguAcceptees).to.be(
+  expect(decodeSessionDuCookie(reponse, indiceDuHeader).cguAcceptees).to.be(
     cguAcceptees
   );
-  expect(decodeTokenDuCookie(reponse, indiceDuHeader).estInvite).to.be(
+  expect(decodeSessionDuCookie(reponse, indiceDuHeader).estInvite).to.be(
     estInvite
   );
 };
 
-module.exports = { enObjet, decodeTokenDuCookie, expectContenuSessionValide };
+module.exports = { enObjet, decodeSessionDuCookie, expectContenuSessionValide };

--- a/test/aides/cookie.js
+++ b/test/aides/cookie.js
@@ -11,7 +11,7 @@ const decodeTokenDuCookie = (reponse, indiceHeader) => {
   try {
     const headerCookie = reponse.headers['set-cookie'];
     const cookieSession = enObjet(headerCookie[indiceHeader]);
-    return JSON.parse(Buffer.from(cookieSession.token, 'base64').toString());
+    return JSON.parse(Buffer.from(cookieSession.session, 'base64').toString());
   } catch (e) {
     return undefined;
   }

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -450,7 +450,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         .put('http://localhost:1234/api/motDePasse', {
           motDePasse: 'mdp_ABC12345',
         })
-        .then((reponse) => testeur.verifieJetonDepose(reponse, done))
+        .then((reponse) => testeur.verifieSessionDeposee(reponse, done))
         .catch((e) => done(e.response?.data || e));
     });
 

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -9,7 +9,7 @@ const {
   unUtilisateur,
 } = require('../../constructeurs/constructeurUtilisateur');
 const {
-  decodeTokenDuCookie,
+  decodeSessionDuCookie,
   expectContenuSessionValide,
 } = require('../../aides/cookie');
 
@@ -470,7 +470,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
             login: 'jean.dupont@mail.fr',
             motDePasse: 'mdp_12345',
           })
-          .then((reponse) => testeur.verifieJetonDepose(reponse, done))
+          .then((reponse) => testeur.verifieSessionDeposee(reponse, done))
           .catch(done);
       });
 
@@ -511,7 +511,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
           motDePasse: 'mdp_12345',
         });
 
-        const token = decodeTokenDuCookie(reponse, 0);
+        const token = decodeSessionDuCookie(reponse, 0);
         expect(token.token).to.be('un token de-MSS');
       });
     });

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -2,7 +2,7 @@ const expect = require('expect.js');
 const testeurMSS = require('../testeurMSS');
 const {
   enObjet,
-  decodeTokenDuCookie,
+  decodeSessionDuCookie,
   expectContenuSessionValide,
 } = require('../../aides/cookie');
 const {
@@ -169,7 +169,7 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
       const reponse = await requeteSansRedirection(
         'http://localhost:1234/oidc/apres-authentification'
       );
-      const tokenDecode = decodeTokenDuCookie(reponse, 1);
+      const tokenDecode = decodeSessionDuCookie(reponse, 1);
       expect(tokenDecode.AgentConnectIdToken).to.be('unIdToken');
     });
 
@@ -231,7 +231,7 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
           'http://localhost:1234/oidc/apres-authentification'
         );
 
-        const tokenDecode = decodeTokenDuCookie(reponse, 1);
+        const tokenDecode = decodeSessionDuCookie(reponse, 1);
         expect(tokenDecode.token).to.be('unJetonJWT-AGENT_CONNECT');
       });
 
@@ -336,7 +336,7 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
           'http://localhost:1234/oidc/apres-authentification'
         );
 
-        const tokenDecode = decodeTokenDuCookie(reponse, 1);
+        const tokenDecode = decodeSessionDuCookie(reponse, 1);
         expect(tokenDecode.token).to.be('unJetonJWT-AGENT_CONNECT-INVITE');
       });
 

--- a/test/routes/nonConnecte/routesNonConnectePage.spec.js
+++ b/test/routes/nonConnecte/routesNonConnectePage.spec.js
@@ -157,7 +157,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Non connecté"', () => {
         );
 
         expect(idRecu).to.be(uuid);
-        await testeur.verifieJetonDepose(reponse, () => {});
+        await testeur.verifieSessionDeposee(reponse, () => {});
       });
 
       it('ajoute une session utilisateur', async () => {

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -46,7 +46,7 @@ const testeurMss = () => {
   let inscriptionUtilisateur;
   let serveur;
 
-  const verifieJetonDepose = (reponse, suite) => {
+  const verifieSessionDeposee = (reponse, suite) => {
     const valeurHeader = reponse.headers['set-cookie'][0];
     expect(valeurHeader).to.match(
       /^session=.+; path=\/; expires=.+; samesite=strict; httponly$/
@@ -201,7 +201,7 @@ const testeurMss = () => {
     arrete,
     initialise,
     verifieRequeteGenereErreurHTTP,
-    verifieJetonDepose,
+    verifieSessionDeposee,
   };
 };
 

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -49,7 +49,7 @@ const testeurMss = () => {
   const verifieJetonDepose = (reponse, suite) => {
     const valeurHeader = reponse.headers['set-cookie'][0];
     expect(valeurHeader).to.match(
-      /^token=.+; path=\/; expires=.+; samesite=strict; httponly$/
+      /^session=.+; path=\/; expires=.+; samesite=strict; httponly$/
     );
     suite();
   };


### PR DESCRIPTION
... plutôt que `token`. 

Ce nommage est très confusant, car le cookie contient lui même un champ `token` qui est le JWT d'authentification. 
On préfère donc `session`.

> [!IMPORTANT]  
> Le `merge` de cette PR entrainera une invalidation de toute les sessions actives :
> - Un clic de navigation renverra vers la page de connexion
> - Un appel API affichera la modale de reconnexion.


> [!WARNING]  
> Il est tout de même préférable de merger cette PR dans un "creu" d'utilisation de la plateforme. Une modification du `secret` n'est pas nécessaire.