### PR TITLE
Ajoute une directive "infobulle" permettant d'afficher correctement un "popover" par-dessus tout le DOM

### DIFF
--- a/public/assets/styles/mss.css
+++ b/public/assets/styles/mss.css
@@ -277,3 +277,35 @@ section:last-of-type {
 .valide-champ-saisie-dsfr:before {
   background-image: url('/statique/assets/images/ui-kit/succes.svg');
 }
+
+.conteneur-infobulle {
+  display: none;
+  width: 360px;
+  padding: 8px;
+  position: fixed;
+  box-shadow: 0 4px 12px 0 rgba(0, 0, 18, 0.16);
+  background: white;
+  flex-direction: column;
+  z-index: 10000;
+}
+
+.conteneur-infobulle:after {
+  content: '';
+  background: white;
+  width: 8px;
+  height: 8px;
+  display: flex;
+  position: absolute;
+  bottom: -4px;
+  left: calc(50% - 4px);
+  transform: rotate(45deg);
+}
+
+.conteneur-infobulle p {
+  margin: 0;
+  font-size: 0.75rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.25rem;
+  color: var(--texte-fonce);
+}

--- a/svelte/lib/ui/Infobulle.svelte
+++ b/svelte/lib/ui/Infobulle.svelte
@@ -1,61 +1,16 @@
 <script lang="ts">
+  import { infobulle } from './directives/infobulle';
+
   export let contenu: string;
 </script>
 
-<div class="infobulle">
-  <div class="conteneur-image">
-    <img src="/statique/assets/images/icone_infobulle.svg" alt={contenu} />
-  </div>
-  <div class="conteneur-information">
-    <p>{contenu}</p>
-  </div>
+<div class="conteneur-image" use:infobulle={contenu}>
+  <img src="/statique/assets/images/icone_infobulle.svg" alt={contenu} />
 </div>
 
 <style lang="scss">
-  .infobulle {
-    position: relative;
-
-    &:hover .conteneur-information {
-      display: flex;
-    }
-
-    .conteneur-image {
-      padding: 8px 8px 4px 8px;
-      cursor: help;
-    }
-
-    .conteneur-information {
-      display: none;
-      width: 360px;
-      padding: 8px;
-      position: absolute;
-      right: 0;
-      top: 0;
-      box-shadow: 0 4px 12px 0 rgba(0, 0, 18, 0.16);
-      background: white;
-      transform: translateX(50%) translateY(-100%);
-      flex-direction: column;
-
-      &:after {
-        content: '';
-        background: white;
-        width: 8px;
-        height: 8px;
-        display: flex;
-        position: absolute;
-        bottom: -4px;
-        right: calc(50% + 12px);
-        transform: rotate(45deg);
-      }
-
-      p {
-        margin: 0;
-        font-size: 0.75rem;
-        font-style: normal;
-        font-weight: 400;
-        line-height: 1.25rem;
-        color: var(--texte-fonce);
-      }
-    }
+  .conteneur-image {
+    padding: 8px 8px 4px 8px;
+    cursor: help;
   }
 </style>

--- a/svelte/lib/ui/directives/infobulle.ts
+++ b/svelte/lib/ui/directives/infobulle.ts
@@ -1,0 +1,33 @@
+export const infobulle = (noeud: HTMLElement, contenu: string) => {
+  noeud.addEventListener('mouseover', affiche);
+  noeud.addEventListener('mouseleave', masque);
+
+  const elementInfobulle = document.createElement('div');
+  const elementContenuInfobulle = document.createElement('p');
+  elementInfobulle.classList.add('conteneur-infobulle');
+  elementContenuInfobulle.textContent = contenu;
+  elementInfobulle.appendChild(elementContenuInfobulle);
+  document.body.appendChild(elementInfobulle);
+
+  function affiche() {
+    elementInfobulle.style.display = 'flex';
+    const { top, left, width } = noeud.getBoundingClientRect();
+    const tailleInfobulle = elementInfobulle.getBoundingClientRect();
+    elementInfobulle.style.top = `${top - tailleInfobulle.height - 4}px`;
+    elementInfobulle.style.left = `${
+      left - tailleInfobulle.width / 2 + width / 2
+    }px`;
+  }
+
+  function masque() {
+    elementInfobulle.style.display = 'none';
+  }
+
+  return {
+    destroy() {
+      noeud?.removeEventListener('mouseover', affiche);
+      noeud?.removeEventListener('mouseleave', masque);
+      elementInfobulle.remove();
+    },
+  };
+};


### PR DESCRIPTION
...en utilisant une directive `use:infobulle`. 
Cette directive a pour but d'insérer un élément dans le DOM, et de le positionner correctement par rapport à sa cible.