### PR TITLE
Corrige le filtrage des mesures spécifiques dans la page "Sécuriser"

### DIFF
--- a/svelte/lib/tableauDesMesures/stores/rechercheParReferentiel.store.ts
+++ b/svelte/lib/tableauDesMesures/stores/rechercheParReferentiel.store.ts
@@ -36,7 +36,7 @@ const estMesureGenerale = (
   mesure: MesureSpecifique | MesureGenerale
 ): mesure is MesureGenerale =>
   // On utilise ici un typeguard, et on se base sur une propriété qui est uniquement présente dans les mesures générales
-  'descriptionLongue' in mesure && mesure.descriptionLongue !== undefined;
+  'referentiel' in mesure && mesure.referentiel !== undefined;
 
 export const appliqueRechercheParReferentiel = (
   mesure: MesureSpecifique | MesureGenerale,

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -34,5 +34,5 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 
 ## Du point de vue de la page "SÉCURISER"
 
-- [ ] Le filtre "Mesures ajoutées" affiche bien les mesures issues d'un modèle
+- [x] Le filtre "Mesures ajoutées" affiche bien les mesures issues d'un modèle
 - [ ] Une mesure spécifique associée, supprimée depuis l'interface, doit supprimé l'association entre le service et le modèle


### PR DESCRIPTION
... car actuellement, on se base sur la présence ou non de "description longue".
Or, cette propriété est maintenant présente dans les mesures spécifiques.