### PR TITLE
[ADMIN] Ajoute la possiblité de cloner "en masse"

### DIFF
--- a/admin/duplicationEnMasseDeServices.js
+++ b/admin/duplicationEnMasseDeServices.js
@@ -1,0 +1,144 @@
+const readline = require('readline');
+const { parse } = require('papaparse');
+const DepotDonnees = require('../src/depotDonnees');
+const {
+  fabriqueAdaptateurChiffrement,
+} = require('../src/adaptateurs/fabriqueAdaptateurChiffrement');
+const adaptateurJWT = require('../src/adaptateurs/adaptateurJWT');
+const { fabriqueAdaptateurUUID } = require('../src/adaptateurs/adaptateurUUID');
+const adaptateurRechercheEntrepriseAPI = require('../src/adaptateurs/adaptateurRechercheEntrepriseAPI');
+const BusEvenements = require('../src/bus/busEvenements');
+const {
+  fabriqueAdaptateurGestionErreur,
+} = require('../src/adaptateurs/fabriqueAdaptateurGestionErreur');
+const Referentiel = require('../src/referentiel');
+const donneesReferentiel = require('../donneesReferentiel');
+const AdaptateurPostgres = require('../src/adaptateurs/adaptateurPostgres');
+const { fabriqueProcedures } = require('../src/routes/procedures');
+const adaptateurMail = require('../src/adaptateurs/adaptateurMailSendinblue');
+const fabriqueAdaptateurTracking = require('../src/adaptateurs/fabriqueAdaptateurTracking');
+
+const log = {
+  jaune: (txt) => process.stdout.write(`\x1b[33m${txt}\x1b[0m`),
+  cyan: (txt) => process.stdout.write(`\x1b[36m${txt}\x1b[0m`),
+  vert: (txt) => process.stdout.write(`\x1b[92m${txt}\x1b[0m`),
+  rouge: (txt) => process.stdout.write(`\x1b[31m${txt}\x1b[0m`),
+};
+
+/* eslint-disable no-console */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+
+const lisEntreeTapeeDansLaConsole = async () => {
+  log.cyan(
+    'Copier/Coller le contenu CSV du fichier de clonage et appuyer sur Ctrl+D (ou "Entrée" deux fois) :'
+  );
+
+  let donnees = '';
+  let derniereLigneVide = false;
+
+  const lecteurStdin = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  for await (const ligne of lecteurStdin) {
+    if (ligne.trim() === '') {
+      if (derniereLigneVide) {
+        break;
+      }
+      derniereLigneVide = true;
+    } else {
+      derniereLigneVide = false;
+      donnees += `${ligne}\n`;
+    }
+  }
+  lecteurStdin.close();
+
+  return donnees;
+};
+
+const transformeEntreeEnTableau = (donnees) => {
+  log.cyan('\nTransformation du CSV…');
+
+  const options = { header: true, skipEmptyLines: true, delimiter: ';' };
+  const donneesFinales = parse(donnees, options).data.map((d) => ({
+    ...d,
+    PROPRIETAIRE: d.PROPRIETAIRE.split(',').map((p) => p.trim()),
+  }));
+
+  log.vert('OK');
+
+  return donneesFinales;
+};
+
+class DuplicationEnMasseDeServices {
+  constructor(environnementNode = process.env.NODE_ENV || 'development') {
+    this.adaptateurPersistance =
+      AdaptateurPostgres.nouvelAdaptateur(environnementNode);
+
+    this.referentiel = Referentiel.creeReferentiel(donneesReferentiel);
+
+    const busEvenements = new BusEvenements({
+      adaptateurGestionErreur: fabriqueAdaptateurGestionErreur(),
+    });
+
+    this.depotDonnees = DepotDonnees.creeDepot({
+      adaptateurChiffrement: fabriqueAdaptateurChiffrement(),
+      adaptateurJWT,
+      adaptateurPersistance: this.adaptateurPersistance,
+      adaptateurUUID: fabriqueAdaptateurUUID(),
+      referentiel: this.referentiel,
+      adaptateurRechercheEntite: adaptateurRechercheEntrepriseAPI,
+      busEvenements,
+    });
+
+    this.procedures = fabriqueProcedures({
+      depotDonnees: this.depotDonnees,
+      adaptateurMail,
+      adaptateurTracking: fabriqueAdaptateurTracking(),
+      busEvenements,
+    });
+  }
+
+  async dupliqueSelonCsvInputDansConsole(
+    emailProprietaireDuModele,
+    idServiceModele
+  ) {
+    const proprietaire = await this.depotDonnees.utilisateurAvecEmail(
+      emailProprietaireDuModele
+    );
+
+    if (!proprietaire) {
+      log.rouge(
+        `Impossible de trouver le propriétaire avec email ${emailProprietaireDuModele}\n`
+      );
+      return;
+    }
+
+    const donnees = await lisEntreeTapeeDansLaConsole();
+    const donneesFormatees = transformeEntreeEnTableau(donnees);
+
+    log.cyan('\nDémarrage de la duplication…');
+
+    for (const serviceADupliquer of donneesFormatees) {
+      const idNouveauService = await this.depotDonnees.dupliqueService(
+        idServiceModele,
+        proprietaire.id,
+        { nomService: serviceADupliquer.ENTITE, siret: serviceADupliquer.SIRET }
+      );
+      for (const emailUtilisateurAInviter of serviceADupliquer.PROPRIETAIRE) {
+        await this.procedures.ajoutContributeurSurServices(
+          emailUtilisateurAInviter,
+          [{ id: idNouveauService }],
+          { estProprietaire: true },
+          proprietaire
+        );
+      }
+    }
+
+    log.vert('\nDuplication terminée avec succès !\n');
+  }
+}
+
+module.exports = DuplicationEnMasseDeServices;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "openid-client": "^5.7.0",
         "p-map": "^4.0.0",
         "p-throttle": "4.1.1",
