### PR TITLE
🛑 DÉPRÉCIÉ : Permets de migrer le sel des hash

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -74,6 +74,10 @@ CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT= # Nom de la clé Transit à utiliser.
 CHIFFREMENT_TOKEN_VAULT= # Token à utiliser pour le chiffrement.
 CHIFFREMENT_CLE_CHACHA20_HEX= # Clé à utiliser pour le chiffrement ChaCha20 en mémoire au format hexadecimal. Ex: f1e2d3c4b5a6978877665544332211ffeeddccbbaa9988776655443322110000
 
+# SELS utilisés pour le hashage de données. Les variables sont au format SEL_DE_HASHAGE_n où n est un nombre entier, unique, et les différentes variables d'environnement `SEL_DE_HASHAGE_n` ont des valeurs de n consécutives et commençant par 1
+SEL_DE_HASHAGE_1= # Sel à utiliser pour le hachage SHA256
+#SEL_DE_HASHAGE_2= # Second sel à utiliser pour le hachage SHA256
+
 # API Baleen
 BALEEN_TOKEN= # Le Personal Access Token (PAT) permettant d'utiliser l'API Baleen
 BALEEN_NAMESPACE = # L'identifiant de l'application Baleen

--- a/migrationHash.js
+++ b/migrationHash.js
@@ -1,0 +1,176 @@
+const Knex = require('knex');
+const config = require('./knexfile');
+const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironnement');
+const {
+  hacheSha256AvecSel,
+} = require('./src/adaptateurs/adaptateurChiffrement');
+
+/* eslint-disable no-console */
+class MigrationHash {
+  constructor(environnementNode = process.env.NODE_ENV || 'development') {
+    const configDuJournal = {
+      client: 'pg',
+      connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
+      pool: { min: 0, max: 10 },
+    };
+    this.knexMSSJournal = Knex(configDuJournal);
+    this.knexMSS = Knex(config[environnementNode]);
+    const sel = adaptateurEnvironnement.chiffrement().sel();
+    if (!sel) {
+      throw new Error('Impossible de hacher sans sel');
+    }
+    const modeMaintenanceActif = adaptateurEnvironnement
+      .modeMaintenance()
+      .actif();
+    if (!modeMaintenanceActif) {
+      throw new Error(
+        'Vous devez activer le mode maintenance avant de jouer cette migration.'
+      );
+    }
+    this.hache = (chaine) => hacheSha256AvecSel(chaine, sel);
+  }
+
+  async migreLesHashDeMss() {
+    await this.knexMSS.transaction(async (trx) => {
+      const services = await trx('services');
+
+      const majServices = services.map(
+        ({
+          id,
+          siret_hash: siretHacheActuel,
+          nom_service_hash: nomServiceHacheActuel,
+        }) => {
+          const siretHacheDeNouveau = siretHacheActuel
+            ? this.hache(siretHacheActuel)
+            : null;
+          const nomServiceHacheDeNouveau = nomServiceHacheActuel
+            ? this.hache(nomServiceHacheActuel)
+            : null;
+
+          return trx('services').where({ id }).update({
+            siret_hash: siretHacheDeNouveau,
+            nom_service_hash: nomServiceHacheDeNouveau,
+          });
+        }
+      );
+
+      const utilisateurs = await trx('utilisateurs');
+
+      const majUtilisateurs = utilisateurs.map(
+        ({ id, email_hash: emailHacheActuel }) => {
+          const emailHacheDeNouveau = this.hache(emailHacheActuel);
+
+          return trx('utilisateurs')
+            .where({ id })
+            .update({ email_hash: emailHacheDeNouveau });
+        }
+      );
+
+      await Promise.all([...majServices, ...majUtilisateurs]);
+    });
+  }
+
+  async migreLesHashDeLaSupervision() {
+    await this.knexMSSJournal.transaction(async (trx) => {
+      const superviseurs = await trx('journal_mss.superviseurs');
+
+      const majSuperviseurs = superviseurs.map(
+        ({
+          id_service: idServiceHacheActuel,
+          id_superviseur: idSuperviseurHacheActuel,
+          siret_service: siretHacheActuel,
+        }) => {
+          const idServiceHacheDeNouveau = this.hache(idServiceHacheActuel);
+          const idSuperviseurHacheDeNouveau = this.hache(
+            idSuperviseurHacheActuel
+          );
+          const siretHacheDeNouveau = this.hache(siretHacheActuel);
+
+          return trx('journal_mss.superviseurs')
+            .where({
+              id_service: idServiceHacheActuel,
+              id_superviseur: idSuperviseurHacheActuel,
+              siret_service: siretHacheActuel,
+            })
+            .update({
+              id_service: idServiceHacheDeNouveau,
+              id_superviseur: idSuperviseurHacheDeNouveau,
+              siret_service: siretHacheDeNouveau,
+            });
+        }
+      );
+
+      await Promise.all(majSuperviseurs);
+    });
+  }
+
+  async migreLesEvenementsDuJournal() {
+    await this.knexMSSJournal.transaction(async (trx) => {
+      const evenements = await trx('journal_mss.evenements');
+
+      const majEvenements = evenements.map(({ id, type, donnees }) => {
+        let nouvellesDonnees;
+
+        switch (type) {
+          case 'COLLABORATIF_SERVICE_MODIFIE':
+            nouvellesDonnees = {
+              ...donnees,
+              idService: this.hache(donnees.idService),
+              autorisations: donnees.autorisations.map((a) => ({
+                ...a,
+                idUtilisateur: this.hache(a.idUtilisateur),
+              })),
+            };
+            break;
+          case 'COMPLETUDE_SERVICE_MODIFIEE':
+          case 'NOUVELLE_HOMOLOGATION_CREEE':
+          case 'RISQUES_SERVICE_MODIFIES':
+          case 'SERVICE_SUPPRIME':
+            nouvellesDonnees = {
+              ...donnees,
+              idService: this.hache(donnees.idService),
+            };
+            break;
+          case 'CONNEXION_UTILISATEUR':
+          case 'NOUVEL_UTILISATEUR_INSCRIT':
+          case 'PROFIL_UTILISATEUR_MODIFIE':
+            nouvellesDonnees = {
+              ...donnees,
+              idUtilisateur: this.hache(donnees.idUtilisateur),
+            };
+            break;
+          case 'RETOUR_UTILISATEUR_MESURE_RECU':
+          case 'NOUVEAU_SERVICE_CREE':
+            nouvellesDonnees = {
+              ...donnees,
+              idUtilisateur: this.hache(donnees.idUtilisateur),
+              idService: this.hache(donnees.idService),
+            };
+            break;
+          default:
+            nouvellesDonnees = donnees;
+        }
+
+        return trx('journal_mss.evenements')
+          .where({ id })
+          .update({ donnees: nouvellesDonnees });
+      });
+
+      await Promise.all(majEvenements);
+    });
+  }
+
+  async migreTout() {
+    console.log('Migration des Hash de MSS (utilisateurs et services)...');
+    await this.migreLesHashDeMss();
+    console.log('Migration des Hash de la supervision...');
+    await this.migreLesHashDeLaSupervision();
+    console.log('Migration des Hash des évènements du journal...');
+    await this.migreLesEvenementsDuJournal();
+    console.log('Migration terminée.');
+  }
+}
+
+/* eslint-enable no-console */
+
+module.exports = MigrationHash;

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,5 +1,6 @@
 const { createHash } = require('crypto');
 const bcrypt = require('bcrypt');
