### PR TITLE
Ajoute la possibilité de migrer vers le dernier sel de la config

### DIFF
--- a/migrationHash.spec.js
+++ b/migrationHash.spec.js
@@ -1,0 +1,40 @@
+const expect = require('expect.js');
+const { tenteDeHacherAvecUnNouveauSel } = require('./migrationHash');
+
+describe("L'outil de migration de sels de hachage", () => {
+  it('hache avec un nouveau sel et augmente la version', () => {
+    const nouveauHash = tenteDeHacherAvecUnNouveauSel(
+      'v1:une chaine-hasheeAvecV1',
+      2,
+      'un sel',
+      (chaine) => `${chaine}-hasheeAvecV2`,
+      'v1'
+    );
+
+    expect(nouveauHash).to.be('v1-v2:une chaine-hasheeAvecV1-hasheeAvecV2');
+  });
+
+  it('ne fait rien si la version du hash de la chaine ne correspond pas à la version attendue', () => {
+    const nouveauHash = tenteDeHacherAvecUnNouveauSel(
+      'v1-v2:une chaine-hasheeAvecV1-hasheeAvecV2',
+      4,
+      'un sel',
+      (chaine) => `${chaine}-hasheeAvecV4`,
+      'v1-v2-v3'
+    );
+
+    expect(nouveauHash).to.be('v1-v2:une chaine-hasheeAvecV1-hasheeAvecV2');
+  });
+
+  it('ne fait rien si la chaine est non définie', () => {
+    const nouveauHash = tenteDeHacherAvecUnNouveauSel(
+      undefined,
+      2,
+      'un sel V2',
+      (chaine) => `${chaine}-hasheeAvecV2`,
+      'v1'
+    );
+
+    expect(nouveauHash).to.be(undefined);
+  });
+});

