### PR TITLE
Exécute l'ordre du service après authentification

### DIFF
--- a/src/utilisateur/executeurApresAuthentification.js
+++ b/src/utilisateur/executeurApresAuthentification.js
@@ -1,7 +1,31 @@
-const executeurApresAuthentification = (
+const SourceAuthentification = require('../modeles/sourceAuthentification');
+
+const executeurApresAuthentification = async (
   ordre,
-  { reponse, adaptateurJWT, urlRedirection, adaptateurEnvironnement }
+  {
+    requete,
+    reponse,
+    agentConnectIdToken,
+    adaptateurJWT,
+    depotDonnees,
+    urlRedirection,
+    adaptateurEnvironnement,
+    serviceGestionnaireSession,
+  }
 ) => {
+  if (ordre.utilisateurAConnecter) {
+    serviceGestionnaireSession.enregistreSession(
+      requete,
+      ordre.utilisateurAConnecter,
+      SourceAuthentification.AGENT_CONNECT
+    );
+    requete.session.AgentConnectIdToken = agentConnectIdToken;
+    await depotDonnees.enregistreNouvelleConnexionUtilisateur(
+      ordre.utilisateurAConnecter.id,
+      SourceAuthentification.AGENT_CONNECT
+    );
+  }
+
   switch (ordre.type) {
     case 'rendu':
       reponse.render(ordre.cible, {

--- a/src/utilisateur/executeurApresAuthentification.js
+++ b/src/utilisateur/executeurApresAuthentification.js
@@ -1,13 +1,19 @@
-const executeurApresAuthentification = (ordre, { reponse, adaptateurJWT }) => {
+const executeurApresAuthentification = (
+  ordre,
+  { reponse, adaptateurJWT, urlRedirection, adaptateurEnvironnement }
+) => {
   switch (ordre.type) {
     case 'rendu':
-      if (ordre.donnees) {
-        reponse.render(ordre.cible, {
+      reponse.render(ordre.cible, {
+        ...(ordre.donnees && {
           tokenDonneesInvite: adaptateurJWT.signeDonnees(ordre.donnees),
-        });
-      } else {
-        reponse.render(ordre.cible);
-      }
+        }),
+        ...(urlRedirection && {
+          urlRedirection: `${adaptateurEnvironnement
+            .mss()
+            .urlBase()}${urlRedirection}`,
+        }),
+      });
       break;
     case 'redirection':
       if (ordre.donnees) {

--- a/src/utilisateur/executeurApresAuthentification.js
+++ b/src/utilisateur/executeurApresAuthentification.js
@@ -1,0 +1,24 @@
+const executeurApresAuthentification = (ordre, { reponse, adaptateurJWT }) => {
+  switch (ordre.type) {
+    case 'rendu':
+      if (ordre.donnees) {
+        reponse.render(ordre.cible, {
+          tokenDonneesInvite: adaptateurJWT.signeDonnees(ordre.donnees),
+        });
+      } else {
+        reponse.render(ordre.cible);
+      }
+      break;
+    case 'redirection':
+      if (ordre.donnees) {
+        const token = adaptateurJWT.signeDonnees(ordre.donnees);
+        reponse.redirect(`${ordre.cible}?token=${token}`);
+      } else {
+        reponse.redirect(`${ordre.cible}`);
+      }
+      break;
+    default:
+      break;
+  }
+};
+module.exports = { executeurApresAuthentification };

--- a/test/utilisateur/executeurApresAuthentification.spec.js
+++ b/test/utilisateur/executeurApresAuthentification.spec.js
@@ -1,0 +1,83 @@
+const expect = require('expect.js');
+const {
+  executeurApresAuthentification,
+} = require('../../src/utilisateur/executeurApresAuthentification');
+
+class MockReponse {
+  redirect(cible) {
+    this.urlRedirection = cible;
+  }
+
+  render(cible, donnees) {
+    this.pageRendue = cible;
+    this.donneesDeRenduDePage = donnees;
+  }
+}
+
+describe("L'executeur après authentification", () => {
+  let reponse;
+  beforeEach(() => {
+    reponse = new MockReponse();
+  });
+  describe("lorsque le type de l'ordre est une redirection", () => {
+    it('redirige', () => {
+      const ordre = {
+        type: 'redirection',
+        cible: '/une-url',
+      };
+
+      executeurApresAuthentification(ordre, { reponse });
+
+      expect(reponse.urlRedirection).to.be('/une-url');
+    });
+
+    it("génère un token avec les données de l'ordre", () => {
+      const ordre = {
+        type: 'redirection',
+        cible: '/une-url',
+        donnees: {
+          champ: 'valeur',
+        },
+      };
+      const adaptateurJWT = {
+        signeDonnees: (donnees) => `${donnees.champ}-jwt`,
+      };
+
+      executeurApresAuthentification(ordre, { reponse, adaptateurJWT });
+
+      expect(reponse.urlRedirection).to.be('/une-url?token=valeur-jwt');
+    });
+  });
+
+  describe("lorsque le type de l'ordre est un rendu", () => {
+    it('rend une page', () => {
+      const ordre = {
+        type: 'rendu',
+        cible: 'un-pug',
+      };
+
+      executeurApresAuthentification(ordre, { reponse });
+
+      expect(reponse.pageRendue).to.be('un-pug');
+    });
+
+    it("génère un token avec les données de l'ordre", () => {
+      const ordre = {
+        type: 'rendu',
+        cible: 'un-pug',
+        donnees: {
+          champ: 'valeur',
+        },
+      };
+      const adaptateurJWT = {
+        signeDonnees: (donnees) => `${donnees.champ}-jwt`,
+      };
+
+      executeurApresAuthentification(ordre, { reponse, adaptateurJWT });
+
+      expect(reponse.donneesDeRenduDePage).to.eql({
+        tokenDonneesInvite: 'valeur-jwt',
+      });
+    });
+  });
+});

--- a/test/utilisateur/executeurApresAuthentification.spec.js
+++ b/test/utilisateur/executeurApresAuthentification.spec.js
@@ -2,6 +2,8 @@ const expect = require('expect.js');
 const {
   executeurApresAuthentification,
 } = require('../../src/utilisateur/executeurApresAuthentification');
+const { unUtilisateur } = require('../constructeurs/constructeurUtilisateur');
+const SourceAuthentification = require('../../src/modeles/sourceAuthentification');
 
 class MockReponse {
   redirect(cible) {
@@ -16,22 +18,24 @@ class MockReponse {
 
 describe("L'executeur après authentification", () => {
   let reponse;
+
   beforeEach(() => {
     reponse = new MockReponse();
   });
+
   describe("lorsque le type de l'ordre est une redirection", () => {
-    it('redirige', () => {
+    it('redirige', async () => {
       const ordre = {
         type: 'redirection',
         cible: '/une-url',
       };
 
-      executeurApresAuthentification(ordre, { reponse });
+      await executeurApresAuthentification(ordre, { reponse });
 
       expect(reponse.urlRedirection).to.be('/une-url');
     });
 
-    it("génère un token avec les données de l'ordre", () => {
+    it("génère un token avec les données de l'ordre", async () => {
       const ordre = {
         type: 'redirection',
         cible: '/une-url',
@@ -43,7 +47,7 @@ describe("L'executeur après authentification", () => {
         signeDonnees: (donnees) => `${donnees.champ}-jwt`,
       };
 
-      executeurApresAuthentification(ordre, { reponse, adaptateurJWT });
+      await executeurApresAuthentification(ordre, { reponse, adaptateurJWT });
 
       expect(reponse.urlRedirection).to.be('/une-url?token=valeur-jwt');
     });
@@ -60,13 +64,13 @@ describe("L'executeur après authentification", () => {
       };
     });
 
-    it('rend une page', () => {
+    it('rend une page', async () => {
       const ordre = {
         type: 'rendu',
         cible: 'un-pug',
       };
 
-      executeurApresAuthentification(ordre, { reponse });
+      await executeurApresAuthentification(ordre, { reponse });
 
       expect(reponse.pageRendue).to.be('un-pug');
     });
@@ -88,16 +92,16 @@ describe("L'executeur après authentification", () => {
         };
       });
 
-      it("génère un token avec les données de l'ordre", () => {
-        executeurApresAuthentification(ordre, { reponse, adaptateurJWT });
+      it("génère un token avec les données de l'ordre", async () => {
+        await executeurApresAuthentification(ordre, { reponse, adaptateurJWT });
 
         expect(reponse.donneesDeRenduDePage).to.eql({
           tokenDonneesInvite: 'valeur-jwt',
         });
       });
 
-      it("ajoute l'url de redirection si elle est fournie", () => {
-        executeurApresAuthentification(ordre, {
+      it("ajoute l'url de redirection si elle est fournie", async () => {
+        await executeurApresAuthentification(ordre, {
           reponse,
           adaptateurEnvironnement,
           urlRedirection: '/tableau-bord',
@@ -111,13 +115,13 @@ describe("L'executeur après authentification", () => {
       });
     });
     describe("lorsqu'aucune donnée n'est fournie", () => {
-      it("ajoute l'url de redirection si elle est fournie", () => {
+      it("ajoute l'url de redirection si elle est fournie", async () => {
         const ordre = {
           type: 'rendu',
           cible: 'un-pug',
         };
 
-        executeurApresAuthentification(ordre, {
+        await executeurApresAuthentification(ordre, {
           reponse,
           adaptateurEnvironnement,
           urlRedirection: '/tableau-bord',
@@ -127,6 +131,90 @@ describe("L'executeur après authentification", () => {
           urlRedirection: 'http://mss/tableau-bord',
         });
       });
+    });
+  });
+
+  describe("lorsqu'il y a un utilisateur à connecter", () => {
+    let utilisateurAConnecter;
+    let ordre;
+    let serviceGestionnaireSession;
+    let requete;
+    let depotDonnees;
+
+    beforeEach(() => {
+      utilisateurAConnecter = unUtilisateur()
+        .avecId('U1')
+        .quiEstComplet()
+        .construis();
+      ordre = {
+        utilisateurAConnecter,
+      };
+      serviceGestionnaireSession = {
+        enregistreSession: () => {},
+      };
+      requete = {
+        session: {},
+      };
+      depotDonnees = {
+        enregistreNouvelleConnexionUtilisateur: async () => {},
+      };
+    });
+
+    it('enregistre une session', async () => {
+      let sessionEnregistree;
+      serviceGestionnaireSession = {
+        enregistreSession: (req, utilisateur, source) => {
+          sessionEnregistree = { requete: req, utilisateur, source };
+        },
+      };
+      await executeurApresAuthentification(ordre, {
+        serviceGestionnaireSession,
+        requete,
+        depotDonnees,
+      });
+
+      expect(sessionEnregistree).not.to.be(undefined);
+      expect(sessionEnregistree.requete).to.eql(requete);
+      expect(sessionEnregistree.utilisateur).to.be(utilisateurAConnecter);
+      expect(sessionEnregistree.source).to.be(
+        SourceAuthentification.AGENT_CONNECT
+      );
+    });
+
+    it("enregistre l'idToken de ProConnect", async () => {
+      await executeurApresAuthentification(ordre, {
+        serviceGestionnaireSession,
+        requete,
+        agentConnectIdToken: 'Un token ProConnect',
+        depotDonnees,
+      });
+
+      expect(requete.session.AgentConnectIdToken).to.be('Un token ProConnect');
+    });
+
+    it('enregistre une nouvelle connexion', async () => {
+      let connexionEnregistree;
+      depotDonnees = {
+        enregistreNouvelleConnexionUtilisateur: async (
+          idUtilisateur,
+          source
+        ) => {
+          connexionEnregistree = { idUtilisateur, source };
+        },
+      };
+
+      await executeurApresAuthentification(ordre, {
+        serviceGestionnaireSession,
+        requete,
+        agentConnectIdToken: 'Un token ProConnect',
+        depotDonnees,
+      });
+
+      expect(connexionEnregistree).not.to.be(undefined);
+      expect(connexionEnregistree.idUtilisateur).to.be('U1');
+      expect(connexionEnregistree.source).to.be(
+        SourceAuthentification.AGENT_CONNECT
+      );
     });
   });
 });


### PR DESCRIPTION
Le `serviceApresAuthentification` retourne un "ordre" qui doit être exécuter.
Il gère la redirection, le rendu de page, la connexion d'un utilisateur et la génération de token JWT.