### PR TITLE
Création d'un service "ApresAuthentification"

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -363,7 +363,7 @@ const creeDepot = (config = {}) => {
         email: donneesMPA.email,
         nom: donneesMPA.nom,
         prenom: donneesMPA.prenom,
-        telephone: donneesMPA.telephone,
+        telephone: donneesMPA.telephone || donneesMSS.telephone,
         entite: {
           nom: donneesMPA.organisation.nom,
           departement: donneesMPA.organisation.departement,

--- a/src/utilisateur/serviceApresAuthentification.js
+++ b/src/utilisateur/serviceApresAuthentification.js
@@ -2,9 +2,14 @@ const serviceApresAuthentification = async ({
   adaptateurProfilAnssi,
   serviceAnnuaire,
   profilProConnect,
+  depotDonnees,
 }) => {
   const profilAnssi = await adaptateurProfilAnssi.recupere();
   let donnees = profilAnssi;
+
+  const utilisateur = await depotDonnees.utilisateurAvecEmail(
+    profilProConnect.email
+  );
 
   if (!profilAnssi) {
     let organisation;
@@ -23,13 +28,15 @@ const serviceApresAuthentification = async ({
       prenom: profilProConnect.prenom,
       email: profilProConnect.email,
       organisation,
+      ...(utilisateur && { invite: true }),
     };
   }
 
   return {
     type: 'redirection',
-    cible: '/creation-compte',
+    cible: utilisateur ? '/apres-authentification' : '/creation-compte',
     donnees,
+    utilisateurAConnecter: utilisateur,
   };
 };
 

--- a/src/utilisateur/serviceApresAuthentification.js
+++ b/src/utilisateur/serviceApresAuthentification.js
@@ -56,8 +56,8 @@ const serviceApresAuthentification = async ({
       serviceAnnuaire,
     });
     return {
-      type: 'redirection',
-      cible: '/apres-authentification',
+      type: 'rendu',
+      cible: 'apresAuthentification',
       donnees: {
         ...donneesUtilisateur,
         invite: true,
@@ -68,9 +68,20 @@ const serviceApresAuthentification = async ({
 
   await depotDonnees.rafraichisProfilUtilisateurLocal(utilisateur.id);
 
+  const utilisateurAJour = await depotDonnees.utilisateur(utilisateur.id);
+  if (!utilisateurAJour.aLesInformationsAgentConnect()) {
+    await depotDonnees.metsAJourUtilisateur(utilisateur.id, {
+      nom: profilProConnect.nom,
+      prenom: profilProConnect.prenom,
+      entite: {
+        siret: profilProConnect.siret,
+      },
+    });
+  }
+
   return {
-    type: 'redirection',
-    cible: '/apres-authentification',
+    type: 'rendu',
+    cible: 'apresAuthentification',
     utilisateurAConnecter: utilisateur,
   };
 };

--- a/src/utilisateur/serviceApresAuthentification.js
+++ b/src/utilisateur/serviceApresAuthentification.js
@@ -1,0 +1,36 @@
+const serviceApresAuthentification = async ({
+  adaptateurProfilAnssi,
+  serviceAnnuaire,
+  profilProConnect,
+}) => {
+  const profilAnssi = await adaptateurProfilAnssi.recupere();
+  let donnees = profilAnssi;
+
+  if (!profilAnssi) {
+    let organisation;
+    if (profilProConnect.siret) {
+      const organisationTrouvee = (
+        await serviceAnnuaire.rechercheOrganisations(profilProConnect.siret)
+      )[0];
+      organisation = organisationTrouvee && {
+        ...organisationTrouvee,
+        siret: profilProConnect.siret,
+      };
+    }
+
+    donnees = {
+      nom: profilProConnect.nom,
+      prenom: profilProConnect.prenom,
+      email: profilProConnect.email,
+      organisation,
+    };
+  }
+
+  return {
+    type: 'redirection',
+    cible: '/creation-compte',
+    donnees,
+  };
+};
+
+module.exports = { serviceApresAuthentification };

--- a/src/utilisateur/serviceApresAuthentification.js
+++ b/src/utilisateur/serviceApresAuthentification.js
@@ -1,16 +1,10 @@
-const serviceApresAuthentification = async ({
+const recupereDonneesUtilisateur = async ({
   adaptateurProfilAnssi,
-  serviceAnnuaire,
   profilProConnect,
-  depotDonnees,
+  serviceAnnuaire,
 }) => {
   const profilAnssi = await adaptateurProfilAnssi.recupere();
   let donnees = profilAnssi;
-
-  const utilisateur = await depotDonnees.utilisateurAvecEmail(
-    profilProConnect.email
-  );
-
   if (!profilAnssi) {
     let organisation;
     if (profilProConnect.siret) {
@@ -28,14 +22,55 @@ const serviceApresAuthentification = async ({
       prenom: profilProConnect.prenom,
       email: profilProConnect.email,
       organisation,
-      ...(utilisateur && { invite: true }),
+    };
+  }
+  return donnees;
+};
+
+const serviceApresAuthentification = async ({
+  adaptateurProfilAnssi,
+  serviceAnnuaire,
+  profilProConnect,
+  depotDonnees,
+}) => {
+  const utilisateur = await depotDonnees.utilisateurAvecEmail(
+    profilProConnect.email
+  );
+
+  if (!utilisateur) {
+    return {
+      type: 'redirection',
+      cible: '/creation-compte',
+      donnees: await recupereDonneesUtilisateur({
+        adaptateurProfilAnssi,
+        profilProConnect,
+        serviceAnnuaire,
+      }),
     };
   }
 
+  if (utilisateur.estUnInvite()) {
+    const donneesUtilisateur = await recupereDonneesUtilisateur({
+      adaptateurProfilAnssi,
+      profilProConnect,
+      serviceAnnuaire,
+    });
+    return {
+      type: 'redirection',
+      cible: '/apres-authentification',
+      donnees: {
+        ...donneesUtilisateur,
+        invite: true,
+      },
+      utilisateurAConnecter: utilisateur,
+    };
+  }
+
+  await depotDonnees.rafraichisProfilUtilisateurLocal(utilisateur.id);
+
   return {
     type: 'redirection',
-    cible: utilisateur ? '/apres-authentification' : '/creation-compte',
-    donnees,
+    cible: '/apres-authentification',
     utilisateurAConnecter: utilisateur,
   };
 };

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -19,6 +19,13 @@ class ConstructeurUtilisateur {
     };
   }
 
+  quiEstComplet() {
+    return this.quiSAppelle('Jean Dujardin')
+      .quiTravaillePourUneEntiteAvecSiret('1234')
+      .avecEstimationNombreServices(50, 100)
+      .quiAccepteCGU();
+  }
+
   quiNAPasRempliSonProfil() {
     this.donnees.prenom = '';
     this.donnees.nom = '';

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -1219,5 +1219,44 @@ describe('Le dépôt de données des utilisateurs', () => {
         transactionnelAccepte: '',
       });
     });
+    it("n'écrase pas le téléphone si MPA ne l'a pas", async () => {
+      adaptateurProfilAnssi.recupere = async () => ({
+        email: 'email2',
+        nom: 'nom2',
+        prenom: 'prenom2',
+        telephone: '',
+        organisation: {
+          nom: 'nomEntite2',
+          departement: 'departement2',
+          siret: 'siret2',
+        },
+        domainesSpecialite: ['domaine2'],
+      });
+      const adaptateurPersistance = unePersistanceMemoire()
+        .ajouteUnUtilisateur(
+          unUtilisateur()
+            .avecId('U1')
+            .quiSAppelle('nom1 prenom1')
+            .quiAccepteCGU()
+            .avecNomEntite('nomEntite1')
+            .avecTelephone('monTelephoneDansMSS')
+            .avecEmail('email1').donnees
+        )
+        .construis();
+
+      const depot = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurPersistance,
+        adaptateurProfilAnssi,
+        adaptateurChiffrement,
+      });
+
+      await depot.rafraichisProfilUtilisateurLocal('U1');
+
+      const apresRafraichissement = (
+        await adaptateurPersistance.utilisateur('U1')
+      ).donnees;
+
+      expect(apresRafraichissement.telephone).to.be('monTelephoneDansMSS');
+    });
   });
 });

--- a/test/utilisateur/serviceApresAuthentification.spec.js
+++ b/test/utilisateur/serviceApresAuthentification.spec.js
@@ -1,0 +1,131 @@
+const expect = require('expect.js');
+const {
+  serviceApresAuthentification,
+} = require('../../src/utilisateur/serviceApresAuthentification');
+
+describe("Le service d'après authentification", () => {
+  let adaptateurProfilAnssi;
+  let serviceAnnuaire;
+  let profilProConnect;
+
+  beforeEach(() => {
+    adaptateurProfilAnssi = {
+      recupere: async () => undefined,
+    };
+    serviceAnnuaire = {
+      rechercheOrganisations: async () => [],
+    };
+    profilProConnect = {
+      complet: () => ({
+        email: 'jean.dujardin@beta.gouv.fr',
+        nom: 'Dujardin',
+        prenom: 'Jean',
+        siret: '1234',
+      }),
+      sansSiret: () => ({
+        ...profilProConnect.complet(),
+        siret: undefined,
+      }),
+    };
+  });
+
+  describe("lorsque MSS ne connaît pas l'utilisateur", () => {
+    it('redirige vers la page de création de compte', async () => {
+      const resultat = await serviceApresAuthentification({
+        adaptateurProfilAnssi,
+        serviceAnnuaire,
+        profilProConnect: {
+          siret: undefined,
+        },
+      });
+
+      expect(resultat.type).to.be('redirection');
+      expect(resultat.cible).to.be('/creation-compte');
+    });
+
+    describe('concernant les données utilisateur', () => {
+      describe("si l'utilisateur est connu dans MPA", () => {
+        it('renvoie les données de MPA', async () => {
+          adaptateurProfilAnssi.recupere = async () => ({
+            email: 'jean.dujardin@beta.gouv.fr',
+            nom: 'Dujardin',
+            prenom: 'Jean',
+            telephone: '0102030405',
+            organisation: {
+              nom: 'MonOrganisation',
+              departement: '75',
+              siret: '1234',
+            },
+            domainesSpecialite: ['RSSI'],
+          });
+          const resultat = await serviceApresAuthentification({
+            adaptateurProfilAnssi,
+          });
+
+          expect(resultat.donnees).to.eql({
+            email: 'jean.dujardin@beta.gouv.fr',
+            nom: 'Dujardin',
+            prenom: 'Jean',
+            telephone: '0102030405',
+            organisation: {
+              nom: 'MonOrganisation',
+              departement: '75',
+              siret: '1234',
+            },
+            domainesSpecialite: ['RSSI'],
+          });
+        });
+      });
+
+      describe("si l'utilisateur est inconnu dans MPA", () => {
+        it("renvoie les données de ProConnect complétées par l'annuaire recherche entreprise", async () => {
+          serviceAnnuaire.rechercheOrganisations = async (siret) =>
+            siret === '1234'
+              ? [{ nom: 'MonOrganisation', departement: '75' }]
+              : [];
+
+          const resultat = await serviceApresAuthentification({
+            adaptateurProfilAnssi,
+            serviceAnnuaire,
+            profilProConnect: profilProConnect.complet(),
+          });
+
+          expect(resultat.donnees).to.eql({
+            email: 'jean.dujardin@beta.gouv.fr',
+            nom: 'Dujardin',
+            prenom: 'Jean',
+            organisation: {
+              nom: 'MonOrganisation',
+              departement: '75',
+              siret: '1234',
+            },
+          });
+        });
+
+        it("reste robuste si le siret n'est pas dans ProConnect", async () => {
+          const resultat = await serviceApresAuthentification({
+            adaptateurProfilAnssi,
+            serviceAnnuaire,
+            profilProConnect: profilProConnect.sansSiret(),
+          });
+
+          expect(resultat.donnees.organisation).to.be(undefined);
+        });
+
+        it("reste robuste si l'entreprise n'est pas trouvée", async () => {
+          const resultat = await serviceApresAuthentification({
+            adaptateurProfilAnssi,
+            serviceAnnuaire: {
+              rechercheOrganisations: async () => [],
+            },
+            profilProConnect: profilProConnect.complet(),
+          });
+
+          expect(resultat.donnees.organisation).to.be(undefined);
+        });
+      });
+    });
+  });
+
+  describe("lorsque MSS connaît l'utilisateur", () => {});
+});


### PR DESCRIPTION
Nous rencontrons des problèmes de compréhension et de lourdeur sur la route responsable de l'authentification d'un utilisateur après ProConnect. Cela est dû au fait que nous essayons désormais d'intégrer MonProfilANSSI. Nous avons donc 3 sources de données potentielles pour un utilisateur : MonProfilANSSI, ProConnect et MonServiceSécurisé.

Cette PR à pour but de sortir la logique de cette route dans un `service` permettant de simplifier la compréhension et les tests associés.

##### Chemin de PR :
- [X] Création du Service Après Authentification :point_left: Cette PR
- [ ] Création d'une fonction "d'execution" utilisant le retour de ce service
- [ ] Utilisation de cette fonction dans la route `/apres-authentification`
- [ ] Nettoyage de la route `/creation-compte`

##### Schéma des cas logiques de la route
![MonServiceSécurisé(3)](https://github.com/user-attachments/assets/fbf81a9a-5374-4f21-807c-03740cce67bd)
