### PR TITLE
[CORRECTION] Coupe le nom du service s'il ne tient pas sur une ligne

### DIFF
--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -955,6 +955,7 @@ p {
   font-weight: 700;
   line-height: 36px;
   margin: 0 0 28px;
+  word-wrap: break-word;
 }
 
 .tampon-homologation .conteneur-cartouches {


### PR DESCRIPTION
... car sinon, un nom de service comme "MonServiceSécurisé" ne tient pas sur une ligne et déborde.