### PR TITLE
[CORRECTION] Ne permet pas de réinitialiser un mot de passe pour les utilisateurs "Pro Connecté"

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -155,6 +155,15 @@ function fabriquePersistance({
       efface: async (id) =>
         adaptateurPersistance.metsAJourIdResetMdpUtilisateur(id, undefined),
     },
+    estProConnecte: async (email) => {
+      const emailMinuscule = email.toLowerCase();
+      const emailHash = adaptateurChiffrement.hacheSha256(emailMinuscule);
+      const donnees =
+        await adaptateurPersistance.utilisateurAvecEmailHash(emailHash);
+      const donneesDechiffrees = await dechiffreDonneesUtilisateur(donnees);
+
+      return !donneesDechiffrees.motDePasse;
+    },
   };
 }
 
@@ -280,6 +289,8 @@ const creeDepot = (config = {}) => {
   const reinitialiseMotDePasse = async (email) => {
     const u = await p.lis.celuiAvecEmail(email);
     if (!u) return undefined;
+
+    if (await p.estProConnecte(email)) return undefined;
 
     const idResetMotDePasse = adaptateurUUID.genereUUID();
     await p.idResetMotDePasse.sauvegarde(u.id, idResetMotDePasse);

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -924,6 +924,7 @@ describe('Le dépôt de données des utilisateurs', () => {
             id: '123',
             email: 'jean.dupont@mail.fr',
             emailHash: 'jean.dupont@mail.fr-haché256',
+            motDePasse: 'UnMDP',
           })
           .construis(),
       });
@@ -941,6 +942,24 @@ describe('Le dépôt de données des utilisateurs', () => {
       const depot = DepotDonneesUtilisateurs.creeDepot({
         adaptateurChiffrement,
         adaptateurPersistance: unePersistanceMemoire().construis(),
+      });
+
+      const u = await depot.reinitialiseMotDePasse('jean.dupont@mail.fr');
+
+      expect(u).to.be(undefined);
+    });
+
+    it("échoue silencieusement si l'utilisateur est ProConnecté", async () => {
+      const depot = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurChiffrement,
+        adaptateurPersistance: unePersistanceMemoire()
+          .ajouteUnUtilisateur({
+            id: '123',
+            email: 'jean.dupont@mail.fr',
+            emailHash: 'jean.dupont@mail.fr-haché256',
+            motDePasse: undefined,
+          })
+          .construis(),
       });
 
       const u = await depot.reinitialiseMotDePasse('jean.dupont@mail.fr');


### PR DESCRIPTION
... en ne persistant pas d'`idResetMdp`, et en n'envoyant pas d'email. 
On sait qu'un utilisateur est ProConnecté s'il n'a pas de mot de passe dans ses données persistées.