### PR TITLE
[SOIN] Répare les scripts de démarrage et de test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 x-app: &configuration-base
   build:
     context: .
+    args:
+      NODE_VERSION: ${NODE_VERSION:-latest}
   env_file:
     - .env
   volumes:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker compose \
-  up web --build --build-arg "NODE_VERSION=$(cat .nvmrc)"
+NODE_VERSION="$(cat .nvmrc)" docker compose \
+  up web --build

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker compose \
-  up test --build --build-arg "NODE_VERSION=$(cat .nvmrc)"
+NODE_VERSION=$(cat .nvmrc) docker compose \
+  up test --build


### PR DESCRIPTION
Les scripts `scripts/start.sh` et `scripts/tests.sh` sont cassés (très probablement depuis [ce commit](https://github.com/betagouv/mon-service-securise/pull/2255/commits/cf6bb8fa015d373b19ce9684eed22cdebe63ba9b)).

Il semblerait que l'option `--build-arg` ne soit pas (plus ?) utilisable, et [qu'il faille spécifier les arguments via `build.args` dans le `docker-compose.yaml`](https://docs.docker.com/reference/compose-file/build/#args).