### PR TITLE
[CORRECTION] Reste robuste si l'utilisateur n'a pas de postes

### DIFF
--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -83,7 +83,7 @@ const routesConnectePage = ({
           ...utilisateur,
           nom: decode(utilisateur.nom),
           prenom: decode(utilisateur.prenom),
-          postes: utilisateur.postes.map(decode),
+          postes: utilisateur.postes?.map(decode) || [],
         },
         departements,
         estimationNombreServices,

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -101,9 +101,9 @@ const routesNonConnecteOidc = ({
         utilisateurExistant.id
       );
       const profilAJour = {
-        nom: utilisateurExistant.nom,
-        prenom: utilisateurExistant.prenom,
-        siret: utilisateurExistant.entite.siret,
+        nom: utilisateurExistant.nom || nom,
+        prenom: utilisateurExistant.prenom || prenom,
+        siret: utilisateurExistant.entite.siret || siret,
         email: utilisateurExistant.email,
       };
       const tokenDonneesInvite = utilisateurExistant.estUnInvite()

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -199,6 +199,20 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
       expect(donneesUtilisateur.postes).to.eql(["Apo'strophe"]);
     });
 
+    it("reste robuste si l'utilisateur n'a pas de postes, qui est possible si l'utilisateur n'a jamais fini de remplir son profil", async () => {
+      testeur.middleware().reinitialise({ idUtilisateur: '456' });
+      testeur.depotDonnees().utilisateur = () =>
+        unUtilisateur().avecPostes(null).construis();
+
+      const reponse = await axios.get(`http://localhost:1234/profil`);
+
+      const donneesUtilisateur = donneesPartagees(
+        reponse.data,
+        'donnees-profil'
+      ).utilisateur;
+      expect(donneesUtilisateur.postes).to.eql([]);
+    });
+
     it('rafraîchis les données avec le Profil ANSSI', async () => {
       let depotAppele = false;
       testeur.depotDonnees().rafraichisProfilUtilisateurLocal = async () => {


### PR DESCRIPTION
... lors de l'affichage du profil.

On en profite pour corrige un bug ou, un utilisateur qui n'a pas d'informations MonProfilAnssi se retrouve avec une création de compte avec des champs "undefined".