### PR TITLE
[SOIN] Variabilise le pool de connexion maximum pour Postgres

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -38,6 +38,7 @@ CLE_SECRETE_INTEGRATION_METABASE_MSS = # La clé secrète d'intégration de Meta
 IDENTIFIANT_DASHBOARD_SUPERVISION_METABASE_MSS = # L'identifiant du dashboard pour les superviseurs dans Metabase
 
 URL_SERVEUR_BASE_DONNEES= # URL du serveur de base de données, ex. postgres://user@mss-db/mss
+BASE_DONNEES_POOL_CONNEXION_MAX= # Nombre de connexions maximum à la base de données
 
 SECRET_COOKIE= # chaîne utilisée pour chiffrer le cookie de session
 SECRET_JWT= # chaîne utilisée pour chiffrer le JWT
@@ -49,6 +50,7 @@ GOOGLE_SEARCH_CONSOLE_VERIFICATION=# Code de vérification de la Google Search C
 
 # Journal MSS
 URL_SERVEUR_BASE_DONNEES_JOURNAL= # URL de la base de données du Journal MSS. ex. postgres://user@mss-journal-db:5432/mss-journal
+BASE_DONNEES_JOURNAL_POOL_CONNEXION_MAX= # Nombre de connexions maximum à la base de données du Journal
 
 # interrupteurs de fonctionnalités (feature switches)
 AVEC_JOURNAL_EN_MEMOIRE= # `true` pour utiliser un « Journal MSS » en mémoire. Sinon le journal utilisera la base de données « URL_SERVEUR_BASE_DONNEES_JOURNAL »

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,15 +1,17 @@
+const { baseDeDonnees } = require('./src/adaptateurs/adaptateurEnvironnement');
+
 module.exports = {
   development: {
     client: 'pg',
     connection: process.env.URL_SERVEUR_BASE_DONNEES,
-    pool: { min: 0, max: 10 },
+    pool: { min: 0, max: baseDeDonnees().poolMaximumConnexion() },
     migrations: { tableName: 'knex_migrations' },
   },
 
   production: {
     client: 'pg',
     connection: process.env.URL_SERVEUR_BASE_DONNEES,
-    pool: { min: 0, max: 10 },
+    pool: { min: 0, max: baseDeDonnees().poolMaximumConnexion() },
     migrations: { tableName: 'knex_migrations' },
   },
 };

--- a/migrationHash.js
+++ b/migrationHash.js
@@ -3,6 +3,7 @@ const config = require('./knexfile');
 const {
   adaptateurChiffrement,
 } = require('./src/adaptateurs/adaptateurChiffrement');
+const { journalMSS } = require('./src/adaptateurs/adaptateurEnvironnement');
 
 /* eslint-disable no-console */
 class MigrationHash {
@@ -10,7 +11,7 @@ class MigrationHash {
     const configDuJournal = {
       client: 'pg',
       connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
-      pool: { min: 0, max: 10 },
+      pool: { min: 0, max: journalMSS().poolMaximumConnexion() },
     };
     this.knexMSSJournal = Knex(configDuJournal);
     this.knexMSS = Knex(config[environnementNode]);

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -1,11 +1,24 @@
+const nombreOuDefautDepuisChaine = (nombre, defaut) =>
+  Number.isNaN(parseInt(nombre, 10)) ? defaut : parseInt(nombre, 10);
+
 const emailMemoire = () => ({
   logEmailDansConsole: () =>
     process.env.AVEC_EMAIL_MEMOIRE_QUI_LOG_CONSOLE === 'true',
 });
 
+const baseDeDonnees = () => ({
+  poolMaximumConnexion: () =>
+    nombreOuDefautDepuisChaine(process.env.BASE_DONNEES_POOL_CONNEXION_MAX, 10),
+});
+
 const journalMSS = () => ({
   logEvenementDansConsole: () =>
     process.env.AVEC_JOURNAL_MEMOIRE_QUI_LOG_CONSOLE === 'true',
+  poolMaximumConnexion: () =>
+    nombreOuDefautDepuisChaine(
+      process.env.BASE_DONNEES_JOURNAL_POOL_CONNEXION_MAX,
+      10
+    ),
 });
 
 const filtrageIp = () => ({
@@ -100,6 +113,7 @@ const mss = () => ({
 });
 
 module.exports = {
+  baseDeDonnees,
   chiffrement,
   emailMemoire,
   featureFlag,

--- a/src/adaptateurs/adaptateurJournalMSSPostgres.js
+++ b/src/adaptateurs/adaptateurJournalMSSPostgres.js
@@ -1,10 +1,11 @@
 const Knex = require('knex');
 const uuid = require('uuid');
+const { journalMSS } = require('./adaptateurEnvironnement');
 
 const config = {
   client: 'pg',
   connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
-  pool: { min: 0, max: 10 },
+  pool: { min: 0, max: journalMSS().poolMaximumConnexion() },
 };
 
 const nouvelAdaptateur = () => {

--- a/src/adaptateurs/adaptateurSupervisionMetabase.js
+++ b/src/adaptateurs/adaptateurSupervisionMetabase.js
@@ -1,5 +1,6 @@
 const Knex = require('knex');
 const { sign } = require('jsonwebtoken');
+const { journalMSS } = require('./adaptateurEnvironnement');
 
 const adaptateurSupervisionMetabase = ({
   adaptateurChiffrement,
@@ -8,7 +9,7 @@ const adaptateurSupervisionMetabase = ({
   const config = {
     client: 'pg',
     connection: process.env.URL_SERVEUR_BASE_DONNEES_JOURNAL,
-    pool: { min: 0, max: 10 },
+    pool: { min: 0, max: journalMSS().poolMaximumConnexion() },
   };
 
   const correspondancesFiltreDate = {


### PR DESCRIPTION
... afin de pouvoir le modifier en fonction de la taille de l'instance déployée.

> [!CAUTION]
> La variable `BASE_DONNEES_POOL_CONNEXION_MAX` doit être valorisée avant de merger 
> La variable `BASE_DONNEES_JOURNAL_POOL_CONNEXION_MAX` doit être valorisée avant de merger 