### PR TITLE
Interdis la mise en cache par défaut

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -385,6 +385,16 @@ const middleware = (configuration = {}) => {
     suite();
   };
 
+  const interdisLaMiseEnCache = (_requete, reponse, suite) => {
+    reponse.set({
+      'cache-control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      pragma: 'no-cache',
+      expires: '0',
+      'surrogate-control': 'no-store',
+    });
+    suite();
+  };
+
   return {
     ajouteVersionFichierCompiles,
     aseptise,
@@ -395,6 +405,7 @@ const middleware = (configuration = {}) => {
     chargeEtatVisiteGuidee,
     chargePreferencesUtilisateur,
     chargeTypeRequete,
+    interdisLaMiseEnCache,
     positionneHeaders,
     positionneHeadersAvecNonce,
     protegeTrafic,

--- a/src/mss.ts
+++ b/src/mss.ts
@@ -58,6 +58,8 @@ const creeServeur = ({
   app.use(middleware.filtreIpAutorisees());
   app.use(middleware.redirigeVersUrlBase);
 
+  app.use(middleware.interdisLaMiseEnCache);
+
   app.use(express.json());
 
   app.use(

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -1196,4 +1196,20 @@ describe('Le middleware MSS', () => {
       });
     });
   });
+
+  describe("sur demande d'interdiction de mise en cache", () => {
+    it('interdit la mise en cache', (done) => {
+      const middleware = leMiddleware({});
+
+      middleware.interdisLaMiseEnCache(requete, reponse, () => {
+        expect(reponse.headers['cache-control']).to.be(
+          'no-store, no-cache, must-revalidate, proxy-revalidate'
+        );
+        expect(reponse.headers.pragma).to.be('no-cache');
+        expect(reponse.headers.expires).to.be('0');
+        expect(reponse.headers['surrogate-control']).to.be('no-store');
+        done();
+      });
+    });
+  });
 });

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -394,6 +394,10 @@ const middlewareFantaisie = {
       ...params
     );
   },
+
+  interdisLaMiseEnCache: (_requete, _reponse, suite) => {
+    suite();
+  },
 };
 
 module.exports = middlewareFantaisie;


### PR DESCRIPTION
Par défaut, on interdit la mise en cache de toutes les réponses. On n'autorise qu'au cas par cas.