### PR TITLE
Rejette les requêtes depuis des IPs invalides avec 401

### DIFF
--- a/src/adaptateurs/adaptateurGestionErreurSentry.js
+++ b/src/adaptateurs/adaptateurGestionErreurSentry.js
@@ -35,8 +35,9 @@ const controleurErreurs = (erreur, requete, reponse, suite) => {
   const estErreurDeFiltrageIp = erreur instanceof IpDeniedError;
   if (estErreurDeFiltrageIp) {
     // On termine la connexion directement si qqun nous appelle sans passer par Baleen.
+    reponse.status(401);
     reponse.end();
-    return suite();
+    return;
   }
   const estErreurCSRF = erreur.message === 'CSRF token mismatch';
   if (estErreurCSRF) {
@@ -51,7 +52,7 @@ const controleurErreurs = (erreur, requete, reponse, suite) => {
     });
   }
 
-  return Sentry.Handlers.errorHandler()(erreur, requete, reponse, suite);
+  Sentry.Handlers.errorHandler()(erreur, requete, reponse, suite);
 };
 
 const identifieUtilisateur = (idUtilisateur, timestampTokenJwt) => {


### PR DESCRIPTION
Lorsqu'on accède à l'application directement sans passer par le waf
Dans le but de le court-circuiter
Alors on doit recevoir une erreur HTTP/401
Pourtant, on observe un code retour HTTP/200

C'était pas catastrophique parce que la réponse était quand même vide et le filtrage IP fonctionnel mais on retournait 200 au lieu de 401.

Comment vérifier, en démo :

```bash
#> curl -k https://domain.scw.clever-cloud.com -H 'Host: demo.monservicesecurise.cyber.gouv.fr' -I
HTTP/1.1 200 OK
```

Alors qu'on attendrait : 

```bash
#> curl -k https://domain.scw.clever-cloud.com -H 'Host: demo.monservicesecurise.cyber.gouv.fr' -I
HTTP/1.1 401 OK
```