### PR TITLE
Simplifie la lecture du README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Créer un fichier `.env` à partir du fichier `.env.template` et renseigner les 
 Démarrer la base de données
 
 ```sh
-$ docker compose up mss-db -d
+$ docker compose up mss-db --build -d
 ```
 
 Se connecter au conteneur de la base de données et créer une nouvelle base `mss` pour un utilisateur postgres.
@@ -65,7 +65,7 @@ Le serveur est configuré et prêt à être redémarré.
 ## 🌐 Lancement du serveur
 
 ```sh
-$ docker compose up web
+$ ./scripts/start.sh
 ```
 
 ⚠ La première fois: l'erreur suivante sur le sels doit s'afficher :
@@ -83,7 +83,7 @@ $ ./scripts/dev_init_sel.sh
 Redémarrez le serveur :
 
 ```sh
-$ docker compose up web
+$ ./scripts/start.sh
 ```
 
 Le serveur devrait être accessible depuis un navigateur à l'URL

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-docker compose up web
+docker compose up web --build


### PR DESCRIPTION
On recommande l'utilisation de --build a chaque run docker compose pour s'assurer qu'on fait bien trouver la dernière version. S'il n'y a pas de changements, le cache docker permet au build de s'exécuter très rapidement.

On abstrait la commande derrière scripts/start.sh