+const adaptateurEnvironnement = require('./adaptateurEnvironnement');
 
 const chiffre = async (chaineOuObjet) => chaineOuObjet;
 
@@ -11,8 +12,20 @@ const hacheBCrypt = (chaineEnClair) =>
 
 const { compare } = bcrypt;
 
-const hacheSha256 = (chaine) =>
-  createHash('sha256').update(chaine).digest('hex');
+const hacheSha256AvecSel = (chaine, sel) =>
+  createHash('sha256')
+    .update(chaine + sel)
+    .digest('hex');
+
+const hacheSha256AvecTousLesSels = (chaineEnClair) => {
+  const tousLesSelsDeHachage = adaptateurEnvironnement
+    .chiffrement()
+    .tousLesSelsDeHachage();
+  return tousLesSelsDeHachage.reduce(
+    (acc, { sel }) => hacheSha256AvecSel(acc, sel),
+    chaineEnClair
+  );
+};
 
 const nonce = () =>
   hacheBCrypt(`${Math.random()}`).then((s) => s.replace(/[/$.]/g, ''));
@@ -22,6 +35,6 @@ module.exports = {
   dechiffre,
   compareBCrypt: compare,
   hacheBCrypt,
-  hacheSha256,
+  hacheSha256: hacheSha256AvecTousLesSels,
   nonce,
 };

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -54,6 +54,18 @@ const chiffrement = () => ({
   cleDuMoteurTransit: () => process.env.CHIFFREMENT_CLE_DU_MOTEUR_TRANSIT,
   tokenVault: () => process.env.CHIFFREMENT_TOKEN_VAULT,
   cleChaCha20Hex: () => process.env.CHIFFREMENT_CLE_CHACHA20_HEX,
+  tousLesSelsDeHachage: () =>
+    Object.entries(process.env)
+      .map(([cle, valeur]) => {
+        const matches = cle.match(/SEL_DE_HASHAGE_(\d+)/);
+        return [matches ? matches[1] : undefined, valeur];
+      })
+      .filter(([cle, _]) => !!cle)
+      .sort(([version1, _], [version2, __]) => version1 - version2)
+      .map(([version, valeur]) => ({
+        version: parseInt(version, 10),
+        sel: valeur,
+      })),
 });
 
 const featureFlag = () => ({

--- a/test/adaptateurs/adaptateurEnvironnement.spec.js
+++ b/test/adaptateurs/adaptateurEnvironnement.spec.js
@@ -1,0 +1,69 @@
+const expect = require('expect.js');
+const {
+  chiffrement,
+} = require('../../src/adaptateurs/adaptateurEnvironnement');
+
+describe("L'adaptateur environnement", () => {
+  let envActuel;
+
+  beforeEach(() => {
+    envActuel = process.env;
+  });
+
+  afterEach(() => {
+    process.env = envActuel;
+  });
+
+  it('sait charger les sels', async () => {
+    process.env = {
+      SEL_DE_HASHAGE_1: 'sel1',
+      SEL_DE_HASHAGE_2: 'sel2',
+    };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage).to.eql([
+      { version: 1, sel: 'sel1' },
+      { version: 2, sel: 'sel2' },
+    ]);
+  });
+
+  it('charge les sels dans le bon ordre', async () => {
+    process.env = {
+      SEL_DE_HASHAGE_1: 'sel1',
+      SEL_DE_HASHAGE_3: 'sel3',
+      SEL_DE_HASHAGE_2: 'sel2',
+    };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage).to.eql([
+      { version: 1, sel: 'sel1' },
+      { version: 2, sel: 'sel2' },
+      { version: 3, sel: 'sel3' },
+    ]);
+  });
+
+  it('ne charge pas les sels qui ne correspondent pas au format indiqué', async () => {
+    process.env = {
+      SEL_DE_HASHAGE_1: 'sel1',
+      SEL_DE_HASHAGE_V3: 'sel3',
+      SEL_DE_HASHAGE_2: 'sel2',
+    };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage).to.eql([
+      { version: 1, sel: 'sel1' },
+      { version: 2, sel: 'sel2' },
+    ]);
+  });
+
+  it('utilise des entiers pour les versions', () => {
+    process.env = { SEL_DE_HASHAGE_1: 'sel1' };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage[0].version === 1).to.be(true);
+  });
+});


### PR DESCRIPTION
...utilisés dans MSS et les données envoyées à MSS journal.

Procédure :
- mettre la variable d'environnement `MODE_MAINTENANCE=true`
- mettre la variable d'environnement  `SEL_DE_HASHAGE=XXX` 

Se connecter en `node` comme pour la consoleAdmin : 

```
const m = require('./migrationHash');
const migration = new m();
await migration.migreTout();
```

# :warning: Ne l'exécuter **QU'UNE SEULE FOIS !**

    
 #### Pour les migrations
- [ ] Vérifier l'état des sels dans les deux bases
- [ ] Demander une validation manuelle à l'administrateur (pour les données hashées) 
- [ ] Écrire la nouvelle version du Sel dans MSS lors d'une migration
- [ ] Écrire la nouvelle version du Sel dans MSS Journal lors d'une migration