### PR TITLE
[TÉLÉVERSEMENT] Retente de récupérer la progression plus tard si une erreur provient du backend

### DIFF
--- a/svelte/lib/rapportTeleversement/RapportTeleversement.svelte
+++ b/svelte/lib/rapportTeleversement/RapportTeleversement.svelte
@@ -53,8 +53,13 @@
 
   let progression = 0;
   const recupereProgression = async () => {
-    const resultat = await progressionTeleversement();
-    progression = resultat.data.progression;
+    try {
+      const resultat = await progressionTeleversement();
+      progression = resultat.data.progression;
+    } catch (e) {
+      setTimeout(recupereProgression, 5000);
+      return;
+    }
     if (progression === 100) {
       document.body.dispatchEvent(new CustomEvent('rafraichis-services'));
       enCoursEnvoi = false;


### PR DESCRIPTION
…afin de compenser les erreurs 503 reçues.