### PR TITLE
[CORRECTION] Empêche le badge de passer sur plusieurs lignes

### DIFF
--- a/public/assets/styles/dossiers.css
+++ b/public/assets/styles/dossiers.css
@@ -46,6 +46,7 @@
   background: #dbeeff;
   width: fit-content;
   border: 1px solid transparent;
+  white-space: nowrap;
 }
 
 .homologation .indice-cyber.personnalise {


### PR DESCRIPTION
... pour éviter un affichage eronné. :point_down: 

| Avant | Après |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0ff9f422-92c0-48ed-8ab0-680d1fb771a9) | ![image](https://github.com/user-attachments/assets/fb7cd852-97ac-45e3-8598-c05c2d01d451) | 