### PR TITLE
[CORRECTION] Cesse d'afficher systématiquement « 1 service valide »

### DIFF
--- a/svelte/lib/tableauDeBord/televersementServices/RapportTeleversementServices.svelte
+++ b/svelte/lib/tableauDeBord/televersementServices/RapportTeleversementServices.svelte
@@ -46,7 +46,7 @@
     );
 
     resume = {
-      elementsValide: { label: labelOK },
+      elementsValide: nbOK ? { label: labelOK } : null,
       elementsErreur: erreurs ? { label: labelErreurs } : null,
       statut: rapport.statut,
       labelValiderTeleversement: singulierPluriel(


### PR DESCRIPTION
Depuis un refacto précédent, la carte « 1 service valide » était toujours affichée même avec un fichier téléversé ne contenant que des erreurs..

Exemple du bug en PROD où un fichier avec seulement 2 lignes donne cet affichage 👇 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/e4ede187-fa88-47e1-82e8-be7e8af21ce1" />


Après correction 👇 

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7b8bc7a5-2f72-46a2-bda0-0bd2b8544351" />

