### PR TITLE
Passe l'identifiant d'erreur Sentry dans l'URL du support utilisateur

### DIFF
--- a/src/vues/erreur.pug
+++ b/src/vues/erreur.pug
@@ -18,6 +18,6 @@ block main
             span Vous pouvez transmettre l'identifiant
             code!= ` ${idSentry} `
             span à notre équipe support pour faciliter la résolution de l'erreur.
-        a.bouton.bouton-primaire(href="https://aide.monservicesecurise.cyber.gouv.fr/fr/") Contacter le support
+        a.bouton.bouton-primaire(href=`https://aide.monservicesecurise.cyber.gouv.fr/fr/?id_erreur=${idSentry}`) Contacter le support
       .contenu-image
         img(src="/statique/assets/images/illustration_maintenance.svg" alt="Illustration d'erreur")


### PR DESCRIPTION
... afin de pouvoir l'utiliser directement dans un message. On utilise du code Javascript "custom" côté Crisp pour détecter ce `queryParams` et l'ajouter dans un message par défaut.