### PR TITLE
Charge les features flags depuis le Middleware

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -82,6 +82,7 @@ BALEEN_TOKEN= # Le Personal Access Token (PAT) permettant d'utiliser l'API Balee
 BALEEN_NAMESPACE = # L'identifiant de l'application Baleen
 
 # Feature Flags
+FEATURE_FLAG_MSC_BANDEAU_DATE_DEBUT = # Date du début d'affichage du bandeau de promotion MesServicesCyber, en UTC
 
 # Crisp
 CRISP_ID_SITE= # L'identifiant "WebsiteID" de MonServiceSécurisé

--- a/server.ts
+++ b/server.ts
@@ -96,6 +96,7 @@ cableTousLesAbonnes(busEvenements, {
 });
 
 const middleware = Middleware({
+  adaptateurHorloge,
   adaptateurEnvironnement,
   adaptateurJWT,
   adaptateurProtection,

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -84,6 +84,7 @@ const featureFlag = () => ({
     process.env.OIDC_URL_BASE &&
     process.env.OIDC_CLIENT_ID &&
     process.env.OIDC_CLIENT_SECRET,
+  dateDebutBandeauMSC: () => process.env.FEATURE_FLAG_MSC_BANDEAU_DATE_DEBUT,
 });
 
 const versionDeBuild = () => {

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -22,6 +22,7 @@ const middleware = (configuration = {}) => {
   const {
     depotDonnees,
     adaptateurEnvironnement = adaptateurEnvironnementParDefaut,
+    adaptateurHorloge,
     adaptateurJWT,
     adaptateurProtection,
     adaptateurGestionErreur,
@@ -387,6 +388,15 @@ const middleware = (configuration = {}) => {
     suite();
   };
 
+  const chargeFeatureFlags = (_requete, reponse, suite) => {
+    reponse.locals.featureFlags = {
+      avecBandeauMSC:
+        adaptateurHorloge.maintenant() >
+        new Date(adaptateurEnvironnement.featureFlag().dateDebutBandeauMSC()),
+    };
+    suite();
+  };
+
   return {
     ajouteVersionFichierCompiles,
     aseptise,
@@ -395,6 +405,7 @@ const middleware = (configuration = {}) => {
     chargeAutorisationsService,
     chargeEtatAgentConnect,
     chargeEtatVisiteGuidee,
+    chargeFeatureFlags,
     chargePreferencesUtilisateur,
     chargeTypeRequete,
     interdisLaMiseEnCache,

--- a/src/mss.ts
+++ b/src/mss.ts
@@ -78,6 +78,7 @@ const creeServeur = ({
 
   app.use(middleware.positionneHeaders);
   app.use(middleware.ajouteVersionFichierCompiles);
+  app.use(middleware.chargeFeatureFlags);
 
   app.disable('x-powered-by');
 

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -394,6 +394,10 @@ const middlewareFantaisie = {
   interdisLaMiseEnCache: (_requete, _reponse, suite) => {
     suite();
   },
+
+  chargeFeatureFlags: (_requete, _reponse, suite) => {
+    suite();
+  },
 };
 
 module.exports = middlewareFantaisie;


### PR DESCRIPTION
... dans `reponse.locals.featureFlags`, afin d'y avoir accès dans le `pug`