+        "papaparse": "^5.5.2",
         "pdf-lib": "^1.17.1",
         "pg": "^8.8.0",
         "pug": "^3.0.2",
@@ -8254,6 +8255,12 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -18464,6 +18471,11 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "openid-client": "^5.7.0",
     "p-map": "^4.0.0",
     "p-throttle": "4.1.1",
+    "papaparse": "^5.5.2",
     "pdf-lib": "^1.17.1",
     "pg": "^8.8.0",
     "pug": "^3.0.2",

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -392,22 +392,31 @@ const creeDepot = (config = {}) => {
     return indexMax(sesServices);
   };
 
-  const dupliqueService = async (idService, idProprietaire) => {
+  const dupliqueService = async (
+    idService,
+    idProprietaire,
+    nouveauNomEtSiret = null
+  ) => {
     const duplique = async (s) => {
-      const nomDuplication = `${s.nomService()} - Copie`;
-      const donneesADupliquer = (index) =>
-        s.donneesADupliquer(`${nomDuplication} ${index}`);
+      if (nouveauNomEtSiret) {
+        const donnees = s.donneesADupliquer(
+          nouveauNomEtSiret.nomService,
+          nouveauNomEtSiret.siret
+        );
+        return nouveauService(idProprietaire, donnees);
+      }
 
-      const index = await trouveIndexDisponible(idProprietaire, nomDuplication);
-      const donnees = donneesADupliquer(index);
-      await nouveauService(idProprietaire, donnees);
+      const nomCopie = `${s.nomService()} - Copie`;
+      const index = await trouveIndexDisponible(idProprietaire, nomCopie);
+      const donnees = s.donneesADupliquer(`${nomCopie} ${index}`);
+      return nouveauService(idProprietaire, donnees);
     };
 
     const s = await p.lis.un(idService);
     if (typeof s === 'undefined')
       throw new ErreurServiceInexistant(`Service "${idService}" non trouvé`);
 
-    await duplique(s);
+    return duplique(s);
   };
 
   const metsAJourService = async (unService) => {

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -305,9 +305,12 @@ class Service {
     this.dossiers.supprimeDossierCourant();
   }
 
-  donneesADupliquer(nomService) {
+  donneesADupliquer(nomService, siret = '') {
     const donnees = this.donneesAPersister().sauf('dossiers', 'id');
     donnees.descriptionService.nomService = nomService;
+    if (siret) {
+      donnees.descriptionService.organisationResponsable.siret = siret;
+    }
     return donnees;
   }
 

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -1562,6 +1562,25 @@ describe('Le dépôt de données des services', () => {
       expect(s2.nomService()).to.equal('Service à dupliquer - Copie 1');
       expect(s3.nomService()).to.equal('Service à dupliquer - Copie 2');
     });
+
+    it('peut utiliser un nom et un siret prédéfini pour le service dupliqué', async () => {
+      await depot.dupliqueService('123-1', '123', {
+        nomService: 'Un nom prédéfini',
+        siret: 'UN_SIRET',
+      });
+
+      // eslint-disable-next-line no-unused-vars
+      const [_, s2] = await depot.services('123');
+
+      expect(s2.nomService()).to.equal('Un nom prédéfini');
+      expect(s2.siretDeOrganisation()).to.equal('UN_SIRET');
+    });
+
+    it("retourne l'id du service dupliqué", async () => {
+      const idServiceDuplique = await depot.dupliqueService('123-1', '123');
+
+      expect(idServiceDuplique).to.match(/[a-zA-Z0-9-]{36}/);
+    });
   });
 
   describe("sur une demande d'un index de copie disponible pour un service à dupliquer", () => {

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -896,6 +896,22 @@ describe('Un service', () => {
       );
     });
 
+    it("utilise le siret s'il est passé en paramètre", () => {
+      const service = new Service(
+        { id: 'id-service', descriptionService },
+        referentiel
+      );
+
+      const duplicata = service.donneesADupliquer(
+        'Nouveau service',
+        'NOUVEAU_SIRET'
+      );
+
+      expect(
+        duplicata.descriptionService.organisationResponsable.siret
+      ).to.equal('NOUVEAU_SIRET');
+    });
+
     it("ne duplique pas les dossiers de l'homologation", () => {
       const service = new Service(
         {


### PR DESCRIPTION
... en permettant la duplication d'un service avec un nom prédéfini.

On augmente la fonction `dupliqueService` du dépôt données actuel, afin de pouvoir modifier le nom et le siret du service dupliqué à la demande. On utilise la `procedure` déjà en place pour l'invitation des contributeurs, afin de bénéficier de la logique métier d'envoie de mail.

[Screencast from 02-04-2025 11:12:24.webm](https://github.com/user-attachments/assets/9276ede7-b22a-4947-add8-3c96a5fb927e)

