### PR TITLE
[SOIN] Uniformise les retours du décodage de JWT

### DIFF
--- a/src/adaptateurs/adaptateurJWT.js
+++ b/src/adaptateurs/adaptateurJWT.js
@@ -1,7 +1,13 @@
 const jwt = require('jsonwebtoken');
+const { ErreurJWTAbsent } = require('../erreurs');
 
 const secret = process.env.SECRET_JWT;
-const decode = (token) => (token ? jwt.verify(token, secret) : undefined);
+const decode = (token) => {
+  if (token) {
+    jwt.verify(token, secret);
+  }
+  throw ErreurJWTAbsent;
+};
 
 const signeDonnees = (donnees) =>
   jwt.sign(donnees, secret, { expiresIn: '1h' });

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -21,6 +21,7 @@ class ErreurBusEvenements extends Error {
 }
 class ErreurHashDeSelInvalide extends Error {}
 class ErreurSelManquant extends Error {}
+class ErreurJWTAbsent extends Error {}
 class ErreurValeurSelIncoherente extends Error {}
 class ErreurVersionSelInvalide extends Error {}
 
@@ -156,6 +157,7 @@ module.exports = {
   ErreurStatutMesureManquant,
   ErreurPrioriteMesureInvalide,
   ErreurSuppressionImpossible,
+  ErreurJWTAbsent,
   ErreurTypeInconnu,
   ErreurUtilisateurExistant,
   ErreurUtilisateurInexistant,

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -83,9 +83,6 @@ const middleware = (configuration = {}) => {
 
     try {
       const token = adaptateurJWT.decode(requete.session.token);
-      if (!token) {
-        return renvoieUtilisateurSansJWTValide();
-      }
 
       const utilisateur = await depotDonnees.utilisateur(token.idUtilisateur);
       if (!utilisateur) return renvoieUtilisateurSansJWTValide();

--- a/src/routes/nonConnecte/routesNonConnectePage.js
+++ b/src/routes/nonConnecte/routesNonConnectePage.js
@@ -66,11 +66,6 @@ const routesNonConnectePage = ({
   routes.get('/creation-compte', async (requete, reponse) => {
     const { token } = requete.query;
 
-    if (!token) {
-      reponse.sendStatus(400);
-      return;
-    }
-
     let informationsProfessionnelles;
     try {
       informationsProfessionnelles = adaptateurJWT.decode(token);


### PR DESCRIPTION
Dans l'API courante, il y a deux types de retours sur des échecs de validation du JWT :
* `undefined` si le JWT n'est pas présent
* levée d'exception si la vérification du JWT échoue

Cela nécessite deux traitements différents de la part de l'appelant (`if` et `throw`).
Cela introduit :
* une duplication dans le cas du `if`, où l'appelant exécute une même vérification que dans le `decode`
* un risque d'erreur en cas d'oubli du `if`, car le code continue de s'exécuter alors que le JWT n'est pas valide (car absent)

Via cette PR, on force la levée d'erreur sur tous les cas non valides de JWT.