### PR TITLE
Publie un évènement sur le bus lors de la modification en masse d'une mesure générale

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-app: &configuration-base
 
 services:
   mss-db:
-    image: postgres
+    image: postgres:14
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:

--- a/src/bus/abonnements/consigneModificationMesureEnMasseDansJournal.js
+++ b/src/bus/abonnements/consigneModificationMesureEnMasseDansJournal.js
@@ -1,0 +1,32 @@
+const {
+  EvenementMesureModifieeEnMasse,
+} = require('../../modeles/journalMSS/evenementMesureModifieeEnMasse');
+
+function consigneModificationMesureEnMasseDansJournal({ adaptateurJournal }) {
+  return async ({
+    type,
+    idMesure,
+    utilisateur,
+    statutModifie,
+    modalitesModifiees,
+    nombreServicesConcernes,
+  }) => {
+    if (!utilisateur)
+      throw new Error(
+        `Impossible de consigner la mise à jour en masse d'une mesure sans avoir l'utilisateur en paramètre.`
+      );
+
+    const evenemementDuJournal = new EvenementMesureModifieeEnMasse({
+      type,
+      idMesure,
+      statutModifie,
+      modalitesModifiees,
+      nombreServicesConcernes,
+      idUtilisateur: utilisateur.id,
+    });
+
+    await adaptateurJournal.consigneEvenement(evenemementDuJournal.toJSON());
+  };
+}
+
+module.exports = { consigneModificationMesureEnMasseDansJournal };

--- a/src/bus/busEvenements.js
+++ b/src/bus/busEvenements.js
@@ -7,6 +7,7 @@ class BusEvenements {
   }
 
   abonne(classeEvenement, handler) {
+    console.log(classeEvenement);
     this.handlers[classeEvenement.name] ??= [];
     this.handlers[classeEvenement.name].push(handler);
   }

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -112,6 +112,10 @@ const {
 const {
   supprimeSuggestionsActions,
 } = require('./abonnements/supprimeSuggestionsActions');
+const EvenementMesureModifieeEnMasse = require('./evenementMesureModifieeEnMasse');
+const {
+  consigneModificationMesureEnMasseDansJournal,
+} = require('./abonnements/consigneModificationMesureEnMasseDansJournal');
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -149,6 +153,11 @@ const cableTousLesAbonnes = (
     }),
     relieServiceEtSuperviseurs({ serviceSupervision }),
   ]);
