### PR TITLE
[MODÈLES MESURE SPECIFIQUE] Associe les mesures à leur modèle

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -100,7 +100,7 @@ const nouvelAdaptateur = (
         suggestions: donnees.suggestionsActions
           .filter((s) => s.idService === unService.id)
           .map((suggestion) => suggestion.nature),
-        modelesDeMesureSpecifique: Object.fromEntries(
+        modelesDisponiblesDeMesureSpecifique: Object.fromEntries(
           modelesDuService.map(({ id, donnees: d }) => [id, d])
         ),
       };

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -84,15 +84,27 @@ const nouvelAdaptateur = (
       servicesRetenus.push(...tousServices);
     }
 
-    return servicesRetenus.map((unService) => ({
-      ...unService,
-      utilisateurs: donnees.autorisations
-        .filter((a) => a.idService === unService.id)
-        .map((a) => donnees.utilisateurs.find((u) => u.id === a.idUtilisateur)),
-      suggestions: donnees.suggestionsActions
-        .filter((s) => s.idService === unService.id)
-        .map((suggestion) => suggestion.nature),
-    }));
+    return servicesRetenus.map((unService) => {
+      const autorisationsDuService = donnees.autorisations.filter(
+        (a) => a.idService === unService.id
+      );
+      const modelesDuService = donnees.modelesMesureSpecifique.filter(
+        ({ idUtilisateur: idU }) =>
+          autorisationsDuService.map((a) => a.idUtilisateur).includes(idU)
+      );
+      return {
+        ...unService,
+        utilisateurs: autorisationsDuService.map((a) =>
+          donnees.utilisateurs.find((u) => u.id === a.idUtilisateur)
+        ),
+        suggestions: donnees.suggestionsActions
+          .filter((s) => s.idService === unService.id)
+          .map((suggestion) => suggestion.nature),
+        modelesDeMesureSpecifique: Object.fromEntries(
+          modelesDuService.map(({ id, donnees: d }) => [id, d])
+        ),
+      };
+    });
   };
 
   const nombreServices = async (idUtilisateur) => {

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -363,6 +363,11 @@ const nouvelAdaptateur = (
       donnees: donneesModele,
     });
 
