### PR TITLE
Supprime un modèle de mesure et toutes les mesures associées

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -375,6 +375,16 @@ const nouvelAdaptateur = (
       donnees: donneesModele,
     });
 
+  const supprimeModeleMesureSpecifique = async (id) => {
+    donnees.modelesMesureSpecifique = donnees.modelesMesureSpecifique.filter(
+      (m) => m.id !== id
+    );
+    donnees.associationModelesMesureSpecifiqueServices =
+      donnees.associationModelesMesureSpecifiqueServices.filter(
+        (a) => a.idModele !== id
+      );
+  };
+
   const metsAJourModeleMesureSpecifique = async (
     id,
     idUtilisateur,
@@ -482,6 +492,7 @@ const nouvelAdaptateur = (
     supprimeAutorisationsContribution,
     supprimeAutorisationsHomologation,
     supprimeLeLienEntreLeModeleEtLesServices,
+    supprimeModeleMesureSpecifique,
     supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
     supprimeService,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -748,6 +748,13 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
     return resultat.rows;
   };
 
+  const supprimeModeleMesureSpecifique = async (idModele) => {
+    await knex('modeles_mesure_specifique').where({ id: idModele }).del();
+    await knex('modeles_mesure_specifique_association_aux_services')
+      .where({ id_modele: idModele })
+      .del();
+  };
+
   return {
     activitesMesure,
     ajouteAutorisation,
@@ -800,6 +807,7 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
     supprimeAutorisations,
     supprimeAutorisationsContribution,
     supprimeAutorisationsHomologation,
+    supprimeModeleMesureSpecifique,
     supprimeNotificationsExpirationHomologation,
     supprimeNotificationsExpirationHomologationPourService,
     supprimeService,

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -41,6 +41,22 @@ const creeDepot = (config = {}) => {
     idUtilisateur,
     idModele
   ) => {
+    const modeles =
+      await persistance.lisModelesMesureSpecifiquePourUtilisateur(
+        idUtilisateur
+      );
+    const modeleASupprimer = modeles.find((m) => m.id === idModele);
+    const idsServicesAssocies = modeleASupprimer.ids_services_associes;
+    const supprimeMesureSpecifiqueAssociee = idsServicesAssocies.map(
+      async (unId) => {
+        const s = await depotServices.service(unId);
+        s.supprimeMesureSpecifiqueAssocieeAuModele(idModele);
+        return s;
+      }
+    );
+    const aPersister = await Promise.all(supprimeMesureSpecifiqueAssociee);
+    await Promise.all(aPersister.map(depotServices.metsAJourService));
+
     await persistance.supprimeModeleMesureSpecifique(idModele);
   };
 

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -1,7 +1,6 @@
 const {
   ErreurUtilisateurInexistant,
   ErreurServiceNonAssocieAuModele,
-  ErreurModeleDeMesureSpecifiqueIntrouvable,
 } = require('../erreurs');
 const {
   VerificationsUtilisateurPeutMuterModele,
@@ -16,7 +15,7 @@ const creeDepot = (config = {}) => {
     depotServices,
   } = config;
 
-  const verificationsAssocieOuDetache =
+  const verificationsModificationModele =
     new VerificationsUtilisateurPeutMuterModele({
       adaptateurPersistance: persistance,
       depotAutorisations,
@@ -49,7 +48,7 @@ const creeDepot = (config = {}) => {
     const modeleASupprimer = modeles.find((m) => m.id === idModele);
     const idsServicesAssocies = modeleASupprimer?.ids_services_associes || [];
 
-    await verificationsAssocieOuDetache.toutes(
+    await verificationsModificationModele.toutes(
       idModele,
       idsServicesAssocies,
       idUtilisateur
@@ -76,10 +75,11 @@ const creeDepot = (config = {}) => {
     const utilisateur = await persistance.utilisateur(idUtilisateur);
     if (!utilisateur) throw new ErreurUtilisateurInexistant();
 
-    const modeleExiste =
-      await persistance.verifieModeleMesureSpecifiqueExiste(idModele);
-    if (!modeleExiste)
-      throw new ErreurModeleDeMesureSpecifiqueIntrouvable(idModele);
+    await verificationsModificationModele.queModeleExiste(idModele);
+    await verificationsModificationModele.queUtilisateurPossedeLeModele(
+      idUtilisateur,
+      idModele
+    );
 
     const donneesChiffrees = await adaptateurChiffrement.chiffre(donnees);
     await persistance.metsAJourModeleMesureSpecifique(
@@ -94,7 +94,7 @@ const creeDepot = (config = {}) => {
     idsServices,
     idUtilisateurAssociant
   ) => {
-    await verificationsAssocieOuDetache.toutes(
+    await verificationsModificationModele.toutes(
       idModele,
       idsServices,
       idUtilisateurAssociant
@@ -121,7 +121,7 @@ const creeDepot = (config = {}) => {
     idsServices,
     idUtilisateurDetachant
   ) => {
-    await verificationsAssocieOuDetache.toutes(
+    await verificationsModificationModele.toutes(
       idModele,
       idsServices,
       idUtilisateurDetachant

--- a/src/depots/depotDonneesModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesModelesMesureSpecifique.js
@@ -37,6 +37,13 @@ const creeDepot = (config = {}) => {
     return idModele;
   };
 
+  const supprimeModeleMesureSpecifiqueEtMesuresAssociees = async (
+    idUtilisateur,
+    idModele
+  ) => {
+    await persistance.supprimeModeleMesureSpecifique(idModele);
+  };
+
   const metsAJourModeleMesureSpecifique = async (
     idUtilisateur,
     idModele,
@@ -142,6 +149,7 @@ const creeDepot = (config = {}) => {
     detacheModeleMesureSpecifiqueDesServices,
     lisModelesMesureSpecifiquePourUtilisateur,
     metsAJourModeleMesureSpecifique,
+    supprimeModeleMesureSpecifiqueEtMesuresAssociees,
   };
 };
 

--- a/src/depots/modelesMesureSpecifique/VerificationsUtilisateurPeutMuterModele.js
+++ b/src/depots/modelesMesureSpecifique/VerificationsUtilisateurPeutMuterModele.js
@@ -19,13 +19,13 @@ class VerificationsUtilisateurPeutMuterModele {
   }
 
   async toutes(idModele, idsServices, idUtilisateur) {
-    await this.#queModeleExiste(idModele);
+    await this.queModeleExiste(idModele);
     await this.#queTousLesServicesExistent(idsServices);
-    await this.#queUtilisateurPossedeLeModele(idUtilisateur, idModele);
+    await this.queUtilisateurPossedeLeModele(idUtilisateur, idModele);
     await this.#peutModifierUnModeleSurLesServices(idUtilisateur, idsServices);
   }
 
-  async #queModeleExiste(idModele) {
+  async queModeleExiste(idModele) {
     const modeleExiste =
       await this.persistance.verifieModeleMesureSpecifiqueExiste(idModele);
     if (!modeleExiste)
@@ -39,7 +39,7 @@ class VerificationsUtilisateurPeutMuterModele {
     if (!tousServicesExistent) throw new ErreurServiceInexistant();
   }
 
-  async #queUtilisateurPossedeLeModele(idUtilisateur, idModele) {
+  async queUtilisateurPossedeLeModele(idUtilisateur, idModele) {
     const possedeLeModele =
       await this.persistance.modeleMesureSpecifiqueAppartientA(
         idUtilisateur,

--- a/src/depots/modelesMesureSpecifique/VerificationsUtilisateurPeutMuterModele.js
+++ b/src/depots/modelesMesureSpecifique/VerificationsUtilisateurPeutMuterModele.js
@@ -12,7 +12,7 @@ const {
 const { ECRITURE } = Permissions;
 const { SECURISER } = Rubriques;
 
-class VerificationsAssocieOuDetache {
+class VerificationsUtilisateurPeutMuterModele {
   constructor({ adaptateurPersistance, depotAutorisations }) {
     this.persistance = adaptateurPersistance;
     this.depotAutorisations = depotAutorisations;
@@ -48,7 +48,7 @@ class VerificationsAssocieOuDetache {
 
     if (!possedeLeModele)
       throw new ErreurAutorisationInexistante(
-        `L'utilisateur ${idUtilisateur} n'est pas propriétaire du modèle ${idModele} qu'il veut associer/détacher`
+        `L'utilisateur ${idUtilisateur} n'est pas propriétaire du modèle ${idModele} qu'il veut modifier.`
       );
   }
 
@@ -70,4 +70,4 @@ class VerificationsAssocieOuDetache {
   }
 }
 
-module.exports = { VerificationsAssocieOuDetache };
+module.exports = { VerificationsUtilisateurPeutMuterModele };

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -8,7 +8,7 @@ class ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique extends Error {
     const s = idServices.join(',');
     const d = JSON.stringify(droitsRequis);
     super(
-      `L'utilisateur ${u} n'a pas les droits suffisants sur ${s}. Droits requis pour associer/détacher un modèle : ${d}`
+      `L'utilisateur ${u} n'a pas les droits suffisants sur ${s}. Droits requis pour modifier un modèle : ${d}`
     );
   }
 }

--- a/src/modeles/mesuresSpecifiques.js
+++ b/src/modeles/mesuresSpecifiques.js
@@ -96,6 +96,10 @@ class MesuresSpecifiques extends ElementsConstructibles {
     });
   }
 
+  supprimeMesureAssocieeAuModele(idModele) {
+    this.items = this.items.filter((m) => m.idModele !== idModele);
+  }
+
   associeAuModele(idModele, idNouvelleMesure) {
     const modele = this.modelesDisponiblesDeMesureSpecifique[idModele];
 

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -225,6 +225,10 @@ class Service {
     this.mesures.mesuresSpecifiques.detacheMesureDuModele(idModele);
   }
 
+  supprimeMesureSpecifiqueAssocieeAuModele(idModele) {
+    this.mesures.mesuresSpecifiques.supprimeMesureAssocieeAuModele(idModele);
+  }
+
   metsAJourMesureGenerale(mesure) {
     const idUtilisateurs = this.contributeurs.map((u) => u.idUtilisateur);
     mesure.responsables = mesure.responsables.filter((r) =>

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -10,7 +10,7 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 
 - [ ] On peut supprimer un modèle du référentiel, mais **sans** supprimer les mesures : elles seront détachées sur chaque service où elles
       sont liées. Supprime et détache
-- [ ] On peut supprimer un modèle du référentiel **et** supprimer les mesures associées : les mesures disparaisssent totalement
+- [x] On peut supprimer un modèle du référentiel **et** supprimer les mesures associées : les mesures disparaisssent totalement
       de tous les services où elles apparaissaient. Supprime et supprime
 - [ ] On peut dissocier une mesure de certains services tout en **conservant** le modèle : les mesures spécifiques disparaissent du service
       et le lien entre modèle et service disparaît aussi. Conserve et supprime

--- a/tdd-todo/import_mesures_specifiques.md
+++ b/tdd-todo/import_mesures_specifiques.md
@@ -6,27 +6,24 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 
 ## Du point de vue des Modèles de mesure
 
+### Suppression
+
 - [ ] On peut supprimer un modèle du référentiel, mais **sans** supprimer les mesures : elles seront détachées sur chaque service où elles
-      sont liées.
+      sont liées. Supprime et détache
 - [ ] On peut supprimer un modèle du référentiel **et** supprimer les mesures associées : les mesures disparaisssent totalement
-      de tous les services où elles apparaissaient.
+      de tous les services où elles apparaissaient. Supprime et supprime
 - [ ] On peut dissocier une mesure de certains services tout en **conservant** le modèle : les mesures spécifiques disparaissent du service
-      et le lien entre modèle et service disparaît aussi.
+      et le lien entre modèle et service disparaît aussi. Conserve et supprime
+
+### CSV
+
 - [ ] On peut créer des modèles de mesure (description, description longue, catégorie) lié à son identifiant utilisateur via un import de CSV
   - Cet import aura une limite en nombre total de modèles détenu par l'utilisateur
 
 ## Du point de vue du Front
 
 - [ ] On veut pouvoir afficher la liste des modèles de mesure dans un onglet à coté de la liste des mesures générales
-  - [x] Les modèles de mesure sont affichés correctement, avec leur référentiel, leur catégorie et le nombre de services associés
-  - [x] La recherche fonctionne encore
-  - [x] Les filtres fonctionnent encore
-    - [x] On affiche uniquement les filtres de "catégories" pour les mesures spécifiques
   - [ ] Les badges des onglets sont mis à jour en fonction de la recherche
-- [x] On veut voir un écran dédié quand la liste de modèle de mesure est vide
-- [x] On montre une étape de confirmation lors de la modification d'un modèle
-- [x] On affiche un onglet "Toutes les mesures"
-  - [x] On affiche les filtres de catégories et de mesures par référentiel (Cf. SÉCURISER)
 - [ ] On veut pouvoir supprimer un modèle de mesure
   - [ ] La mesure est supprimée de la liste & des services (on retire l'association, les mesures spécifiques concernées et le modèle)
   - [ ] La mesure est supprimée de la liste, mais détachée des services (on retire l'association et le modèle, mais on conserve les mesures spécifiques une fois détachées)
@@ -34,5 +31,4 @@ On dit [Modèles de mesure spécifique] pour parler de la partie « référentie
 
 ## Du point de vue de la page "SÉCURISER"
 
-- [x] Le filtre "Mesures ajoutées" affiche bien les mesures issues d'un modèle
-- [ ] Une mesure spécifique associée, supprimée depuis l'interface, doit supprimé l'association entre le service et le modèle
+- [ ] Une mesure spécifique associée, supprimée depuis l'interface, doit supprimer l'association entre le service et le modèle

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -566,4 +566,44 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
       expect(modeles[0].idsServicesAssocies).to.eql(['S1']);
     });
   });
+
+  describe("concernant la suppression d'un modèle et de toutes les mesures associées", () => {
+    it('supprime le modèle', async () => {
+      persistance = unePersistanceMemoire()
+        .avecUnModeleDeMesureSpecifique({ id: 'MOD-1', idUtilisateur: 'U1' })
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .construis();
+
+      const depot = leDepot();
+      await depot.supprimeModeleMesureSpecifiqueEtMesuresAssociees(
+        'U1',
+        'MOD-1'
+      );
+
+      const modelesVides =
+        await depot.lisModelesMesureSpecifiquePourUtilisateur('U1');
+      expect(modelesVides).to.eql([]);
+    });
+
+    it('supprime les associations des services à ce modèle', async () => {
+      persistance = unePersistanceMemoire()
+        .avecUnModeleDeMesureSpecifique({ id: 'MOD-1', idUtilisateur: 'U1' })
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .associeLeServiceAuxModelesDeMesureSpecifique('S1', ['MOD-1'])
+        .construis();
+
+      const depot = leDepot();
+      await depot.supprimeModeleMesureSpecifiqueEtMesuresAssociees(
+        'U1',
+        'MOD-1'
+      );
+
+      const estAssocie =
+        await persistance.tousServicesSontAssociesAuModeleMesureSpecifique(
+          ['S1'],
+          'MOD-1'
+        );
+      expect(estAssocie).to.eql(false);
+    });
+  });
 });

--- a/test/depots/depotDonneesModelesMesureSpecifique.spec.js
+++ b/test/depots/depotDonneesModelesMesureSpecifique.spec.js
@@ -95,6 +95,16 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
     beforeEach(() => {
       persistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
+        .avecUnModeleDeMesureSpecifique({
+          id: 'MOD-99',
+          idUtilisateur: 'U1',
+          donnees: {
+            description: 'avant description',
+            descriptionLongue: 'avant longue',
+            categorie: 'gouvernance',
+          },
+        })
         .construis();
     });
 
@@ -119,6 +129,16 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         expect().fail("L'appel aurait dû lever une erreur.");
       } catch (e) {
         expect(e).to.be.an(ErreurModeleDeMesureSpecifiqueIntrouvable);
+      }
+    });
+
+    it("jette une erreur si l'utilisateur n'est pas propriétaire du modèle", async () => {
+      const depot = leDepot();
+      try {
+        await depot.metsAJourModeleMesureSpecifique('U2', 'MOD-99', {});
+        expect().fail("L'appel aurait dû lever une erreur.");
+      } catch (e) {
+        expect(e).to.be.an(ErreurAutorisationInexistante);
       }
     });
 
@@ -147,7 +167,7 @@ describe('Le dépôt de données des modèles de mesure spécifique', () => {
         await depot.lisModelesMesureSpecifiquePourUtilisateur('U1');
 
       expect(lesDonneesSontChiffrees).to.be(true);
-      expect(modelesPersistes[0]).to.eql({
+      expect(modelesPersistes[1]).to.eql({
         description: 'après description',
         descriptionLongue: 'après longue',
         categorie: 'gouvernance',

--- a/test/modeles/mesuresSpecifiques.spec.js
+++ b/test/modeles/mesuresSpecifiques.spec.js
@@ -409,4 +409,24 @@ describe('La liste des mesures spécifiques', () => {
       ]);
     });
   });
+
+  describe("sur demande de suppression d'une mesure associée à un modèle", () => {
+    it('supprime la mesure', () => {
+      const modelesDisponiblesDeMesureSpecifique = {
+        'MOD-1': { categorie: 'categorie1' },
+      };
+
+      const mesures = new MesuresSpecifiques(
+        {
+          mesuresSpecifiques: [{ id: 'M1', idModele: 'MOD-1', statut: 'fait' }],
+        },
+        referentiel,
+        modelesDisponiblesDeMesureSpecifique
+      );
+
+      mesures.supprimeMesureAssocieeAuModele('MOD-1');
+
+      expect(mesures.donneesSerialisees()).to.eql([]);
+    });
+  });
 });


### PR DESCRIPTION
Dans ce cas de figure, on souhaite supprimer un modèle ainsi que toutes les mesures spécifiques associées.
Cette PR ajoute les méthodes nécessaires.

On ajoutera, dans la PR suivante, la route ainsi que le front.