### PR TITLE
[CORRECTION] Utilise une valeur par défaut pour les `postes` des Utilisateurs

### DIFF
--- a/src/modeles/utilisateur.js
+++ b/src/modeles/utilisateur.js
@@ -24,11 +24,11 @@ class Utilisateur extends Base {
         'email',
         'telephone',
         'cguAcceptees',
-        'postes',
         'infolettreAcceptee',
         'transactionnelAccepte',
         'estimationNombreServices',
       ],
+      proprietesListes: ['postes'],
     });
     valide(donnees);
     this.entite = new Entite(donnees.entite);

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -83,7 +83,7 @@ const routesConnectePage = ({
           ...utilisateur,
           nom: decode(utilisateur.nom),
           prenom: decode(utilisateur.prenom),
-          postes: utilisateur.postes?.map(decode) || [],
+          postes: utilisateur.postes.map(decode),
         },
         departements,
         estimationNombreServices,

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -215,6 +215,15 @@ describe('Un utilisateur', () => {
     expect(Utilisateur.nomsProprietesBase()).to.eql(nomsProprietes);
   });
 
+  it("initialise les postes s'ils ne sont pas définis", () => {
+    const utilisateur = new Utilisateur({
+      email: 'email',
+      postes: undefined,
+    });
+
+    expect(utilisateur.postes).to.eql([]);
+  });
+
   describe("sur une demande de validation des données d'un utilisateur", () => {
     let donnees;
 


### PR DESCRIPTION
... suite à un bug en prod.
On veut que cette propriété soit toujours exploitables.

C'était une erreur lors de l'ajoute de cette propriété, de la mettre en tant que "propriété atomique".