### PR TITLE
[CORRECTION] Affiche le tiroir au-dessus du Centre d'aide

### DIFF
--- a/public/assets/styles/tiroir.css
+++ b/public/assets/styles/tiroir.css
@@ -10,7 +10,7 @@
   box-shadow: -10px 0px 34px 0px #00000026;
   background: #fff;
   visibility: hidden;
-  z-index: 20;
+  z-index: 1001;
   display: flex;
   flex-direction: column;
 }

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -42,7 +42,7 @@
     align-items: flex-end;
     gap: 1em;
     padding-top: 2em;
-    z-index: 99;
+    z-index: 1002;
   }
 
   article {


### PR DESCRIPTION
... afin d'éviter le chevauchement.

Le centre d'aide, qui provient de l'UI Kit, a un `z-index` de 1000.

Cela corrige l'issue #2149 