+
+  busEvenements.abonne(
+    EvenementMesureModifieeEnMasse,
+    consigneModificationMesureEnMasseDansJournal({ adaptateurJournal })
+  );
 
   busEvenements.abonnePlusieurs(EvenementMesureServiceModifiee, [
     consigneCompletudeDansJournal({

--- a/src/bus/evenementMesureModifieeEnMasse.js
+++ b/src/bus/evenementMesureModifieeEnMasse.js
@@ -1,0 +1,18 @@
+class EvenementMesureModifieeEnMasse {
+  constructor({
+    utilisateur,
+    idMesure,
+    statutModifie,
+    modalitesModifiees,
+    nombreServicesConcernes,
+  }) {
+    this.utilisateur = utilisateur;
+    this.idMesure = idMesure;
+    this.statutModifie = statutModifie;
+    this.modalitesModifiees = modalitesModifiees;
+    this.nombreServicesConcernes = nombreServicesConcernes;
+    this.type = 'generale';
+  }
+}
+
+module.exports = EvenementMesureModifieeEnMasse;

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -23,6 +23,7 @@ const {
   avecPMapPourChaqueElementSansPromesse,
 } = require('../utilitaires/pMap');
 const MesureGenerale = require('../modeles/mesureGenerale');
+const EvenementMesureModifieeEnMasse = require('../bus/evenementMesureModifieeEnMasse');
 
 const fabriqueChiffrement = (adaptateurChiffrement) => {
   const chiffre = async (chaine) => adaptateurChiffrement.chiffre(chaine);
@@ -507,6 +508,15 @@ const creeDepot = (config = {}) => {
     };
 
     await Promise.all(servicesConcernes.map(pourUnService));
+    await busEvenements.publie(
+      new EvenementMesureModifieeEnMasse({
+        utilisateur,
+        idMesure,
+        statutModifie: !!statut,
+        modalitesModifiees: !!modalites,
+        nombreServicesConcernes: servicesConcernes.length,
+      })
+    );
   };
 
   const metsAJourMesureSpecifiqueDuService = async (

--- a/src/modeles/journalMSS/evenementMesureModifieeEnMasse.js
+++ b/src/modeles/journalMSS/evenementMesureModifieeEnMasse.js
@@ -1,0 +1,32 @@
+const Evenement = require('./evenement');
+
+class EvenementMesureModifieeEnMasse extends Evenement {
+  constructor(
+    {
+      idUtilisateur,
+      type,
+      idMesure,
+      statutModifie,
+      modalitesModifiees,
+      nombreServicesConcernes,
+    },
+    options = {}
+  ) {
+    const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
+
+    super(
+      'MESURE_MODIFIEE_EN_MASSE',
+      {
+        idUtilisateur: adaptateurChiffrement.hacheSha256(idUtilisateur),
+        type,
+        idMesure,
+        statutModifie,
+        modalitesModifiees,
+        nombreServicesConcernes,
+      },
+      date
+    );
+  }
+}
+
+module.exports = { EvenementMesureModifieeEnMasse };

--- a/test/bus/abonnements/consigneModificationMesureEnMasseDansJournal.spec.js
+++ b/test/bus/abonnements/consigneModificationMesureEnMasseDansJournal.spec.js
@@ -1,0 +1,55 @@
+const expect = require('expect.js');
+const AdaptateurJournalMSSMemoire = require('../../../src/adaptateurs/adaptateurJournalMSSMemoire');
+const {
+  unUtilisateur,
+} = require('../../constructeurs/constructeurUtilisateur');
+const {
+  consigneModificationMesureEnMasseDansJournal,
+} = require('../../../src/bus/abonnements/consigneModificationMesureEnMasseDansJournal');
+
+describe("L'abonnement qui consigne la modification en masse d'une mesure dans le journal MSS", () => {
+  let adaptateurJournal;
+
+  beforeEach(() => {
+    adaptateurJournal = AdaptateurJournalMSSMemoire.nouvelAdaptateur();
+  });
+
+  it('consigne un événement de mesure modifiée en masse', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneModificationMesureEnMasseDansJournal({ adaptateurJournal })({
+      utilisateur: unUtilisateur().avecId('ABC').construis(),
+      idMesure: 'uneMesure',
+      statutModifie: true,
+      modalitesModifiees: false,
+      nombreServicesConcernes: 2,
+      type: 'generale',
+    });
+
+    expect(evenementRecu.type).to.equal('MESURE_MODIFIEE_EN_MASSE');
+    expect(evenementRecu.donnees.idUtilisateur).not.to.be(undefined);
+    expect(evenementRecu.donnees.idMesure).to.be('uneMesure');
+    expect(evenementRecu.donnees.statutModifie).to.be(true);
+    expect(evenementRecu.donnees.modalitesModifiees).to.be(false);
+    expect(evenementRecu.donnees.nombreServicesConcernes).to.be(2);
+    expect(evenementRecu.donnees.type).to.be('generale');
+  });
+
+  it("lève une exception s'il ne reçoit pas d'utilisateur", async () => {
+    try {
+      await consigneModificationMesureEnMasseDansJournal({ adaptateurJournal })(
+        {
+          utilisateur: null,
+        }
+      );
+      expect().fail("L'instanciation aurait dû lever une exception.");
+    } catch (e) {
+      expect(e.message).to.be(
+        "Impossible de consigner la mise à jour en masse d'une mesure sans avoir l'utilisateur en paramètre."
+      );
+    }
+  });
+});

--- a/test/bus/aides/busPourLesTests.js
+++ b/test/bus/aides/busPourLesTests.js
@@ -13,7 +13,8 @@ const fabriqueBusPourLesTests = () => {
     },
     recupereEvenement: (typeAttendu) =>
       evenementsRecus.find((e) => e instanceof typeAttendu),
-    tousEvenements: () => [...evenementsRecus],
+    recupereEvenements: (typeAttendu) =>
+      evenementsRecus.filter((e) => e instanceof typeAttendu),
   };
 };
 

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -49,6 +49,7 @@ const {
 } = require('../../src/modeles/autorisations/gestionDroits');
 const { fabriqueBusPourLesTests } = require('../bus/aides/busPourLesTests');
 const EvenementNouveauServiceCree = require('../../src/bus/evenementNouveauServiceCree');
+const EvenementMesureModifieeEnMasse = require('../../src/bus/evenementMesureModifieeEnMasse');
 const {
   EvenementDescriptionServiceModifiee,
 } = require('../../src/bus/evenementDescriptionServiceModifiee');
@@ -2504,7 +2505,9 @@ describe('Le dépôt de données des services', () => {
       expect(
         busEvenements.aRecuUnEvenement(EvenementMesureServiceModifiee)
       ).to.be(true);
-      const tousEvenements = busEvenements.tousEvenements();
+      const tousEvenements = busEvenements.recupereEvenements(
+        EvenementMesureServiceModifiee
+      );
       expect(tousEvenements.length).to.be(2);
       expect(tousEvenements[0].ancienneMesure).to.be(undefined);
       expect(tousEvenements[0].nouvelleMesure.id).to.be('uneMesure');
@@ -2512,6 +2515,29 @@ describe('Le dépôt de données des services', () => {
       expect(tousEvenements[1].ancienneMesure.id).to.be('uneMesure');
       expect(tousEvenements[1].nouvelleMesure.id).to.be('uneMesure');
       expect(tousEvenements[1].service.id).to.be('S2');
+    });
+
+    it("publie un événement de 'Mesure modifiée en masse'", async () => {
+      await depot.metsAJourMesureGeneraleDesServices(
+        'U1',
+        ['S1', 'S2'],
+        'uneMesure',
+        'fait',
+        ''
+      );
+
+      expect(
+        busEvenements.aRecuUnEvenement(EvenementMesureModifieeEnMasse)
+      ).to.be(true);
+      const evenement = busEvenements.recupereEvenement(
+        EvenementMesureModifieeEnMasse
+      );
+      expect(evenement.utilisateur.id).to.be('U1');
+      expect(evenement.idMesure).to.be('uneMesure');
+      expect(evenement.statutModifie).to.be(true);
+      expect(evenement.modalitesModifiees).to.be(false);
+      expect(evenement.nombreServicesConcernes).to.be(2);
+      expect(evenement.type).to.be('generale');
     });
   });
 });

