### PR TITLE
[MODELE MESURE SPÉCIFIQUE] Permet de détacher une mesure spécifique de son modèle

### DIFF
--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -53,6 +53,7 @@ class ErreurModeleDeMesureSpecifiqueIntrouvable extends ErreurModele {
     );
   }
 }
+class ErreurDetachementModeleMesureSpecifiqueImpossible extends ErreurModele {}
 class ErreurMotDePasseIncorrect extends ErreurModele {}
 class ErreurNiveauGraviteInconnu extends ErreurModele {}
 class ErreurNiveauVraisemblanceInconnu extends ErreurModele {}
@@ -94,6 +95,7 @@ module.exports = {
   ErreurChainageMiddleware,
   ErreurDateHomologationInvalide,
   ErreurDateRenouvellementInvalide,
+  ErreurDetachementModeleMesureSpecifiqueImpossible,
   ErreurDonneesObligatoiresManquantes,
   ErreurDonneesReferentielIncorrectes,
   ErreurDonneesStatistiques,

--- a/src/modeles/mesureSpecifique.js
+++ b/src/modeles/mesureSpecifique.js
@@ -1,5 +1,8 @@
 const Mesure = require('./mesure');
-const { ErreurCategorieInconnue } = require('../erreurs');
+const {
+  ErreurCategorieInconnue,
+  ErreurDetachementModeleMesureSpecifiqueImpossible,
+} = require('../erreurs');
 const Referentiel = require('../referentiel');
 
 class MesureSpecifique extends Mesure {
@@ -52,6 +55,15 @@ class MesureSpecifique extends Mesure {
 
   supprimeResponsable(idUtilisateur) {
     this.responsables = this.responsables.filter((r) => r !== idUtilisateur);
+  }
+
+  detacheDeSonModele() {
+    if (!this.idModele)
+      throw new ErreurDetachementModeleMesureSpecifiqueImpossible(
+        `Impossible de détacher la mesure '${this.id}' : elle n'est pas reliée à un modèle.`
+      );
+
+    delete this.idModele;
   }
 
   static proprietesObligatoires() {

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -79,6 +79,14 @@ class MesuresSpecifiques extends ElementsConstructibles {
   avecId(idMesure) {
     return this.toutes().find((m) => m.id === idMesure);
   }
+
+  detacheMesureDuModele(idModele) {
+    this.items.forEach((m) => {
+      if (m.idModele === idModele) {
+        m.detacheDeSonModele();
+      }
+    });
+  }
 }
 
 module.exports = MesuresSpecifiques;

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -217,6 +217,10 @@ class Service {
     return this.mesures.mesuresSpecifiques;
   }
 
+  detacheMesureSpecfiqueDuModele(idModele) {
+    this.mesures.mesuresSpecifiques.detacheMesureDuModele(idModele);
+  }
+
   metsAJourMesureGenerale(mesure) {
     const idUtilisateurs = this.contributeurs.map((u) => u.idUtilisateur);
     mesure.responsables = mesure.responsables.filter((r) =>

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -13,9 +13,9 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 ## Du point de vue du Service
 
 - [ ] Le service va chercher le détail d'une mesure spécifique liée à un [modèle de mesure spécifique] lors de sa construction
-- [ ] Le servir peut détacher une mesure spécifique de son modèle de mesure
-  - Conséquence : tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service et
-    le lien entre modèle et service disparaît
+- [ ] Le service peut détacher une mesure spécifique de son modèle de mesure
+  - [x] Conséquence : tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
+  - [ ] et le lien entre modèle et service disparaît
 - [ ] Un service peut être relié à un modèle de mesure, à condition que le modèle appartienne à un utilisateur avec les droits d'écriture
       sur le service
   - [?] Question en cours : quel niveau de droit le contributeur doit avoir au minimum pour pouvoir lier un service à ses modèles

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -5,6 +5,7 @@ const {
   ErreurStatutMesureInvalide,
   ErreurPrioriteMesureInvalide,
   ErreurEcheanceMesureInvalide,
+  ErreurDetachementModeleMesureSpecifiqueImpossible,
 } = require('../../src/erreurs');
 const Referentiel = require('../../src/referentiel');
 const InformationsService = require('../../src/modeles/informationsService');
@@ -217,5 +218,36 @@ describe('Une mesure spécifique', () => {
         expect(persistance.categorie).to.be(undefined);
       }
     );
+  });
+
+  describe('concernant le détachement de son modèle', () => {
+    it("jette une erreur si la mesure n'est pas reliée à un modèle", () => {
+      const mesure = new MesureSpecifique({ id: 'MS1', idModele: undefined });
+
+      expect(() => mesure.detacheDeSonModele()).to.throwError((e) => {
+        expect(e).to.be.an(ErreurDetachementModeleMesureSpecifiqueImpossible);
+        expect(e.message).to.be(
+          "Impossible de détacher la mesure 'MS1' : elle n'est pas reliée à un modèle."
+        );
+      });
+    });
+
+    it("supprime l'identifiant du modèle, la rendant donc autonome", () => {
+      const mesure = new MesureSpecifique({
+        id: 'MS1',
+        idModele: 'MOD-1',
+        statut: 'fait',
+        description: 'Ma mesure spécifique',
+      });
+
+      mesure.detacheDeSonModele();
+
+      expect(mesure.donneesSerialisees()).to.eql({
+        id: 'MS1',
+        description: 'Ma mesure spécifique',
+        responsables: [],
+        statut: 'fait',
+      });
+    });
   });
 });

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -303,4 +303,46 @@ describe('La liste des mesures spécifiques', () => {
       });
     });
   });
+
+  describe("sur demande de détachement d'un modèle", () => {
+    it('détache la mesure spécifique liée à ce modèle', () => {
+      const modelesDeMesureSpecifique = {
+        'MOD-1': {
+          description: 'Description du modèle 1',
+          descriptionLongue: 'Longue du modèle 1',
+          categorie: 'categorie1',
+        },
+        'MOD-2': {
+          description: 'Description du modèle 2',
+          descriptionLongue: 'Longue du modèle 2',
+          categorie: 'categorie1',
+        },
+      };
+
+      const mesures = new MesuresSpecifiques(
+        {
+          mesuresSpecifiques: [
+            { id: 'M1', idModele: 'MOD-1', statut: 'fait' },
+            { id: 'M2', idModele: 'MOD-2', statut: 'fait' },
+          ],
+        },
+        referentiel,
+        modelesDeMesureSpecifique
+      );
+
+      mesures.detacheMesureDuModele('MOD-1');
+
+      expect(mesures.donneesSerialisees()).to.eql([
+        {
+          id: 'M1',
+          categorie: 'categorie1',
+          description: 'Description du modèle 1',
+          descriptionLongue: 'Longue du modèle 1',
+          responsables: [],
+          statut: 'fait',
+        },
+        { id: 'M2', idModele: 'MOD-2', responsables: [], statut: 'fait' },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Grâce à la manière dont sont construites les mesures spécifiques, il suffit juste de supprimer la propriété `idModele`.

De ce fait, les détails de la mesure spécifique sont déjà présents dans l'objet et la persistance suivant enregistrera donc cette mesure spécifique comme une mesure "autonome".