### PR TITLE
[SEL] Vérifie la cohérence au démarrage et utilise les sels configurés

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -71,6 +71,10 @@ NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes auto
 CHIFFREMENT_CHACHA20_CLE_HEX= # Clé à utiliser pour le chiffrement ChaCha20 en mémoire au format hexadecimal. Ex: f1e2d3c4b5a6978877665544332211ffeeddccbbaa9988776655443322110000
 CHIFFREMENT_CHACHA20_ACTIF= #` true` pour utiliser l'adaptateur de chiffrement qui utilise ChaCha20. Cela nécessite de valoriser les variables d'environnement `CHIFFREMENT_…`.
 
+# SELS utilisés pour le hashage de données. Les variables sont au format CHIFFREMENT_SEL_DE_HASHAGE_n où n est un nombre entier, unique, et les différentes variables d'environnement `CHIFFREMENT_SEL_DE_HASHAGE_n` ont des valeurs de n consécutives et commençant par 1
+CHIFFREMENT_SEL_DE_HASHAGE_1= # Sel à utiliser pour le hachage SHA256
+#CHIFFREMENT_SEL_DE_HASHAGE_2= # Second sel à utiliser pour le hachage SHA256
+
 # API Baleen
 BALEEN_TOKEN= # Le Personal Access Token (PAT) permettant d'utiliser l'API Baleen
 BALEEN_NAMESPACE = # L'identifiant de l'application Baleen

--- a/migrationHash.js
+++ b/migrationHash.js
@@ -1,6 +1,8 @@
 const Knex = require('knex');
 const config = require('./knexfile');
