### PR TITLE
Remonte le tiroir `Svelte` au-dessus du centre d'aide

### DIFF
--- a/svelte/lib/tiroir/Tiroir.svelte
+++ b/svelte/lib/tiroir/Tiroir.svelte
@@ -41,7 +41,7 @@
     box-shadow: -10px 0px 34px 0px #00000026;
     background: #fff;
     visibility: hidden;
-    z-index: 20;
+    z-index: 1001;
     display: flex;
     flex-direction: column;
     color: var(--texte-fonce);


### PR DESCRIPTION
... car cela n'avait été fait que pour le tiroir "legacy".