### PR TITLE
[Téléversement] Début du calcul du rapport de téléversement

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -15,6 +15,9 @@ const nouvelAdaptateur = (
   donnees.superviseurs ||= [];
   donnees.modelesMesureSpecifique ||= [];
   donnees.associationModelesMesureSpecifiqueServices ||= [];
+  donnees.televersements = {
+    modelesMesureSpecifique: [],
+  };
 
   const supprimeEnregistrement = async (nomTable, id) => {
     donnees[nomTable] = donnees[nomTable].filter((e) => e.id !== id);
@@ -462,9 +465,19 @@ const nouvelAdaptateur = (
       }));
 
   const ajouteTeleversementModelesMesureSpecifique = async (
-    _idUtilisateur,
-    _donnees
-  ) => {};
+    idUtilisateur,
+    donneesTeleversement
+  ) => {
+    donnees.televersements.modelesMesureSpecifique.push({
+      idUtilisateur,
+      donneesTeleversement,
+    });
+  };
+
+  const lisTeleversementModelesMesureSpecifique = async (idUtilisateur) =>
+    donnees.televersements.modelesMesureSpecifique.find(
+      (m) => m.idUtilisateur === idUtilisateur
+    ).donneesTeleversement;
 
   return {
     activitesMesure,
@@ -489,6 +502,7 @@ const nouvelAdaptateur = (
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,
     lisSuperviseursConcernes,
+    lisTeleversementModelesMesureSpecifique,
     marqueNouveauteLue,
     marqueSuggestionActionFaiteMaintenant,
     marqueTacheDeServiceLue,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -619,18 +619,6 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
       .onConflict('id_utilisateur')
       .merge();
 
-  const ajouteTeleversementModelesMesureSpecifique = async (
-    idUtilisateur,
-    donnees
-  ) =>
-    knex('televersement_modeles_mesure_specifique')
-      .insert({
-        id_utilisateur: idUtilisateur,
-        donnees: { modeles_mesure_specifique: donnees },
-      })
-      .onConflict('id_utilisateur')
-      .merge();
-
   const lisTeleversementServices = async (idUtilisateur) =>
     knex('televersement_services')
       .where({ id_utilisateur: idUtilisateur })
@@ -655,6 +643,28 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
     knex('televersement_services')
       .where({ id_utilisateur: idUtilisateur })
       .update({ progression });
+
+  const ajouteTeleversementModelesMesureSpecifique = async (
+    idUtilisateur,
+    donnees
+  ) =>
+    knex('televersement_modeles_mesure_specifique')
+      .insert({
+        id_utilisateur: idUtilisateur,
+        donnees: { modeles_mesure_specifique: donnees },
+      })
+      .onConflict('id_utilisateur')
+      .merge();
+
+  const lisTeleversementModelesMesureSpecifique = async (idUtilisateur) => {
+    const resultat = await knex.raw(
+      `SELECT donnees->>'modeles_mesure_specifique' as "modeles"
+        FROM televersement_modeles_mesure_specifique
+        WHERE id_utilisateur = ?`,
+      [idUtilisateur]
+    );
+    return JSON.parse(resultat.rows[0].modeles);
+  };
 
   const verifieTousLesServicesExistent = async (idsServices) => {
     const resultat = await knex.raw(
@@ -805,6 +815,7 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
     lisParcoursUtilisateur,
     lisProgressionTeleversementServices,
     lisSuperviseursConcernes,
+    lisTeleversementModelesMesureSpecifique,
     lisTeleversementServices,
     marqueNouveauteLue,
     marqueSuggestionActionFaiteMaintenant,

--- a/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
+++ b/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
@@ -24,9 +24,9 @@ async function extraisDonneesTeleversees(buffer) {
   if (!lignesCompletes) throw new ErreurFichierXlsInvalide();
 
   return donneesBrutes.map((ligne) => ({
-    description: encode(ligne[ENTETE_INTITULE].trim()), // Chez MSS, l'intitulé va bien dans "description".
-    descriptionLongue: encode(ligne[ENTETE_DESCRIPTION].trim()),
-    categorie: ligne[ENTETE_CATEGORIE].trim(),
+    description: encode(ligne[ENTETE_INTITULE]?.trim()), // Chez MSS, l'intitulé va bien dans "description".
+    descriptionLongue: encode(ligne[ENTETE_DESCRIPTION]?.trim()),
+    categorie: ligne[ENTETE_CATEGORIE]?.trim(),
   }));
 }
 

--- a/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
+++ b/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
@@ -26,7 +26,7 @@ async function extraisDonneesTeleversees(buffer) {
   return donneesBrutes.map((ligne) => ({
     description: encode(ligne[ENTETE_INTITULE]?.trim()), // Chez MSS, l'intitulé va bien dans "description".
     descriptionLongue: encode(ligne[ENTETE_DESCRIPTION]?.trim()),
-    categorie: ligne[ENTETE_CATEGORIE]?.trim()?.toLowerCase(),
+    categorie: ligne[ENTETE_CATEGORIE]?.trim(),
   }));
 }
 

--- a/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
+++ b/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
@@ -26,7 +26,7 @@ async function extraisDonneesTeleversees(buffer) {
   return donneesBrutes.map((ligne) => ({
     description: encode(ligne[ENTETE_INTITULE]?.trim()), // Chez MSS, l'intitulé va bien dans "description".
     descriptionLongue: encode(ligne[ENTETE_DESCRIPTION]?.trim()),
-    categorie: ligne[ENTETE_CATEGORIE]?.trim(),
+    categorie: ligne[ENTETE_CATEGORIE]?.trim()?.toLowerCase(),
   }));
 }
 

--- a/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
+++ b/src/adaptateurs/adaptateurTeleversementModelesMesureSpecifique.xls.js
@@ -24,9 +24,9 @@ async function extraisDonneesTeleversees(buffer) {
   if (!lignesCompletes) throw new ErreurFichierXlsInvalide();
 
   return donneesBrutes.map((ligne) => ({
-    description: encode(ligne[ENTETE_INTITULE]), // Chez MSS, l'intitulé va bien dans "description".
-    descriptionLongue: encode(ligne[ENTETE_DESCRIPTION]),
-    categorie: ligne[ENTETE_CATEGORIE],
+    description: encode(ligne[ENTETE_INTITULE].trim()), // Chez MSS, l'intitulé va bien dans "description".
+    descriptionLongue: encode(ligne[ENTETE_DESCRIPTION].trim()),
+    categorie: ligne[ENTETE_CATEGORIE].trim(),
   }));
 }
 

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -124,6 +124,7 @@ const creeDepot = (config = {}) => {
     depotDonneesTeleversementModelesMesureSpecifique.creeDepot({
       adaptateurPersistance,
       adaptateurChiffrement,
+      referentiel,
     });
 
   const depotModelesMesureSpecifique =

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -251,8 +251,10 @@ const creeDepot = (config = {}) => {
     supprimeTeleversementServices,
   } = depotTeleversementServices;
 
-  const { nouveauTeleversementModelesMesureSpecifique } =
-    depotTeleversementModelesMesureSpecifique;
+  const {
+    nouveauTeleversementModelesMesureSpecifique,
+    lisTeleversementModelesMesureSpecifique,
+  } = depotTeleversementModelesMesureSpecifique;
 
   const {
     ajouteModeleMesureSpecifique,
@@ -304,6 +306,7 @@ const creeDepot = (config = {}) => {
     lisParcoursUtilisateur,
     lisPourcentageProgressionTeleversementServices,
     lisSuperviseurs,
+    lisTeleversementModelesMesureSpecifique,
     lisTeleversementServices,
     marqueNouveauteLue,
     marqueTacheDeServiceLue,

--- a/src/depots/depotDonneesTeleversementModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesTeleversementModelesMesureSpecifique.js
@@ -4,6 +4,7 @@ const creeDepot = (config = {}) => {
   const {
     adaptateurPersistance: persistance,
     adaptateurChiffrement: chiffrement,
+    referentiel,
   } = config;
 
   const nouveauTeleversementModelesMesureSpecifique = async (
@@ -26,7 +27,7 @@ const creeDepot = (config = {}) => {
     if (!persistees) return undefined;
 
     const enClair = await chiffrement.dechiffre(persistees);
-    return new TeleversementModelesMesureSpecifique(enClair);
+    return new TeleversementModelesMesureSpecifique(enClair, referentiel);
   };
 
   return {
@@ -34,5 +35,4 @@ const creeDepot = (config = {}) => {
     lisTeleversementModelesMesureSpecifique,
   };
 };
-
 module.exports = { creeDepot };

--- a/src/depots/depotDonneesTeleversementModelesMesureSpecifique.js
+++ b/src/depots/depotDonneesTeleversementModelesMesureSpecifique.js
@@ -1,3 +1,5 @@
+const TeleversementModelesMesureSpecifique = require('../modeles/televersement/televersementModelesMesureSpecifique');
+
 const creeDepot = (config = {}) => {
   const {
     adaptateurPersistance: persistance,
@@ -17,8 +19,19 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  const lisTeleversementModelesMesureSpecifique = async (idUtilisateur) => {
+    const persistees =
+      await persistance.lisTeleversementModelesMesureSpecifique(idUtilisateur);
+
+    if (!persistees) return undefined;
+
+    const enClair = await chiffrement.dechiffre(persistees);
+    return new TeleversementModelesMesureSpecifique(enClair);
+  };
+
   return {
     nouveauTeleversementModelesMesureSpecifique,
+    lisTeleversementModelesMesureSpecifique,
   };
 };
 

--- a/src/modeles/televersement/serviceTeleverse.js
+++ b/src/modeles/televersement/serviceTeleverse.js
@@ -143,25 +143,25 @@ class ServiceTeleverse extends Base {
   enDonneesService() {
     const donneesDescriptionService = {
       delaiAvantImpactCritique:
-        this.referentiel.delaiAvantImpactCritiqueAvecDescription(
+        this.referentiel.delaiAvantImpactCritiqueParDescription(
           this.delaiAvantImpactCritique
         ),
-      localisationDonnees: this.referentiel.localisationDonneesAvecDescription(
+      localisationDonnees: this.referentiel.localisationDonneesParDescription(
         this.localisation
       ),
       nomService: this.nom,
-      provenanceService: this.referentiel.provenanceServiceAvecDescription(
+      provenanceService: this.referentiel.provenanceServiceParDescription(
         this.provenance
       ),
-      statutDeploiement: this.referentiel.statutDeploiementAvecDescription(
+      statutDeploiement: this.referentiel.statutDeploiementParDescription(
         this.statut
       ),
-      typeService: [this.referentiel.typeServiceAvecDescription(this.type)],
+      typeService: [this.referentiel.typeServiceParDescription(this.type)],
       organisationResponsable: {
         siret: this.siretFormatte(),
       },
       nombreOrganisationsUtilisatrices:
-        this.referentiel.nombreOrganisationsUtilisatricesAvecLabel(
+        this.referentiel.nombreOrganisationsUtilisatricesParLabel(
           this.nombreOrganisationsUtilisatrices
         ),
     };
@@ -177,7 +177,7 @@ class ServiceTeleverse extends Base {
           decision: {
             dateHomologation: this.dateHomologation,
             dureeValidite:
-              this.referentiel.echeanceRenouvellementAvecDescription(
+              this.referentiel.echeanceRenouvellementParDescription(
                 this.dureeHomologation
               ),
           },

--- a/src/modeles/televersement/televersementModelesMesureSpecifique.js
+++ b/src/modeles/televersement/televersementModelesMesureSpecifique.js
@@ -1,6 +1,9 @@
+const Referentiel = require('../../referentiel');
+
 class TeleversementModelesMesureSpecifique {
-  constructor(donnees) {
+  constructor(donnees, referentiel = Referentiel.creeReferentielVide()) {
     this.modelesTeleverses = donnees;
+    this.referentiel = referentiel;
   }
 
   rapportDetaille() {
@@ -16,11 +19,14 @@ class TeleversementModelesMesureSpecifique {
   #controleUnModele(modele) {
     const erreurs = [];
 
-    if (!modele.description || modele.description.trim() === '')
-      erreurs.push('INTITULE_MANQUANT');
+    if (!modele.description) erreurs.push('INTITULE_MANQUANT');
 
-    if (!modele.categorie || modele.categorie.trim() === '')
-      erreurs.push('CATEGORIE_MANQUANTE');
+    if (
+      !this.referentiel
+        .identifiantsCategoriesMesures()
+        .includes(modele.categorie)
+    )
+      erreurs.push('CATEGORIE_INCONNUE');
 
     return erreurs;
   }

--- a/src/modeles/televersement/televersementModelesMesureSpecifique.js
+++ b/src/modeles/televersement/televersementModelesMesureSpecifique.js
@@ -1,0 +1,7 @@
+class TeleversementModelesMesureSpecifique {
+  constructor(donnees) {
+    this.modelesTeleverses = donnees;
+  }
+}
+
+module.exports = TeleversementModelesMesureSpecifique;

--- a/src/modeles/televersement/televersementModelesMesureSpecifique.js
+++ b/src/modeles/televersement/televersementModelesMesureSpecifique.js
@@ -2,6 +2,28 @@ class TeleversementModelesMesureSpecifique {
   constructor(donnees) {
     this.modelesTeleverses = donnees;
   }
+
+  rapportDetaille() {
+    return {
+      modelesTeleverses: this.modelesTeleverses.map((m) => ({
+        modele: m,
+        erreurs: this.#controleUnModele(m),
+      })),
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #controleUnModele(modele) {
+    const erreurs = [];
+
+    if (!modele.description || modele.description.trim() === '')
+      erreurs.push('INTITULE_MANQUANT');
+
+    if (!modele.categorie || modele.categorie.trim() === '')
+      erreurs.push('CATEGORIE_MANQUANTE');
+
+    return erreurs;
+  }
 }
 
 module.exports = TeleversementModelesMesureSpecifique;

--- a/src/modeles/televersement/televersementModelesMesureSpecifique.js
+++ b/src/modeles/televersement/televersementModelesMesureSpecifique.js
@@ -21,11 +21,7 @@ class TeleversementModelesMesureSpecifique {
 
     if (!modele.description) erreurs.push('INTITULE_MANQUANT');
 
-    if (
-      !this.referentiel
-        .identifiantsCategoriesMesures()
-        .includes(modele.categorie)
-    )
+    if (!this.referentiel.categorieMesureParLabel(modele.categorie))
       erreurs.push('CATEGORIE_INCONNUE');
 
     return erreurs;

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -395,30 +395,30 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const labelsNombreOrganisationsUtilisatrices = () =>
     Object.values(donnees.nombreOrganisationsUtilisatrices).map((v) => v.label);
 
-  const proprieteAvecDescription = (proprietes, description) =>
+  const proprieteParDescription = (proprietes, description) =>
     Object.entries(proprietes).find(
       ([_cle, valeur]) => valeur.description === description
     )[0];
 
-  const typeServiceAvecDescription = (description) =>
-    proprieteAvecDescription(donnees.typesService, description);
+  const typeServiceParDescription = (description) =>
+    proprieteParDescription(donnees.typesService, description);
 
-  const provenanceServiceAvecDescription = (description) =>
-    proprieteAvecDescription(donnees.provenancesService, description);
+  const provenanceServiceParDescription = (description) =>
+    proprieteParDescription(donnees.provenancesService, description);
 
-  const statutDeploiementAvecDescription = (description) =>
-    proprieteAvecDescription(donnees.statutsDeploiement, description);
+  const statutDeploiementParDescription = (description) =>
+    proprieteParDescription(donnees.statutsDeploiement, description);
 
-  const localisationDonneesAvecDescription = (description) =>
-    proprieteAvecDescription(donnees.localisationsDonnees, description);
+  const localisationDonneesParDescription = (description) =>
+    proprieteParDescription(donnees.localisationsDonnees, description);
 
-  const delaiAvantImpactCritiqueAvecDescription = (description) =>
-    proprieteAvecDescription(donnees.delaisAvantImpactCritique, description);
+  const delaiAvantImpactCritiqueParDescription = (description) =>
+    proprieteParDescription(donnees.delaisAvantImpactCritique, description);
 
-  const echeanceRenouvellementAvecDescription = (description) =>
-    proprieteAvecDescription(donnees.echeancesRenouvellement, description);
+  const echeanceRenouvellementParDescription = (description) =>
+    proprieteParDescription(donnees.echeancesRenouvellement, description);
 
-  const nombreOrganisationsUtilisatricesAvecLabel = (label) => {
+  const nombreOrganisationsUtilisatricesParLabel = (label) => {
     const nombreAvecLabel = donnees.nombreOrganisationsUtilisatrices.find(
       (description) => description.label === label
     );
@@ -444,7 +444,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     coefficientIndiceCyberStatutPartiel,
     indiceCyberNoteMax,
     definitionRisque,
-    delaiAvantImpactCritiqueAvecDescription,
+    delaiAvantImpactCritiqueParDescription,
     delaisAvantImpactCritique,
     departement,
     departements,
@@ -461,7 +461,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     descriptionsFonctionnalites,
     detailCategoriesRisque,
     donneesCaracterePersonnel,
-    echeanceRenouvellementAvecDescription,
+    echeanceRenouvellementParDescription,
     echeancesRenouvellement,
     enrichis,
     estCodeDepartement,
@@ -493,7 +493,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     libelleEtape,
     labelsNombreOrganisationsUtilisatrices,
     localisationDonnees,
-    localisationDonneesAvecDescription,
+    localisationDonneesParDescription,
     localisationsDonnees,
     matriceNiveauxRisques,
     mesure,
@@ -509,14 +509,14 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     niveauVraisemblance,
     niveauxVraisemblance,
     nombreOrganisationsUtilisatrices,
-    nombreOrganisationsUtilisatricesAvecLabel,
+    nombreOrganisationsUtilisatricesParLabel,
     nouvellesFonctionnalites,
     numeroEtape,
     optionsFiltrageDate,
     premiereEtapeParcours,
     prioritesMesures,
     provenancesService,
-    provenanceServiceAvecDescription,
+    provenanceServiceParDescription,
     recharge,
     reglesPersonnalisation,
     retoursUtilisateurMesure,
@@ -525,14 +525,14 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     descriptionStatutDeploiement,
     statutsAvisDossierHomologation,
     statutsDeploiement,
-    statutDeploiementAvecDescription,
+    statutDeploiementParDescription,
     statutDeploiementValide,
     statutHomologation,
     statutsMesures,
     tacheCompletudeProfil,
     trancheIndiceCyber,
     typeService,
-    typeServiceAvecDescription,
+    typeServiceParDescription,
     typesService,
     verifieCategoriesMesuresSontRepertoriees,
     etapePrecedenteVisiteGuidee,

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -418,6 +418,11 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const echeanceRenouvellementParDescription = (description) =>
     proprieteParDescription(donnees.echeancesRenouvellement, description);
 
+  const categorieMesureParLabel = (label) =>
+    Object.entries(donnees.categoriesMesures).find(
+      ([, leLabel]) => label === leLabel
+    );
+
   const nombreOrganisationsUtilisatricesParLabel = (label) => {
     const nombreAvecLabel = donnees.nombreOrganisationsUtilisatrices.find(
       (description) => description.label === label
@@ -436,6 +441,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   valideDonnees();
 
   return {
+    categorieMesureParLabel,
     categoriesRisque,
     categoriesMesures,
     codeDepartements,

--- a/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
+++ b/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
@@ -36,7 +36,8 @@ const routesConnecteApiTeleversementModelesMesureSpecifique = ({
       await depotDonnees.lisTeleversementModelesMesureSpecifique(
         requete.idUtilisateurCourant
       );
-    reponse.json(televersement);
+
+    reponse.json(televersement.rapportDetaille());
   });
 
   return routes;

--- a/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
+++ b/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
@@ -31,6 +31,14 @@ const routesConnecteApiTeleversementModelesMesureSpecifique = ({
     }
   });
 
+  routes.get('/', async (requete, reponse) => {
+    const televersement =
+      await depotDonnees.lisTeleversementModelesMesureSpecifique(
+        requete.idUtilisateurCourant
+      );
+    reponse.json(televersement);
+  });
+
   return routes;
 };
 

--- a/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
+++ b/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
@@ -37,7 +37,9 @@ const routesConnecteApiTeleversementModelesMesureSpecifique = ({
         requete.idUtilisateurCourant
       );
 
-    reponse.json(televersement.rapportDetaille());
+    if (!televersement) return reponse.sendStatus(404);
+
+    return reponse.json(televersement.rapportDetaille());
   });
 
   return routes;

--- a/tdd-todo/televersement_mesures_specifiques.md
+++ b/tdd-todo/televersement_mesures_specifiques.md
@@ -14,6 +14,7 @@
   - [x] Le rapport contient les erreurs de catégorie manquante
   - [x] Le rapport contient les erreurs de catégorie inconnue
   - [ ] Le rapport contient les erreurs de mesures en double
+- [x] On a une 404 si le rapport est démandé mais que rien n'a été téléversé
 - [ ] Sur le rapport, un bouton « Importer » permet de déclencher la création des modèles
 - [ ] Le tiroir de téléversement montre, dans les limitations, combien de mesures sont encore ajoutables (idéalement on veut soustraire la varenv et le nombre actuel)
 

--- a/tdd-todo/televersement_mesures_specifiques.md
+++ b/tdd-todo/televersement_mesures_specifiques.md
@@ -12,7 +12,7 @@
   - [x] Le rapport de téléversement des services est réutilisable
   - [x] Le rapport contient les erreurs d'intitulé manquant
   - [x] Le rapport contient les erreurs de catégorie manquante
-  - [ ] Le rapport contient les erreurs de catégorie inconnue
+  - [x] Le rapport contient les erreurs de catégorie inconnue
   - [ ] Le rapport contient les erreurs de mesures en double
 - [ ] Sur le rapport, un bouton « Importer » permet de déclencher la création des modèles
 - [ ] Le tiroir de téléversement montre, dans les limitations, combien de mesures sont encore ajoutables (idéalement on veut soustraire la varenv et le nombre actuel)

--- a/tdd-todo/televersement_mesures_specifiques.md
+++ b/tdd-todo/televersement_mesures_specifiques.md
@@ -10,6 +10,10 @@
 - [ ] Le bouton « ajouter une/des mesures » est grisé si l'utilisateur a déjà atteint le nombre limites
 - [ ] Un rapport de téléversement est affiché, basé sur les mesures persistées ci-dessus
   - [x] Le rapport de téléversement des services est réutilisable
+  - [x] Le rapport contient les erreurs d'intitulé manquant
+  - [x] Le rapport contient les erreurs de catégorie manquante
+  - [ ] Le rapport contient les erreurs de catégorie inconnue
+  - [ ] Le rapport contient les erreurs de mesures en double
 - [ ] Sur le rapport, un bouton « Importer » permet de déclencher la création des modèles
 - [ ] Le tiroir de téléversement montre, dans les limitations, combien de mesures sont encore ajoutables (idéalement on veut soustraire la varenv et le nombre actuel)
 

--- a/test/modeles/televersement/televersementModelesMesureSpecifique.spec.js
+++ b/test/modeles/televersement/televersementModelesMesureSpecifique.spec.js
@@ -1,0 +1,49 @@
+const expect = require('expect.js');
+const TeleversementModelesMesureSpecifique = require('../../../src/modeles/televersement/televersementModelesMesureSpecifique');
+
+describe('Un téléversement de modèles de mesure spécifique', () => {
+  const unTeleversement = (donnees) =>
+    new TeleversementModelesMesureSpecifique(donnees);
+
+  describe('sur demande de rapport détaillé', () => {
+    it('met dans chaque ligne du rapport le modèle concerné', () => {
+      const rapport = unTeleversement([
+        { description: 'D1', categorie: 'gouvernance' },
+        { description: 'D2', categorie: 'gouvernance' },
+      ]).rapportDetaille();
+
+      expect(rapport.modelesTeleverses.length).to.be(2);
+      const [d1, d2] = rapport.modelesTeleverses;
+      expect(d1.modele.description).to.be('D1');
+      expect(d2.modele.description).to.be('D2');
+    });
+
+    it('sait détecter une erreur de description manquante (colonne Intitulé dans le Excel)', () => {
+      const sansDescription = {
+        description: '  ',
+        modalites: '',
+        categorie: 'gouvernance',
+      };
+
+      const rapport = unTeleversement([sansDescription]).rapportDetaille();
+
+      expect(rapport.modelesTeleverses[0].erreurs).to.eql([
+        'INTITULE_MANQUANT',
+      ]);
+    });
+
+    it('sait détecter une erreur de catégorie manquante', () => {
+      const sansCategorie = {
+        categorie: '',
+        description: 'D1',
+        modalites: '',
+      };
+
+      const rapport = unTeleversement([sansCategorie]).rapportDetaille();
+
+      expect(rapport.modelesTeleverses[0].erreurs).to.eql([
+        'CATEGORIE_MANQUANTE',
+      ]);
+    });
+  });
+});

--- a/test/modeles/televersement/televersementModelesMesureSpecifique.spec.js
+++ b/test/modeles/televersement/televersementModelesMesureSpecifique.spec.js
@@ -30,7 +30,7 @@ describe('Un téléversement de modèles de mesure spécifique', () => {
     it('sait détecter une erreur de description manquante (colonne Intitulé dans le Excel)', () => {
       const sansDescription = {
         description: '',
-        modalites: '',
+        descriptionLongue: '',
         categorie: 'gouvernance',
       };
 
@@ -42,7 +42,11 @@ describe('Un téléversement de modèles de mesure spécifique', () => {
     });
 
     it('sait détecter une erreur de catégorie inconnue du référentiel', () => {
-      const categorieZ = { categorie: 'Z', description: 'D…', modalites: '' };
+      const categorieZ = {
+        categorie: 'Z',
+        description: 'D…',
+        descriptionLongue: '',
+      };
 
       const rapport = unTeleversement([categorieZ]).rapportDetaille();
 
@@ -52,7 +56,11 @@ describe('Un téléversement de modèles de mesure spécifique', () => {
     });
 
     it('indique une erreur de catégorie inconnue en cas de catégorie manquante', () => {
-      const sansCategorie = { categorie: '', description: 'D…', modalites: '' };
+      const sansCategorie = {
+        categorie: '',
+        description: 'D…',
+        descriptionLongue: '',
+      };
 
       const rapport = unTeleversement([sansCategorie]).rapportDetaille();
 

--- a/test/modeles/televersement/televersementModelesMesureSpecifique.spec.js
+++ b/test/modeles/televersement/televersementModelesMesureSpecifique.spec.js
@@ -7,7 +7,7 @@ describe('Un téléversement de modèles de mesure spécifique', () => {
 
   beforeEach(() => {
     referentiel = Referentiel.creeReferentiel({
-      categoriesMesures: { gouvernance: {} },
+      categoriesMesures: { gouvernance: 'Gouvernance' },
     });
   });
 
@@ -17,8 +17,8 @@ describe('Un téléversement de modèles de mesure spécifique', () => {
   describe('sur demande de rapport détaillé', () => {
     it('met dans chaque ligne du rapport le modèle concerné', () => {
       const rapport = unTeleversement([
-        { description: 'D1', categorie: 'gouvernance' },
-        { description: 'D2', categorie: 'gouvernance' },
+        { description: 'D1', categorie: 'Gouvernance' },
+        { description: 'D2', categorie: 'Gouvernance' },
       ]).rapportDetaille();
 
       expect(rapport.modelesTeleverses.length).to.be(2);
@@ -31,7 +31,7 @@ describe('Un téléversement de modèles de mesure spécifique', () => {
       const sansDescription = {
         description: '',
         descriptionLongue: '',
-        categorie: 'gouvernance',
+        categorie: 'Gouvernance',
       };
 
       const rapport = unTeleversement([sansDescription]).rapportDetaille();

--- a/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
+++ b/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
@@ -120,5 +120,19 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
 
       expect(idDemande).to.be('U1');
     });
+
+    it("renvoie une erreur 404 si l'utilisateur n'a pas de téléversement en cours", async () => {
+      testeur.depotDonnees().lisTeleversementModelesMesureSpecifique =
+        async () => undefined;
+
+      try {
+        await axios.get(
+          'http://localhost:1234/api/televersement/modelesMesureSpecifique'
+        );
+        expect().fail("L'appel aurait dû lever une erreur");
+      } catch (e) {
+        expect(e.response.status).to.be(404);
+      }
+    });
   });
 });

--- a/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
+++ b/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
@@ -98,4 +98,26 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
       expect(donneesRecues).to.eql([{ description: 'Mesure téléversée' }]);
     });
   });
+
+  describe('Quand requête GET sur `/api/televersement/modelesMesuresSpecifique`', () => {
+    beforeEach(() => {
+      testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
+    });
+
+    it("récupère le téléversement de l'utilisateur courant grâce au dépôt de données", async () => {
+      let idDemande;
+      testeur.depotDonnees().lisTeleversementModelesMesureSpecifique = async (
+        idUtilisateur
+      ) => {
+        idDemande = idUtilisateur;
+        return {};
+      };
+
+      await axios.get(
+        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
+      );
+
+      expect(idDemande).to.be('U1');
+    });
+  });
 });

--- a/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
+++ b/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const expect = require('expect.js');
 const testeurMSS = require('../testeurMSS');
 const { ErreurFichierXlsInvalide } = require('../../../src/erreurs');
+const TeleversementModelesMesureSpecifique = require('../../../src/modeles/televersement/televersementModelesMesureSpecifique');
 
 describe('Les routes connecté de téléversement des modèles de mesure spécifique', () => {
   const testeur = testeurMSS();
@@ -110,7 +111,7 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
         idUtilisateur
       ) => {
         idDemande = idUtilisateur;
-        return {};
+        return new TeleversementModelesMesureSpecifique([]);
       };
 
       await axios.get(


### PR DESCRIPTION
Cette PR pose les bases pour que `GET /api/televersement/modelesMesureSpecifique` renvoie une payload exploitable par le front pour montrer le rapport de téléversement.

On s'inspire de l'architecture du téléversement de Service, mais en plus simple : `TeleversementModelesMesureSpecifique` n'a pas du tout d'héritage, et pour le moment fait la validation elle-même. Ça tient.

Il manque le contrôle sur les noms de mesure non doublonnés : c'est tracé dans le `.md` de TDD.

Pour tester au runtime :
 - téléverser un fichier de mesures
 - visiter la page `/api/televersement/modelesMesureSpecifique` pour récupérer le `rapportDetaille()` en `JSON` 👇 
<img width="669" height="409" alt="image" src="https://github.com/user-attachments/assets/6229feef-0edb-4b2e-b06f-cb4a0bc0d134" />
