### PR TITLE
Implémente le détachement d'un modèle de mesure spécifique et d'un service

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -395,6 +395,17 @@ const nouvelAdaptateur = (
     donnees.modelesMesureSpecifique.find((m) => m.id === idModele) !==
     undefined;
 
+  const tousServicesSontAssociesAuModeleMesureSpecifique = async (
+    idsServices,
+    idModele
+  ) =>
+    idsServices.every(
+      (unId) =>
+        donnees.associationModelesMesureSpecifiqueServices.find(
+          (a) => a.idService === unId && a.idModele === idModele
+        ) !== undefined
+    );
+
   return {
     activitesMesure,
     ajouteActiviteMesure,
@@ -441,6 +452,7 @@ const nouvelAdaptateur = (
     supprimeUtilisateur,
     supprimeUtilisateurs,
     tachesDeServicePour,
+    tousServicesSontAssociesAuModeleMesureSpecifique,
     tousUtilisateurs,
     utilisateur,
     utilisateurAvecEmailHash,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -391,6 +391,18 @@ const nouvelAdaptateur = (
       })
     );
 
+  const supprimeLeLienEntreLeModeleEtLesServices = async (
+    idModele,
+    idsServices
+  ) => {
+    donnees.associationModelesMesureSpecifiqueServices =
+      donnees.associationModelesMesureSpecifiqueServices.filter((a) => {
+        const estUnLien =
+          a.idModele === idModele && idsServices.includes(a.idService);
+        return !estUnLien;
+      });
+  };
+
   const verifieModeleMesureSpecifiqueExiste = async (idModele) =>
     donnees.modelesMesureSpecifique.find((m) => m.id === idModele) !==
     undefined;
@@ -445,6 +457,7 @@ const nouvelAdaptateur = (
     supprimeAutorisations,
     supprimeAutorisationsContribution,
     supprimeAutorisationsHomologation,
+    supprimeLeLienEntreLeModeleEtLesServices,
     supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
     supprimeService,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -706,11 +706,25 @@ const nouvelAdaptateur = (env) => {
       `SELECT DISTINCT id_service
        FROM modeles_mesure_specifique_association_aux_services
        WHERE id_modele = ? 
-       AND id_service IN (${bindingIdsServices})`,
+       AND id_service IN (${bindingIdsServices}) ;`,
       [idModele, ...idsServices]
     );
 
     return resultat.rows.length === idsServices.length;
+  };
+
+  const supprimeLeLienEntreLeModeleEtLesServices = async (
+    idModele,
+    idsServices
+  ) => {
+    const bindingIdsServices = idsServices.map(() => '?').join(',');
+    await knex.raw(
+      `DELETE
+       FROM modeles_mesure_specifique_association_aux_services
+       WHERE id_modele = ? 
+       AND id_service IN (${bindingIdsServices}) ;`,
+      [idModele, ...idsServices]
+    );
   };
 
   return {
@@ -779,6 +793,7 @@ const nouvelAdaptateur = (env) => {
     utilisateurAvecEmailHash,
     utilisateurAvecIdReset,
     servicesComplets,
+    supprimeLeLienEntreLeModeleEtLesServices,
     verifieModeleMesureSpecifiqueExiste,
     verifieServiceExiste,
     verifieTousLesServicesExistent,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -696,6 +696,23 @@ const nouvelAdaptateur = (env) => {
     return resultat.rows.length === 1;
   };
 
+  const tousServicesSontAssociesAuModeleMesureSpecifique = async (
+    idsServices,
+    idModele
+  ) => {
+    const bindingIdsServices = idsServices.map(() => '?').join(',');
+
+    const resultat = await knex.raw(
+      `SELECT DISTINCT id_service
+       FROM modeles_mesure_specifique_association_aux_services
+       WHERE id_modele = ? 
+       AND id_service IN (${bindingIdsServices})`,
+      [idModele, ...idsServices]
+    );
+
+    return resultat.rows.length === idsServices.length;
+  };
+
   return {
     activitesMesure,
     ajouteAutorisation,
@@ -756,6 +773,7 @@ const nouvelAdaptateur = (env) => {
     supprimeUtilisateurs,
     tachesDeServicePour,
     tousLesSelsDeHachage,
+    tousServicesSontAssociesAuModeleMesureSpecifique,
     tousUtilisateurs,
     utilisateur,
     utilisateurAvecEmailHash,

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -77,9 +77,17 @@ const creeDepot = (config = {}) => {
         idsServices,
         idModele
       );
-
     if (!tousAssocies)
       throw new ErreurServiceNonAssocieAuModele(idsServices, idModele);
+
+    const detacheDesServices = idsServices.map(async (unId) => {
+      const s = await depotServices.service(unId);
+      s.detacheMesureSpecfiqueDuModele(idModele);
+      return s;
+    });
+    const aPersister = await Promise.all(detacheDesServices);
+
+    await Promise.all(aPersister.map(depotServices.metsAJourService));
   };
 
   return {

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -9,25 +9,25 @@ const {
 const creeDepot = (config = {}) => {
   const {
     adaptateurChiffrement,
-    adaptateurPersistance,
+    adaptateurPersistance: persistance,
     adaptateurUUID,
     depotAutorisations,
     depotServices,
   } = config;
 
   const verificationsAssocieOuDetache = new VerificationsAssocieOuDetache({
-    adaptateurPersistance,
+    adaptateurPersistance: persistance,
     depotAutorisations,
   });
 
   const ajouteModeleMesureSpecifique = async (idUtilisateur, donnees) => {
-    const utilisateur = await adaptateurPersistance.utilisateur(idUtilisateur);
+    const utilisateur = await persistance.utilisateur(idUtilisateur);
     if (!utilisateur) throw new ErreurUtilisateurInexistant();
 
     const idModele = adaptateurUUID.genereUUID();
     const donneesChiffrees = await adaptateurChiffrement.chiffre(donnees);
 
-    await adaptateurPersistance.ajouteModeleMesureSpecifique(
+    await persistance.ajouteModeleMesureSpecifique(
       idModele,
       idUtilisateur,
       donneesChiffrees
@@ -55,7 +55,7 @@ const creeDepot = (config = {}) => {
 
     await Promise.all(aPersister.map(depotServices.metsAJourService));
 
-    await adaptateurPersistance.associeModeleMesureSpecifiqueAuxServices(
+    await persistance.associeModeleMesureSpecifiqueAuxServices(
       idModele,
       idsServices
     );
@@ -73,7 +73,7 @@ const creeDepot = (config = {}) => {
     );
 
     const tousAssocies =
-      await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
+      await persistance.tousServicesSontAssociesAuModeleMesureSpecifique(
         idsServices,
         idModele
       );
@@ -88,7 +88,7 @@ const creeDepot = (config = {}) => {
     const aPersister = await Promise.all(detacheDesServices);
 
     await Promise.all(aPersister.map(depotServices.metsAJourService));
-    await adaptateurPersistance.supprimeLeLienEntreLeModeleEtLesServices(
+    await persistance.supprimeLeLienEntreLeModeleEtLesServices(
       idModele,
       idsServices
     );

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -117,6 +117,9 @@ const creeDepot = (config = {}) => {
     idUtilisateurDetachant
   ) => {
     await verifieModeleExiste(idModele);
+    const tousServicesExistent =
+      await adaptateurPersistance.verifieTousLesServicesExistent(idsServices);
+    if (!tousServicesExistent) throw new ErreurServiceInexistant();
 
     const tousAssocies =
       await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -106,6 +106,11 @@ const creeDepot = (config = {}) => {
     idsServices,
     idUtilisateurDetachant
   ) => {
+    const modeleExiste =
+      await adaptateurPersistance.verifieModeleMesureSpecifiqueExiste(idModele);
+    if (!modeleExiste)
+      throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
+
     const tousAssocies =
       await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
         idsServices,

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -4,6 +4,7 @@ const {
   ErreurUtilisateurInexistant,
   ErreurDroitsInsuffisants,
   ErreurAutorisationInexistante,
+  ErreurServiceNonAssocieAuModele,
 } = require('../erreurs');
 const {
   Permissions,
@@ -90,9 +91,24 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  const detacheModeleMesureSpecifiqueDesServices = async (
+    idModele,
+    idsServices,
+    idUtilisateurDetachant
+  ) => {
+    const tousAssocies =
+      await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
+        idsServices,
+        idModele
+      );
+    if (!tousAssocies)
+      throw new ErreurServiceNonAssocieAuModele(idsServices, idModele);
+  };
+
   return {
     ajouteModeleMesureSpecifique,
     associeModeleMesureSpecifiqueAuxServices,
+    detacheModeleMesureSpecifiqueDesServices,
   };
 };
 module.exports = { creeDepot };

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -119,6 +119,16 @@ const creeDepot = (config = {}) => {
       idUtilisateurDetachant,
       idsServices
     );
+
+    const possedeLeModele =
+      await adaptateurPersistance.modeleMesureSpecifiqueAppartientA(
+        idUtilisateurDetachant,
+        idModele
+      );
+    if (!possedeLeModele)
+      throw new ErreurAutorisationInexistante(
+        `L'utilisateur ${idUtilisateurDetachant} n'est pas propriétaire du modèle ${idModele} qu'il veut associer/détacher`
+      );
   };
 
   return {

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -88,6 +88,10 @@ const creeDepot = (config = {}) => {
     const aPersister = await Promise.all(detacheDesServices);
 
     await Promise.all(aPersister.map(depotServices.metsAJourService));
+    await adaptateurPersistance.supprimeLeLienEntreLeModeleEtLesServices(
+      idModele,
+      idsServices
+    );
   };
 
   return {

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -75,6 +75,12 @@ const creeDepot = (config = {}) => {
       );
   }
 
+  async function verifieQueTousLesServicesExistent(idsServices) {
+    const tousServicesExistent =
+      await adaptateurPersistance.verifieTousLesServicesExistent(idsServices);
+    if (!tousServicesExistent) throw new ErreurServiceInexistant();
+  }
+
   const associeModeleMesureSpecifiqueAuxServices = async (
     idModele,
     idsServices,
@@ -85,10 +91,7 @@ const creeDepot = (config = {}) => {
       idUtilisateurAssociant,
       idModele
     );
-
-    const tousServicesExistent =
-      await adaptateurPersistance.verifieTousLesServicesExistent(idsServices);
-    if (!tousServicesExistent) throw new ErreurServiceInexistant();
+    await verifieQueTousLesServicesExistent(idsServices);
 
     await verifiePeutModifierUnModeleSurLesServices(
       idUtilisateurAssociant,
@@ -117,9 +120,7 @@ const creeDepot = (config = {}) => {
     idUtilisateurDetachant
   ) => {
     await verifieModeleExiste(idModele);
-    const tousServicesExistent =
-      await adaptateurPersistance.verifieTousLesServicesExistent(idsServices);
-    if (!tousServicesExistent) throw new ErreurServiceInexistant();
+    await verifieQueTousLesServicesExistent(idsServices);
 
     const tousAssocies =
       await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -87,12 +87,11 @@ const creeDepot = (config = {}) => {
     idUtilisateurAssociant
   ) => {
     await verifieModeleExiste(idModele);
+    await verifieQueTousLesServicesExistent(idsServices);
     await verifieQueUtilisateurPossedeLeModele(
       idUtilisateurAssociant,
       idModele
     );
-    await verifieQueTousLesServicesExistent(idsServices);
-
     await verifiePeutModifierUnModeleSurLesServices(
       idUtilisateurAssociant,
       idsServices
@@ -121,6 +120,14 @@ const creeDepot = (config = {}) => {
   ) => {
     await verifieModeleExiste(idModele);
     await verifieQueTousLesServicesExistent(idsServices);
+    await verifieQueUtilisateurPossedeLeModele(
+      idUtilisateurDetachant,
+      idModele
+    );
+    await verifiePeutModifierUnModeleSurLesServices(
+      idUtilisateurDetachant,
+      idsServices
+    );
 
     const tousAssocies =
       await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
@@ -130,16 +137,6 @@ const creeDepot = (config = {}) => {
 
     if (!tousAssocies)
       throw new ErreurServiceNonAssocieAuModele(idsServices, idModele);
-
-    await verifiePeutModifierUnModeleSurLesServices(
-      idUtilisateurDetachant,
-      idsServices
-    );
-
-    await verifieQueUtilisateurPossedeLeModele(
-      idUtilisateurDetachant,
-      idModele
-    );
   };
 
   return {

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -63,22 +63,28 @@ const creeDepot = (config = {}) => {
       throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
   }
 
+  async function verifieQueUtilisateurPossedeLeModele(idUtilisateur, idModele) {
+    const possedeLeModele =
+      await adaptateurPersistance.modeleMesureSpecifiqueAppartientA(
+        idUtilisateur,
+        idModele
+      );
+    if (!possedeLeModele)
+      throw new ErreurAutorisationInexistante(
+        `L'utilisateur ${idUtilisateur} n'est pas propriétaire du modèle ${idModele} qu'il veut associer/détacher`
+      );
+  }
+
   const associeModeleMesureSpecifiqueAuxServices = async (
     idModele,
     idsServices,
     idUtilisateurAssociant
   ) => {
     await verifieModeleExiste(idModele);
-
-    const possedeLeModele =
-      await adaptateurPersistance.modeleMesureSpecifiqueAppartientA(
-        idUtilisateurAssociant,
-        idModele
-      );
-    if (!possedeLeModele)
-      throw new ErreurAutorisationInexistante(
-        `L'utilisateur ${idUtilisateurAssociant} n'est pas propriétaire du modèle ${idModele} qu'il veut associer`
-      );
+    await verifieQueUtilisateurPossedeLeModele(
+      idUtilisateurAssociant,
+      idModele
+    );
 
     const tousServicesExistent =
       await adaptateurPersistance.verifieTousLesServicesExistent(idsServices);
@@ -126,15 +132,10 @@ const creeDepot = (config = {}) => {
       idsServices
     );
 
-    const possedeLeModele =
-      await adaptateurPersistance.modeleMesureSpecifiqueAppartientA(
-        idUtilisateurDetachant,
-        idModele
-      );
-    if (!possedeLeModele)
-      throw new ErreurAutorisationInexistante(
-        `L'utilisateur ${idUtilisateurDetachant} n'est pas propriétaire du modèle ${idModele} qu'il veut associer/détacher`
-      );
+    await verifieQueUtilisateurPossedeLeModele(
+      idUtilisateurDetachant,
+      idModele
+    );
   };
 
   return {

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -56,15 +56,19 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  async function verifieModeleExiste(idModele) {
+    const modeleExiste =
+      await adaptateurPersistance.verifieModeleMesureSpecifiqueExiste(idModele);
+    if (!modeleExiste)
+      throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
+  }
+
   const associeModeleMesureSpecifiqueAuxServices = async (
     idModele,
     idsServices,
     idUtilisateurAssociant
   ) => {
-    const modeleExiste =
-      await adaptateurPersistance.verifieModeleMesureSpecifiqueExiste(idModele);
-    if (!modeleExiste)
-      throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
+    await verifieModeleExiste(idModele);
 
     const possedeLeModele =
       await adaptateurPersistance.modeleMesureSpecifiqueAppartientA(
@@ -106,10 +110,7 @@ const creeDepot = (config = {}) => {
     idsServices,
     idUtilisateurDetachant
   ) => {
-    const modeleExiste =
-      await adaptateurPersistance.verifieModeleMesureSpecifiqueExiste(idModele);
-    if (!modeleExiste)
-      throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
+    await verifieModeleExiste(idModele);
 
     const tousAssocies =
       await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(

--- a/src/depots/modelesMesureSpecifique/VerificationsAssocieOuDetache.js
+++ b/src/depots/modelesMesureSpecifique/VerificationsAssocieOuDetache.js
@@ -1,0 +1,73 @@
+const {
+  ErreurModeleDeMesureSpecifiqueIntrouvable,
+  ErreurServiceInexistant,
+  ErreurAutorisationInexistante,
+  ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique,
+} = require('../../erreurs');
+const {
+  Permissions,
+  Rubriques,
+} = require('../../modeles/autorisations/gestionDroits');
+
+const { ECRITURE } = Permissions;
+const { SECURISER } = Rubriques;
+
+class VerificationsAssocieOuDetache {
+  constructor({ adaptateurPersistance, depotAutorisations }) {
+    this.persistance = adaptateurPersistance;
+    this.depotAutorisations = depotAutorisations;
+  }
+
+  async toutes(idModele, idsServices, idUtilisateur) {
+    await this.#queModeleExiste(idModele);
+    await this.#queTousLesServicesExistent(idsServices);
+    await this.#queUtilisateurPossedeLeModele(idUtilisateur, idModele);
+    await this.#peutModifierUnModeleSurLesServices(idUtilisateur, idsServices);
+  }
+
+  async #queModeleExiste(idModele) {
+    const modeleExiste =
+      await this.persistance.verifieModeleMesureSpecifiqueExiste(idModele);
+    if (!modeleExiste)
+      throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
+  }
+
+  async #queTousLesServicesExistent(idsServices) {
+    const tousServicesExistent =
+      await this.persistance.verifieTousLesServicesExistent(idsServices);
+
+    if (!tousServicesExistent) throw new ErreurServiceInexistant();
+  }
+
+  async #queUtilisateurPossedeLeModele(idUtilisateur, idModele) {
+    const possedeLeModele =
+      await this.persistance.modeleMesureSpecifiqueAppartientA(
+        idUtilisateur,
+        idModele
+      );
+
+    if (!possedeLeModele)
+      throw new ErreurAutorisationInexistante(
+        `L'utilisateur ${idUtilisateur} n'est pas propriétaire du modèle ${idModele} qu'il veut associer/détacher`
+      );
+  }
+
+  async #peutModifierUnModeleSurLesServices(idUtilisateur, idsServices) {
+    const droitsRequis = { [SECURISER]: ECRITURE };
+    const droitsSontSuffisants =
+      await this.depotAutorisations.accesAutoriseAUneListeDeService(
+        idUtilisateur,
+        idsServices,
+        droitsRequis
+      );
+
+    if (!droitsSontSuffisants)
+      throw new ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique(
+        idUtilisateur,
+        idsServices,
+        droitsRequis
+      );
+  }
+}
+
+module.exports = { VerificationsAssocieOuDetache };

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -70,6 +70,14 @@ class ErreurModeleDeMesureSpecifiqueDejaAssociee extends ErreurModele {
     );
   }
 }
+class ErreurServiceNonAssocieAuModele extends ErreurModele {
+  constructor(idsServices, idModele) {
+    const s = idsServices.join(',');
+    super(
+      `Les services [${s}] ne sont pas tous associés au modèle ${idModele}`
+    );
+  }
+}
 class ErreurDetachementModeleMesureSpecifiqueImpossible extends ErreurModele {}
 class ErreurMotDePasseIncorrect extends ErreurModele {}
 class ErreurNiveauGraviteInconnu extends ErreurModele {}
@@ -142,6 +150,7 @@ module.exports = {
   ErreurRisqueInconnu,
   ErreurSelManquant,
   ErreurServiceInexistant,
+  ErreurServiceNonAssocieAuModele,
   ErreurStatutDeploiementInvalide,
   ErreurStatutMesureInvalide,
   ErreurStatutMesureManquant,

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -2,13 +2,13 @@ class EchecAutorisation extends Error {}
 class EchecEnvoiMessage extends Error {}
 class ErreurApiBrevo extends Error {}
 class ErreurDroitsIncoherents extends Error {}
-class ErreurDroitsInsuffisants extends Error {
+class ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique extends Error {
   constructor(idUtilisateur, idServices, droitsRequis) {
     const u = idUtilisateur;
     const s = idServices.join(',');
     const d = JSON.stringify(droitsRequis);
     super(
-      `L'utilisateur ${u} n'a pas les droits suffisants sur ${s}. Droits requis pour associer un modèle : ${d}`
+      `L'utilisateur ${u} n'a pas les droits suffisants sur ${s}. Droits requis pour associer/détacher un modèle : ${d}`
     );
   }
 }
@@ -131,7 +131,7 @@ module.exports = {
   ErreurDossierNonFinalise,
   ErreurDossiersInvalides,
   ErreurDroitsIncoherents,
-  ErreurDroitsInsuffisants,
+  ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique,
   ErreurDureeValiditeInvalide,
   ErreurEcheanceMesureInvalide,
   ErreurEmailManquant,

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -18,6 +18,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
   - [ ] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
     - [ ] une erreur qui montre les détails utilisateur et id service
   - [ ] à condition que l'utilisateur soit propriétaire du modèle
+  - [x] à condition que tous les services soient associés au modèle
   - Conséquence
     - [x] tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
     - [ ] et le lien entre modèle et service disparaît

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -15,10 +15,9 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [ ] Le service va chercher le détail d'une mesure spécifique liée à un [modèle de mesure spécifique] lors de sa construction
 - [ ] Le service est hydraté avec TOUS les modèles disponibles (pas seulement les modèles déjà associés)
 - [ ] Le service peut détacher une mesure spécifique de son modèle de mesure
-  - [ ] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
-    - [ ] une erreur qui montre les détails utilisateur et id service
-  - [ ] à condition que l'utilisateur soit propriétaire du modèle
+  - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
   - [x] à condition que tous les services soient associés au modèle
+  - [ ] à condition que l'utilisateur soit propriétaire du modèle
   - Conséquence
     - [x] tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
     - [ ] et le lien entre modèle et service disparaît

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -36,8 +36,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [x] On appelle `modelesDisponiblesDeMesureSpecifique` la liste de tous les modèles associables.
 - [x] On ne peut pas associer 2 fois un service à un même modèle
   - On peut séparer la boucle sur le domaine de la boucle sur le `depotServices.metsAJourService(s);` comme ça le domaine peut `throw` avant même qu'on déclenche les MAJ en BDD
-- [ ] On aimerait mutualiser le code qui vérifie les permissions de associer/détacher
-  - MAIS ça signifie des setups de tests compliqués, car il faut mimer les changements de permissions pendant les tests…
+- [x] On aimerait mutualiser le code qui vérifie les permissions de associer/détacher
 
 ## Du point de vue des Modèles de mesure
 

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -17,7 +17,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [ ] Le service peut détacher une mesure spécifique de son modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
   - [x] à condition que tous les services soient associés au modèle
-  - [ ] à condition que l'utilisateur soit propriétaire du modèle
+  - [x] à condition que l'utilisateur soit propriétaire du modèle
   - Conséquence
     - [x] tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
     - [ ] et le lien entre modèle et service disparaît
@@ -36,6 +36,8 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 - [x] On appelle `modelesDisponiblesDeMesureSpecifique` la liste de tous les modèles associables.
 - [x] On ne peut pas associer 2 fois un service à un même modèle
   - On peut séparer la boucle sur le domaine de la boucle sur le `depotServices.metsAJourService(s);` comme ça le domaine peut `throw` avant même qu'on déclenche les MAJ en BDD
+- [ ] On aimerait mutualiser le code qui vérifie les permissions de associer/détacher
+  - MAIS ça signifie des setups de tests compliqués, car il faut mimer les changements de permissions pendant les tests…
 
 ## Du point de vue des Modèles de mesure
 

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -14,13 +14,13 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 
 - [ ] Le service va chercher le détail d'une mesure spécifique liée à un [modèle de mesure spécifique] lors de sa construction
 - [ ] Le service est hydraté avec TOUS les modèles disponibles (pas seulement les modèles déjà associés)
-- [ ] Le service peut détacher une mesure spécifique de son modèle de mesure
+- [x] Le service peut détacher une mesure spécifique de son modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
   - [x] à condition que tous les services soient associés au modèle
   - [x] à condition que l'utilisateur soit propriétaire du modèle
   - Conséquence
     - [x] tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
-    - [ ] et le lien entre modèle et service disparaît
+    - [x] et le lien entre modèle et service disparaît
     - [x] le service relu ne connait plus l'association
 - [x] Un service peut être relié à un modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -21,7 +21,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
   - Conséquence
     - [x] tout le détail du modèle (label, description, catégorie) est recopiée **dans** les mesures spés du service
     - [ ] et le lien entre modèle et service disparaît
-    - [ ] le service relu ne connait plus l'association
+    - [x] le service relu ne connait plus l'association
 - [x] Un service peut être relié à un modèle de mesure
   - [x] à condition que le modèle appartienne à un utilisateur avec les droits [ECRITURE sur SÉCURISER]
     - [x] une erreur qui montre les détails utilisateur et id service

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -10,6 +10,7 @@ class ConstructeurAdaptateurPersistanceMemoire {
     this.suggestionsActions = [];
     this.activitesMesure = [];
     this.modelesMesureSpecifique = [];
+    this.associationModelesMesureSpecifiqueServices = [];
     this.adaptateurChiffrement = adaptateurChiffrement;
   }
 
@@ -66,6 +67,16 @@ class ConstructeurAdaptateurPersistanceMemoire {
     return this;
   }
 
+  associeLeServiceAuxModelesDeMesureSpecifique(idService, idsModeles) {
+    idsModeles.map((unModele) =>
+      this.associationModelesMesureSpecifiqueServices.push({
+        idService,
+        idModele: unModele,
+      })
+    );
+    return this;
+  }
+
   construis() {
     return AdaptateurPersistanceMemoire.nouvelAdaptateur({
       autorisations: this.autorisations,
@@ -76,6 +87,8 @@ class ConstructeurAdaptateurPersistanceMemoire {
       suggestionsActions: this.suggestionsActions,
       activitesMesure: this.activitesMesure,
       modelesMesureSpecifique: this.modelesMesureSpecifique,
+      associationModelesMesureSpecifiqueServices:
+        this.associationModelesMesureSpecifiqueServices,
     });
   }
 }

--- a/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
+++ b/test/constructeurs/constructeurAdaptateurPersistanceMemoire.js
@@ -1,5 +1,6 @@
 const AdaptateurPersistanceMemoire = require('../../src/adaptateurs/adaptateurPersistanceMemoire');
 const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
+const { uneAutorisation } = require('./constructeurAutorisation');
 
 class ConstructeurAdaptateurPersistanceMemoire {
   constructor(adaptateurChiffrement) {
@@ -16,6 +17,16 @@ class ConstructeurAdaptateurPersistanceMemoire {
 
   ajouteUneAutorisation(autorisation) {
     this.autorisations.push(autorisation);
+    return this;
+  }
+
+  nommeCommeProprietaire(idUtilisateur, idsServices) {
+    idsServices
+      .map((unService) =>
+        uneAutorisation().deProprietaire(idUtilisateur, unService)
+      )
+      .map((autorisation) => this.ajouteUneAutorisation(autorisation.donnees));
+
     return this;
   }
 

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -104,12 +104,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         })
         // U1 a deux services et un modèle
         .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
-        .ajouteUneAutorisation(
-          uneAutorisation().deProprietaire('U1', 'S1').donnees
-        )
-        .ajouteUneAutorisation(
-          uneAutorisation().deProprietaire('U1', 'S2').donnees
-        )
+        .nommeCommeProprietaire('U1', ['S1', 'S2'])
         .avecUnModeleDeMesureSpecifique({
           id: 'MOD-1',
           idUtilisateur: 'U1',
@@ -308,12 +303,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         ])
         .ajouteUnService({ id: 'S11', descriptionService: {} })
         .ajouteUnUtilisateur(unUtilisateur().avecId('U10').donnees)
-        .ajouteUneAutorisation(
-          uneAutorisation().deProprietaire('U10', 'S10').donnees
-        )
-        .ajouteUneAutorisation(
-          uneAutorisation().deProprietaire('U10', 'S11').donnees
-        )
+        .nommeCommeProprietaire('U10', ['S10', 'S11'])
         .avecUnModeleDeMesureSpecifique({
           id: 'MOD-10',
           idUtilisateur: 'U10',
@@ -325,9 +315,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
           idUtilisateur: 'U11',
         })
         .ajouteUnUtilisateur(unUtilisateur().avecId('U12').donnees)
-        .ajouteUneAutorisation(
-          uneAutorisation().deProprietaire('U12', 'S10').donnees
-        )
+        .nommeCommeProprietaire('U12', ['S10'])
         .construis();
 
       depotServices = DepotDonneesServices.creeDepot({

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -335,20 +335,38 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
       });
     });
 
+    it("jette une erreur si le modèle n'existe pas", async () => {
+      adaptateurPersistance.verifieModeleMesureSpecifiqueExiste = async () =>
+        false;
+
+      const depot = leDepot();
+
+      try {
+        await depot.detacheModeleMesureSpecifiqueDesServices(
+          'MOD-10',
+          ['S10'],
+          'U10'
+        );
+        expect().fail("L'appel aurait dû lever une erreur.");
+      } catch (e) {
+        expect(e).to.be.an(ErreurModeleDeMesureSpecifiqueIntrouvable);
+      }
+    });
+
     it("jette une erreur dès qu'un service n'est pas associé au modèle", async () => {
       const depot = leDepot();
 
       try {
         await depot.detacheModeleMesureSpecifiqueDesServices(
-          'MOD-NON-ASSOCIÉ',
-          ['S10'],
+          'MOD-10',
+          ['S11'],
           'U10'
         );
         expect().fail("L'appel aurait du lever une erreur.");
       } catch (e) {
         expect(e).to.be.an(ErreurServiceNonAssocieAuModele);
         expect(e.message).to.be(
-          'Les services [S10] ne sont pas tous associés au modèle MOD-NON-ASSOCIÉ'
+          'Les services [S11] ne sont pas tous associés au modèle MOD-10'
         );
       }
     });

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -7,7 +7,7 @@ const {
   ErreurModeleDeMesureSpecifiqueIntrouvable,
   ErreurServiceInexistant,
   ErreurUtilisateurInexistant,
-  ErreurDroitsInsuffisants,
+  ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique,
   ErreurAutorisationInexistante,
   ErreurServiceNonAssocieAuModele,
 } = require('../../src/erreurs');
@@ -214,9 +214,11 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         );
         expect().fail("L'appel aurait dû lever une erreur.");
       } catch (e) {
-        expect(e).to.be.an(ErreurDroitsInsuffisants);
+        expect(e).to.be.an(
+          ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique
+        );
         expect(e.message).to.be(
-          'L\'utilisateur U2 n\'a pas les droits suffisants sur S1. Droits requis pour associer un modèle : {"SECURISER":2}'
+          'L\'utilisateur U2 n\'a pas les droits suffisants sur S1. Droits requis pour associer/détacher un modèle : {"SECURISER":2}'
         );
       }
     });
@@ -290,6 +292,31 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         expect(e).to.be.an(ErreurServiceNonAssocieAuModele);
         expect(e.message).to.be(
           'Les services [S1] ne sont pas tous associés au modèle MOD-NON-ASSOCIÉ'
+        );
+      }
+    });
+
+    it("jette une erreur si l'utilisateur qui veut détacher la mesure n'a pas les droits en écriture sur tous les services", async () => {
+      const depot = leDepot();
+      await depot.associeModeleMesureSpecifiqueAuxServices(
+        'MOD-1',
+        ['S1'],
+        'U1'
+      );
+
+      try {
+        await depot.detacheModeleMesureSpecifiqueDesServices(
+          'MOD-1',
+          ['S1'],
+          'U2'
+        );
+        expect().fail("L'appel aurait dû lever une erreur.");
+      } catch (e) {
+        expect(e).to.be.an(
+          ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique
+        );
+        expect(e.message).to.be(
+          'L\'utilisateur U2 n\'a pas les droits suffisants sur S1. Droits requis pour associer/détacher un modèle : {"SECURISER":2}'
         );
       }
     });

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -9,6 +9,7 @@ const {
   ErreurUtilisateurInexistant,
   ErreurDroitsInsuffisants,
   ErreurAutorisationInexistante,
+  ErreurServiceNonAssocieAuModele,
 } = require('../../src/erreurs');
 const DepotDonneesAutorisations = require('../../src/depots/depotDonneesAutorisations');
 const {
@@ -270,6 +271,26 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
 
         const s2ApresTentative = await depotServices.service('S2');
         expect(s2ApresTentative.mesuresSpecifiques().toutes().length).to.be(0);
+      }
+    });
+  });
+
+  describe('concernant le détachement entre un modèle de mesure et des services y étant associés', () => {
+    it("jette une erreur dès qu'un service n'est pas associé au modèle", async () => {
+      const depot = leDepot();
+
+      try {
+        await depot.detacheModeleMesureSpecifiqueDesServices(
+          'MOD-NON-ASSOCIÉ',
+          ['S1'],
+          'U1'
+        );
+        expect().fail("L'appel aurait du lever une erreur.");
+      } catch (e) {
+        expect(e).to.be.an(ErreurServiceNonAssocieAuModele);
+        expect(e.message).to.be(
+          'Les services [S1] ne sont pas tous associés au modèle MOD-NON-ASSOCIÉ'
+        );
       }
     });
   });

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -256,7 +256,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
       } catch (e) {
         expect(e).to.be.an(ErreurAutorisationInexistante);
         expect(e.message).to.be(
-          "L'utilisateur U-NON-PROPRIETAIRE n'est pas propriétaire du modèle MOD-1 qu'il veut associer"
+          "L'utilisateur U-NON-PROPRIETAIRE n'est pas propriétaire du modèle MOD-1 qu'il veut associer/détacher"
         );
       }
     });

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -19,7 +19,7 @@ const fauxAdaptateurChiffrement = require('../mocks/adaptateurChiffrement');
 
 describe('Le dépôt de données des modèles de mesure spécifique', () => {
   let adaptateurChiffrement;
-  let adaptateurPersistance;
+  let persistance;
   let adaptateurUUID;
   let depotServices;
 
@@ -27,9 +27,9 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
     DepotDonneesModelesMesureSpecifique.creeDepot({
       adaptateurUUID,
       adaptateurChiffrement,
-      adaptateurPersistance,
+      adaptateurPersistance: persistance,
       depotAutorisations: DepotDonneesAutorisations.creeDepot({
-        adaptateurPersistance,
+        adaptateurPersistance: persistance,
       }),
       depotServices,
     });
@@ -41,7 +41,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
 
   describe("concernant l'ajout d'un modèle de mesure", () => {
     beforeEach(() => {
-      adaptateurPersistance = unePersistanceMemoire()
+      persistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
         .construis();
     });
@@ -52,7 +52,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         ...donnees,
         chiffree: true,
       });
-      adaptateurPersistance.ajouteModeleMesureSpecifique = async (
+      persistance.ajouteModeleMesureSpecifique = async (
         idModele,
         idUtilisateur,
         donnees
@@ -90,7 +90,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
 
   describe("concernant l'association d'un modèle et de services", () => {
     beforeEach(() => {
-      adaptateurPersistance = unePersistanceMemoire()
+      persistance = unePersistanceMemoire()
         .ajouteUnService({
           id: 'S1',
           descriptionService: { nomService: 'Service 1' },
@@ -112,10 +112,10 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         .construis();
 
       depotServices = DepotDonneesServices.creeDepot({
-        adaptateurPersistance,
+        adaptateurPersistance: persistance,
         adaptateurChiffrement,
         depotDonneesUtilisateurs: DepotDonneesUtilisateurs.creeDepot({
-          adaptateurPersistance,
+          adaptateurPersistance: persistance,
           adaptateurChiffrement,
         }),
       });
@@ -123,7 +123,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
 
     it('associe les services au modèle via la persistance', async () => {
       let donneesPersistees = {};
-      adaptateurPersistance.associeModeleMesureSpecifiqueAuxServices = async (
+      persistance.associeModeleMesureSpecifiqueAuxServices = async (
         idModele,
         idsServices
       ) => {
@@ -176,8 +176,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
     });
 
     it("jette une erreur si le modèle n'existe pas", async () => {
-      adaptateurPersistance.verifieModeleMesureSpecifiqueExiste = async () =>
-        false;
+      persistance.verifieModeleMesureSpecifiqueExiste = async () => false;
       const depot = leDepot();
 
       try {
@@ -228,7 +227,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
     });
 
     it("jette une erreur si le modèle n'appartient pas à l'utilisateur qui veut associer", async () => {
-      adaptateurPersistance.modeleMesureSpecifiqueAppartientA = async (
+      persistance.modeleMesureSpecifiqueAppartientA = async (
         idUtilisateur,
         idModele
       ) => {
@@ -283,7 +282,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
 
   describe('concernant le détachement entre un modèle de mesure et des services y étant associés', () => {
     beforeEach(() => {
-      adaptateurPersistance = unePersistanceMemoire()
+      persistance = unePersistanceMemoire()
         // On a un service (S10) déjà associé à deux modèles (MOD-10 et MOD-11).
         // On a un service vide (S11).
         // L'utilisateur U10 est propriétaire des services et du premier modèle.
@@ -314,10 +313,10 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         .construis();
 
       depotServices = DepotDonneesServices.creeDepot({
-        adaptateurPersistance,
+        adaptateurPersistance: persistance,
         adaptateurChiffrement,
         depotDonneesUtilisateurs: DepotDonneesUtilisateurs.creeDepot({
-          adaptateurPersistance,
+          adaptateurPersistance: persistance,
           adaptateurChiffrement,
         }),
       });
@@ -339,7 +338,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
 
     it('supprime le lien entre le modèle et le service, dans la table de liaison', async () => {
       const avant =
-        await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
+        await persistance.tousServicesSontAssociesAuModeleMesureSpecifique(
           ['S10'],
           'MOD-10'
         );
@@ -353,7 +352,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
       );
 
       const apres =
-        await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
+        await persistance.tousServicesSontAssociesAuModeleMesureSpecifique(
           ['S10'],
           'MOD-10'
         );
@@ -361,8 +360,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
     });
 
     it("jette une erreur si le modèle n'existe pas", async () => {
-      adaptateurPersistance.verifieModeleMesureSpecifiqueExiste = async () =>
-        false;
+      persistance.verifieModeleMesureSpecifiqueExiste = async () => false;
 
       const depot = leDepot();
 

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -337,6 +337,29 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
       expect(mesureDetachee.toJSON().idModele).to.be(undefined);
     });
 
+    it('supprime le lien entre le modèle et le service, dans la table de liaison', async () => {
+      const avant =
+        await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
+          ['S10'],
+          'MOD-10'
+        );
+      expect(avant).to.be(true);
+
+      const depot = leDepot();
+      await depot.detacheModeleMesureSpecifiqueDesServices(
+        'MOD-10',
+        ['S10'],
+        'U10'
+      );
+
+      const apres =
+        await adaptateurPersistance.tousServicesSontAssociesAuModeleMesureSpecifique(
+          ['S10'],
+          'MOD-10'
+        );
+      expect(apres).to.be(false);
+    });
+
     it("jette une erreur si le modèle n'existe pas", async () => {
       adaptateurPersistance.verifieModeleMesureSpecifiqueExiste = async () =>
         false;

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -302,6 +302,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
           'MOD-10',
           'MOD-11',
         ])
+        .ajouteUnService({ id: 'S11', descriptionService: {} })
         // U10 a un service et un modèle
         .ajouteUnUtilisateur(unUtilisateur().avecId('U10').donnees)
         .ajouteUneAutorisation(
@@ -406,6 +407,21 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         expect(e.message).to.be(
           "L'utilisateur U12 n'est pas propriétaire du modèle MOD-10 qu'il veut associer/détacher"
         );
+      }
+    });
+
+    it("jette une erreur si au moins un des services n'existe pas", async () => {
+      const depot = leDepot();
+
+      try {
+        await depot.detacheModeleMesureSpecifiqueDesServices(
+          'MOD-10',
+          ['S-INTROUVABLE-1'],
+          'U10'
+        );
+        expect().fail("L'appel aurait dû lever une erreur.");
+      } catch (e) {
+        expect(e).to.be.an(ErreurServiceInexistant);
       }
     });
   });

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -292,7 +292,11 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
   describe('concernant le détachement entre un modèle de mesure et des services y étant associés', () => {
     beforeEach(() => {
       adaptateurPersistance = unePersistanceMemoire()
-        // S10 est déjà associé à MOD-10 et MOD-11
+        // On a un service (S10) déjà associé à deux modèles (MOD-10 et MOD-11).
+        // On a un service vide (S11).
+        // L'utilisateur U10 est propriétaire des services et du premier modèle.
+        // L'utilisateur U11 est propriétaire du second modèle.
+        // C'est un gros jeu de données… mais ça semble nécessaire pour tester nos cas.
         .ajouteUnService({
           id: 'S10',
           descriptionService: { nomService: 'Service 10' },
@@ -303,23 +307,23 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
           'MOD-11',
         ])
         .ajouteUnService({ id: 'S11', descriptionService: {} })
-        // U10 a un service et un modèle
         .ajouteUnUtilisateur(unUtilisateur().avecId('U10').donnees)
         .ajouteUneAutorisation(
           uneAutorisation().deProprietaire('U10', 'S10').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('U10', 'S11').donnees
         )
         .avecUnModeleDeMesureSpecifique({
           id: 'MOD-10',
           idUtilisateur: 'U10',
           donnees: { description: 'Le modèle 10' },
         })
-        // U11 a seulement un modèle
         .ajouteUnUtilisateur(unUtilisateur().avecId('U11').donnees)
         .avecUnModeleDeMesureSpecifique({
           id: 'MOD-11',
           idUtilisateur: 'U11',
         })
-        // U12 est seulement propriétaire de S10
         .ajouteUnUtilisateur(unUtilisateur().avecId('U12').donnees)
         .ajouteUneAutorisation(
           uneAutorisation().deProprietaire('U12', 'S10').donnees


### PR DESCRIPTION
Cette PR ajoute la fonction `depotDonneesModelesMesureSpecifique.detacheModeleMesureSpecifiqueDesServices()` qui permet de détacher un modèle de mesure spécifique de certains des services auquel il est associé.

Après détachement :
 - la mesure spécifique **reste** dans le service, mais elle est indépendante : elle ne connaît plus son modèle de mesure.
 - le lien entre le service et le modèle est supprimé dans la table qui contient toutes les associations

Les même contrôles métier que sur `associeModeleMesureSpecifiqueAuxServices()` sont opérés avant d'autoriser le détachement. Ils ont été factorisés dans `VerificationsAssocieOuDetache`