### PR TITLE
[CORRECTION] Supprime les suggestions d'actions des services supprimés

### DIFF
--- a/admin/consoleAdministration.js
+++ b/admin/consoleAdministration.js
@@ -819,6 +819,15 @@ class ConsoleAdministration {
 
     console.log('Migration effectuée');
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  async rattrapageSuppressionSuggestionsActions() {
+    const knex = Knex(configKnex.production);
+    const nbSuppression = await knex('suggestions_actions')
+      .whereNotIn('id_service', knex('services').select('id'))
+      .del();
+    console.log(`${nbSuppression} suggestions supprimées`);
+  }
 }
 
 module.exports = ConsoleAdministration;

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -480,6 +480,9 @@ const nouvelAdaptateur = (env) => {
       .update({ date_acquittement: knex.fn.now() });
   };
 
+  const supprimeSuggestionsActionsPourService = async (idService) =>
+    knex('suggestions_actions').where({ id_service: idService }).del();
+
   const sauvegardeNouvelIndiceCyber = async (
     idService,
     indiceCyber,
@@ -665,6 +668,7 @@ const nouvelAdaptateur = (env) => {
     supprimeNotificationsExpirationHomologationPourService,
     supprimeService,
     supprimeServices,
+    supprimeSuggestionsActionsPourService,
     supprimeTeleversementServices,
     supprimeUtilisateur,
     supprimeUtilisateurs,

--- a/src/bus/abonnements/supprimeSuggestionsActions.js
+++ b/src/bus/abonnements/supprimeSuggestionsActions.js
@@ -1,0 +1,12 @@
+function supprimeSuggestionsActions({ depotDonnees }) {
+  return async ({ idService }) => {
+    if (!idService)
+      throw new Error(
+        "Impossible de supprimer les suggestions d'actions d'un service sans avoir l'ID du service en paramètre."
+      );
+
+    await depotDonnees.supprimeSuggestionsActionsPourService(idService);
+  };
+}
+
+module.exports = { supprimeSuggestionsActions };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -109,6 +109,9 @@ const EvenementServicesImportes = require('./evenementServicesImportes');
 const {
   consigneTeleversementServicesRealiseDansJournal,
 } = require('./abonnements/consigneTeleversementServicesRealiseDansJournal');
+const {
+  supprimeSuggestionsActions,
+} = require('./abonnements/supprimeSuggestionsActions');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -241,6 +244,7 @@ const cableTousLesAbonnes = (
     supprimeNotificationsExpirationHomologation({ depotDonnees }),
     metAJourContactsBrevoDesContributeurs({ crmBrevo, depotDonnees }),
     delieServiceEtSuperviseurs({ serviceSupervision }),
+    supprimeSuggestionsActions({ depotDonnees }),
   ]);
 
   busEvenements.abonne(

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -195,8 +195,11 @@ const creeDepot = (config = {}) => {
     supprimeNotificationsExpirationHomologationPourService,
   } = depotNotificationsExpirationHomologation;
 
-  const { acquitteSuggestionAction, ajouteSuggestionAction } =
-    depotSuggestionsActions;
+  const {
+    acquitteSuggestionAction,
+    ajouteSuggestionAction,
+    supprimeSuggestionsActionsPourService,
+  } = depotSuggestionsActions;
 
   const { ajouteActiviteMesure, lisActivitesMesure } = depotActivitesMesure;
 
@@ -292,6 +295,7 @@ const creeDepot = (config = {}) => {
     supprimeIdResetMotDePassePourUtilisateur,
     supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
+    supprimeSuggestionsActionsPourService,
     supprimeUtilisateur,
     tachesDesServices,
     tousUtilisateurs,

--- a/src/depots/depotDonneesSuggestionsActions.js
+++ b/src/depots/depotDonneesSuggestionsActions.js
@@ -13,7 +13,14 @@ const creeDepot = ({ adaptateurPersistance }) => {
     });
   };
 
-  return { acquitteSuggestionAction, ajouteSuggestionAction };
+  const supprimeSuggestionsActionsPourService = async (idService) =>
+    adaptateurPersistance.supprimeSuggestionsActionsPourService(idService);
+
+  return {
+    acquitteSuggestionAction,
+    ajouteSuggestionAction,
+    supprimeSuggestionsActionsPourService,
+  };
 };
 
 module.exports = { creeDepot };

--- a/test/bus/abonnements/supprimeSuggestionsActions.spec.js
+++ b/test/bus/abonnements/supprimeSuggestionsActions.spec.js
@@ -1,0 +1,40 @@
+const expect = require('expect.js');
+const {
+  supprimeSuggestionsActions,
+} = require('../../../src/bus/abonnements/supprimeSuggestionsActions');
+
+describe("L'abonnement qui supprime (en base de données) les suggestions d'actions d'un service", () => {
+  let depotDonnees;
+
+  beforeEach(() => {
+    depotDonnees = {
+      supprimeSuggestionsActionsPourService: async () => {},
+    };
+  });
+
+  it("lève une exception s'il ne reçoit pas l'ID du service", async () => {
+    try {
+      await supprimeSuggestionsActions({ depotDonnees })({
+        idService: null,
+      });
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de supprimer les suggestions d'actions d'un service sans avoir l'ID du service en paramètre."
+      );
+    }
+  });
+
+  it("demande au dépôt de supprimer les suggestions d'actions pour ce service", async () => {
+    let depotAppele = false;
+    depotDonnees.supprimeSuggestionsActionsPourService = async () => {
+      depotAppele = true;
+    };
+
+    await supprimeSuggestionsActions({ depotDonnees })({
+      idService: '123',
+    });
+
+    expect(depotAppele).to.be(true);
+  });
+});

--- a/test/depots/depotDonneesSuggestionsActions.spec.js
+++ b/test/depots/depotDonneesSuggestionsActions.spec.js
@@ -40,4 +40,17 @@ describe("Le dépôt de données des suggestions d'actions", () => {
 
     expect(persistanceAppelee).to.eql({ idService: 'S1', nature: 'SIRET' });
   });
+
+  it('peut supprimer une suggestion', async () => {
+    let idRecu = {};
+    adaptateurPersistance.supprimeSuggestionsActionsPourService = async (
+      idService
+    ) => {
+      idRecu = idService;
+    };
+
+    await depot.supprimeSuggestionsActionsPourService('S1');
+
+    expect(idRecu).to.eql('S1');
+  });
 });


### PR DESCRIPTION
... en se câblant sur l'évènement dédié dans le bus.

> [!IMPORTANT]
> Il faut jouer la méthode "rattrapageSuppressionSuggestionsActions" dans la console admin au moment du déploiement. 