+  const modeleMesureSpecifiqueAppartientA = async (idUtilisateur, idModele) =>
+    donnees.modelesMesureSpecifique.find(
+      (m) => m.id === idModele && m.idUtilisateur === idUtilisateur
+    ) !== undefined;
+
   const associeModeleMesureSpecifiqueAuxServices = async (
     idModele,
     idsServices
@@ -403,6 +408,7 @@ const nouvelAdaptateur = (
     marqueTacheDeServiceLue,
     metsAJourIdResetMdpUtilisateur,
     metsAJourUtilisateur,
+    modeleMesureSpecifiqueAppartientA,
     nbAutorisationsProprietaire,
     nombreServices,
     nouveautesPourUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -667,6 +667,15 @@ const nouvelAdaptateur = (env) => {
       donnees,
     });
 
+  const modeleMesureSpecifiqueAppartientA = async (idUtilisateur, idModele) => {
+    const resultat = await knex.raw(
+      'SELECT 1 FROM modeles_mesure_specifique WHERE id_utilisateur = :idUtilisateur AND id = :idModele;',
+      { idUtilisateur, idModele }
+    );
+
+    return resultat.rows.length === 1;
+  };
+
   const associeModeleMesureSpecifiqueAuxServices = async (
     idModele,
     idsServices
@@ -719,6 +728,7 @@ const nouvelAdaptateur = (env) => {
     metsAJourParrainage,
     metsAJourProgressionTeleversement,
     metsAJourUtilisateur,
+    modeleMesureSpecifiqueAppartientA,
     nbAutorisationsProprietaire,
     nombreServices,
     nouveautesPourUtilisateur,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -124,6 +124,7 @@ const creeDepot = (config = {}) => {
       adaptateurChiffrement,
       adaptateurPersistance,
       adaptateurUUID,
+      depotAutorisations,
     });
 
   const {

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -125,6 +125,7 @@ const creeDepot = (config = {}) => {
       adaptateurPersistance,
       adaptateurUUID,
       depotAutorisations,
+      depotServices,
     });
 
   const {

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -19,6 +19,7 @@ const creeDepot = (config = {}) => {
     adaptateurPersistance,
     adaptateurUUID,
     depotAutorisations,
+    depotServices,
   } = config;
 
   const ajouteModeleMesureSpecifique = async (idUtilisateur, donnees) => {
@@ -72,6 +73,13 @@ const creeDepot = (config = {}) => {
         idsServices,
         droitsRequis
       );
+
+    const majServices = idsServices.map(async (unId) => {
+      const s = await depotServices.service(unId);
+      s.associeMesureSpecifiqueAuModele(idModele);
+      await depotServices.metsAJourService(s);
+    });
+    await Promise.all(majServices);
 
     await adaptateurPersistance.associeModeleMesureSpecifiqueAuxServices(
       idModele,

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -3,6 +3,7 @@ const {
   ErreurServiceInexistant,
   ErreurUtilisateurInexistant,
   ErreurDroitsInsuffisants,
+  ErreurAutorisationInexistante,
 } = require('../erreurs');
 const {
   Permissions,
@@ -44,9 +45,19 @@ const creeDepot = (config = {}) => {
     if (!modeleExiste)
       throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
 
-    const tousExistent =
+    const possedeLeModele =
+      await adaptateurPersistance.modeleMesureSpecifiqueAppartientA(
+        idUtilisateurAssociant,
+        idModele
+      );
+    if (!possedeLeModele)
+      throw new ErreurAutorisationInexistante(
+        `L'utilisateur ${idUtilisateurAssociant} n'est pas propriétaire du modèle ${idModele} qu'il veut associer`
+      );
+
+    const tousServicesExistent =
       await adaptateurPersistance.verifieTousLesServicesExistent(idsServices);
-    if (!tousExistent) throw new ErreurServiceInexistant();
+    if (!tousServicesExistent) throw new ErreurServiceInexistant();
 
     const droitsRequis = { [SECURISER]: ECRITURE };
     const droitsSontSuffisants =

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -76,7 +76,8 @@ const creeDepot = (config = {}) => {
 
     const majServices = idsServices.map(async (unId) => {
       const s = await depotServices.service(unId);
-      s.associeMesureSpecifiqueAuModele(idModele);
+      const idNouvelleMesure = adaptateurUUID.genereUUID();
+      s.associeMesureSpecifiqueAuModele(idModele, idNouvelleMesure);
       await depotServices.metsAJourService(s);
     });
     await Promise.all(majServices);

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -48,13 +48,19 @@ const creeDepot = (config = {}) => {
       await adaptateurPersistance.verifieTousLesServicesExistent(idsServices);
     if (!tousExistent) throw new ErreurServiceInexistant();
 
+    const droitsRequis = { [SECURISER]: ECRITURE };
     const droitsSontSuffisants =
       await depotAutorisations.accesAutoriseAUneListeDeService(
         idUtilisateurAssociant,
         idsServices,
-        { [SECURISER]: ECRITURE }
+        droitsRequis
       );
-    if (!droitsSontSuffisants) throw new ErreurDroitsInsuffisants();
+    if (!droitsSontSuffisants)
+      throw new ErreurDroitsInsuffisants(
+        idUtilisateurAssociant,
+        idsServices,
+        droitsRequis
+      );
 
     await adaptateurPersistance.associeModeleMesureSpecifiqueAuxServices(
       idModele,

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -426,8 +426,10 @@ const creeDepot = (config = {}) => {
   };
 
   const metsAJourService = async (unService) => {
-    const s = await p.lis.un(unService.id);
-    if (typeof s === 'undefined')
+    const existe = await adaptateurPersistance.verifieServiceExiste(
+      unService.id
+    );
+    if (!existe)
       throw new ErreurServiceInexistant(`Service "${unService.id}" non trouvé`);
 
     const { id, ...donnees } = unService.donneesAPersister().toutes();

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -2,6 +2,7 @@ class EchecAutorisation extends Error {}
 class EchecEnvoiMessage extends Error {}
 class ErreurApiBrevo extends Error {}
 class ErreurDroitsIncoherents extends Error {}
+class ErreurDroitsInsuffisants extends Error {}
 class ErreurChainageMiddleware extends Error {}
 class ErreurBusEvenements extends Error {
   constructor(typeEvenement, erreurDeAbonne) {
@@ -106,6 +107,7 @@ module.exports = {
   ErreurDossierNonFinalise,
   ErreurDossiersInvalides,
   ErreurDroitsIncoherents,
+  ErreurDroitsInsuffisants,
   ErreurDureeValiditeInvalide,
   ErreurEcheanceMesureInvalide,
   ErreurEmailManquant,

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -2,7 +2,16 @@ class EchecAutorisation extends Error {}
 class EchecEnvoiMessage extends Error {}
 class ErreurApiBrevo extends Error {}
 class ErreurDroitsIncoherents extends Error {}
-class ErreurDroitsInsuffisants extends Error {}
+class ErreurDroitsInsuffisants extends Error {
+  constructor(idUtilisateur, idServices, droitsRequis) {
+    const u = idUtilisateur;
+    const s = idServices.join(',');
+    const d = JSON.stringify(droitsRequis);
+    super(
+      `L'utilisateur ${u} n'a pas les droits suffisants sur ${s}. Droits requis pour associer un modèle : ${d}`
+    );
+  }
+}
 class ErreurChainageMiddleware extends Error {}
 class ErreurBusEvenements extends Error {
   constructor(typeEvenement, erreurDeAbonne) {

--- a/src/modeles/mesures.js
+++ b/src/modeles/mesures.js
@@ -26,7 +26,7 @@ class Mesures extends InformationsService {
     donnees = {},
     referentiel = Referentiel.creeReferentielVide(),
     mesuresPersonnalisees = {},
-    modelesDeMesureSpecifique = {}
+    modelesDisponiblesDeMesureSpecifique = {}
   ) {
     super();
 
@@ -38,7 +38,7 @@ class Mesures extends InformationsService {
     this.mesuresSpecifiques = new MesuresSpecifiques(
       { mesuresSpecifiques: donnees.mesuresSpecifiques || [] },
       referentiel,
-      modelesDeMesureSpecifique
+      modelesDisponiblesDeMesureSpecifique
     );
 
     this.referentiel = referentiel;

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -11,28 +11,29 @@ class MesuresSpecifiques extends ElementsConstructibles {
   constructor(
     donnees = {},
     referentiel = Referentiel.creeReferentielVide(),
-    modelesDeMesureSpecifique = {}
+    modelesDisponiblesDeMesureSpecifique = {}
   ) {
     const { mesuresSpecifiques = [] } = donnees;
 
     const mesuresCompletees = MesuresSpecifiques.completeMesuresSpecifiques(
       mesuresSpecifiques,
-      modelesDeMesureSpecifique
+      modelesDisponiblesDeMesureSpecifique
     );
 
     super(MesureSpecifique, { items: mesuresCompletees }, referentiel);
-    this.modelesDeMesureSpecifique = modelesDeMesureSpecifique;
+    this.modelesDisponiblesDeMesureSpecifique =
+      modelesDisponiblesDeMesureSpecifique;
   }
 
   static completeMesuresSpecifiques(
     mesuresSpecifiques,
-    modelesDeMesureSpecifique
+    modelesDisponiblesDeMesureSpecifique
   ) {
     return mesuresSpecifiques.map((m) => {
       const lieeAUnModele = m.idModele;
       if (!lieeAUnModele) return m;
 
-      const modele = modelesDeMesureSpecifique[m.idModele];
+      const modele = modelesDisponiblesDeMesureSpecifique[m.idModele];
       if (!modele)
         throw new ErreurModeleDeMesureSpecifiqueIntrouvable(m.idModele);
 
@@ -91,7 +92,7 @@ class MesuresSpecifiques extends ElementsConstructibles {
   }
 
   associeAuModele(idModele, idNouvelleMesure) {
-    const modele = this.modelesDeMesureSpecifique[idModele];
+    const modele = this.modelesDisponiblesDeMesureSpecifique[idModele];
 
     const modeleInconnu = !modele;
     if (modeleInconnu)

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -90,7 +90,7 @@ class MesuresSpecifiques extends ElementsConstructibles {
     });
   }
 
-  associeAuModele(idModele) {
+  associeAuModele(idModele, idNouvelleMesure) {
     const modele = this.modelesDeMesureSpecifique[idModele];
 
     const modeleInconnu = !modele;
@@ -102,6 +102,7 @@ class MesuresSpecifiques extends ElementsConstructibles {
       new MesureSpecifique(
         {
           idModele,
+          id: idNouvelleMesure,
           description,
           descriptionLongue,
           categorie,

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -5,6 +5,7 @@ const {
   ErreurMesureInconnue,
   ErreurModeleDeMesureSpecifiqueIntrouvable,
 } = require('../erreurs');
+const Mesure = require('./mesure');
 
 class MesuresSpecifiques extends ElementsConstructibles {
   constructor(
@@ -20,6 +21,7 @@ class MesuresSpecifiques extends ElementsConstructibles {
     );
 
     super(MesureSpecifique, { items: mesuresCompletees }, referentiel);
+    this.modelesDeMesureSpecifique = modelesDeMesureSpecifique;
   }
 
   static completeMesuresSpecifiques(
@@ -86,6 +88,28 @@ class MesuresSpecifiques extends ElementsConstructibles {
         m.detacheDeSonModele();
       }
     });
+  }
+
+  associeAuModele(idModele) {
+    const modele = this.modelesDeMesureSpecifique[idModele];
+
+    const modeleInconnu = !modele;
+    if (modeleInconnu)
+      throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
+
+    const { description, descriptionLongue, categorie } = modele;
+    this.items.push(
+      new MesureSpecifique(
+        {
+          idModele,
+          description,
+          descriptionLongue,
+          categorie,
+          statut: Mesure.STATUT_A_LANCER,
+        },
+        this.referentiel
+      )
+    );
   }
 }
 

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -217,6 +217,10 @@ class Service {
     return this.mesures.mesuresSpecifiques;
   }
 
+  associeMesureSpecifiqueAuModele(idModele) {
+    this.mesures.mesuresSpecifiques.associeAuModele(idModele);
+  }
+
   detacheMesureSpecfiqueDuModele(idModele) {
     this.mesures.mesuresSpecifiques.detacheMesureDuModele(idModele);
   }

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -217,8 +217,8 @@ class Service {
     return this.mesures.mesuresSpecifiques;
   }
 
-  associeMesureSpecifiqueAuModele(idModele) {
-    this.mesures.mesuresSpecifiques.associeAuModele(idModele);
+  associeMesureSpecifiqueAuModele(idModele, idNouvelleMesure) {
+    this.mesures.mesuresSpecifiques.associeAuModele(idModele, idNouvelleMesure);
   }
 
   detacheMesureSpecfiqueDuModele(idModele) {

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -40,7 +40,7 @@ class Service {
       rolesResponsabilites = {},
       suggestionsActions = [],
       prochainIdNumeriqueDeRisqueSpecifique = 1,
-      modelesDeMesureSpecifique = {},
+      modelesDisponiblesDeMesureSpecifique = {},
     } = donnees;
 
     this.id = id;
@@ -63,7 +63,7 @@ class Service {
       { mesuresGenerales, mesuresSpecifiques },
       referentiel,
       mesuresPersonnalisees,
-      modelesDeMesureSpecifique
+      modelesDisponiblesDeMesureSpecifique
     );
 
     this.rolesResponsabilites = new RolesResponsabilites(rolesResponsabilites);

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -28,6 +28,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
     - [x] **et** elle a un identifiant de mesure (en plus de l'identifiant du modèle)
     - [x] le service relu depuis le dépôt connaitrait l'association
 - [x] `depotDonneesService.metAjour` devrait utiliser une fonction "SELECT 1" pour vérifier l'existence du service
+- [x] On appelle `modelesDisponiblesDeMesureSpecifique` la liste de tous les modèles associables.
 
 ## Du point de vue des Modèles de mesure
 

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -16,10 +16,11 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [ ] Le service peut détacher une mesure spécifique de son modèle de mesure
   - [x] Conséquence : tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
   - [ ] et le lien entre modèle et service disparaît
-- [ ] Un service peut être relié à un modèle de mesure, à condition que le modèle appartienne à un utilisateur avec les droits d'écriture
-      sur le service
-  - [?] Question en cours : quel niveau de droit le contributeur doit avoir au minimum pour pouvoir lier un service à ses modèles
-  - Conséquence : le service se retrouve avec une mesure spécifique au statut « À lancer ». Cette mesure est reliée au modèle **et** elle apparaît dans la table d'association.
+- [ ] Un service peut être relié à un modèle de mesure, à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
+  - Conséquence :
+    - [ ] le service se retrouve avec une mesure spécifique au statut « À lancer ».
+    - [ ] Cette mesure est reliée au modèle
+    - [x] **et** elle apparaît dans la table d'association.
 
 ## Du point de vue des Modèles de mesure
 

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -25,6 +25,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
     - [x] Cette mesure est reliée au modèle
     - [x] **et** elle apparaît dans la table d'association.
     - [ ] le service relu depuis le dépôt connaitrait l'association
+- [x] `depotDonneesService.metAjour` devrait utiliser une fonction "SELECT 1" pour vérifier l'existence du service
 
 ## Du point de vue des Modèles de mesure
 

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -16,6 +16,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [ ] Le service peut détacher une mesure spécifique de son modèle de mesure
   - [x] Conséquence : tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
   - [ ] et le lien entre modèle et service disparaît
+  - [ ] le service relu ne connait plus l'association
 - [ ] Un service peut être relié à un modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
     - [x] une erreur qui montre les détails utilisateur et id service
@@ -24,7 +25,8 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
     - [x] le service se retrouve avec une mesure spécifique au statut « À lancer ».
     - [x] Cette mesure est reliée au modèle
     - [x] **et** elle apparaît dans la table d'association.
-    - [ ] le service relu depuis le dépôt connaitrait l'association
+    - [ ] **et** elle a un identifiant de mesure (en plus de l'identifiant du modèle)
+    - [x] le service relu depuis le dépôt connaitrait l'association
 - [x] `depotDonneesService.metAjour` devrait utiliser une fonction "SELECT 1" pour vérifier l'existence du service
 
 ## Du point de vue des Modèles de mesure

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -18,7 +18,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
   - [ ] et le lien entre modèle et service disparaît
 - [ ] Un service peut être relié à un modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
-    - [ ] une erreur qui montre les détails utilisateur et id service
+    - [x] une erreur qui montre les détails utilisateur et id service
   - [ ] à condition que l'utilisateur soit propriétaire du modèle
   - Conséquence :
     - [x] le service se retrouve avec une mesure spécifique au statut « À lancer ».

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -17,7 +17,9 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
   - [x] Conséquence : tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
   - [ ] et le lien entre modèle et service disparaît
 - [ ] Un service peut être relié à un modèle de mesure
-  - [ ] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
+  - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
+    - [ ] une erreur qui montre les détails utilisateur et id service
+  - [ ] à condition que l'utilisateur soit propriétaire du modèle
   - Conséquence :
     - [x] le service se retrouve avec une mesure spécifique au statut « À lancer ».
     - [x] Cette mesure est reliée au modèle

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -16,10 +16,11 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [ ] Le service peut détacher une mesure spécifique de son modèle de mesure
   - [x] Conséquence : tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
   - [ ] et le lien entre modèle et service disparaît
-- [ ] Un service peut être relié à un modèle de mesure, à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
+- [ ] Un service peut être relié à un modèle de mesure
+  - [ ] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
   - Conséquence :
-    - [ ] le service se retrouve avec une mesure spécifique au statut « À lancer ».
-    - [ ] Cette mesure est reliée au modèle
+    - [x] le service se retrouve avec une mesure spécifique au statut « À lancer ».
+    - [x] Cette mesure est reliée au modèle
     - [x] **et** elle apparaît dans la table d'association.
 
 ## Du point de vue des Modèles de mesure

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -17,7 +17,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
   - [x] Conséquence : tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
   - [ ] et le lien entre modèle et service disparaît
   - [ ] le service relu ne connait plus l'association
-- [ ] Un service peut être relié à un modèle de mesure
+- [x] Un service peut être relié à un modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
     - [x] une erreur qui montre les détails utilisateur et id service
   - [x] à condition que l'utilisateur soit propriétaire du modèle
@@ -25,7 +25,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
     - [x] le service se retrouve avec une mesure spécifique au statut « À lancer ».
     - [x] Cette mesure est reliée au modèle
     - [x] **et** elle apparaît dans la table d'association.
-    - [ ] **et** elle a un identifiant de mesure (en plus de l'identifiant du modèle)
+    - [x] **et** elle a un identifiant de mesure (en plus de l'identifiant du modèle)
     - [x] le service relu depuis le dépôt connaitrait l'association
 - [x] `depotDonneesService.metAjour` devrait utiliser une fonction "SELECT 1" pour vérifier l'existence du service
 

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -19,11 +19,12 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [ ] Un service peut être relié à un modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
     - [x] une erreur qui montre les détails utilisateur et id service
-  - [ ] à condition que l'utilisateur soit propriétaire du modèle
+  - [x] à condition que l'utilisateur soit propriétaire du modèle
   - Conséquence :
     - [x] le service se retrouve avec une mesure spécifique au statut « À lancer ».
     - [x] Cette mesure est reliée au modèle
     - [x] **et** elle apparaît dans la table d'association.
+    - [ ] le service relu depuis le dépôt connaitrait l'association
 
 ## Du point de vue des Modèles de mesure
 

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -158,6 +158,9 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         expect().fail("L'appel aurait dû lever une erreur.");
       } catch (e) {
         expect(e).to.be.an(ErreurDroitsInsuffisants);
+        expect(e.message).to.be(
+          'L\'utilisateur U-SANS-DROIT n\'a pas les droits suffisants sur S1. Droits requis pour associer un modèle : {"SECURISER":2}'
+        );
       }
     });
   });

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -137,6 +137,13 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
     });
 
     it("met à jour chaque service pour qu'il connaisse la mesure associée", async () => {
+      let compteur = 0;
+      adaptateurUUID = {
+        genereUUID: () => {
+          compteur += 1;
+          return `UUID-${compteur}`;
+        },
+      };
       const depot = leDepot();
 
       await depot.associeModeleMesureSpecifiqueAuxServices(
@@ -148,6 +155,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
       const s1 = await depotServices.service('S1');
       expect(s1.mesuresSpecifiques().toutes()[0].toJSON()).to.eql({
         idModele: 'MOD-1',
+        id: 'UUID-1',
         statut: 'aLancer',
         responsables: [],
         description: 'Il faut faire A,B,C',
@@ -155,6 +163,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
       const s2 = await depotServices.service('S2');
       expect(s2.mesuresSpecifiques().toutes()[0].toJSON()).to.eql({
         idModele: 'MOD-1',
+        id: 'UUID-2',
         statut: 'aLancer',
         responsables: [],
         description: 'Il faut faire A,B,C',

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -11,14 +11,12 @@ const Referentiel = require('../../src/referentiel');
 const InformationsService = require('../../src/modeles/informationsService');
 const MesureSpecifique = require('../../src/modeles/mesureSpecifique');
 
-const elle = it;
-
 describe('Une mesure spécifique', () => {
   const referentiel = Referentiel.creeReferentiel({
     categoriesMesures: { uneCategorie: 'Une catégorie' },
   });
 
-  elle('sait se décrire', () => {
+  it('sait se décrire', () => {
     referentiel.enrichis({ prioritesMesures: { p3: {} } });
 
     const mesure = new MesureSpecifique(
@@ -52,7 +50,7 @@ describe('Une mesure spécifique', () => {
     ]);
   });
 
-  elle('connaît ses propriétés obligatoires', () => {
+  it('connaît ses propriétés obligatoires', () => {
     expect(MesureSpecifique.proprietesObligatoires()).to.eql([
       'id',
       'description',
@@ -61,24 +59,21 @@ describe('Une mesure spécifique', () => {
     ]);
   });
 
-  elle(
-    'ne tient pas compte du champ `modalites` ni de la priorite pour déterminer le statut de saisie',
-    () => {
-      const mesure = new MesureSpecifique(
-        {
-          id: 'x',
-          description: 'Une mesure spécifique',
-          categorie: 'uneCategorie',
-          statut: 'fait',
-        },
-        referentiel
-      );
+  it('ne tient pas compte du champ `modalites` ni de la priorite pour déterminer le statut de saisie', () => {
+    const mesure = new MesureSpecifique(
+      {
+        id: 'x',
+        description: 'Une mesure spécifique',
+        categorie: 'uneCategorie',
+        statut: 'fait',
+      },
+      referentiel
+    );
 
-      expect(mesure.statutSaisie()).to.equal(InformationsService.COMPLETES);
-    }
-  );
+    expect(mesure.statutSaisie()).to.equal(InformationsService.COMPLETES);
+  });
 
-  elle('vérifie que le statut est bien valide', (done) => {
+  it('vérifie que le statut est bien valide', (done) => {
     try {
       new MesureSpecifique({ statut: 'statutInconnu' });
       done('La création de la mesure aurait dû lever une exception.');
@@ -110,7 +105,7 @@ describe('Une mesure spécifique', () => {
     }
   });
 
-  elle('vérifie que la catégorie est bien répertoriée', (done) => {
+  it('vérifie que la catégorie est bien répertoriée', (done) => {
     try {
       new MesureSpecifique({ categorie: 'categorieInconnue' });
       done('La création de la mesure aurait dû lever une exception.');
@@ -123,31 +118,28 @@ describe('Une mesure spécifique', () => {
     }
   });
 
-  elle(
-    "ne tient pas compte de la catégorie si elle n'est pas renseignée",
-    (done) => {
-      try {
-        new MesureSpecifique();
-        done();
-      } catch {
-        done(
-          "La création de la mesure sans catégorie n'aurait pas dû lever d'exception."
-        );
-      }
+  it("ne tient pas compte de la catégorie si elle n'est pas renseignée", (done) => {
+    try {
+      new MesureSpecifique();
+      done();
+    } catch {
+      done(
+        "La création de la mesure sans catégorie n'aurait pas dû lever d'exception."
+      );
     }
-  );
+  });
 
-  elle("n'est pas indispensable selon l'ANSSI", () => {
+  it("n'est pas indispensable selon l'ANSSI", () => {
     const mesure = new MesureSpecifique();
     expect(mesure.estIndispensable()).to.be(false);
   });
 
-  elle("n'est pas recommandée par l'ANSSI", () => {
+  it("n'est pas recommandée par l'ANSSI", () => {
     const mesure = new MesureSpecifique();
     expect(mesure.estRecommandee()).to.be(false);
   });
 
-  elle('sait si son statut est renseigné', () => {
+  it('sait si son statut est renseigné', () => {
     const mesure = new MesureSpecifique({ statut: 'fait' });
     expect(mesure.statutRenseigne()).to.be(true);
   });
@@ -170,7 +162,7 @@ describe('Une mesure spécifique', () => {
       };
     });
 
-    elle("persiste sa date d'échéance au format ISO en UTC", () => {
+    it("persiste sa date d'échéance au format ISO en UTC", () => {
       const janvierNonIso = '01/23/2024 10:00Z';
       const avecEcheance = new MesureSpecifique(
         { echeance: janvierNonIso },
@@ -182,7 +174,7 @@ describe('Une mesure spécifique', () => {
       expect(persistance.echeance).to.be('2024-01-23T10:00:00.000Z');
     });
 
-    elle('persiste toutes ses données', () => {
+    it('persiste toutes ses données', () => {
       const mesureSpecifique = new MesureSpecifique(
         donneesMesureSpecifique,
         referentiel
@@ -203,21 +195,18 @@ describe('Une mesure spécifique', () => {
       });
     });
 
-    elle(
-      'ne persiste pas les données du modèle si la mesure a un modèle, car elles ne doivent apparaître que dans le modèle',
-      () => {
-        const mesureAvecModele = new MesureSpecifique(
-          { ...donneesMesureSpecifique, idModele: 'MS1' },
-          referentiel
-        );
+    it('ne persiste pas les données du modèle si la mesure a un modèle, car elles ne doivent apparaître que dans le modèle', () => {
+      const mesureAvecModele = new MesureSpecifique(
+        { ...donneesMesureSpecifique, idModele: 'MS1' },
+        referentiel
+      );
 
-        const persistance = mesureAvecModele.donneesSerialisees();
+      const persistance = mesureAvecModele.donneesSerialisees();
 
-        expect(persistance.description).to.be(undefined);
-        expect(persistance.descriptionLongue).to.be(undefined);
-        expect(persistance.categorie).to.be(undefined);
-      }
-    );
+      expect(persistance.description).to.be(undefined);
+      expect(persistance.descriptionLongue).to.be(undefined);
+      expect(persistance.categorie).to.be(undefined);
+    });
   });
 
   describe('concernant le détachement de son modèle', () => {

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -3,7 +3,10 @@ const expect = require('expect.js');
 const MesureSpecifique = require('../../src/modeles/mesureSpecifique');
 const MesuresSpecifiques = require('../../src/modeles/mesuresSpecifiques');
 const Referentiel = require('../../src/referentiel');
-const { ErreurMesureInconnue } = require('../../src/erreurs');
+const {
+  ErreurMesureInconnue,
+  ErreurModeleDeMesureSpecifiqueIntrouvable,
+} = require('../../src/erreurs');
 
 describe('La liste des mesures spécifiques', () => {
   let referentiel;
@@ -300,6 +303,43 @@ describe('La liste des mesures spécifiques', () => {
 
       expect(() => mesures.metsAJourMesure(mesureAJour)).to.throwError((e) => {
         expect(e).to.be.an(ErreurMesureInconnue);
+      });
+    });
+  });
+
+  describe("sur demande d'association à un modèle", () => {
+    it('ajoute une mesure spécifique qui reprend les données du modèle, avec un statut « À lancer »', () => {
+      const modelesAvecM1 = {
+        'M-1': { description: 'Mesure M1', categorie: 'categorie1' },
+      };
+      const connaitM1 = new MesuresSpecifiques(
+        { mesuresSpecifiques: [] },
+        referentiel,
+        modelesAvecM1
+      );
+
+      connaitM1.associeAuModele('M-1');
+
+      expect(connaitM1.toutes()[0].toJSON()).to.eql({
+        idModele: 'M-1',
+        categorie: 'categorie1',
+        description: 'Mesure M1',
+        statut: 'aLancer',
+        responsables: [],
+      });
+    });
+
+    it('jette une erreur si le modèle est introuvable', () => {
+      const modelesAvecM1 = { 'M-1': {} };
+
+      const connaitM1 = new MesuresSpecifiques(
+        { mesuresSpecifiques: [] },
+        referentiel,
+        modelesAvecM1
+      );
+
+      expect(() => connaitM1.associeAuModele('M-2')).to.throwError((e) => {
+        expect(e).to.be.an(ErreurModeleDeMesureSpecifiqueIntrouvable);
       });
     });
   });

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -215,7 +215,7 @@ describe('La liste des mesures spécifiques', () => {
 
   describe('concernant les mesures spécifiques liées à un modèle', () => {
     it('complète les mesures rattachées à un modèle avec les données extraites du modèle… pour que les consommateurs ne fassent pas la différence avec des mesures "classiques"', () => {
-      const modelesDeMesureSpecifique = {
+      const modelesDisponiblesDeMesureSpecifique = {
         'MOD-1': {
           description: 'Description du modèle',
           descriptionLongue: 'Longue du modèle',
@@ -230,7 +230,7 @@ describe('La liste des mesures spécifiques', () => {
           ],
         },
         referentiel,
-        modelesDeMesureSpecifique
+        modelesDisponiblesDeMesureSpecifique
       );
 
       const mesureCompletee = avecUnModele.toutes()[0];
@@ -347,7 +347,7 @@ describe('La liste des mesures spécifiques', () => {
 
   describe("sur demande de détachement d'un modèle", () => {
     it('détache la mesure spécifique liée à ce modèle', () => {
-      const modelesDeMesureSpecifique = {
+      const modelesDisponiblesDeMesureSpecifique = {
         'MOD-1': {
           description: 'Description du modèle 1',
           descriptionLongue: 'Longue du modèle 1',
@@ -368,7 +368,7 @@ describe('La liste des mesures spécifiques', () => {
           ],
         },
         referentiel,
-        modelesDeMesureSpecifique
+        modelesDisponiblesDeMesureSpecifique
       );
 
       mesures.detacheMesureDuModele('MOD-1');

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -308,7 +308,7 @@ describe('La liste des mesures spécifiques', () => {
   });
 
   describe("sur demande d'association à un modèle", () => {
-    it('ajoute une mesure spécifique qui reprend les données du modèle, avec un statut « À lancer »', () => {
+    it('ajoute une mesure spécifique qui reprend les données du modèle, avec un statut « À lancer » et un identifiant', () => {
       const modelesAvecM1 = {
         'M-1': { description: 'Mesure M1', categorie: 'categorie1' },
       };
@@ -318,10 +318,11 @@ describe('La liste des mesures spécifiques', () => {
         modelesAvecM1
       );
 
-      connaitM1.associeAuModele('M-1');
+      connaitM1.associeAuModele('M-1', 'ID-MESURE-1');
 
       expect(connaitM1.toutes()[0].toJSON()).to.eql({
         idModele: 'M-1',
+        id: 'ID-MESURE-1',
         categorie: 'categorie1',
         description: 'Mesure M1',
         statut: 'aLancer',

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -1226,7 +1226,7 @@ describe('Un service', () => {
   it('Passe les modèles de mesures spécifiques à la classe de Mesures, afin de faire passe plat pour les Mesures Spécifiques', () => {
     const service = new Service({
       id: '123',
-      modelesDeMesureSpecifique: {
+      modelesDisponiblesDeMesureSpecifique: {
         'MOD-1': { description: 'Mon modèle de mesure' },
       },
       mesuresSpecifiques: [{ idModele: 'MOD-1' }],


### PR DESCRIPTION
Afin de pouvoir correctement associer un modèle à des services, nous augmentons les capacités du dépôt de données.

Ce dernier est maintenant responsable de :
- vérifier la propriété du modèle
- vérifier les permissions de l'utilisateur sur ces services
- muter les services
- presister les services à jour