### PR TITLE
[CORRECTION] Ne tente pas de créer un objet de Date si la chaine de caractère est vide

### DIFF
--- a/svelte/lib/rapportTeleversement/composants/LigneService.svelte
+++ b/svelte/lib/rapportTeleversement/composants/LigneService.svelte
@@ -18,11 +18,12 @@
   const contientErreur = (erreur: ErreurService) =>
     service.erreurs.includes(erreur);
 
-  const dateEnFrancais = (chaineDateISO: string) => {
-    return new Date(chaineDateISO).toLocaleString('fr-FR', {
-      dateStyle: 'short',
-    });
-  };
+  const dateEnFrancais = (chaineDateISO: string) =>
+    chaineDateISO
+      ? new Date(chaineDateISO).toLocaleString('fr-FR', {
+          dateStyle: 'short',
+        })
+      : '';
 </script>
 
 <tr>


### PR DESCRIPTION
… dans le rapport de téléversement.
Cela permet de ne pas afficher un message "Invalid date".