--- a/test/modeles/journalMSS/evenementMesureModifieeEnMasse.spec.js
+++ b/test/modeles/journalMSS/evenementMesureModifieeEnMasse.spec.js
@@ -1,0 +1,44 @@
+const expect = require('expect.js');
+const {
+  EvenementMesureModifieeEnMasse,
+} = require('../../../src/modeles/journalMSS/evenementMesureModifieeEnMasse');
+
+describe('Un événement de mesure modifiée en masse', () => {
+  const hacheEnMajuscules = { hacheSha256: (valeur) => valeur?.toUpperCase() };
+
+  it("chiffre l'identifiant utilisateur qui lui est donné", () => {
+    const evenement = new EvenementMesureModifieeEnMasse(
+      { idUtilisateur: 'def' },
+      { adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+    expect(evenement.toJSON().donnees.idUtilisateur).to.be('DEF');
+  });
+
+  it('sait se convertir en JSON', () => {
+    const evenement = new EvenementMesureModifieeEnMasse(
+      {
+        idUtilisateur: 'def',
+        idMesure: 'uneMesure',
+        statutModifie: true,
+        modalitesModifiees: false,
+        nombreServicesConcernes: 2,
+        type: 'generale',
+      },
+      { date: 1751358284051, adaptateurChiffrement: hacheEnMajuscules }
+    );
+
+    expect(evenement.toJSON()).to.eql({
+      type: 'MESURE_MODIFIEE_EN_MASSE',
+      donnees: {
+        idUtilisateur: 'DEF',
+        idMesure: 'uneMesure',
+        statutModifie: true,
+        modalitesModifiees: false,
+        nombreServicesConcernes: 2,
+        type: 'generale',
+      },
+      date: 1751358284051,
+    });
+  });
+});


### PR DESCRIPTION
Afin de pouvoir comptabiliser les utilisations de cette fonctionnalité dans metabase