### PR TITLE
Ajoute un "ZeroWidthSpace" sur le nom du service

### DIFF
--- a/src/pdf/modeles/tamponHomologation.pug
+++ b/src/pdf/modeles/tamponHomologation.pug
@@ -18,7 +18,8 @@ block page
           if (resultat.length < longueurInitiale) resultat += '…';
           return resultat
         }
-      h1!= texteTronque(service.nomService(), 60)
+        const insereEspaceInvisible = (texte) => texte.replace(/(\p{Ll})(\p{Lu})/gu, '$1\u200B$2');
+      h1!= texteTronque(insereEspaceInvisible(service.nomService()), 60)
       .conteneur-cartouches
         +cartouche('Organisation responsable', texteTronque(service.descriptionService.organisationResponsable.nom, 67))
         +cartouche("Date d’homologation", formatteDateFrancaise(new Date(dossier.decision.dateHomologation)))


### PR DESCRIPTION
... afin de pouvoir "couper" proprement les noms de service trop long.