### PR TITLE
Clarifie l'explication sur CSRF

### DIFF
--- a/src/http/configurationServeur.js
+++ b/src/http/configurationServeur.js
@@ -5,8 +5,10 @@ const TYPES_REQUETES = {
 };
 
 const ENDPOINTS_SANS_CSRF = [
-  // Inspiration : https://stackoverflow.com/a/60941601
-  // L'obtention du token nécessite une action utilisateur (saisie Login + MDP) donc on la protège pas.
+  // Les routes suivantes sont toutes publiques et ne nécessitent pas de protection CSRF.
+  // Un attaquand pourrait requêter la page qui pose le token CSRF avant d'accéder à ces routes.
+  // en conséquence, on ne protège pas ces routes publiques contre les attaques CSRF.
+  // Cf. https://stackoverflow.com/a/60941601
   { path: '/api/token', type: 'exact' },
   // Pareil pour l'inscription.
   { path: '/api/utilisateur', type: 'exact' },


### PR DESCRIPTION
Certaines pages sont publiques et ne nécessitent aucune authentification donc elles ne sont pas sujettes à une attaque CSRF. Donc on désactive la protection CSRF sur ces pages.

Le but de ce changement est de clarifier ce point pour le lecteur.