### PR TITLE
Pas de valeur par défaut pour trust proxy

### DIFF
--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -110,7 +110,12 @@ const oidc = () => ({
 });
 
 const trustProxy = () => {
-  const trustProxyEnChaine = process.env.NB_REQUETES_TRUST_PROXY || '0';
+  if (process.env.NB_REQUETES_TRUST_PROXY === undefined) {
+    throw new Error(
+      `la variable d'environnement NB_REQUETES_TRUST_PROXY est obligatoire mais absente`
+    );
+  }
+  const trustProxyEnChaine = process.env.NB_REQUETES_TRUST_PROXY;
   const trustProxyEnNombre = Number(trustProxyEnChaine);
   if (Number.isNaN(trustProxyEnNombre)) {
     /* eslint-disable no-console */


### PR DESCRIPTION
Lorsque la variable d'environnement NB_REQUETES_TRUST_PROXY est mal positionné alors on observe certains environnements qui disfonctionnent. Par exemple, impossible de s'authentifier sur l'env. de PR.

Afin de faciliter la détection d'erreur lorsqu'on a oublié de positionner cette variable, le service refuse de démarrer avec un message d'erreur explicite plutôt que d'utiliser une valeur par défaut.