### PR TITLE
[CORRECTION] Utilise `pmap` pour limiter les promesses concurrentes lors de l'enrichissement d'un service

### DIFF
--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -18,6 +18,9 @@ const Entite = require('../modeles/entite');
 const EvenementMesureServiceModifiee = require('../bus/evenementMesureServiceModifiee');
 const EvenementMesureServiceSupprimee = require('../bus/evenementMesureServiceSupprimee');
 const EvenementRisqueServiceModifie = require('../bus/evenementRisqueServiceModifie');
+const {
+  avecPMapPourChaqueElementSansPromesse,
+} = require('../utilitaires/pMap');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = async (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -83,8 +86,9 @@ const fabriquePersistance = (
         const donneesServices =
           await adaptateurPersistance.services(idUtilisateur);
 
-        const servicesEnrichis = await Promise.all(
-          donneesServices.map(async (ds) => enrichisService(ds))
+        const servicesEnrichis = await avecPMapPourChaqueElementSansPromesse(
+          donneesServices,
+          enrichisService
         );
 
         return servicesEnrichis.sort((s1, s2) =>

--- a/src/utilitaires/pMap.js
+++ b/src/utilitaires/pMap.js
@@ -1,7 +1,15 @@
 const pmap = require('p-map');
 
+const avecPMap = (items, fonctionAAppliquer) =>
+  pmap(items, fonctionAAppliquer, { concurrency: 2 });
+
 const avecPMapPourChaqueElement = (itemsDansPromesse, fonctionAAppliquer) =>
-  itemsDansPromesse.then((items) =>
-    pmap(items, fonctionAAppliquer, { concurrency: 2 })
-  );
-module.exports = { avecPMapPourChaqueElement };
+  itemsDansPromesse.then((items) => avecPMap(items, fonctionAAppliquer));
+
+const avecPMapPourChaqueElementSansPromesse = (items, fonctionAAppliquer) =>
+  avecPMap(items, fonctionAAppliquer);
+
+module.exports = {
+  avecPMapPourChaqueElement,
+  avecPMapPourChaqueElementSansPromesse,
+};


### PR DESCRIPTION
... car, pour chaque service, on effectue :
- une requête pour lire les contributeurs
- une requête pour lire les suggestions d'actions

Or, comme tous les services sont enrichis en même temps, toutes ces requêtes utilisent le pool de connexion de la base de données.