### PR TITLE
[CORRECTION] Ajoute une sécurité si l'API ne renvoi pas de notification

### DIFF
--- a/svelte/lib/ui/stores/notifications.store.ts
+++ b/svelte/lib/ui/stores/notifications.store.ts
@@ -19,7 +19,7 @@ export const storeNotifications = {
   subscribe,
   rafraichis: async () => {
     const reponse = await axios.get('/api/notifications');
-    const toutesNotifications = reponse.data.notifications;
+    const toutesNotifications = reponse.data.notifications ?? [];
     set({
       pourCentreNotifications: toutesNotifications.filter(
         (n: Notification) => n.canalDiffusion === 'centreNotifications'


### PR DESCRIPTION
... en lien avec les erreurs sur Sentry `Cannot read properties of undefined (reading 'filter')`