### PR TITLE
[DOCKER] Ajoute une version de node par défaut dans le dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=
+ARG NODE_VERSION=22
 
 #checkov:skip=CKV_DOCKER_2:Uniquement utilisé en local pour le dev
 #checkov:skip=CKV_DOCKER_3:Uniquement utilisé en local pour le dev


### PR DESCRIPTION
... afin d'éviter un warning lors du lancement.

```
WARN: InvalidDefaultArgInFrom: Default value for ARG docker.io/node:$NODE_VERSION 
results in empty or invalid base image name (line 5)
```