### PR TITLE
Optimise les performances de chargement des mesures

### DIFF
--- a/src/modeles/mesureGenerale.js
+++ b/src/modeles/mesureGenerale.js
@@ -18,7 +18,7 @@ class MesureGenerale extends Mesure {
   }
 
   donneesReferentiel() {
-    return this.referentiel.mesures()[this.id];
+    return this.referentiel.mesure(this.id);
   }
 
   descriptionMesure() {

--- a/src/moteurRegles.js
+++ b/src/moteurRegles.js
@@ -29,13 +29,8 @@ class MoteurRegles {
             rendreIndispensables: profils[profil].mesuresARendreIndispensables,
           })
       )
-      .flatMap((profil) => profil[mesuresACibler](valeursDescriptionService))
-      .reduce(
-        (accumulateur, mesure) => ({ ...accumulateur, [mesure]: mesure }),
-        {}
-      );
-
-    return Object.keys(mapMesures);
+      .flatMap((profil) => profil[mesuresACibler](valeursDescriptionService));
+    return [...new Set(mapMesures)];
   }
 
   mesuresAAjouter(descriptionService) {

--- a/src/moteurRegles.js
+++ b/src/moteurRegles.js
@@ -60,27 +60,18 @@ class MoteurRegles {
       .concat(mesuresAAjouter)
       .filter((mesure) => !mesuresARetirer.includes(mesure));
 
-    const mesureAvecImportanceAjustee = (idsMesuresReference, idMesure) => {
-      const mesure = this.referentiel.mesure(idMesure);
-      mesure.indispensable ||= idsMesuresReference.includes(idMesure);
+    const litMesuresEtRendIndispensable = () => {
+      const idsARendreIndispensables = new Set(mesuresARendreIndispensables);
+      const resultat = new Map();
 
-      return mesure;
-    };
-
-    const ajouteEtRendsIndispensable = (
-      idsMesuresReference,
-      accumulateur,
-      idMesure
-    ) =>
-      Object.assign(accumulateur, {
-        [idMesure]: mesureAvecImportanceAjustee(idsMesuresReference, idMesure),
+      idsMesures.forEach((idMesure) => {
+        const mesure = this.referentiel.mesure(idMesure);
+        mesure.indispensable = idsARendreIndispensables.has(idMesure);
+        resultat.set(idMesure, mesure);
       });
-
-    return idsMesures.reduce(
-      (...parametres) =>
-        ajouteEtRendsIndispensable(mesuresARendreIndispensables, ...parametres),
-      {}
-    );
+      return Object.fromEntries(resultat.entries());
+    };
+    return litMesuresEtRendIndispensable();
   }
 }
 

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -94,10 +94,10 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     Object.keys(localisationsDonnees());
   const mesureIndispensable = (idMesure) =>
     !!donnees.mesures[idMesure].indispensable;
-  const mesures = () => JSON.parse(JSON.stringify(donnees.mesures));
-  const identifiantsMesures = () => Object.keys(mesures());
+  const mesures = () => structuredClone(donnees.mesures);
+  const identifiantsMesures = () => Object.keys(donnees.mesures);
   const estIdentifiantMesureConnu = (id) => identifiantsMesures().includes(id);
-  const mesure = (id) => mesures()[id];
+  const mesure = (id) => structuredClone(donnees.mesures[id]);
   const typesService = () => donnees.typesService;
   const nbMoisDecalage = (idEcheance) =>
     echeancesRenouvellement()[idEcheance]?.nbMoisDecalage;

--- a/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
+++ b/src/routes/connecte/routesConnecteApiServiceActivitesMesure.js
@@ -30,7 +30,7 @@ const routesConnecteApiServiceActivitesMesure = ({
         idActeur: a.idActeur,
         identifiantNumeriqueMesure:
           a.typeMesure === 'generale'
-            ? referentiel.mesures()[a.idMesure].identifiantNumerique
+            ? referentiel.mesure(a.idMesure).identifiantNumerique
             : undefined,
         type: a.type,
         details: a.details,


### PR DESCRIPTION
Dans l'objectif d'optimiser le chargement du tableau de bord, on se penche sur les performances.
Pour créer un objet métier `Service`, MSS construit la liste des mesures de ce service.
Cette construction est très lente. On optimise donc de la manière suivante :
- Les `reduce` sont remplacés par des `Map` si possible, car plus performant
- La lecture des mesures du référentiel n'utilise plus `JSON.parse(JSON.stringify(...))`, au profit de `structuredClone`
- On s'attache à appeler la méthode `mesure(id)` plutot que `mesures()[id]` si nécessaire
- On réécrit le code qui rend les mesures indispensable, car il était trop complexe à comprendre