### PR TITLE
Ajoute des headers de `cross-origin-*`

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -61,6 +61,8 @@ const middleware = (configuration = {}) => {
       'x-frame-options': 'deny',
       'x-content-type-options': 'nosniff',
       'referrer-policy': 'no-referrer',
+      'cross-origin-opener-policy': 'same-origin',
+      'cross-origin-resource-policy': 'same-origin',
     });
 
     suite();

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -668,6 +668,22 @@ describe('Le middleware MSS', () => {
       verifiePositionnementHeader('referrer-policy', /^no-referrer$/, done);
     });
 
+    it("applique une politique 'same-origin' sur les 'cross-origin-opener'", (done) => {
+      verifiePositionnementHeader(
+        'cross-origin-opener-policy',
+        /^same-origin$/,
+        done
+      );
+    });
+
+    it("applique une politique 'same-origin' sur les 'cross-origin-resource'", (done) => {
+      verifiePositionnementHeader(
+        'cross-origin-resource-policy',
+        /^same-origin$/,
+        done
+      );
+    });
+
     it('positionne un nonce dans le reponse.locals', (done) => {
       const middleware = leMiddleware({
         adaptateurChiffrement: {


### PR DESCRIPTION
* [`cross-origin-opener-policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy), afin de notamment interdire l'utilisation de lien avec `rel=opener`.
* [`cross-origin-resource-policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cross-Origin_Resource_Policy) pour limiter quelles pages peuvent "lire" notre site.