### PR TITLE
[CORRECTION] Ne tente pas de mettre à jour MPA si le profil de l'utilisateur n'est pas complet

### DIFF
--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -277,7 +277,8 @@ const creeDepot = (config = {}) => {
 
     const u = await p.lis.un(id);
 
-    await adaptateurProfilAnssi.metsAJour(u);
+    if (u.completudeProfil().estComplet)
+      await adaptateurProfilAnssi.metsAJour(u);
 
     await busEvenements.publie(
       new EvenementUtilisateurModifie({ utilisateur: u })

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -380,7 +380,10 @@ describe('Le dépôt de données des utilisateurs', () => {
 
       await depot.metsAJourUtilisateur(
         '124',
-        unUtilisateur().avecId('124').quiSAppelle('Justine Lange').donnees
+        unUtilisateur()
+          .avecId('124')
+          .quiSAppelle('Justine Lange')
+          .quiEstComplet().donnees
       );
 
       const utilisateur = await depot.utilisateur('124');
@@ -394,11 +397,31 @@ describe('Le dépôt de données des utilisateurs', () => {
 
       await depot.metsAJourUtilisateur(
         '123',
-        unUtilisateur().avecId('123').quiSAppelle('Justine Lange').donnees
+        unUtilisateur()
+          .avecId('123')
+          .quiSAppelle('Justine Lange')
+          .quiEstComplet().donnees
       );
 
       const utilisateur = await depot.utilisateur('123');
       expect(profilAnssiEnvoyeAAdaptateurPourMiseAJour).to.eql(utilisateur);
+    });
+
+    it('ne mets pas à jour MonProfilAnssi pour un utilisateur MSS qui a un profil incomplet', async () => {
+      let miseAJourFaite = false;
+      adaptateurProfilAnssi.metsAJour = () => {
+        miseAJourFaite = true;
+      };
+
+      await depot.metsAJourUtilisateur(
+        '124',
+        unUtilisateur()
+          .avecId('124')
+          .quiSAppelle('Justine Lange')
+          .quiNAPasRempliSonProfil().donnees
+      );
+
+      expect(miseAJourFaite).to.be(false);
     });
   });
 


### PR DESCRIPTION
... afin de ne pas créer d'erreur côté MPA, car les champs suivants sont obligatoires : nom, prenom, organisation, postes