### PR TITLE
[CORRECTION] Ne casse pas les liens des descriptions de mesure lors d'une recherche textuelle

### DIFF
--- a/svelte/lib/mesure/contenus/ContenuOngletMesure.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletMesure.svelte
@@ -14,10 +14,15 @@
   export let retourUtilisateur: string;
   export let commentaireRetourUtilisateur: string;
 
-  $: texteSurligne = $store.mesureEditee.mesure.descriptionLongue?.replace(
-    new RegExp($rechercheTextuelle, 'ig'),
-    (texte: string) => ($rechercheTextuelle ? `<mark>${texte}</mark>` : texte)
-  );
+  $: texteSurligne = $store.mesureEditee.mesure.descriptionLongue
+    ?.replace(new RegExp($rechercheTextuelle, 'ig'), (texte: string) =>
+      $rechercheTextuelle ? `<mark>${texte}</mark>` : texte
+    )
+    .replace(
+      new RegExp(/<a.*(<mark>(.*)<\/mark>).*\/a>/gi),
+      (chaineEntiere: string, baliseMark: string, contenuSansBalise: string) =>
+        chaineEntiere.replaceAll(baliseMark, contenuSansBalise)
+    );
 </script>
 
 <div class:visible id="contenu-onglet-mesure">


### PR DESCRIPTION
... en effaçant les balises <mark> qui se sont potentiellement glissées à l'intérieur de la balise <a>