### PR TITLE
Chiffrer en mémoire avec ChaCha20 les données stockées en base

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -72,6 +72,7 @@ NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes auto
 CHIFFREMENT_URL_BASE_DU_SERVICE= # URL de base du service de chiffrement. Tout jusqu'à `/v1` exclu.
 CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT= # Nom de la clé Transit à utiliser.
 CHIFFREMENT_TOKEN_VAULT= # Token à utiliser pour le chiffrement.
+CHIFFREMENT_CLE_CHACHA20_HEX= # Clé à utiliser pour le chiffrement ChaCha20 en mémoire au format hexadecimal. Ex: f1e2d3c4b5a6978877665544332211ffeeddccbbaa9988776655443322110000
 
 # API Baleen
 BALEEN_TOKEN= # Le Personal Access Token (PAT) permettant d'utiliser l'API Baleen

--- a/src/adaptateurs/adaptateurChiffrementChaCha20.js
+++ b/src/adaptateurs/adaptateurChiffrementChaCha20.js
@@ -1,0 +1,84 @@
+const { randomBytes, createCipheriv, createDecipheriv } = require('crypto');
+const {
+  compareBCrypt,
+  hacheBCrypt,
+  hacheSha256,
+  nonce,
+} = require('./adaptateurChiffrement');
+
+const decoupeLaChaineChiffree = (chaineChiffree) => ({
+  chaineDonneesChiffrees: chaineChiffree.slice(56, -32),
+  chaineIV: chaineChiffree.slice(0, 24),
+  chaineDonneesAdditionnelles: chaineChiffree.slice(24, 56),
+  chaineTag: chaineChiffree.slice(-32),
+});
+
+const adaptateurChiffrementChaCha20 = ({ adaptateurEnvironnement }) => {
+  const clefSecrete = Buffer.from(
+    adaptateurEnvironnement.chiffrement().cleChaCha20Hex(),
+    'hex'
+  );
+  return {
+    chiffre: async (chaineOuObjet) => {
+      const iv = randomBytes(12);
+      const donneesAdditionnelles = randomBytes(16);
+      const brut = JSON.stringify(chaineOuObjet);
+      const chiffrement = createCipheriv('chacha20-poly1305', clefSecrete, iv, {
+        authTagLength: 16,
+      });
+      chiffrement.setAAD(donneesAdditionnelles, {
+        plaintextLength: Buffer.byteLength(brut),
+      });
+
+      const donneesChiffrees = Buffer.concat([
+        chiffrement.update(brut, 'utf-8'),
+        chiffrement.final(),
+      ]);
+      const tag = chiffrement.getAuthTag();
+
+      return Buffer.concat([
+        iv,
+        donneesAdditionnelles,
+        donneesChiffrees,
+        tag,
+      ]).toString('hex');
+    },
+    dechiffre: async (chaineChiffree) => {
+      const {
+        chaineDonneesChiffrees,
+        chaineIV,
+        chaineDonneesAdditionnelles,
+        chaineTag,
+      } = decoupeLaChaineChiffree(chaineChiffree);
+      const iv = Buffer.from(chaineIV, 'hex');
+      const donneesChiffrees = Buffer.from(chaineDonneesChiffrees, 'hex');
+      const tag = Buffer.from(chaineTag, 'hex');
+
+      const dechiffrement = createDecipheriv(
+        'chacha20-poly1305',
+        clefSecrete,
+        iv,
+        { authTagLength: 16 }
+      );
+      dechiffrement.setAAD(Buffer.from(chaineDonneesAdditionnelles, 'hex'), {
+        plaintextLength: chaineDonneesChiffrees.length,
+      });
+      dechiffrement.setAuthTag(Buffer.from(tag));
+
+      const donneesDechiffrees = dechiffrement.update(donneesChiffrees);
+      const chaineDechiffree = Buffer.concat([
+        donneesDechiffrees,
+        dechiffrement.final(),
+      ]).toString();
+      return JSON.parse(chaineDechiffree);
+    },
+    compareBCrypt,
+    hacheBCrypt,
+    hacheSha256,
+    nonce,
+  };
+};
+
+module.exports = {
+  adaptateurChiffrementChaCha20,
+};

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -53,6 +53,7 @@ const chiffrement = () => ({
   urlBaseDuService: () => process.env.CHIFFREMENT_URL_BASE_DU_SERVICE,
   cleDuMoteurTransit: () => process.env.CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT,
   tokenVault: () => process.env.CHIFFREMENT_TOKEN_VAULT,
+  cleChaCha20Hex: () => process.env.CHIFFREMENT_CLE_CHACHA20_HEX,
 });
 
 const featureFlag = () => ({

--- a/test/adaptateurs/adaptateurChiffrementChaCha20.spec.js
+++ b/test/adaptateurs/adaptateurChiffrementChaCha20.spec.js
@@ -1,0 +1,29 @@
+const expect = require('expect.js');
+const {
+  adaptateurChiffrementChaCha20,
+} = require('../../src/adaptateurs/adaptateurChiffrementChaCha20');
+
+describe("L'adaptateur qui chiffre et déchiffre avec l'algorithme ChaCha20", () => {
+  it("retrouve la données d'origine", async () => {
+    const adaptateur = adaptateurChiffrementChaCha20({
+      adaptateurEnvironnement: {
+        chiffrement: () => ({
+          cleChaCha20Hex: () =>
+            'f1e2d3c4b5a6978877665544332211ffeeddccbbaa9988776655443322110000',
+        }),
+      },
+    });
+
+    const utilisateur = {
+      nom: 'Toto',
+      prenom: 'Poum',
+      id: 12043,
+    };
+    process.env.CHIFFREMENT_CLE_CHACHA20 = 'toto';
+
+    const utilisateurChiffre = await adaptateur.chiffre(utilisateur);
+    const utilisateurDechiffre = await adaptateur.dechiffre(utilisateurChiffre);
+
+    expect(utilisateurDechiffre).to.eql(utilisateur);
+  });
+});


### PR DESCRIPTION
En tant qu'attaquant,
Si j'arrive à mettre la main sur un dump de la base de données
Et seulement ce dump
Alors, me voilà bien embêté car je découvre que ces données sont chiffrées et que je ne peux pas les lire.

On utilise l'algorithme ChaCha20 pour le chiffrement dans un nouvel adaptateur. Celui n'est pas activé par cette PR.