### PR TITLE
Branche le service après authentification

### DIFF
--- a/src/mss.ts
+++ b/src/mss.ts
@@ -143,6 +143,8 @@ const creeServeur = ({
       middleware,
       adaptateurEnvironnement,
       serviceGestionnaireSession,
+      adaptateurProfilAnssi,
+      serviceAnnuaire,
     })
   );
   app.use(

--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -4,6 +4,9 @@ const { estUrlLegalePourRedirection } = require('../../http/redirection');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('../../adaptateurs/fabriqueAdaptateurGestionErreur');
+const {
+  serviceApresAuthentification,
+} = require('../../utilisateur/serviceApresAuthentification');
 
 const routesNonConnecteOidc = ({
   adaptateurOidc,
@@ -12,6 +15,8 @@ const routesNonConnecteOidc = ({
   middleware,
   adaptateurEnvironnement,
   serviceGestionnaireSession,
+  adaptateurProfilAnssi,
+  serviceAnnuaire,
 }) => {
   const routes = express.Router();
 
@@ -59,6 +64,14 @@ const routesNonConnecteOidc = ({
       const { nom, prenom, email, siret } =
         await adaptateurOidc.recupereInformationsUtilisateur(accessToken);
       const profilProConnect = { nom, prenom, email, siret };
+
+      await serviceApresAuthentification({
+        adaptateurProfilAnssi,
+        serviceAnnuaire,
+        profilProConnect,
+        depotDonnees,
+      });
+
       let utilisateurExistant = await depotDonnees.utilisateurAvecEmail(email);
 
       if (!utilisateurExistant) {

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -10,8 +10,6 @@ const routesNonConnectePage = ({
   adaptateurEnvironnement,
   adaptateurStatistiques,
   adaptateurJWT,
-  adaptateurProfilAnssi,
-  serviceAnnuaire,
   depotDonnees,
   middleware,
   referentiel,
@@ -74,40 +72,19 @@ const routesNonConnectePage = ({
       return;
     }
 
-    let donneesUtilisateur;
+    let informationsProfessionnelles;
     try {
-      donneesUtilisateur = adaptateurJWT.decode(token);
+      informationsProfessionnelles = adaptateurJWT.decode(token);
     } catch (e) {
       reponse.sendStatus(400);
       return;
     }
 
-    const { prenom, nom, email, siret, invite } = donneesUtilisateur;
-
-    const profilAnssi = await adaptateurProfilAnssi.recupere(email);
-
-    let organisation;
-    if (profilAnssi) organisation = profilAnssi.organisation;
-    else if (siret) {
-      const organisations = await serviceAnnuaire.rechercheOrganisations(siret);
-      if (organisations.length > 0)
-        organisation = {
-          siret,
-          departement: organisations[0].departement,
-          nom: organisations[0].nom,
-        };
-    }
+    const { invite } = informationsProfessionnelles;
 
     reponse.render('creation-compte', {
       estimationNombreServices: referentiel.estimationNombreServices(),
-      informationsProfessionnelles: {
-        prenom,
-        nom,
-        email,
-        organisation,
-        telephone: profilAnssi?.telephone,
-        domainesSpecialite: profilAnssi?.domainesSpecialite,
-      },
+      informationsProfessionnelles,
       departements: referentiel.departements(),
       invite: !!invite,
     });

--- a/src/utilisateur/serviceApresAuthentification.js
+++ b/src/utilisateur/serviceApresAuthentification.js
@@ -21,7 +21,7 @@ const recupereDonneesUtilisateur = async ({
       nom: profilProConnect.nom,
       prenom: profilProConnect.prenom,
       email: profilProConnect.email,
-      organisation,
+      ...(organisation && { organisation }),
     };
   }
   return donnees;

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -100,6 +100,7 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
       testeur.depotDonnees().utilisateur = () => utilisateur;
       testeur.depotDonnees().enregistreNouvelleConnexionUtilisateur = () => {};
       testeur.depotDonnees().metsAJourUtilisateur = () => {};
+      testeur.depotDonnees().rafraichisProfilUtilisateurLocal = () => {};
       testeur.middleware().reinitialise({
         fonctionDeposeCookieAAppeler: (requete) =>
           (requete.cookies.AgentConnectInfo = {
@@ -107,6 +108,8 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
             nonce: 'unNonce',
           }),
       });
+      testeur.adaptateurProfilAnssi().recupere = () => undefined;
+      testeur.serviceAnnuaire().rechercheOrganisations = () => [];
     });
 
     it('sert une page HTML', async () => {

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -214,7 +214,6 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
           email: 'unEmailInconnu',
           nom: 'Dujardin',
           prenom: 'Jean',
-          siret: '12345',
         });
       });
     });
@@ -405,11 +404,15 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
           donneesRecuesPourCreationTokenSigne = donnees;
           return 'unJetonSigne';
         };
+        testeur.adaptateurOidc().recupereInformationsUtilisateur =
+          async () => ({
+            email: 'jean.dujardin@beta.gouv.fr',
+            nom: 'Dujardin',
+            prenom: 'Jean',
+          });
         testeur.depotDonnees().utilisateur = async () => {
           const utilisateurExistant = unUtilisateur()
             .avecEmail('jean.dujardin@beta.gouv.fr')
-            .quiSAppelle('Jean Dujardin')
-            .quiTravaillePourUneEntiteAvecSiret('12345')
             .quiAEteInvite()
             .construis();
           utilisateurExistant.genereToken = () => 'un token';
@@ -428,7 +431,6 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
           email: 'jean.dujardin@beta.gouv.fr',
           nom: 'Dujardin',
           prenom: 'Jean',
-          siret: '12345',
           invite: true,
         });
         expect(donneesPartagees(reponse.data, 'tokenDonneesInvite')).to.eql({
@@ -473,7 +475,6 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
           email: 'jean.dujardin@beta.gouv.fr',
           nom: 'Dujardin ProConnect',
           prenom: 'Jean ProConnect',
-          siret: '12345',
           invite: true,
         });
         expect(donneesPartagees(reponse.data, 'tokenDonneesInvite')).to.eql({

--- a/test/utilisateur/serviceApresAuthentification.spec.js
+++ b/test/utilisateur/serviceApresAuthentification.spec.js
@@ -132,6 +132,7 @@ describe("Le service d'après authentification", () => {
           });
 
           expect(resultat.donnees.organisation).to.be(undefined);
+          expect(Object.keys(resultat.donnees)).to.not.contain('organisation');
         });
       });
     });


### PR DESCRIPTION
Le `serviceApresAuthentification` retourne un "ordre" qui est exécuté et qui remplace le mécanisme de la route OIDC existante.

##### Chemin de PR :
- [X] #2144 
- [X] #2147 
- [X] Utilisation de cette fonction dans la route `/apres-authentification` :point_left: **Cette PR**
- [X] Nettoyage de la route `/creation-compte` :point_left: **Cette PR**

##### Schéma des cas logiques de la route
![MonServiceSécurisé(3)](https://github.com/user-attachments/assets/fbf81a9a-5374-4f21-807c-03740cce67bd)