### PR TITLE
[UI Kit] Passe en version 1.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lab-anssi/lib": "^1.4.2",
-        "@lab-anssi/ui-kit": "1.1.1",
         "@sentry/node": "^7.102.1",
         "@tiptap/core": "^2.7.1",
         "@tiptap/extension-mention": "^2.7.1",
@@ -1231,15 +1230,6 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@lab-anssi/ui-kit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lab-anssi/ui-kit/-/ui-kit-1.1.1.tgz",
-      "integrity": "sha512-t4qoreD0Ydy51aOHl4V5OWIlH59oQyWG/sFlCLLILJTeWxI/rdKi2cdeFEwJEl2zryUsE2wKWP6CQPGzfg83og==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "svelte": "^4.2.19"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -14430,12 +14420,6 @@
           }
         }
       }
-    },
-    "@lab-anssi/ui-kit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lab-anssi/ui-kit/-/ui-kit-1.1.1.tgz",
-      "integrity": "sha512-t4qoreD0Ydy51aOHl4V5OWIlH59oQyWG/sFlCLLILJTeWxI/rdKi2cdeFEwJEl2zryUsE2wKWP6CQPGzfg83og==",
-      "requires": {}
     },
     "@mapbox/node-pre-gyp": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/betagouv/mon-service-securise#readme",
   "dependencies": {
     "@lab-anssi/lib": "^1.4.2",
-    "@lab-anssi/ui-kit": "1.1.1",
     "@sentry/node": "^7.102.1",
     "@tiptap/core": "^2.7.1",
     "@tiptap/extension-mention": "^2.7.1",

--- a/public/assets/styles/theme-ui-kit.css
+++ b/public/assets/styles/theme-ui-kit.css
@@ -51,6 +51,7 @@
   --liste-articles-couleur-texte: #09416a;
   --couleur-focus: #0a76f6;
   --bouton-secondaire-tertiaire-couleur-texte: #0079d0;
+  --bouton-secondaire-couleur-bordure: #0079d0;
   --bouton-primaire-couleur-texte: #ffffff;
   --bouton-primaire-couleur-fond: #0079d0;
   --bouton-primaire-couleur-fond-survol: #0c5c98;

--- a/src/vues/mss.pug
+++ b/src/vues/mss.pug
@@ -8,7 +8,7 @@ block page
   block scripts
     script(src='/statique/bibliotheques/axios-1.0.0.min.js')
     script(src='/statique/bibliotheques/jquery-3.6.0.min.js')
-    script(src='https://lab-anssi-ui-kit-prod-s3-assets.cellar-c2.services.clever-cloud.com/1.22.0/lab-anssi-ui-kit.iife.js' nonce=nonce)
+    script(src='https://lab-anssi-ui-kit-prod-s3-assets.cellar-c2.services.clever-cloud.com/1.24.0/lab-anssi-ui-kit.iife.js' nonce=nonce)
 
   block styles
     link(href='/statique/assets/styles/palette.css', rel='stylesheet')


### PR DESCRIPTION
… pour récupérer le tout dernier `lab-anssi-bouton` qui sera utilisé dans les tiroirs de téléversement.

Pas besoin de conserver l'ui-kit dans le package.json car MSS se sert seulement des WebC de l'UI Kit qui sont contenus dans le bundle déployé sur le cellar.