### PR TITLE
[TÉLÉVERSEMENT] Ajout de la route de récuperation des validations métier

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -601,6 +601,14 @@ const nouvelAdaptateur = (env) => {
       .onConflict('id_utilisateur')
       .merge();
 
+  const lisTeleversementServices = async (idUtilisateur) =>
+    knex('televersement_services')
+      .where({ id_utilisateur: idUtilisateur })
+      .select({
+        donnees: 'donnees',
+      })
+      .first();
+
   return {
     activitesMesure,
     ajouteAutorisation,
@@ -625,6 +633,7 @@ const nouvelAdaptateur = (env) => {
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     lisSuperviseursConcernes,
+    lisTeleversementServices,
     marqueNouveauteLue,
     marqueSuggestionActionFaiteMaintenant,
     marqueTacheDeServiceLue,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -115,6 +115,7 @@ const creeDepot = (config = {}) => {
     depotDonneesTeleversementServices.creeDepot({
       adaptateurChiffrement,
       adaptateurPersistance,
+      referentiel,
     });
 
   const {
@@ -218,7 +219,8 @@ const creeDepot = (config = {}) => {
     await adaptateurPersistance.sante();
   };
 
-  const { nouveauTeleversementServices } = depotTeleversementServices;
+  const { lisTeleversementServices, nouveauTeleversementServices } =
+    depotTeleversementServices;
 
   return {
     accesAutorise,
@@ -250,6 +252,7 @@ const creeDepot = (config = {}) => {
     lisNotificationsExpirationHomologationEnDate,
     lisParcoursUtilisateur,
     lisSuperviseurs,
+    lisTeleversementServices,
     marqueNouveauteLue,
     marqueTacheDeServiceLue,
     metsAJourMotDePasse,

--- a/src/depots/depotDonneesTeleversementServices.js
+++ b/src/depots/depotDonneesTeleversementServices.js
@@ -1,5 +1,7 @@
+const TeleversementServices = require('../modeles/televersement/televersementServices');
+
 const creeDepot = (config = {}) => {
-  const { adaptateurPersistance, adaptateurChiffrement } = config;
+  const { adaptateurPersistance, adaptateurChiffrement, referentiel } = config;
 
   const nouveauTeleversementServices = async (
     idUtilisateur,
@@ -14,7 +16,18 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  const lisTeleversementServices = async (idUtilisateur) => {
+    const donneesChiffrees =
+      await adaptateurPersistance.lisTeleversementServices(idUtilisateur);
+    if (!donneesChiffrees) return undefined;
+    const services = await adaptateurChiffrement.dechiffre(
+      donneesChiffrees.donnees.services
+    );
+    return new TeleversementServices({ services }, referentiel);
+  };
+
   return {
+    lisTeleversementServices,
     nouveauTeleversementServices,
   };
 };

--- a/src/routes/connecte/routesConnecteApiTeleversement.js
+++ b/src/routes/connecte/routesConnecteApiTeleversement.js
@@ -8,6 +8,7 @@ const routesConnecteApiTeleversement = ({
   middleware,
 }) => {
   const routes = express.Router();
+
   routes.post(
     '/services',
     middleware.protegeTrafic(),
@@ -31,6 +32,28 @@ const routesConnecteApiTeleversement = ({
       reponse.sendStatus(201);
     }
   );
+
+  routes.get('/services', async (requete, reponse) => {
+    const services = await depotDonnees.services(requete.idUtilisateurCourant);
+    const nomsServicesExistants = services.map((service) =>
+      service.nomService()
+    );
+    const televersementServices = await depotDonnees.lisTeleversementServices(
+      requete.idUtilisateurCourant
+    );
+
+    if (!televersementServices) {
+      reponse.sendStatus(404);
+      return;
+    }
+
+    const rapportDetaille = televersementServices.rapportDetaille(
+      nomsServicesExistants
+    );
+
+    reponse.json(rapportDetaille);
+  });
+
   return routes;
 };
 

--- a/test/routes/connecte/routesConnecteApiTeleversement.spec.js
+++ b/test/routes/connecte/routesConnecteApiTeleversement.spec.js
@@ -2,6 +2,9 @@ const axios = require('axios');
 const expect = require('expect.js');
 const testeurMSS = require('../testeurMSS');
 const { ErreurFichierXlsInvalide } = require('../../../src/erreurs');
+const TeleversementServices = require('../../../src/modeles/televersement/televersementServices');
+const Referentiel = require('../../../src/referentiel');
+const donneesReferentiel = require('../../../donneesReferentiel');
 
 describe('Les routes connecté de téléversement', () => {
   const testeur = testeurMSS();
@@ -99,6 +102,95 @@ describe('Les routes connecté de téléversement', () => {
 
         expect(idUtilisateurCourantRecue).to.equal('123');
         expect(donneesRecues).to.eql([{ nom: 'Un service' }]);
+      });
+    });
+
+    describe('Quand requête GET sur `/api/televersement/services`', () => {
+      const donneesServiceValide = {
+        nom: 'Nom du service',
+        siret: '13000000000000',
+        type: 'Site Internet',
+        provenance: 'Proposé en ligne par un fournisseur',
+        statut: 'En projet',
+        localisation: 'France',
+        delaiAvantImpactCritique: "Plus d'une journée",
+        dateHomologation: '01/01/2025',
+        dureeHomologation: '6 mois',
+        nomAutoriteHomologation: 'Nom Prénom',
+        fonctionAutoriteHomologation: 'Fonction',
+      };
+      let referentiel;
+      let televersementService;
+
+      beforeEach(() => {
+        referentiel = Referentiel.creeReferentiel({
+          ...donneesReferentiel,
+        });
+        televersementService = new TeleversementServices(
+          { services: [{ ...donneesServiceValide }] },
+          referentiel
+        );
+        testeur.middleware().reinitialise({ idUtilisateur: '123' });
+        testeur.depotDonnees().services = async () => [];
+        testeur.depotDonnees().lisTeleversementServices = async () =>
+          televersementService;
+      });
+
+      it("vérifie que l'utilisateur est authentifié", (done) => {
+        testeur.middleware().verifieRequeteExigeAcceptationCGU(
+          {
+            method: 'get',
+            url: 'http://localhost:1234/api/televersement/services',
+          },
+          done
+        );
+      });
+
+      it('délègue la récupération des noms de services existants au dépôt de données', async () => {
+        let idUtilisateurRecu;
+        testeur.depotDonnees().services = async (idUtilisateur) => {
+          idUtilisateurRecu = idUtilisateur;
+          return [];
+        };
+
+        await axios.get('http://localhost:1234/api/televersement/services');
+
+        expect(idUtilisateurRecu).to.be('123');
+      });
+
+      it('délègue la récupération du téléversement de service au dépôt de données', async () => {
+        let idUtilisateurRecu;
+        testeur.depotDonnees().lisTeleversementServices = async (
+          idUtilisateur
+        ) => {
+          idUtilisateurRecu = idUtilisateur;
+          return televersementService;
+        };
+
+        await axios.get('http://localhost:1234/api/televersement/services');
+
+        expect(idUtilisateurRecu).to.be('123');
+      });
+
+      it("renvoie une erreur 404 si l'utilisateur n'a pas de téléversement en cours", async () => {
+        testeur.depotDonnees().lisTeleversementServices = async () => undefined;
+
+        try {
+          await axios.get('http://localhost:1234/api/televersement/services');
+          expect().fail("L'appel aurait dû lever une erreur");
+        } catch (e) {
+          expect(e.response.status).to.be(404);
+        }
+      });
+
+      it('retourne le rapport détaillé du téléversement de service', async () => {
+        const reponse = await axios.get(
+          'http://localhost:1234/api/televersement/services'
+        );
+
+        expect(reponse.data.statut).to.be('VALIDE');
+        expect(reponse.data.services[0].service).to.eql(donneesServiceValide);
+        expect(reponse.data.services[0].erreurs.length).to.be(0);
       });
     });
   });


### PR DESCRIPTION
Cette route sera ensuite exploitée par le front afin d'afficher un rapport détaillé pour chaque ligne de service importé.
On se repose sur le modèle métier `TeleversementServices` fait précedemment.