### PR TITLE
[CORRECTION] Passe les dates Excel qui sont FR en dates ISO

### DIFF
--- a/src/adaptateurs/adaptateurXLS.js
+++ b/src/adaptateurs/adaptateurXLS.js
@@ -1,6 +1,7 @@
 const xlsx = require('xlsx');
 const { encode } = require('html-entities');
 const { ErreurFichierXlsInvalide } = require('../erreurs');
+const { chaineDateFrEnChaineDateISO } = require('../utilitaires/date');
 
 const ENTETE_NOM = 'Nom du service numérique *';
 const ENTETE_SIRET = "Siret de l'organisation *";
@@ -71,7 +72,9 @@ const extraisTeleversementServices = async (buffer) => {
     statut: service[ENTETE_STATUT],
     localisation: service[ENTETE_LOCALISATION],
     delaiAvantImpactCritique: service[ENTETE_DELAI_AVANT_IMPACT_CRITIQUE],
-    dateHomologation: service[ENTETE_DATE_HOMOLOGATION],
+    dateHomologation: service[ENTETE_DATE_HOMOLOGATION]
+      ? chaineDateFrEnChaineDateISO(service[ENTETE_DATE_HOMOLOGATION])
+      : undefined,
     dureeHomologation: service[ENTETE_DUREE_HOMOLOGATION],
     nomAutoriteHomologation: encode(service[ENTETE_NOM_AUTORITE]),
     fonctionAutoriteHomologation: encode(service[ENTETE_FONCTION_AUTORITE]),

--- a/src/utilitaires/date.js
+++ b/src/utilitaires/date.js
@@ -28,10 +28,16 @@ const dateYYYYMMDD = (date) => dateEnIso(date).replaceAll('-', '');
 const dateInvalide = (chaineDate) =>
   Number.isNaN(new Date(chaineDate).valueOf());
 
+const chaineDateFrEnChaineDateISO = (chaineDateFr) => {
+  const [jour, mois, annee] = chaineDateFr.split('/');
+  return `${annee}-${mois}-${jour}`;
+};
+
 module.exports = {
   ajouteMoisADate,
   dateEnFrancais,
   dateEnIso,
+  chaineDateFrEnChaineDateISO,
   dateInvalide,
   dateYYYYMMDD,
 };


### PR DESCRIPTION
… pour qu'elles arrivent en date ISO dans le code du domaine. 

On fait ça dans l'adaptateur Excel car c'est un détail de l'Excel que les dates soient en format FR.

Sans ça, les dates des homologations en BDD ne sont pas cohérentes avec toutes les autres.
Ça fait, entre autre, crasher Metabase qui ne connaît que des dates `YYYY-MM-DD` d'habitude.

On veut donc garder la cohérence.

On veut transformer `24/02/2025`👇 
![image](https://github.com/user-attachments/assets/d8dd9c7d-8529-4761-b9af-595834e5464a)

… en `2025-02-24` 👇 
![image](https://github.com/user-attachments/assets/8866456e-8d9b-4ab1-8d0e-ebd8c06c507d)
