### PR TITLE
Répond 401 si une déconnexion est tentée alors qu'il manque le cookie

### DIFF
--- a/src/routes/nonConnecte/routesNonConnecteOidc.js
+++ b/src/routes/nonConnecte/routesNonConnecteOidc.js
@@ -91,7 +91,7 @@ const routesNonConnecteOidc = ({
   });
 
   routes.get('/apres-deconnexion', async (requete, reponse) => {
-    const { state } = requete.cookies.AgentConnectInfo;
+    const state = requete.cookies.AgentConnectInfo?.state;
     if (state !== requete.query.state) {
       reponse.sendStatus(401);
       return;

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -518,6 +518,20 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
       expect(reponse.status).to.be(401);
     });
 
+    it("ne déconnecte pas l'utilisateur si le cookie n'est pas positionné", async () => {
+      testeur.middleware().reinitialise({
+        fonctionDeposeCookieAAppeler: (requete) => {
+          requete.cookies.AgentConnectInfo = null;
+        },
+      });
+
+      const reponse = await requeteSansRedirection(
+        'http://localhost:1234/oidc/apres-deconnexion?state=unState'
+      );
+
+      expect(reponse.status).to.be(401);
+    });
+
     it('supprime le cookie contenant le state', async () => {
       const reponse = await requeteSansRedirection(
         'http://localhost:1234/oidc/apres-deconnexion?state=unState'


### PR DESCRIPTION
Lorsqu'on accédait à l'url de deconnexion et qu'il manquait le cookie, le service levait une exception et ne répondait pas, provoquant une erreur 503. On préfère retourner 401 dans ce cas.