### PR TITLE
Corrige rate-limit

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -66,6 +66,7 @@ GENERATION_PDF_TOKEN_DU_SERVICE= # Token de connexion au Browserless. En local, 
 CACHE_CONTROL_FICHIERS_STATIQUES= # politique de `cache-control` sur les fichiers statiques, mettre à `no-store` ou `public, max-age=0` pour le dev. local
 
 # configuration du `rate-limit`
+NB_REQUETES_TRUST_PROXY = # optionnel (0 par défaut) nombre de proxies en amont du service ou configuration plus fine de trust proxy, Cf.  https://expressjs.com/en/guide/behind-proxies.html
 NB_REQUETES_MAX_PAR_MINUTE= # Nombre maximal de requêtes autorisées par IP et par minute, supprimer la variable permet de désactiver la protection
 NB_REQUETES_MAX_PAR_MINUTE_ENDPOINT_SENSIBLE= # Nombre maximal de requêtes autorisées par IP et par minute pour les endpoints sensibles (connexion, inscription, modification de mot de passe, creation de service), supprimer la variable permet de désactiver la protection
 

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -109,6 +109,20 @@ const oidc = () => ({
   clientSecret: () => process.env.OIDC_CLIENT_SECRET,
 });
 
+const trustProxy = () => {
+  const trustProxyEnChaine = process.env.NB_REQUETES_TRUST_PROXY || '0';
+  const trustProxyEnNombre = Number(trustProxyEnChaine);
+  if (Number.isNaN(trustProxyEnNombre)) {
+    /* eslint-disable no-console */
+    console.warn(
+      `Attention ! NB_REQUETES_TRUST_PROXY positionné à ${trustProxyEnChaine}`
+    );
+    /* eslint-enable no-console */
+    return trustProxyEnChaine;
+  }
+  return trustProxyEnNombre;
+};
+
 const mss = () => ({
   urlBase: () => process.env.URL_BASE_MSS,
 });
@@ -127,5 +141,6 @@ module.exports = {
   sendinblue,
   sentry,
   supervision,
+  trustProxy,
   versionDeBuild,
 };

--- a/src/adaptateurs/adaptateurProtection.js
+++ b/src/adaptateurs/adaptateurProtection.js
@@ -3,14 +3,12 @@ const rateLimit = require('express-rate-limit');
 const {
   fabriqueAdaptateurGestionErreur,
 } = require('./fabriqueAdaptateurGestionErreur');
-const { extraisIp } = require('../http/requeteHttp');
 
 const uneMinute = 60 * 1000;
 const parametresCommuns = (typeRequete, doitFermerConnexion = false) => ({
   windowMs: uneMinute,
-  keyGenerator: (requete, _reponse) => extraisIp(requete.headers).client,
   handler: (requete, reponse) => {
-    const attaque = extraisIp(requete.headers).client?.replaceAll('.', '*');
+    const attaque = requete.ip.replaceAll('.', '*');
 
     if (typeRequete === 'Navigation')
       // eslint-disable-next-line no-console

--- a/src/mss.ts
+++ b/src/mss.ts
@@ -82,7 +82,7 @@ const creeServeur = ({
 
   app.disable('x-powered-by');
 
-  app.set('trust proxy', 1);
+  app.set('trust proxy', adaptateurEnvironnement.trustProxy());
   app.set('view engine', 'pug');
   app.set('views', './src/vues');
 

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -104,6 +104,7 @@ const testeurMss = () => {
       mss: () => ({
         urlBase: () => 'http://localhost:1234',
       }),
+      trustProxy: () => 0,
     };
     adaptateurProtection = {
       protectionCsrf: () => (_requete, _reponse, suite) => suite(),


### PR DESCRIPTION
C'est la première IP dans la liste des IPs pour lesquelles on a forwardé qui était prise en compte pour le rate limit alors qu'on doit parcourir la liste de droite à gauche et prendre la première qui n'est pas un proxy.

On utilise trust proxy qui gère cela mieux que nous.

Il faut positionner la variable d'environnement `NB_REQUETES_TRUST_PROXY` avec le nombre de proxy sur le chemin.