### PR TITLE
[CORRECTION] Corrige les responsables manquants lors de la duplication d'un service

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -56,7 +56,6 @@ class ErreurStatutDeploiementInvalide extends ErreurModele {}
 class ErreurPrioriteMesureInvalide extends ErreurModele {}
 class ErreurEcheanceMesureInvalide extends ErreurModele {}
 class ErreurStatutMesureInvalide extends ErreurModele {}
-class ErreurResponsablesMesureInvalides extends ErreurModele {}
 class ErreurSuppressionImpossible extends Error {}
 class ErreurUtilisateurInexistant extends ErreurModele {}
 class ErreurTypeInconnu extends ErreurModele {}
@@ -117,7 +116,6 @@ module.exports = {
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,
   ErreurPrioriteMesureInvalide,
-  ErreurResponsablesMesureInvalides,
   ErreurSuppressionImpossible,
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -218,11 +218,9 @@ class Service {
 
   metsAJourMesureGenerale(mesure) {
     const idUtilisateurs = this.contributeurs.map((u) => u.idUtilisateur);
-    if (mesure.responsables.some((r) => !idUtilisateurs.includes(r))) {
-      throw new ErreurResponsablesMesureInvalides(
-        "Les responsables d'une mesure générale doivent être des contributeurs du service."
-      );
-    }
+    mesure.responsables = mesure.responsables.filter((r) =>
+      idUtilisateurs.includes(r)
+    );
     this.mesures.mesuresGenerales.metsAJourMesure(mesure);
   }
 

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -13,7 +13,6 @@ const ObjetPDFAnnexeMesures = require('./objetsPDF/objetPDFAnnexeMesures');
 const ObjetPDFAnnexeRisques = require('./objetsPDF/objetPDFAnnexeRisques');
 const Autorisation = require('./autorisations/autorisation');
 const SuggestionAction = require('./suggestionAction');
-const { ErreurResponsablesMesureInvalides } = require('../erreurs');
 const { dateEnIso } = require('../utilitaires/date');
 const { Contributeur } = require('./contributeur');
 
@@ -395,11 +394,9 @@ class Service {
 
   metsAJourMesureSpecifique(mesure) {
     const idContributeurs = this.contributeurs.map((u) => u.idUtilisateur);
-    if (mesure.responsables.some((r) => !idContributeurs.includes(r))) {
-      throw new ErreurResponsablesMesureInvalides(
-        "Les responsables d'une mesure spécifique doivent être des contributeurs du service."
-      );
-    }
+    mesure.responsables = mesure.responsables.filter((r) =>
+      idContributeurs.includes(r)
+    );
     this.mesures.mesuresSpecifiques.metsAJourMesure(mesure);
   }
 

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -12,7 +12,6 @@ const {
   ErreurDonneesReferentielIncorrectes,
   ErreurPrioriteMesureInvalide,
   ErreurEcheanceMesureInvalide,
-  ErreurResponsablesMesureInvalides,
   ErreurRisqueInconnu,
   ErreurNiveauGraviteInconnu,
   ErreurIntituleRisqueManquant,
@@ -310,10 +309,6 @@ const routesConnecteApiService = ({
           return;
         }
 
-        if (e instanceof ErreurResponsablesMesureInvalides) {
-          reponse.status(403).send(e.message);
-          return;
-        }
         reponse.status(400).send(e.message);
       }
     }
@@ -377,10 +372,6 @@ const routesConnecteApiService = ({
           e instanceof ErreurEcheanceMesureInvalide
         ) {
           reponse.status(400).send('La mesure est invalide.');
-          return;
-        }
-        if (e instanceof ErreurResponsablesMesureInvalides) {
-          reponse.status(403).send(e.message);
           return;
         }
         suite(e);

--- a/svelte/lib/ui/SelectionResponsables.svelte
+++ b/svelte/lib/ui/SelectionResponsables.svelte
@@ -9,6 +9,12 @@
   export let responsables: IdUtilisateur[] | null;
   export let estLectureSeule: boolean;
 
+  $: responsablesAffiches = responsables
+    ? [...responsables].filter((r) =>
+        $contributeurs.map((c) => c.id).includes(r)
+      )
+    : [];
+
   let menuOuvert = false;
 
   const ouvreTiroirContributeurs = () => {
@@ -34,7 +40,7 @@
     <div class="conteneur-image">
       <img src="/statique/assets/images/icone_utilisateur_trait.svg" alt="" />
     </div>
-    <span>{responsables?.length || 0}</span>
+    <span>{responsablesAffiches.length}</span>
   </div>
   <div
     class="conteneur-responsables"

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -1008,32 +1008,27 @@ describe('Un service', () => {
       });
     });
 
-    it('jette une erreur si les responsables de la mesure ne font pas tous partie des contributeurs', async () => {
-      try {
-        const utilisateur = unUtilisateur()
-          .avecId('unIdDeContributeur')
-          .construis();
-        const service = unService()
-          .ajouteUnContributeur(utilisateur)
-          .construis();
-        const mesure = new MesureSpecifique(
-          {
-            id: 'M1',
-            statut: 'fait',
-            responsables: ['unIdDeContributeur', 'pasUnIdDeContributeur'],
-          },
-          referentiel
-        );
+    it('ignore les responsables de la mesure qui ne font pas partie des contributeurs', async () => {
+      const utilisateur = unUtilisateur()
+        .avecId('unIdDeContributeur')
+        .construis();
+      const mesure = new MesureSpecifique(
+        {
+          id: 'M1',
+          statut: 'fait',
+          responsables: ['unIdDeContributeur', 'pasUnIdDeContributeur'],
+        },
+        referentiel
+      );
+      const service = unService().ajouteUnContributeur(utilisateur).construis();
+      let donneesRecues;
+      service.mesures.mesuresSpecifiques.metsAJourMesure = (mesureRecu) => {
+        donneesRecues = mesureRecu;
+      };
 
-        await service.metsAJourMesureSpecifique(mesure);
+      await service.metsAJourMesureSpecifique(mesure);
 
-        expect().fail("L'appel aurait dû échouer");
-      } catch (e) {
-        expect(e).to.be.an(ErreurResponsablesMesureInvalides);
-        expect(e.message).to.be(
-          "Les responsables d'une mesure spécifique doivent être des contributeurs du service."
-        );
-      }
+      expect(donneesRecues.responsables).to.eql(['unIdDeContributeur']);
     });
 
     it('mets à jour la mesure', async () => {

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -954,32 +954,25 @@ describe('Un service', () => {
         },
       });
     });
-    it('jette une erreur si les responsables de la mesure ne font pas tous partie des contributeurs', async () => {
-      try {
-        const utilisateur = unUtilisateur()
-          .avecId('unIdDeContributeur')
-          .construis();
-        const service = unService()
-          .ajouteUnContributeur(utilisateur)
-          .construis();
-        const mesure = new MesureGenerale(
-          {
-            id: 'identifiantMesure',
-            statut: 'fait',
-            responsables: ['unIdDeContributeur', 'pasUnIdDeContributeur'],
-          },
-          referentiel
-        );
+    it('ignore les responsables de la mesure qui ne font pas partie des contributeurs', async () => {
+      const utilisateur = unUtilisateur()
+        .avecId('unIdDeContributeur')
+        .construis();
+      const service = unService().ajouteUnContributeur(utilisateur).construis();
+      const mesure = new MesureGenerale(
+        {
+          id: 'identifiantMesure',
+          statut: 'fait',
+          responsables: ['unIdDeContributeur', 'pasUnIdDeContributeur'],
+        },
+        referentiel
+      );
 
-        await service.metsAJourMesureGenerale(mesure);
+      await service.metsAJourMesureGenerale(mesure);
 
-        expect().fail("L'appel aurait dû échouer");
-      } catch (e) {
-        expect(e).to.be.an(ErreurResponsablesMesureInvalides);
-        expect(e.message).to.be(
-          "Les responsables d'une mesure générale doivent être des contributeurs du service."
-        );
-      }
+      expect(
+        service.mesuresGenerales().avecId('identifiantMesure').responsables
+      ).to.eql(['unIdDeContributeur']);
     });
 
     it('mets à jour la mesure', async () => {

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -22,7 +22,6 @@ const {
 } = require('../constructeurs/constructeurAutorisation');
 const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
 const Mesures = require('../../src/modeles/mesures');
-const { ErreurResponsablesMesureInvalides } = require('../../src/erreurs');
 const MesureSpecifique = require('../../src/modeles/mesureSpecifique');
 const { Contributeur } = require('../../src/modeles/contributeur');
 

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -9,7 +9,6 @@ const { unService } = require('../../constructeurs/constructeurService');
 const {
   ErreurDonneesObligatoiresManquantes,
   ErreurNomServiceDejaExistant,
-  ErreurResponsablesMesureInvalides,
   ErreurMesureInconnue,
   ErreurRisqueInconnu,
 } = require('../../../src/erreurs');
@@ -472,32 +471,6 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       );
     });
 
-    it('jette une erreur 403 si les responsables ne sont pas des contributeurs du service', async () => {
-      testeur.depotDonnees().ajouteMesureSpecifiqueAuService = async () => {
-        throw new ErreurResponsablesMesureInvalides(
-          "Les responsables d'une mesure spécifique doivent être des contributeurs du service."
-        );
-      };
-
-      const mesure = {
-        statut: 'fait',
-        responsables: ['pasUnIdDeContributeur'],
-      };
-
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/mesuresSpecifiques',
-          mesure
-        );
-        expect().fail('L’appel aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-        expect(e.response.data).to.be(
-          "Les responsables d'une mesure spécifique doivent être des contributeurs du service."
-        );
-      }
-    });
-
     it('jette une erreur 400 si le statut est vide', async () => {
       const mesure = {
         statut: '',
@@ -807,32 +780,6 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         },
         done
       );
-    });
-
-    it('jette une erreur 403 si les responsables ne sont pas des contributeurs du service', async () => {
-      testeur.depotDonnees().metsAJourMesureGeneraleDuService = async () => {
-        throw new ErreurResponsablesMesureInvalides(
-          "Les responsables d'une mesure générale doivent être des contributeurs du service."
-        );
-      };
-
-      const mesureGenerale = {
-        statut: 'fait',
-        responsables: ['pasUnIdDeContributeur'],
-      };
-
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/mesures/audit',
-          mesureGenerale
-        );
-        expect().fail('L’appel aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-        expect(e.response.data).to.be(
-          "Les responsables d'une mesure générale doivent être des contributeurs du service."
-        );
-      }
     });
 
     it('jette une erreur 400 si le statut est vide', async () => {


### PR DESCRIPTION
Aujourd'hui, un service dupliqué conserve ses mesures.
Il peut donc y avoir des responsables de mesures.

Or, ce service dupliqué ne conserve pas les contributeurs.
On veut donc éviter ces erreurs, en omettant les responsables de mesures inutiles au niveau de l'API.