### PR TITLE
[MODÈLES MESURE SPÉCIFIQUE] Affiche les services associés dans la modale

### DIFF
--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -112,7 +112,8 @@ const routesConnecteApi = ({
             .aLesPermissions({ [SECURISER]: LECTURE })
         )
         .map((service) => {
-          const { mesuresGenerales } = objetGetMesures.donnees(service);
+          const { mesuresGenerales, mesuresSpecifiques } =
+            objetGetMesures.donnees(service);
 
           const mesuresAssociees = Object.fromEntries(
             Object.entries(mesuresGenerales).map(
@@ -135,6 +136,7 @@ const routesConnecteApi = ({
             organisationResponsable:
               service.descriptionService.organisationResponsable.nom,
             mesuresAssociees,
+            mesuresSpecifiques,
             peutEtreModifie: autorisations
               .find((a) => a.idService === service.id)
               .aLesPermissions({ [SECURISER]: ECRITURE }),

--- a/svelte/lib/listeMesures/ListeMesures.svelte
+++ b/svelte/lib/listeMesures/ListeMesures.svelte
@@ -31,7 +31,7 @@
     type CleOngletListeMesure,
   } from './kit/OngletsListeMesures.svelte';
   import { modelesMesureSpecifique } from './stores/modelesMesureSpecifique.store';
-  import type { MesureDeLaListe } from './listeMesures.d';
+  import type { ModeleDeMesure } from './listeMesures.d';
 
   export let statuts: ReferentielStatut;
   export let typesService: ReferentielTypesService;
@@ -44,8 +44,8 @@
   let modaleDetailsMesure: ModaleDetailsMesure;
   let ongletActif: CleOngletListeMesure = 'generales';
 
-  const afficheModaleDetailsMesure = async (mesure: MesureDeLaListe) => {
-    await modaleDetailsMesure.affiche(mesure);
+  const afficheModaleDetailsMesure = async (modeleMesure: ModeleDeMesure) => {
+    await modaleDetailsMesure.affiche(modeleMesure);
   };
 
   const optionsFiltrage = {
@@ -87,7 +87,7 @@
     ],
   };
 
-  let donneesMesures: MesureDeLaListe[];
+  let donneesMesures: ModeleDeMesure[];
   $: {
     if (ongletActif === 'generales')
       donneesMesures = Object.values($mesuresReferentiel).map((m) => ({
@@ -103,22 +103,18 @@
       }));
   }
 
-  const estMesureGenerale = (
-    mesure: MesureDeLaListe
-  ): mesure is MesureReferentiel => mesure.type === 'generale';
+  const estModeleMesureGenerale = (
+    modeleMesure: ModeleDeMesure
+  ): modeleMesure is MesureReferentiel => modeleMesure.type === 'generale';
 
-  const estMesureSpecifique = (
-    mesure: MesureDeLaListe
-  ): mesure is ModeleMesureSpecifique => mesure.type === 'specifique';
-
-  const afficheDetailServiceAssocies = async (mesure: MesureDeLaListe) => {
-    await afficheModaleDetailsMesure(mesure);
+  const afficheDetailServiceAssocies = async (modeleMesure: ModeleDeMesure) => {
+    await afficheModaleDetailsMesure(modeleMesure);
   };
 
-  const afficheTiroirConfigurationMesure = (mesure: MesureDeLaListe) => {
-    if (estMesureGenerale(mesure))
+  const afficheTiroirConfigurationMesure = (modeleMesure: ModeleDeMesure) => {
+    if (estModeleMesureGenerale(modeleMesure))
       tiroirStore.afficheContenu(TiroirConfigurationMesure, {
-        mesure,
+        mesure: modeleMesure,
         statuts,
       });
   };

--- a/svelte/lib/listeMesures/ListeMesures.svelte
+++ b/svelte/lib/listeMesures/ListeMesures.svelte
@@ -31,6 +31,7 @@
     type CleOngletListeMesure,
   } from './kit/OngletsListeMesures.svelte';
   import { modelesMesureSpecifique } from './stores/modelesMesureSpecifique.store';
+  import type { MesureDeLaListe } from './listeMesures.d';
 
   export let statuts: ReferentielStatut;
   export let typesService: ReferentielTypesService;
@@ -43,7 +44,7 @@
   let modaleDetailsMesure: ModaleDetailsMesure;
   let ongletActif: CleOngletListeMesure = 'generales';
 
-  const afficheModaleDetailsMesure = async (mesure: MesureReferentiel) => {
+  const afficheModaleDetailsMesure = async (mesure: MesureDeLaListe) => {
     await modaleDetailsMesure.affiche(mesure);
   };
 
@@ -86,17 +87,6 @@
     ],
   };
 
-  type MesureDeLaListe = {
-    id: string;
-    categorie: CategorieMesure;
-    description: string;
-    descriptionLongue: string;
-    identifiantNumerique?: string;
-    referentiel: Referentiel;
-    idsServicesAssocies: string[];
-    type: 'generale' | 'specifique';
-  };
-
   let donneesMesures: MesureDeLaListe[];
   $: {
     if (ongletActif === 'generales')
@@ -122,7 +112,7 @@
   ): mesure is ModeleMesureSpecifique => mesure.type === 'specifique';
 
   const afficheDetailServiceAssocies = async (mesure: MesureDeLaListe) => {
-    if (estMesureGenerale(mesure)) await afficheModaleDetailsMesure(mesure);
+    await afficheModaleDetailsMesure(mesure);
   };
 
   const afficheTiroirConfigurationMesure = (mesure: MesureDeLaListe) => {
@@ -201,7 +191,6 @@
             titre={`${donnee.idsServicesAssocies.length} ${
               donnee.idsServicesAssocies.length > 1 ? 'services' : 'service'
             }`}
-            actif={typeMesure === 'generale'}
             on:click={async () => {
               await afficheDetailServiceAssocies(donnee);
             }}

--- a/svelte/lib/listeMesures/kit/DescriptionCompleteMesure.svelte
+++ b/svelte/lib/listeMesures/kit/DescriptionCompleteMesure.svelte
@@ -2,20 +2,25 @@
   import CartoucheIdentifiantMesure from '../../ui/CartoucheIdentifiantMesure.svelte';
   import CartoucheCategorieMesure from '../../ui/CartoucheCategorieMesure.svelte';
   import CartoucheReferentiel from '../../ui/CartoucheReferentiel.svelte';
-  import type { MesureReferentiel } from '../../ui/types.d';
   import DescriptionLongueMesure from '../../ui/DescriptionLongueMesure.svelte';
+  import type { ModeleDeMesure } from '../listeMesures.d';
 
-  export let mesure: MesureReferentiel;
+  export let modeleDeMesure: Omit<
+    ModeleDeMesure,
+    'type' | 'idsServicesAssocies'
+  >;
 </script>
 
-<p class="description">{mesure.description}</p>
+<p class="description">{modeleDeMesure.description}</p>
 <div class="cartouches">
-  <CartoucheReferentiel referentiel={mesure.referentiel} />
-  <CartoucheCategorieMesure categorie={mesure.categorie} />
-  <CartoucheIdentifiantMesure identifiant={mesure.identifiantNumerique} />
+  <CartoucheReferentiel referentiel={modeleDeMesure.referentiel} />
+  <CartoucheCategorieMesure categorie={modeleDeMesure.categorie} />
+  <CartoucheIdentifiantMesure
+    identifiant={modeleDeMesure.identifiantNumerique}
+  />
 </div>
 <DescriptionLongueMesure
-  description={mesure.descriptionLongue}
+  description={modeleDeMesure.descriptionLongue}
   repliee={true}
 />
 

--- a/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
+++ b/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import type {
-    MesureReferentiel,
     ReferentielStatut,
     ReferentielTypesService,
   } from '../../ui/types.d';
-  import { mesuresAvecServicesAssociesStore } from '../stores/mesuresAvecServicesAssocies.store';
   import { servicesAvecMesuresAssociees } from '../stores/servicesAvecMesuresAssociees.store';
   import DescriptionCompleteMesure from './DescriptionCompleteMesure.svelte';
   import Modale from '../../ui/Modale.svelte';
@@ -13,24 +11,26 @@
   import { tiroirStore } from '../../ui/stores/tiroir.store';
   import TiroirConfigurationMesure from './tiroir/TiroirConfigurationMesure.svelte';
   import TableauServicesAssocies from './TableauServicesAssocies.svelte';
+  import type { MesureDeLaListe } from '../listeMesures.d';
 
   export let referentielStatuts: ReferentielStatut;
   export let referentielTypesService: ReferentielTypesService;
 
   let elementModale: Modale;
-  let mesure: MesureReferentiel;
+  let mesure: MesureDeLaListe;
   $: servicesAvecMesure =
     mesure &&
     $servicesAvecMesuresAssociees
-      .filter((s) => {
-        return $mesuresAvecServicesAssociesStore[mesure.id].includes(s?.id);
-      })
-      .map(({ mesuresAssociees, ...autresDonnees }) => ({
+      .filter((s) => mesure.idsServicesAssocies.includes(s?.id))
+      .map(({ mesuresAssociees, mesuresSpecifiques, ...autresDonnees }) => ({
         ...autresDonnees,
-        mesure: mesuresAssociees[mesure.id],
+        mesure:
+          mesure.type === 'generale'
+            ? mesuresAssociees[mesure.id]
+            : mesuresSpecifiques.find((ms) => ms.idModele === mesure.id),
       }));
 
-  export const affiche = async (mesureAAfficher: MesureReferentiel) => {
+  export const affiche = async (mesureAAfficher: MesureDeLaListe) => {
     mesure = mesureAAfficher;
     await tick();
     elementModale.affiche();

--- a/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
+++ b/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
@@ -11,37 +11,40 @@
   import { tiroirStore } from '../../ui/stores/tiroir.store';
   import TiroirConfigurationMesure from './tiroir/TiroirConfigurationMesure.svelte';
   import TableauServicesAssocies from './TableauServicesAssocies.svelte';
-  import type { MesureDeLaListe } from '../listeMesures.d';
+  import type { ModeleDeMesure } from '../listeMesures.d';
 
   export let referentielStatuts: ReferentielStatut;
   export let referentielTypesService: ReferentielTypesService;
 
   let elementModale: Modale;
-  let mesure: MesureDeLaListe;
+  let modeleDeMesure: ModeleDeMesure;
+
   $: servicesAvecMesure =
-    mesure &&
+    modeleDeMesure &&
     $servicesAvecMesuresAssociees
-      .filter((s) => mesure.idsServicesAssocies.includes(s?.id))
+      .filter((s) => modeleDeMesure.idsServicesAssocies.includes(s?.id))
       .map(({ mesuresAssociees, mesuresSpecifiques, ...autresDonnees }) => ({
         ...autresDonnees,
         mesure:
-          mesure.type === 'generale'
-            ? mesuresAssociees[mesure.id]
-            : mesuresSpecifiques.find((ms) => ms.idModele === mesure.id),
+          modeleDeMesure.type === 'generale'
+            ? mesuresAssociees[modeleDeMesure.id]
+            : mesuresSpecifiques.find(
+                (ms) => ms.idModele === modeleDeMesure.id
+              ),
       }));
 
-  export const affiche = async (mesureAAfficher: MesureDeLaListe) => {
-    mesure = mesureAAfficher;
+  export const affiche = async (modeleMesureAAfficher: ModeleDeMesure) => {
+    modeleDeMesure = modeleMesureAAfficher;
     await tick();
     elementModale.affiche();
   };
 </script>
 
-{#if mesure}
+{#if modeleDeMesure}
   <Modale bind:this={elementModale}>
     <svelte:fragment slot="entete">
       <h4>Mesure</h4>
-      <DescriptionCompleteMesure {mesure} />
+      <DescriptionCompleteMesure {modeleDeMesure} />
       <h4>
         {servicesAvecMesure.length}
         {servicesAvecMesure.length > 1
@@ -72,7 +75,7 @@
         icone="configuration"
         on:click={() => {
           tiroirStore.afficheContenu(TiroirConfigurationMesure, {
-            mesure,
+            mesure: modeleDeMesure,
             statuts: referentielStatuts,
           });
           elementModale.ferme();

--- a/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
+++ b/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
@@ -89,6 +89,7 @@
         type="primaire"
         taille="moyen"
         icone="configuration"
+        actif={modeleDeMesure.type === 'generale'}
         on:click={configureMesure}
       />
     </svelte:fragment>

--- a/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
+++ b/svelte/lib/listeMesures/kit/ModaleDetailsMesure.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type {
+    MesureReferentiel,
     ReferentielStatut,
     ReferentielTypesService,
   } from '../../ui/types.d';
@@ -11,13 +12,18 @@
   import { tiroirStore } from '../../ui/stores/tiroir.store';
   import TiroirConfigurationMesure from './tiroir/TiroirConfigurationMesure.svelte';
   import TableauServicesAssocies from './TableauServicesAssocies.svelte';
-  import type { ModeleDeMesure } from '../listeMesures.d';
+  import type {
+    ModeleDeMesure,
+    ServiceAssocieAUneMesure,
+  } from '../listeMesures.d';
 
   export let referentielStatuts: ReferentielStatut;
   export let referentielTypesService: ReferentielTypesService;
 
   let elementModale: Modale;
   let modeleDeMesure: ModeleDeMesure;
+
+  let servicesAvecMesure: ServiceAssocieAUneMesure[] = [];
 
   $: servicesAvecMesure =
     modeleDeMesure &&
@@ -30,13 +36,23 @@
             ? mesuresAssociees[modeleDeMesure.id]
             : mesuresSpecifiques.find(
                 (ms) => ms.idModele === modeleDeMesure.id
-              ),
+              )!,
       }));
 
   export const affiche = async (modeleMesureAAfficher: ModeleDeMesure) => {
     modeleDeMesure = modeleMesureAAfficher;
     await tick();
     elementModale.affiche();
+  };
+
+  const configureMesure = () => {
+    if (modeleDeMesure.type === 'generale') {
+      tiroirStore.afficheContenu(TiroirConfigurationMesure, {
+        mesure: modeleDeMesure as MesureReferentiel,
+        statuts: referentielStatuts,
+      });
+      elementModale.ferme();
+    }
   };
 </script>
 
@@ -73,13 +89,7 @@
         type="primaire"
         taille="moyen"
         icone="configuration"
-        on:click={() => {
-          tiroirStore.afficheContenu(TiroirConfigurationMesure, {
-            mesure: modeleDeMesure,
-            statuts: referentielStatuts,
-          });
-          elementModale.ferme();
-        }}
+        on:click={configureMesure}
       />
     </svelte:fragment>
   </Modale>

--- a/svelte/lib/listeMesures/kit/tiroir/TiroirConfigurationMesure.svelte
+++ b/svelte/lib/listeMesures/kit/tiroir/TiroirConfigurationMesure.svelte
@@ -86,7 +86,7 @@
 <ContenuTiroir>
   {#if etapeCourante === 1}
     <div>
-      <DescriptionCompleteMesure {mesure} />
+      <DescriptionCompleteMesure modeleDeMesure={mesure} />
       <hr />
     </div>
   {/if}

--- a/svelte/lib/listeMesures/kit/tiroir/etapes/TroisiemeEtape.svelte
+++ b/svelte/lib/listeMesures/kit/tiroir/etapes/TroisiemeEtape.svelte
@@ -11,7 +11,7 @@
 
   export let mesure: MesureReferentiel;
   export let statuts: ReferentielStatut;
-  export let statutSelectionne: StatutMesure;
+  export let statutSelectionne: StatutMesure | '';
   export let precision: string;
   export let idsServicesSelectionnes: string[];
 

--- a/svelte/lib/listeMesures/listeMesures.api.ts
+++ b/svelte/lib/listeMesures/listeMesures.api.ts
@@ -8,7 +8,7 @@ export const enregistreModificationMesureSurServicesMultiples = async ({
 }: {
   idMesure: string;
   idsServices: string[];
-  statut: StatutMesure | null;
+  statut: StatutMesure | '';
   modalites: string | null;
 }) => {
   await axios.put(`/api/services/mesures/${idMesure}`, {

--- a/svelte/lib/listeMesures/listeMesures.d.ts
+++ b/svelte/lib/listeMesures/listeMesures.d.ts
@@ -1,10 +1,10 @@
 import type {
   IdNiveauDeSecurite,
-  MesureReferentiel,
   IdTypeService,
+  MesureReferentiel,
+  MesureSpecifique,
   ReferentielStatut,
 } from '../ui/types.d';
-import type { StatutMesure } from '../modeles/modeleMesure';
 
 declare global {
   interface HTMLElementEventMap {
@@ -29,6 +29,7 @@ export type ServiceAvecMesuresAssociees = {
   nomService: string;
   organisationResponsable: string;
   mesuresAssociees: Record<string, PersonnalisationMesure>;
+  mesuresSpecifiques: MesureSpecifique[];
   peutEtreModifie: boolean;
   niveauSecurite: IdNiveauDeSecurite;
   typeService: IdTypeService[];
@@ -42,4 +43,15 @@ export type ServiceAssocieAUneMesure = {
   peutEtreModifie: boolean;
   niveauSecurite: IdNiveauDeSecurite;
   typeService: IdTypeService[];
+};
+
+export type MesureDeLaListe = {
+  id: string;
+  categorie: CategorieMesure;
+  description: string;
+  descriptionLongue: string;
+  identifiantNumerique?: string;
+  referentiel: Referentiel;
+  idsServicesAssocies: string[];
+  type: 'generale' | 'specifique';
 };

--- a/svelte/lib/listeMesures/listeMesures.d.ts
+++ b/svelte/lib/listeMesures/listeMesures.d.ts
@@ -45,7 +45,7 @@ export type ServiceAssocieAUneMesure = {
   typeService: IdTypeService[];
 };
 
-export type MesureDeLaListe = {
+export type ModeleDeMesure = {
   id: string;
   categorie: CategorieMesure;
   description: string;

--- a/svelte/lib/modeles/modeleMesure.ts
+++ b/svelte/lib/modeles/modeleMesure.ts
@@ -1,4 +1,4 @@
-export const planDActionDisponible = (statut: StatutMesure) =>
+export const planDActionDisponible = (statut: StatutMesure | undefined) =>
   statut === 'aLancer' || statut === 'enCours';
 
-export type StatutMesure = string;
+export type StatutMesure = 'aLancer' | 'enCours' | 'fait' | 'nonFait';

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -17,7 +17,10 @@
   import { rechercheTextuelle } from '../stores/rechercheTextuelle.store';
   import SelectionPriorite from '../../ui/SelectionPriorite.svelte';
   import SelectionEcheance from '../../ui/SelectionEcheance.svelte';
-  import { planDActionDisponible } from '../../modeles/modeleMesure';
+  import {
+    planDActionDisponible,
+    type StatutMesure,
+  } from '../../modeles/modeleMesure';
   import SelectionResponsables from '../../ui/SelectionResponsables.svelte';
 
   type IdDom = string;
@@ -34,7 +37,7 @@
   export let priorites: ReferentielPriorite;
 
   const dispatch = createEventDispatcher<{
-    modificationStatut: { statut: string };
+    modificationStatut: { statut: StatutMesure };
     modificationPriorite: { priorite: PrioriteMesure | undefined };
   }>();
 

--- a/svelte/lib/tableauDesMesures/stores/mesures.store.ts
+++ b/svelte/lib/tableauDesMesures/stores/mesures.store.ts
@@ -1,6 +1,7 @@
 import type { Mesures, IdUtilisateur } from '../tableauDesMesures.d';
 import { writable } from 'svelte/store';
 import type { EcheanceMesure, PrioriteMesure } from '../../ui/types';
+import type { StatutMesure } from '../../modeles/modeleMesure';
 
 export const mesuresParDefaut = (): Mesures => ({
   mesuresGenerales: {},
@@ -48,12 +49,12 @@ export const mesures = {
       valeur.mesuresSpecifiques[idMesure].responsables = responsables;
       return valeur;
     }),
-  metAJourStatutMesureGenerale: (idMesure: string, statut: string) =>
+  metAJourStatutMesureGenerale: (idMesure: string, statut: StatutMesure) =>
     toutesLesMesures.update((valeur) => {
       valeur.mesuresGenerales[idMesure].statut = statut;
       return valeur;
     }),
-  metAJourStatutMesureSpecifique: (idMesure: number, statut: string) =>
+  metAJourStatutMesureSpecifique: (idMesure: number, statut: StatutMesure) =>
     toutesLesMesures.update((valeur) => {
       valeur.mesuresSpecifiques[idMesure].statut = statut;
       return valeur;

--- a/svelte/lib/ui/SelectionStatut.svelte
+++ b/svelte/lib/ui/SelectionStatut.svelte
@@ -2,6 +2,7 @@
   import type { ReferentielStatut } from './types.d';
   import { validationChamp } from '../directives/validationChamp';
   import { createEventDispatcher } from 'svelte';
+  import type { StatutMesure } from '../modeles/modeleMesure';
 
   export let id: string;
   export let statut: string | undefined;
@@ -13,7 +14,7 @@
   export let version: 'normale' | 'accentuee' = 'normale';
   export let labelChoixVide: string = '';
 
-  const dispatch = createEventDispatcher<{ input: { statut: string } }>();
+  const dispatch = createEventDispatcher<{ input: { statut: StatutMesure } }>();
 
   $: {
     if (!statut) statut = '';

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -77,6 +77,17 @@ export type ModeleMesureSpecifique = {
   idsServicesAssocies: string[];
 };
 
+export type MesureSpecifique = {
+  id: string;
+  categorie: CategorieMesure;
+  description: string;
+  descriptionLongue?: string;
+  idModele?: string;
+  responsables: string[];
+  statut: StatutMesure;
+  modalite: string;
+};
+
 export type ObjetDeDonnees = Record<string, any>;
 
 export type IdNiveauDeSecurite = 'niveau1' | 'niveau2' | 'niveau3';

--- a/svelte/test/listeMesures/mesuresAvecServicesAssocies.store.spec.ts
+++ b/svelte/test/listeMesures/mesuresAvecServicesAssocies.store.spec.ts
@@ -13,6 +13,7 @@ const unService = (
   nomService,
   organisationResponsable: 'SuperEntreprise',
   mesuresAssociees,
+  mesuresSpecifiques: [],
   peutEtreModifie: true,
   niveauSecurite: 'niveau1',
   typeService: ['api'],

--- a/svelte/test/tableauDesMesures/stores/volumetrieMesures.store.spec.ts
+++ b/svelte/test/tableauDesMesures/stores/volumetrieMesures.store.spec.ts
@@ -20,7 +20,7 @@ describe('Le store dérivé de volumétrie des mesures', () => {
             id: 'M1',
             categorie: 'Protection',
             modalites: '',
-            statut: 'Fait',
+            statut: 'fait',
             description: '',
             identifiantNumerique: '000',
           },
@@ -60,7 +60,7 @@ describe('Le store dérivé de volumétrie des mesures', () => {
           mesureFaite: {
             categorie: 'Protection',
             indispensable: true,
-            statut: 'Faite',
+            statut: 'fait',
             descriptionLongue: '',
             referentiel: Referentiel.ANSSI,
             modalites: '',

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -250,9 +250,50 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             A: { statut: 'fait', modalites: 'Mon commentaire' },
             B: {},
           },
+          mesuresSpecifiques: [],
           niveauSecurite: 'niveau2',
           typeService: ['api', 'siteInternet'],
           peutEtreModifie: true,
+        },
+      ]);
+    });
+
+    it('retourne une liste de services avec leurs mesures spécifiques associées', async () => {
+      const mesures = new Mesures(
+        {
+          mesuresSpecifiques: [
+            { id: 'MS1', idModele: 'MOD-1', statut: 'enCours' },
+          ],
+        },
+        testeur.referentiel(),
+        {},
+        { 'MOD-1': {} }
+      );
+      testeur.depotDonnees().autorisations = () => [
+        uneAutorisation().deProprietaire('U1', 'S1').construis(),
+      ];
+      const descriptionService = uneDescriptionValide(
+        testeur.referentiel()
+      ).donnees;
+      testeur.depotDonnees().services = () => [
+        unService(testeur.referentiel())
+          .avecId('S1')
+          .avecDescription(descriptionService)
+          .avecMesures(mesures)
+          .construis(),
+      ];
+
+      const reponse = await axios.get(
+        'http://localhost:1234/api/services/mesures'
+      );
+
+      expect(reponse.status).to.be(200);
+      expect(reponse.data[0].mesuresSpecifiques).to.eql([
+        {
+          id: 'MS1',
+          idModele: 'MOD-1',
+          statut: 'enCours',
+          responsables: [],
         },
       ]);
     });


### PR DESCRIPTION
... de la même manière que pour les mesures générales.

> [!TIP]
>  On voit émerger une forte ressemblance entre `MesureReferentiel` et `ModeleMesureSpecifique`.
> 
> Les `MesureReferentiel` sont en fait les mesures générales provenant du référentiel, qui peuvent donc être considérées comme des "Modèles" de mesure personnalisée.
> Nous cherchons donc à mutualiser et génériser l'utilisation de ces deux entités métier au sein de notre front, à suivre dans les prochaines PR.


 