### PR TITLE
[TÉLÉVERSEMENT] Ajoute la route de confirmation de téléversement

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -128,6 +128,7 @@ const serviceSupervision = new ServiceSupervision({
 serviceVerificationCoherenceSels.verifieLaCoherenceDesSels().then(() => {
   const serveur = MSS.creeServeur({
     depotDonnees,
+    busEvenements,
     middleware,
     referentiel,
     moteurRegles,

--- a/src/mss.ts
+++ b/src/mss.ts
@@ -43,6 +43,7 @@ const creeServeur = ({
   adaptateurProfilAnssi,
   adaptateurControleFichier,
   adaptateurXLS,
+  busEvenements,
   serviceSupervision,
   serviceCgu,
   serviceGestionnaireSession,
@@ -164,6 +165,7 @@ const creeServeur = ({
     routesConnecteApi({
       middleware,
       adaptateurMail,
+      busEvenements,
       depotDonnees,
       referentiel,
       adaptateurHorloge,

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -35,6 +35,7 @@ const routesConnecteApiTeleversement = require('./routesConnecteApiTeleversement
 const routesConnecteApi = ({
   middleware,
   adaptateurMail,
+  busEvenements,
   depotDonnees,
   referentiel,
   adaptateurHorloge,
@@ -184,6 +185,7 @@ const routesConnecteApi = ({
     routesConnecteApiTeleversement({
       adaptateurControleFichier,
       adaptateurXLS,
+      busEvenements,
       depotDonnees,
       middleware,
     })

--- a/src/routes/connecte/routesConnecteApiTeleversement.js
+++ b/src/routes/connecte/routesConnecteApiTeleversement.js
@@ -4,6 +4,7 @@ const { ErreurFichierXlsInvalide } = require('../../erreurs');
 const routesConnecteApiTeleversement = ({
   adaptateurControleFichier,
   adaptateurXLS,
+  busEvenements,
   depotDonnees,
   middleware,
 }) => {
@@ -56,6 +57,31 @@ const routesConnecteApiTeleversement = ({
       requete.idUtilisateurCourant
     );
     reponse.sendStatus(aSupprime ? 200 : 404);
+  });
+
+  routes.post('/services/confirme', async (requete, reponse) => {
+    const services = await depotDonnees.services(requete.idUtilisateurCourant);
+    const nomsServicesExistants = services.map((service) =>
+      service.nomService()
+    );
+    const televersementServices = await depotDonnees.lisTeleversementServices(
+      requete.idUtilisateurCourant
+    );
+
+    if (!televersementServices) return reponse.sendStatus(404);
+
+    try {
+      await televersementServices.creeLesServices(
+        requete.idUtilisateurCourant,
+        nomsServicesExistants,
+        depotDonnees,
+        busEvenements
+      );
+
+      return reponse.sendStatus(200);
+    } catch (e) {
+      return reponse.sendStatus(400);
+    }
   });
 
   return routes;

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -18,6 +18,7 @@ const { fabriqueServiceCgu } = require('../../src/serviceCgu');
 const {
   fabriqueServiceGestionnaireSession,
 } = require('../../src/session/serviceGestionnaireSession');
+const { fabriqueBusPourLesTests } = require('../bus/aides/busPourLesTests');
 
 const testeurMss = () => {
   let serviceAnnuaire;
@@ -46,6 +47,7 @@ const testeurMss = () => {
   let referentiel;
   let procedures;
   let inscriptionUtilisateur;
+  let busEvenements;
   let serveur;
 
   const verifieSessionDeposee = (reponse, suite) => {
@@ -139,6 +141,7 @@ const testeurMss = () => {
     adaptateurXLS = {
       extraisTeleversementServices: async () => {},
     };
+    busEvenements = fabriqueBusPourLesTests();
 
     moteurRegles = new MoteurRegles(referentiel);
     depotVide()
@@ -177,6 +180,7 @@ const testeurMss = () => {
           serviceCgu,
           procedures,
           inscriptionUtilisateur,
+          busEvenements,
           avecCookieSecurise: false,
           avecPageErreur: false,
         });
@@ -206,6 +210,7 @@ const testeurMss = () => {
     adaptateurProfilAnssi: () => adaptateurProfilAnssi,
     adaptateurControleFichier: () => adaptateurControleFichier,
     adaptateurXLS: () => adaptateurXLS,
+    busEvenements: () => busEvenements,
     depotDonnees: () => depotDonnees,
     middleware: () => middleware,
     moteurRegles: () => moteurRegles,


### PR DESCRIPTION
... afin d'importer "réellement" un service.
Cette route permet de convertir des objets de type `ServiceTeleverse` en vraies données de service, et de les persister.