### PR TITLE
[CORRECTION] Décode les informations de l'utilisateur avant de les rendre dans le front du Profil

### DIFF
--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -78,7 +78,12 @@ const routesConnectePage = ({
       const entite = utilisateur.entite.siret ? utilisateur.entite : undefined;
 
       reponse.render('profil', {
-        utilisateur,
+        utilisateur: {
+          ...utilisateur,
+          nom: decode(utilisateur.nom),
+          prenom: decode(utilisateur.prenom),
+          postes: utilisateur.postes.map(decode),
+        },
         departements,
         estimationNombreServices,
         entite,

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -169,6 +169,26 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
         undefined
       );
     });
+
+    it("décode le nom, le prénom et les postes de l'utilisateur", async () => {
+      const apostrophe = '&#x27;';
+      testeur.middleware().reinitialise({ idUtilisateur: '456' });
+      testeur.depotDonnees().utilisateur = () =>
+        unUtilisateur()
+          .quiSAppelle(`un${apostrophe}e apo${apostrophe}strophe`)
+          .avecPostes([`Apo${apostrophe}strophe`])
+          .construis();
+
+      const reponse = await axios.get(`http://localhost:1234/profil`);
+
+      const donneesUtilisateur = donneesPartagees(
+        reponse.data,
+        'donnees-profil'
+      ).utilisateur;
+      expect(donneesUtilisateur.prenom).to.be("un'e");
+      expect(donneesUtilisateur.nom).to.be("apo'strophe");
+      expect(donneesUtilisateur.postes).to.eql(["Apo'strophe"]);
+    });
   });
 
   describe('quand GET sur /tableauDeBord', () => {


### PR DESCRIPTION
... car les chaines sont "encodées" en HTML Entities.

| Avant | Après |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cd4ad4c7-c7e3-4959-a220-29cecac52e98) | ![image](https://github.com/user-attachments/assets/8ba660af-48d9-4e83-8583-eaf7b1c5825e) | 