-const { hacheBCrypt } = require('./src/adaptateurs/adaptateurChiffrement');
+const {
+  adaptateurChiffrement,
+} = require('./src/adaptateurs/adaptateurChiffrement');
 
 /* eslint-disable no-console */
 class MigrationHash {
@@ -149,7 +151,7 @@ class MigrationHash {
   }
 
   async ajouteVersion1DansTableDesSels() {
-    const empreinte = await hacheBCrypt('');
+    const empreinte = await adaptateurChiffrement().hacheBCrypt('');
     await this.knexMSS('sels_de_hachage').insert({
       version: 1,
       empreinte,

--- a/migrations/20240813070846_insereEmailHashUtilisateurs.js
+++ b/migrations/20240813070846_insereEmailHashUtilisateurs.js
@@ -1,6 +1,7 @@
-const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+const { createHash } = require('crypto');
 
-const hache = (email) => hacheSha256(email);
+const hache = (chaine) =>
+  `v1:${createHash('sha256').update(chaine).digest('hex')}`;
 
 exports.up = async (knex) => {
   await knex.transaction(async (trx) => {

--- a/migrations/20240819091430_insereNomServiceHash.js
+++ b/migrations/20240819091430_insereNomServiceHash.js
@@ -1,6 +1,7 @@
-const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+const { createHash } = require('crypto');
 
-const hache = (nom) => hacheSha256(nom);
+const hache = (chaine) =>
+  `v1:${createHash('sha256').update(chaine).digest('hex')}`;
 
 exports.up = async (knex) => {
   await knex.transaction(async (trx) => {

--- a/migrations/20241107084938_remplaceMajusculeDansEmailUtilisateur.js
+++ b/migrations/20241107084938_remplaceMajusculeDansEmailUtilisateur.js
@@ -1,6 +1,7 @@
-const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+const { createHash } = require('crypto');
 
-const hache = (email) => hacheSha256(email);
+const hache = (chaine) =>
+  `v1:${createHash('sha256').update(chaine).digest('hex')}`;
 
 exports.up = async (knex) => {
   await knex.transaction(async (trx) => {

--- a/migrations/20241107100049_insereSiretHash.js
+++ b/migrations/20241107100049_insereSiretHash.js
@@ -1,6 +1,7 @@
-const { hacheSha256 } = require('../src/adaptateurs/adaptateurChiffrement');
+const { createHash } = require('crypto');
 
-const hache = (nom) => hacheSha256(nom);
+const hache = (chaine) =>
+  `v1:${createHash('sha256').update(chaine).digest('hex')}`;
 
 exports.up = async (knex) => {
   await knex.transaction(async (trx) => {

--- a/server.ts
+++ b/server.ts
@@ -101,6 +101,7 @@ const middleware = Middleware({
   adaptateurProtection,
   adaptateurGestionErreur,
   depotDonnees,
+  adaptateurChiffrement,
 });
 
 const procedures = fabriqueProcedures({

--- a/server.ts
+++ b/server.ts
@@ -45,6 +45,9 @@ const ServiceSupervision = require('./src/supervision/serviceSupervision');
 const {
   fabriqueServiceGestionnaireSession,
 } = require('./src/session/serviceGestionnaireSession');
+const {
+  fabriqueServiceVerificationCoherenceSels,
+} = require('./src/sel/serviceVerificationCoherenceSels');
 
 const adaptateurProfilAnssi = fabriqueAdaptateurProfilAnssi();
 const adaptateurGestionErreur = fabriqueAdaptateurGestionErreur();
@@ -74,6 +77,12 @@ const serviceAnnuaire = fabriqueAnnuaire({
 });
 
 const serviceGestionnaireSession = fabriqueServiceGestionnaireSession();
+
+const serviceVerificationCoherenceSels =
+  fabriqueServiceVerificationCoherenceSels({
+    adaptateurEnvironnement,
+    depotDonnees,
+  });
 
 cableTousLesAbonnes(busEvenements, {
   adaptateurHorloge,
@@ -112,38 +121,38 @@ const serviceSupervision = new ServiceSupervision({
   adaptateurSupervision,
 });
 
-const serveur = MSS.creeServeur({
-  depotDonnees,
-  middleware,
-  referentiel,
-  moteurRegles,
-  adaptateurCmsCrisp,
-  adaptateurMail,
-  adaptateurPdf,
-  adaptateurHorloge,
-  adaptateurGestionErreur,
-  serviceAnnuaire,
-  adaptateurCsv,
-  adaptateurZip,
-  adaptateurTracking,
-  adaptateurProtection,
-  adaptateurJournal,
-  adaptateurOidc,
-  adaptateurEnvironnement,
-  adaptateurStatistiques,
-  adaptateurJWT,
-  adaptateurProfilAnssi,
-  serviceGestionnaireSession,
-  serviceSupervision,
-  serviceCgu,
-  procedures,
-  inscriptionUtilisateur,
-});
+serviceVerificationCoherenceSels.verifieLaCoherenceDesSels().then(() => {
+  const serveur = MSS.creeServeur({
+    depotDonnees,
+    middleware,
+    referentiel,
+    moteurRegles,
+    adaptateurCmsCrisp,
+    adaptateurMail,
+    adaptateurPdf,
+    adaptateurHorloge,
+    adaptateurGestionErreur,
+    serviceAnnuaire,
+    adaptateurCsv,
+    adaptateurZip,
+    adaptateurTracking,
+    adaptateurProtection,
+    adaptateurJournal,
+    adaptateurOidc,
+    adaptateurEnvironnement,
+    adaptateurStatistiques,
+    adaptateurJWT,
+    adaptateurProfilAnssi,
+    serviceGestionnaireSession,
+    serviceSupervision,
+    serviceCgu,
+    procedures,
+    inscriptionUtilisateur,
+  });
 
-serveur.ecoute(port, () => {
-  /* eslint-disable no-console */
-
-  console.log(`MonServiceSécurisé est démarré et écoute le port ${port} !…`);
-
-  /* eslint-enable no-console */
+  serveur.ecoute(port, () => {
+    /* eslint-disable no-console */
+    console.log(`MonServiceSécurisé est démarré et écoute le port ${port} !…`);
+    /* eslint-enable no-console */
+  });
 });

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -1,27 +1,28 @@
 const { createHash } = require('crypto');
 const bcrypt = require('bcrypt');
 
-const chiffre = async (chaineOuObjet) => chaineOuObjet;
+const adaptateurChiffrement = () => {
+  const NOMBRE_DE_PASSES = 10;
+  const hacheBCrypt = (chaineEnClair) =>
+    bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
 
-const dechiffre = async (chaineChiffree) => chaineChiffree;
+  return {
+    chiffre: async (chaineOuObjet) => chaineOuObjet,
 
-const NOMBRE_DE_PASSES = 10;
-const hacheBCrypt = (chaineEnClair) =>
-  bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
+    dechiffre: async (chaineChiffree) => chaineChiffree,
 
-const { compare } = bcrypt;
+    hacheBCrypt,
 
-const hacheSha256 = (chaine) =>
-  `v1:${createHash('sha256').update(chaine).digest('hex')}`;
+    compareBCrypt: bcrypt.compare,
 
-const nonce = () =>
-  hacheBCrypt(`${Math.random()}`).then((s) => s.replace(/[/$.]/g, ''));
+    hacheSha256: (chaine) =>
+      `v1:${createHash('sha256').update(chaine).digest('hex')}`,
+
+    nonce: () =>
+      hacheBCrypt(`${Math.random()}`).then((s) => s.replace(/[/$.]/g, '')),
+  };
+};
 
 module.exports = {
-  chiffre,
-  dechiffre,
-  compareBCrypt: compare,
-  hacheBCrypt,
-  hacheSha256,
-  nonce,
+  adaptateurChiffrement,
 };

--- a/src/adaptateurs/adaptateurChiffrementChaCha20.js
+++ b/src/adaptateurs/adaptateurChiffrementChaCha20.js
@@ -1,12 +1,9 @@
 const { randomBytes, createCipheriv, createDecipheriv } = require('crypto');
-const {
-  compareBCrypt,
-  hacheBCrypt,
-  hacheSha256,
-  nonce,
-} = require('./adaptateurChiffrement');
+const { adaptateurChiffrement } = require('./adaptateurChiffrement');
 
 const adaptateurChiffrementChaCha20 = ({ adaptateurEnvironnement }) => {
+  const adaptateurChiffrementDeBase = adaptateurChiffrement();
+
   const clefSecrete = Buffer.from(
     adaptateurEnvironnement.chiffrement().cleChaCha20Hex(),
     'hex'
@@ -57,10 +54,10 @@ const adaptateurChiffrementChaCha20 = ({ adaptateurEnvironnement }) => {
       ]);
       return JSON.parse(chaineDechiffree);
     },
-    compareBCrypt,
-    hacheBCrypt,
-    hacheSha256,
-    nonce,
+    compareBCrypt: adaptateurChiffrementDeBase.compareBCrypt,
+    hacheBCrypt: adaptateurChiffrementDeBase.hacheBCrypt,
+    hacheSha256: adaptateurChiffrementDeBase.hacheSha256,
+    nonce: adaptateurChiffrementDeBase.nonce,
   };
 };
 

--- a/src/adaptateurs/adaptateurChiffrementChaCha20.js
+++ b/src/adaptateurs/adaptateurChiffrementChaCha20.js
@@ -2,7 +2,9 @@ const { randomBytes, createCipheriv, createDecipheriv } = require('crypto');
 const { adaptateurChiffrement } = require('./adaptateurChiffrement');
 
 const adaptateurChiffrementChaCha20 = ({ adaptateurEnvironnement }) => {
-  const adaptateurChiffrementDeBase = adaptateurChiffrement();
+  const adaptateurChiffrementDeBase = adaptateurChiffrement({
+    adaptateurEnvironnement,
+  });
 
   const clefSecrete = Buffer.from(
     adaptateurEnvironnement.chiffrement().cleChaCha20Hex(),

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -51,6 +51,18 @@ const chiffrement = () => ({
   utiliseChiffrementChaCha20: () =>
     process.env.CHIFFREMENT_CHACHA20_ACTIF === 'true',
   cleChaCha20Hex: () => process.env.CHIFFREMENT_CHACHA20_CLE_HEX,
+  tousLesSelsDeHachage: () =>
+    Object.entries(process.env)
+      .map(([cle, valeur]) => {
+        const matches = cle.match(/CHIFFREMENT_SEL_DE_HASHAGE_(\d+)/);
+        return [matches ? matches[1] : undefined, valeur];
+      })
+      .filter(([cle, _]) => !!cle)
+      .sort(([version1, _], [version2, __]) => version1 - version2)
+      .map(([version, valeur]) => ({
+        version: parseInt(version, 10),
+        sel: valeur,
+      })),
 });
 
 const featureFlag = () => ({

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -586,6 +586,12 @@ const nouvelAdaptateur = (env) => {
       })
       .where({ id_utilisateur_filleul: idUtilisateurFilleul });
 
+  const tousLesSelsDeHachage = async () =>
+    knex('sels_de_hachage').select({
+      version: 'version',
+      empreinte: 'empreinte',
+    });
+
   return {
     activitesMesure,
     ajouteAutorisation,
@@ -640,6 +646,7 @@ const nouvelAdaptateur = (env) => {
     supprimeUtilisateur,
     supprimeUtilisateurs,
     tachesDeServicePour,
+    tousLesSelsDeHachage,
     tousLesServices,
     tousUtilisateurs,
     utilisateur,

--- a/src/adaptateurs/fabriqueAdaptateurChiffrement.js
+++ b/src/adaptateurs/fabriqueAdaptateurChiffrement.js
@@ -1,13 +1,13 @@
 const adaptateurEnvironnement = require('./adaptateurEnvironnement');
-const adaptateurChiffrementPassePlat = require('./adaptateurChiffrement');
 const {
   adaptateurChiffrementChaCha20,
 } = require('./adaptateurChiffrementChaCha20');
+const { adaptateurChiffrement } = require('./adaptateurChiffrement');
 
 const fabriqueAdaptateurChiffrement = () => {
   if (adaptateurEnvironnement.chiffrement().utiliseChiffrementChaCha20())
     return adaptateurChiffrementChaCha20({ adaptateurEnvironnement });
 
-  return adaptateurChiffrementPassePlat;
+  return adaptateurChiffrement();
 };
 module.exports = { fabriqueAdaptateurChiffrement };

--- a/src/adaptateurs/fabriqueAdaptateurChiffrement.js
+++ b/src/adaptateurs/fabriqueAdaptateurChiffrement.js
@@ -8,6 +8,6 @@ const fabriqueAdaptateurChiffrement = () => {
   if (adaptateurEnvironnement.chiffrement().utiliseChiffrementChaCha20())
     return adaptateurChiffrementChaCha20({ adaptateurEnvironnement });
 
-  return adaptateurChiffrement();
+  return adaptateurChiffrement({ adaptateurEnvironnement });
 };
 module.exports = { fabriqueAdaptateurChiffrement };

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -13,6 +13,7 @@ const depotDonneesActivitesMesure = require('./depots/depotDonneesActivitesMesur
 const depotDonneesEvolutionsIndiceCyber = require('./depots/depotDonneesEvolutionsIndiceCyber');
 const depotDonneesSuperviseurs = require('./depots/depotDonneesSuperviseurs');
 const depotDonneesParrainages = require('./depots/depotDonneesParrainages');
+const depotDonneesSelsDeHachage = require('./depots/depotDonneesSelsDeHachage');
 
 const {
   fabriqueAdaptateurChiffrement,
@@ -101,6 +102,12 @@ const creeDepot = (config = {}) => {
 
   const depotParrainages = depotDonneesParrainages.creeDepot({
     adaptateurPersistance,
+  });
+
+  const depotSelsDeHachage = depotDonneesSelsDeHachage.creeDepot({
+    adaptateurPersistance,
+    adaptateurChiffrement,
+    adaptateurEnvironnement,
   });
 
   const {
@@ -197,6 +204,8 @@ const creeDepot = (config = {}) => {
   const { ajouteParrainage, parrainagePour, metsAJourParrainage } =
     depotParrainages;
 
+  const { verifieLaCoherenceDesSels } = depotSelsDeHachage;
+
   const santeDuDepot = async () => {
     await adaptateurPersistance.sante();
   };
@@ -273,6 +282,7 @@ const creeDepot = (config = {}) => {
     utilisateurExiste,
     utilisateurAvecEmail,
     valideAcceptationCGUPourUtilisateur,
+    verifieLaCoherenceDesSels,
     verifieMotDePasse,
   };
 };

--- a/src/depots/depotDonneesSelsDeHachage.js
+++ b/src/depots/depotDonneesSelsDeHachage.js
@@ -1,0 +1,68 @@
+const { ErreurHashDeSelInvalide, ErreurSelManquant } = require('../erreurs');
+
+const creeDepot = (config = {}) => {
+  const {
+    adaptateurPersistance,
+    adaptateurEnvironnement,
+    adaptateurChiffrement,
+  } = config;
+
+  const verifieLaCoherenceDesSels = async () => {
+    const tousLesSelsDeLaConfig = adaptateurEnvironnement
+      .chiffrement()
+      .tousLesSelsDeHachage();
+
+    if (tousLesSelsDeLaConfig.length === 0) {
+      throw new ErreurSelManquant('Aucun sel de hachage dans la config.');
+    }
+
+    const tousLesSelsAppliques =
+      await adaptateurPersistance.tousLesSelsDeHachage();
+
+    for (let i = 0; i < tousLesSelsDeLaConfig.length; i += 1) {
+      const { version: versionDeLaConfig, sel: valeurSelEnClair } =
+        tousLesSelsDeLaConfig[i];
+      const leSelAppliqueCorrespondant = tousLesSelsAppliques.find(
+        ({ version: versionEnBase }) => versionEnBase === versionDeLaConfig
+      );
+
+      if (!leSelAppliqueCorrespondant) {
+        throw new ErreurSelManquant(
+          `La version ${versionDeLaConfig} du sel noté dans la config est manquante dans la persistance.`
+        );
+      }
+      // Comme expliqué dans la documentation, si un `loop` doit `break`, on peut utiliser `await`
+      // https://eslint.org/docs/latest/rules/no-await-in-loop#when-not-to-use-it
+      // eslint-disable-next-line no-await-in-loop
+      const estValide = await adaptateurChiffrement.compareBCrypt(
+        valeurSelEnClair,
+        leSelAppliqueCorrespondant.empreinte
+      );
+
+      if (!estValide) {
+        throw new ErreurHashDeSelInvalide(
+          `La version ${versionDeLaConfig} du sel de la config a une valeur différente de celle déjà appliquée.`
+        );
+      }
+    }
+
+    for (let i = 0; i < tousLesSelsAppliques.length; i += 1) {
+      const { version: versionAppliquee } = tousLesSelsAppliques[i];
+      if (
+        !tousLesSelsDeLaConfig.some(
+          ({ version: versionDansLaConfig }) =>
+            versionAppliquee === versionDansLaConfig
+        )
+      ) {
+        throw new ErreurSelManquant(
+          `La version ${versionAppliquee} du sel déjà appliquée est manquante dans la config.`
+        );
+      }
+    }
+  };
+
+  return {
+    verifieLaCoherenceDesSels,
+  };
+};
+module.exports = { creeDepot };

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -9,6 +9,9 @@ class ErreurBusEvenements extends Error {
     super(`Erreur dans un abonné à [${typeEvenement}]`, details);
   }
 }
+class ErreurHashDeSelInvalide extends Error {}
+class ErreurSelManquant extends Error {}
+
 class ErreurModele extends Error {}
 class ErreurArticleCrispIntrouvable extends ErreurModele {}
 class ErreurAutorisationExisteDeja extends ErreurModele {}
@@ -96,6 +99,7 @@ module.exports = {
   ErreurDureeValiditeInvalide,
   ErreurEcheanceMesureInvalide,
   ErreurEmailManquant,
+  ErreurHashDeSelInvalide,
   ErreurIdentifiantNouveauteInconnu,
   ErreurIntituleRisqueManquant,
   ErreurLocalisationDonneesInvalide,
@@ -106,6 +110,7 @@ module.exports = {
   ErreurNiveauVraisemblanceInconnu,
   ErreurNomServiceDejaExistant,
   ErreurRisqueInconnu,
+  ErreurSelManquant,
   ErreurServiceInexistant,
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -16,7 +16,6 @@ const {
 const { ajouteLaRedirectionPostConnexion } = require('./redirection');
 const { extraisIp } = require('./requeteHttp');
 const SourceAuthentification = require('../modeles/sourceAuthentification');
-const { nonce: genereNonce } = require('../adaptateurs/adaptateurChiffrement');
 const { TYPES_REQUETES } = require('./configurationServeur');
 
 const middleware = (configuration = {}) => {
@@ -26,6 +25,7 @@ const middleware = (configuration = {}) => {
     adaptateurJWT,
     adaptateurProtection,
     adaptateurGestionErreur,
+    adaptateurChiffrement,
   } = configuration;
 
   const positionneHeaders = (requete, reponse, suite) => {
@@ -67,7 +67,7 @@ const middleware = (configuration = {}) => {
   };
 
   const positionneHeadersAvecNonce = async (requete, reponse, suite) => {
-    const nonce = await genereNonce();
+    const nonce = await adaptateurChiffrement.nonce();
     requete.nonce = nonce;
     reponse.locals.nonce = nonce;
     positionneHeaders(requete, reponse, suite);

--- a/src/sel/serviceVerificationCoherenceSels.js
+++ b/src/sel/serviceVerificationCoherenceSels.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-console */
+const fabriqueServiceVerificationCoherenceSels = ({
+  adaptateurEnvironnement,
+  depotDonnees,
+}) => ({
+  verifieLaCoherenceDesSels: async () => {
+    if (adaptateurEnvironnement.modeMaintenance().actif()) {
+      console.log('🏗 Pas de vérification des sels en mode maintenance');
+    }
+
+    try {
+      await depotDonnees.verifieLaCoherenceDesSels();
+      console.log('✅ Vérification des sels réussie');
+    } catch (e) {
+      process.stdout.write(
+        `💥 Erreur de vérification des sels: ${e?.message}\n`
+      );
+      process.exit(1);
+    }
+  },
+});
+/* eslint-enable no-console */
+
+module.exports = { fabriqueServiceVerificationCoherenceSels };

--- a/test/adaptateurs/adaptateurChiffrement.spec.js
+++ b/test/adaptateurs/adaptateurChiffrement.spec.js
@@ -5,12 +5,38 @@ const {
 
 describe("L'adaptateur chiffrement", () => {
   describe('sur demande de hachage SHA256', () => {
-    it('ajoute v1 en préfixe de la chaîne hachée', async () => {
-      const hache = adaptateurChiffrement().hacheSha256(
-        '7276abd6-98bb-4bc9-bd17-d50a56aba7e4'
-      );
+    it('hache avec un sel', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [{ version: 1, sel: '' }],
+        }),
+      };
+
+      const hache = adaptateurChiffrement({
+        adaptateurEnvironnement,
+      }).hacheSha256('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
+
       expect(hache).to.be(
         'v1:335ceb3ca583427ae371a2069ceb54708d93f0befbd55ac10daec0f7c7bdeee4'
+      );
+    });
+
+    it('hache avec deux sels', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [
+            { version: 1, sel: '' },
+            { version: 2, sel: 'abc' },
+          ],
+        }),
+      };
+
+      const hache = adaptateurChiffrement({
+        adaptateurEnvironnement,
+      }).hacheSha256('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
+
+      expect(hache).to.be(
+        'v1-v2:cb932aca72319407a746bc174d548cdacb68985c5afa2a3405110cc7696663df'
       );
     });
   });

--- a/test/adaptateurs/adaptateurChiffrement.spec.js
+++ b/test/adaptateurs/adaptateurChiffrement.spec.js
@@ -1,11 +1,14 @@
 const expect = require('expect.js');
-const { hacheSha256 } = require('../../src/adaptateurs/adaptateurChiffrement');
+const {
+  adaptateurChiffrement,
+} = require('../../src/adaptateurs/adaptateurChiffrement');
 
 describe("L'adaptateur chiffrement", () => {
   describe('sur demande de hachage SHA256', () => {
     it('ajoute v1 en préfixe de la chaîne hachée', async () => {
-      const hache = hacheSha256('7276abd6-98bb-4bc9-bd17-d50a56aba7e4');
-
+      const hache = adaptateurChiffrement().hacheSha256(
+        '7276abd6-98bb-4bc9-bd17-d50a56aba7e4'
+      );
       expect(hache).to.be(
         'v1:335ceb3ca583427ae371a2069ceb54708d93f0befbd55ac10daec0f7c7bdeee4'
       );

--- a/test/adaptateurs/adaptateurEnvironnement.spec.js
+++ b/test/adaptateurs/adaptateurEnvironnement.spec.js
@@ -1,0 +1,69 @@
+const expect = require('expect.js');
+const {
+  chiffrement,
+} = require('../../src/adaptateurs/adaptateurEnvironnement');
+
+describe("L'adaptateur environnement", () => {
+  let envActuel;
+
+  beforeEach(() => {
+    envActuel = process.env;
+  });
+
+  afterEach(() => {
+    process.env = envActuel;
+  });
+
+  it('sait charger les sels', async () => {
+    process.env = {
+      CHIFFREMENT_SEL_DE_HASHAGE_1: 'sel1',
+      CHIFFREMENT_SEL_DE_HASHAGE_2: 'sel2',
+    };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage).to.eql([
+      { version: 1, sel: 'sel1' },
+      { version: 2, sel: 'sel2' },
+    ]);
+  });
+
+  it('charge les sels dans le bon ordre', async () => {
+    process.env = {
+      CHIFFREMENT_SEL_DE_HASHAGE_1: 'sel1',
+      CHIFFREMENT_SEL_DE_HASHAGE_3: 'sel3',
+      CHIFFREMENT_SEL_DE_HASHAGE_2: 'sel2',
+    };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage).to.eql([
+      { version: 1, sel: 'sel1' },
+      { version: 2, sel: 'sel2' },
+      { version: 3, sel: 'sel3' },
+    ]);
+  });
+
+  it('ne charge pas les sels qui ne correspondent pas au format indiqué', async () => {
+    process.env = {
+      CHIFFREMENT_SEL_DE_HASHAGE_1: 'sel1',
+      CHIFFREMENT_SEL_DE_HASHAGE_V3: 'sel3',
+      CHIFFREMENT_SEL_DE_HASHAGE_2: 'sel2',
+    };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage).to.eql([
+      { version: 1, sel: 'sel1' },
+      { version: 2, sel: 'sel2' },
+    ]);
+  });
+
+  it('utilise des entiers pour les versions', () => {
+    process.env = { CHIFFREMENT_SEL_DE_HASHAGE_1: 'sel1' };
+
+    const tousLesSelsDeHachage = chiffrement().tousLesSelsDeHachage();
+
+    expect(tousLesSelsDeHachage[0].version === 1).to.be(true);
+  });
+});

--- a/test/depots/depotDonneesSelsDeHachage.spec.js
+++ b/test/depots/depotDonneesSelsDeHachage.spec.js
@@ -1,0 +1,189 @@
+const expect = require('expect.js');
+const { creeDepot } = require('../../src/depots/depotDonneesSelsDeHachage');
+const {
+  ErreurHashDeSelInvalide,
+  ErreurSelManquant,
+} = require('../../src/erreurs');
+
+describe('Le dépôt de sels de hachage', () => {
+  describe('sur vérification de cohérence des sels', () => {
+    it('jette une erreur si un sel est invalide', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [{ version: 1, sel: 'unAutreSel' }],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [
+          { version: 1, empreinte: 'sel-crypte' },
+        ],
+      };
+      const adaptateurChiffrement = {
+        compareBCrypt: async () => false,
+      };
+
+      const depot = creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSels();
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurHashDeSelInvalide);
+        expect(e.message).to.be(
+          'La version 1 du sel de la config a une valeur différente de celle déjà appliquée.'
+        );
+      }
+    });
+
+    it("jette une erreur si le deuxième sel est invalide, peu importe l'ordre", async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [
+            { version: 2, sel: 'unAutreSel' },
+            { version: 1, sel: 'sel' },
+          ],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [
+          { version: 1, empreinte: 'sel-crypte' },
+          { version: 2, empreinte: 'sel2-crypte' },
+        ],
+      };
+      const adaptateurChiffrement = {
+        compareBCrypt: async (selEnClair) => selEnClair !== 'unAutreSel',
+      };
+
+      const depot = creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSels();
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurHashDeSelInvalide);
+        expect(e.message).to.be(
+          'La version 2 du sel de la config a une valeur différente de celle déjà appliquée.'
+        );
+      }
+    });
+
+    it('ne fait rien si tous les sels sont valides', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [{ version: 1, sel: 'sel' }],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [
+          { version: 1, empreinte: 'sel-crypte' },
+        ],
+      };
+      const adaptateurChiffrement = {
+        compareBCrypt: async () => true,
+      };
+
+      const depot = creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      const resultat = await depot.verifieLaCoherenceDesSels();
+      expect(resultat).to.be(undefined);
+    });
+
+    it("jette une erreur si un sel n'est pas présent dans la persistance", async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [
+            { version: 1, sel: 'sel1' },
+            { version: 2, sel: 'sel2' },
+          ],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [{ version: 2, sel: 'sel2-crypte' }],
+      };
+      const adaptateurChiffrement = {
+        compareBCrypt: async () => true,
+      };
+
+      const depot = creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSels();
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurSelManquant);
+        expect(e.message).to.be(
+          'La version 1 du sel noté dans la config est manquante dans la persistance.'
+        );
+      }
+    });
+
+    it("jette une erreur si un sel de la persistance n'est pas présent dans la config", async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [{ version: 2, sel: 'sel2' }],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [
+          { version: 1, sel: 'sel1-crypte' },
+          { version: 2, sel: 'sel2-crypte' },
+        ],
+      };
+      const adaptateurChiffrement = {
+        compareBCrypt: async () => true,
+      };
+
+      const depot = creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSels();
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurSelManquant);
+        expect(e.message).to.be(
+          'La version 1 du sel déjà appliquée est manquante dans la config.'
+        );
+      }
+    });
+
+    it("jette une erreur si aucun sel n'est présent dans la config", async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [],
+        }),
+      };
+
+      const depot = creeDepot({
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSels();
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurSelManquant);
+        expect(e.message).to.be('Aucun sel de hachage dans la config.');
+      }
+    });
+  });
+});

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -16,6 +16,9 @@ const { creeReferentiel } = require('../../src/referentiel');
 const Utilisateur = require('../../src/modeles/utilisateur');
 const { TYPES_REQUETES } = require('../../src/http/configurationServeur');
 const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+const {
+  fabriqueAdaptateurChiffrement,
+} = require('../../src/adaptateurs/fabriqueAdaptateurChiffrement');
 
 const prepareVerificationReponse = (reponse, status, ...params) => {
   let message;
@@ -76,6 +79,7 @@ describe('Le middleware MSS', () => {
         identifieUtilisateur: () => {},
       },
       depotDonnees,
+      adaptateurChiffrement: fabriqueAdaptateurChiffrement(),
     });
 
   beforeEach(() => {


### PR DESCRIPTION
- Vérifie la cohérence des sels au démarrage (tous les sels en base sont dans la config, tous les sels de la config sont en base, l'empreinte en base correspond au sel de la config)
- Utilise tous les sels de la config pour hacher

> [!IMPORTANT]
>  Vous devez ajouter à votre .env la clé `CHIFFREMENT_SEL_DE_HASHAGE_1=` avec la valeur de sel correspondant à votre v1

> [!IMPORTANT]
>  Si vous n'avez jamais joué la migration des hash v1, vous devez la jouer pour que l'application démarre (vous pouvez démarrer en mode maintenance pour faire la migration)

> [!CAUTION]
> - Il faut ajouter la variable  `CHIFFREMENT_SEL_DE_HASHAGE_1` pour mettre en prod