--- a/src/adaptateurs/adaptateurChiffrement.js
+++ b/src/adaptateurs/adaptateurChiffrement.js
@@ -3,8 +3,14 @@ const bcrypt = require('bcrypt');
 
 const adaptateurChiffrement = ({ adaptateurEnvironnement }) => {
   const NOMBRE_DE_PASSES = 10;
+
   const hacheBCrypt = (chaineEnClair) =>
     bcrypt.hash(chaineEnClair, NOMBRE_DE_PASSES);
+
+  const hacheSha256AvecUnSeulSel = (chaine, sel) =>
+    createHash('sha256')
+      .update(chaine + sel)
+      .digest('hex');
 
   return {
     chiffre: async (chaineOuObjet) => chaineOuObjet,
@@ -15,18 +21,15 @@ const adaptateurChiffrement = ({ adaptateurEnvironnement }) => {
 
     compareBCrypt: bcrypt.compare,
 
-    hacheSha256: (chaineEnClair) => {
-      const hacheSha256AvecSel = (chaine, sel) =>
-        createHash('sha256')
-          .update(chaine + sel)
-          .digest('hex');
+    hacheSha256AvecUnSeulSel,
 
+    hacheSha256: (chaineEnClair) => {
       const tousLesSelsDeHachage = adaptateurEnvironnement
         .chiffrement()
         .tousLesSelsDeHachage();
 
       const hashFinal = tousLesSelsDeHachage.reduce(
-        (acc, { sel }) => hacheSha256AvecSel(acc, sel),
+        (acc, { sel }) => hacheSha256AvecUnSeulSel(acc, sel),
         chaineEnClair
       );
 

--- a/src/depots/depotDonneesSelsDeHachage.js
+++ b/src/depots/depotDonneesSelsDeHachage.js
@@ -1,4 +1,56 @@
-const { ErreurHashDeSelInvalide, ErreurSelManquant } = require('../erreurs');
+const {
+  ErreurHashDeSelInvalide,
+  ErreurSelManquant,
+  ErreurVersionSelInvalide,
+  ErreurValeurSelIncoherente,
+} = require('../erreurs');
+
+const verifieQueChaqueSelEstCoherent = async (
+  tousLesSelsDeLaConfig,
+  tousLesSelsAppliques,
+  adaptateurChiffrement
+) => {
+  for (let i = 0; i < tousLesSelsDeLaConfig.length; i += 1) {
+    const { version: versionDeLaConfig, sel: valeurSelEnClair } =
+      tousLesSelsDeLaConfig[i];
+    const leSelAppliqueCorrespondant = tousLesSelsAppliques.find(
+      ({ version: versionEnBase }) => versionEnBase === versionDeLaConfig
+    );
+
+    if (!leSelAppliqueCorrespondant) {
+      throw new ErreurSelManquant(
+        `La version ${versionDeLaConfig} du sel noté dans la config est manquante dans la persistance.`
+      );
+    }
+    // Comme expliqué dans la documentation, si un `loop` doit `break`, on peut utiliser `await`
+    // https://eslint.org/docs/latest/rules/no-await-in-loop#when-not-to-use-it
+    // eslint-disable-next-line no-await-in-loop
+    const estValide = await adaptateurChiffrement.compareBCrypt(
+      valeurSelEnClair,
+      leSelAppliqueCorrespondant.empreinte
+    );
+
+    if (!estValide) {
+      throw new ErreurHashDeSelInvalide(
+        `La version ${versionDeLaConfig} du sel de la config a une valeur différente de celle déjà appliquée.`
+      );
+    }
+  }
+
+  for (let i = 0; i < tousLesSelsAppliques.length; i += 1) {
+    const { version: versionAppliquee } = tousLesSelsAppliques[i];
+    if (
+      !tousLesSelsDeLaConfig.some(
+        ({ version: versionDansLaConfig }) =>
+          versionAppliquee === versionDansLaConfig
+      )
+    ) {
+      throw new ErreurSelManquant(
+        `La version ${versionAppliquee} du sel déjà appliquée est manquante dans la config.`
+      );
+    }
+  }
+};
 
 const creeDepot = (config = {}) => {
   const {
@@ -19,50 +71,55 @@ const creeDepot = (config = {}) => {
     const tousLesSelsAppliques =
       await adaptateurPersistance.tousLesSelsDeHachage();
 
-    for (let i = 0; i < tousLesSelsDeLaConfig.length; i += 1) {
-      const { version: versionDeLaConfig, sel: valeurSelEnClair } =
-        tousLesSelsDeLaConfig[i];
-      const leSelAppliqueCorrespondant = tousLesSelsAppliques.find(
-        ({ version: versionEnBase }) => versionEnBase === versionDeLaConfig
+    await verifieQueChaqueSelEstCoherent(
+      tousLesSelsDeLaConfig,
+      tousLesSelsAppliques,
+      adaptateurChiffrement
+    );
+  };
+
+  const verifieLaCoherenceDesSelsAvantMigration = async (
+    versionAMigrer,
+    valeurSelAMigrer
+  ) => {
+    const tousLesSelsDeLaConfig = adaptateurEnvironnement
+      .chiffrement()
+      .tousLesSelsDeHachage();
+
+    const tousLesSelsAppliques =
+      await adaptateurPersistance.tousLesSelsDeHachage();
+
+    if (tousLesSelsDeLaConfig.length === tousLesSelsAppliques.length)
+      throw new ErreurSelManquant(
+        'Aucun nouveau sel présent dans la configuration. La migration ne peut pas être effectuée.'
       );
 
-      if (!leSelAppliqueCorrespondant) {
-        throw new ErreurSelManquant(
-          `La version ${versionDeLaConfig} du sel noté dans la config est manquante dans la persistance.`
-        );
-      }
-      // Comme expliqué dans la documentation, si un `loop` doit `break`, on peut utiliser `await`
-      // https://eslint.org/docs/latest/rules/no-await-in-loop#when-not-to-use-it
-      // eslint-disable-next-line no-await-in-loop
-      const estValide = await adaptateurChiffrement.compareBCrypt(
-        valeurSelEnClair,
-        leSelAppliqueCorrespondant.empreinte
+    if (tousLesSelsDeLaConfig.length !== tousLesSelsAppliques.length + 1)
+      throw new ErreurSelManquant("Plus d'un sel à migrer.");
+
+    const leDernierSelDeLaConfig =
+      tousLesSelsDeLaConfig[tousLesSelsDeLaConfig.length - 1];
+
+    if (versionAMigrer !== leDernierSelDeLaConfig.version)
+      throw new ErreurVersionSelInvalide(
+        `La version v${versionAMigrer} est incompatible avec la configuration actuelle.`
       );
 
-      if (!estValide) {
-        throw new ErreurHashDeSelInvalide(
-          `La version ${versionDeLaConfig} du sel de la config a une valeur différente de celle déjà appliquée.`
-        );
-      }
-    }
+    if (valeurSelAMigrer !== leDernierSelDeLaConfig.sel)
+      throw new ErreurValeurSelIncoherente(
+        'La valeur du sel est incohérente avec la configuration actuelle.'
+      );
 
-    for (let i = 0; i < tousLesSelsAppliques.length; i += 1) {
-      const { version: versionAppliquee } = tousLesSelsAppliques[i];
-      if (
-        !tousLesSelsDeLaConfig.some(
-          ({ version: versionDansLaConfig }) =>
-            versionAppliquee === versionDansLaConfig
-        )
-      ) {
-        throw new ErreurSelManquant(
-          `La version ${versionAppliquee} du sel déjà appliquée est manquante dans la config.`
-        );
-      }
-    }
+    await verifieQueChaqueSelEstCoherent(
+      tousLesSelsDeLaConfig.slice(0, tousLesSelsDeLaConfig.length - 1),
+      tousLesSelsAppliques,
+      adaptateurChiffrement
+    );
   };
 
   return {
     verifieLaCoherenceDesSels,
+    verifieLaCoherenceDesSelsAvantMigration,
   };
 };
 module.exports = { creeDepot };

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -11,6 +11,8 @@ class ErreurBusEvenements extends Error {
 }
 class ErreurHashDeSelInvalide extends Error {}
 class ErreurSelManquant extends Error {}
+class ErreurValeurSelIncoherente extends Error {}
+class ErreurVersionSelInvalide extends Error {}
 
 class ErreurModele extends Error {}
 class ErreurArticleCrispIntrouvable extends ErreurModele {}
@@ -120,6 +122,8 @@ module.exports = {
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,
   ErreurUtilisateurInexistant,
+  ErreurValeurSelIncoherente,
+  ErreurVersionSelInvalide,
   ErreurDonneesNiveauSecuriteInsuffisant,
   ErreurIdentifiantTacheInconnu,
 };

--- a/src/sel/serviceVerificationCoherenceSels.js
+++ b/src/sel/serviceVerificationCoherenceSels.js
@@ -6,6 +6,7 @@ const fabriqueServiceVerificationCoherenceSels = ({
   verifieLaCoherenceDesSels: async () => {
     if (adaptateurEnvironnement.modeMaintenance().actif()) {
       console.log('🏗 Pas de vérification des sels en mode maintenance');
+      return;
     }
 
     try {

--- a/test/depots/depotDonneesSelsDeHachage.spec.js
+++ b/test/depots/depotDonneesSelsDeHachage.spec.js
@@ -3,6 +3,8 @@ const { creeDepot } = require('../../src/depots/depotDonneesSelsDeHachage');
 const {
   ErreurHashDeSelInvalide,
   ErreurSelManquant,
+  ErreurVersionSelInvalide,
+  ErreurValeurSelIncoherente,
 } = require('../../src/erreurs');
 
 describe('Le dépôt de sels de hachage', () => {
@@ -183,6 +185,189 @@ describe('Le dépôt de sels de hachage', () => {
       } catch (e) {
         expect(e).to.be.an(ErreurSelManquant);
         expect(e.message).to.be('Aucun sel de hachage dans la config.');
+      }
+    });
+  });
+
+  describe('sur vérification de cohérence des sels avant migration', () => {
+    it("jette une erreur si plus d'un nouveau sel est présent dans la configuration", async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [
+            { version: 1 },
+            { version: 2 },
+            { version: 3 },
+          ],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [{ version: 1 }],
+      };
+
+      const depot = creeDepot({
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSelsAvantMigration();
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurSelManquant);
+        expect(e.message).to.be("Plus d'un sel à migrer.");
+      }
+    });
+
+    it("jette une erreur si aucun nouveau sel n'est présent dans la configuration", async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [{ version: 1 }],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [{ version: 1 }],
+      };
+
+      const depot = creeDepot({
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSelsAvantMigration();
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurSelManquant);
+        expect(e.message).to.be(
+          'Aucun nouveau sel présent dans la configuration. La migration ne peut pas être effectuée.'
+        );
+      }
+    });
+
+    it('jette une erreur si la version du nouveau sel ne correspond pas au paramètre reçu', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [{ version: 1 }, { version: 2 }],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [{ version: 1 }],
+      };
+
+      const depot = creeDepot({
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSelsAvantMigration(3);
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurVersionSelInvalide);
+        expect(e.message).to.be(
+          'La version v3 est incompatible avec la configuration actuelle.'
+        );
+      }
+    });
+
+    it('jette une erreur si la valeur du nouveau sel ne correspond pas au paramètre reçu', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [
+            { version: 1 },
+            { version: 2, sel: 'un sel' },
+          ],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [{ version: 1 }],
+      };
+
+      const depot = creeDepot({
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSelsAvantMigration(2, 'un autre sel');
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurValeurSelIncoherente);
+        expect(e.message).to.be(
+          'La valeur du sel est incohérente avec la configuration actuelle.'
+        );
+      }
+    });
+
+    it('jette une erreur si les précédents sels appliqués ne sont pas cohérents avec la config', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [
+            { version: 1, sel: 'unAutreSel' },
+            { version: 2, sel: 'un nouveau sel' },
+          ],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [
+          { version: 1, empreinte: 'sel-crypte' },
+        ],
+      };
+      const adaptateurChiffrement = {
+        compareBCrypt: async () => false,
+      };
+
+      const depot = creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSelsAvantMigration(
+          2,
+          'un nouveau sel'
+        );
+        expect().fail('La méthode aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurHashDeSelInvalide);
+        expect(e.message).to.be(
+          'La version 1 du sel de la config a une valeur différente de celle déjà appliquée.'
+        );
+      }
+    });
+
+    it('ne fait rien si tout est cohérent', async () => {
+      const adaptateurEnvironnement = {
+        chiffrement: () => ({
+          tousLesSelsDeHachage: () => [
+            { version: 1, sel: 'sel' },
+            { version: 2, sel: 'un nouveau sel' },
+          ],
+        }),
+      };
+      const adaptateurPersistance = {
+        tousLesSelsDeHachage: async () => [
+          { version: 1, empreinte: 'sel-crypte' },
+        ],
+      };
+      const adaptateurChiffrement = {
+        compareBCrypt: async () => true,
+      };
+
+      const depot = creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance,
+        adaptateurEnvironnement,
+      });
+
+      try {
+        await depot.verifieLaCoherenceDesSelsAvantMigration(
+          2,
+          'un nouveau sel'
+        );
+      } catch (e) {
+        expect().fail(e);
       }
     });
   });

--- a/test/sel/serviceVerificationCoherenceSels.spec.js
+++ b/test/sel/serviceVerificationCoherenceSels.spec.js
@@ -28,12 +28,14 @@ describe('Le service de vérification de cohérence des sels de hashage', () => 
 
     it("ne fait rien si l'application est en mode maintenance", async () => {
       const exitActuel = process.exit;
-      let codeRecu;
-      process.exit = (codeDeRetour) => (codeRecu = codeDeRetour);
+      let depotAppele = false;
+      depotDonnees.verifieLaCoherenceDesSels = () => {
+        depotAppele = true;
+      };
       adaptateurEnvironnement.modeMaintenance = () => ({ actif: () => true });
 
       await serviceVerificationCoherenceSels.verifieLaCoherenceDesSels();
-      expect(codeRecu).to.be(undefined);
+      expect(depotAppele).to.be(false);
 
       process.exit = exitActuel;
     });


### PR DESCRIPTION
..avec les fusibles associés, afin de ne pas migrer les hashs
- sans être en mode maintenance
- si plusieurs hashs sont nouveaux
- si les hashs appliqués ne correspondent pas à la config
- si la chaine est déjà hachée avec ce hash
- si la chaine n'est pas hachée avec tous les hash précédents