### PR TITLE
[CORRECTION] Conserve le statut "indispensable" d'une mesure

### DIFF
--- a/src/moteurRegles.js
+++ b/src/moteurRegles.js
@@ -66,7 +66,7 @@ class MoteurRegles {
 
       idsMesures.forEach((idMesure) => {
         const mesure = this.referentiel.mesure(idMesure);
-        mesure.indispensable = idsARendreIndispensables.has(idMesure);
+        mesure.indispensable ||= idsARendreIndispensables.has(idMesure);
         resultat.set(idMesure, mesure);
       });
       return Object.fromEntries(resultat.entries());

--- a/test/moteurRegles.spec.js
+++ b/test/moteurRegles.spec.js
@@ -222,10 +222,11 @@ describe('Le moteur de règles', () => {
     const referentiel = Referentiel.creeReferentiel({
       mesures: {
         supervision: {},
+        dejaIndispensable: { indispensable: true },
       },
       reglesPersonnalisation: {
         clefsDescriptionServiceAConsiderer: ['delaiAvantImpactCritique'],
-        mesuresBase: [],
+        mesuresBase: ['dejaIndispensable'],
         profils: {
           mssPlusPlus: {
             regles: [
@@ -244,8 +245,10 @@ describe('Le moteur de règles', () => {
     const service = new DescriptionService({
       delaiAvantImpactCritique: ['moinsUneHeure'],
     });
-    expect(moteur.mesures(service)).to.eql({
+    const mesures = moteur.mesures(service);
+    expect(mesures).to.eql({
       supervision: { indispensable: true },
+      dejaIndispensable: { indispensable: true },
     });
   });
 


### PR DESCRIPTION
… s'il est déjà défini dans la mesure de base.