### PR TITLE
[SOIN] Factorise la validation de données dans les événement du journal

### DIFF
--- a/src/modeles/journalMSS/erreurs.js
+++ b/src/modeles/journalMSS/erreurs.js
@@ -1,14 +1,5 @@
 class ErreurJournal extends Error {}
-class ErreurAutorisationsServiceManquantes extends ErreurJournal {}
-class ErreurDateDerniereConnexionManquante extends ErreurJournal {}
 class ErreurDateDerniereConnexionInvalide extends ErreurJournal {}
-class ErreurDateHomologationManquante extends ErreurJournal {}
-class ErreurDureeHomologationManquante extends ErreurJournal {}
-class ErreurIdentifiantServiceManquant extends ErreurJournal {}
-class ErreurIdentifiantUtilisateurManquant extends ErreurJournal {}
-class ErreurIdentifiantMesureManquant extends ErreurJournal {}
-class ErreurIdentifiantRetourUtilisateurManquant extends ErreurJournal {}
-class ErreurNombreServicesImportes extends ErreurJournal {}
 class ErreurServiceManquant extends ErreurJournal {}
 class ErreurUtilisateurManquant extends ErreurJournal {}
 class ErreurDonneeManquante extends ErreurJournal {
@@ -20,17 +11,8 @@ class ErreurDonneeManquante extends ErreurJournal {
 }
 
 module.exports = {
-  ErreurAutorisationsServiceManquantes,
-  ErreurDateDerniereConnexionManquante,
   ErreurDateDerniereConnexionInvalide,
-  ErreurDateHomologationManquante,
   ErreurDonneeManquante,
-  ErreurDureeHomologationManquante,
-  ErreurIdentifiantServiceManquant,
-  ErreurIdentifiantUtilisateurManquant,
-  ErreurIdentifiantMesureManquant,
-  ErreurIdentifiantRetourUtilisateurManquant,
-  ErreurNombreServicesImportes,
   ErreurServiceManquant,
   ErreurUtilisateurManquant,
 };

--- a/src/modeles/journalMSS/evenement.js
+++ b/src/modeles/journalMSS/evenement.js
@@ -1,6 +1,7 @@
 const {
   fabriqueAdaptateurChiffrement,
 } = require('../../adaptateurs/fabriqueAdaptateurChiffrement');
+const { ErreurDonneeManquante } = require('./erreurs');
 
 class Evenement {
   static optionsParDefaut(options) {
@@ -9,6 +10,14 @@ class Evenement {
       adaptateurChiffrement:
         options.adaptateurChiffrement ?? fabriqueAdaptateurChiffrement(),
     };
+  }
+
+  static valide(donnees, proprietesRequises) {
+    const manque = (valeur) => typeof valeur === 'undefined';
+
+    proprietesRequises.forEach((requise) => {
+      if (manque(donnees[requise])) throw new ErreurDonneeManquante(requise);
+    });
   }
 
   constructor(type, donnees, date) {

--- a/src/modeles/journalMSS/evenement.js
+++ b/src/modeles/journalMSS/evenement.js
@@ -12,7 +12,7 @@ class Evenement {
     };
   }
 
-  static valide(donnees, proprietesRequises) {
+  static verifieProprietesRenseignees(donnees, proprietesRequises) {
     const manque = (valeur) => typeof valeur === 'undefined' || valeur === null;
 
     proprietesRequises.forEach((requise) => {

--- a/src/modeles/journalMSS/evenement.js
+++ b/src/modeles/journalMSS/evenement.js
@@ -13,7 +13,7 @@ class Evenement {
   }
 
   static valide(donnees, proprietesRequises) {
-    const manque = (valeur) => typeof valeur === 'undefined';
+    const manque = (valeur) => typeof valeur === 'undefined' || valeur === null;
 
     proprietesRequises.forEach((requise) => {
       if (manque(donnees[requise])) throw new ErreurDonneeManquante(requise);

--- a/src/modeles/journalMSS/evenementCollaboratifServiceModifie.js
+++ b/src/modeles/journalMSS/evenementCollaboratifServiceModifie.js
@@ -1,23 +1,10 @@
 const Evenement = require('./evenement');
-const {
-  ErreurIdentifiantServiceManquant,
-  ErreurAutorisationsServiceManquantes,
-} = require('./erreurs');
 
 class EvenementCollaboratifServiceModifie extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      const manque = (donnee) => typeof donnee === 'undefined';
-
-      if (manque(donnees.idService))
-        throw new ErreurIdentifiantServiceManquant();
-      if (manque(donnees.autorisations) || donnees.autorisations.length === 0)
-        throw new ErreurAutorisationsServiceManquantes();
-    };
-
-    valide();
+    Evenement.valide(donnees, ['idService', 'autorisations']);
 
     super(
       'COLLABORATIF_SERVICE_MODIFIE',

--- a/src/modeles/journalMSS/evenementCollaboratifServiceModifie.js
+++ b/src/modeles/journalMSS/evenementCollaboratifServiceModifie.js
@@ -4,7 +4,10 @@ class EvenementCollaboratifServiceModifie extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, ['idService', 'autorisations']);
+    Evenement.verifieProprietesRenseignees(donnees, [
+      'idService',
+      'autorisations',
+    ]);
 
     super(
       'COLLABORATIF_SERVICE_MODIFIE',

--- a/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
+++ b/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
@@ -1,24 +1,17 @@
 const Evenement = require('./evenement');
-const { ErreurServiceManquant } = require('./erreurs');
 const { estimeNiveauDeSecurite } = require('../descriptionService');
 
 class EvenementCompletudeServiceModifiee extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      const manque = (donnee) => typeof donnee === 'undefined';
-
-      if (manque(donnees.service)) throw new ErreurServiceManquant();
-    };
+    Evenement.valide(donnees, ['service']);
 
     const enTableau = (donneesIndiceCyber) =>
       Object.entries(donneesIndiceCyber).reduce(
         (acc, [categorie, indice]) => [...acc, { categorie, indice }],
         []
       );
-
-    valide();
 
     const { service } = donnees;
     const niveauSecuriteMinimal = estimeNiveauDeSecurite(

--- a/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
+++ b/src/modeles/journalMSS/evenementCompletudeServiceModifiee.js
@@ -5,7 +5,7 @@ class EvenementCompletudeServiceModifiee extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, ['service']);
+    Evenement.verifieProprietesRenseignees(donnees, ['service']);
 
     const enTableau = (donneesIndiceCyber) =>
       Object.entries(donneesIndiceCyber).reduce(

--- a/src/modeles/journalMSS/evenementConnexionUtilisateur.js
+++ b/src/modeles/journalMSS/evenementConnexionUtilisateur.js
@@ -6,7 +6,10 @@ class EvenementConnexionUtilisateur extends Evenement {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
     const valide = () => {
-      Evenement.valide(donnees, ['idUtilisateur', 'dateDerniereConnexion']);
+      Evenement.verifieProprietesRenseignees(donnees, [
+        'idUtilisateur',
+        'dateDerniereConnexion',
+      ]);
 
       if (Number.isNaN(new Date(donnees.dateDerniereConnexion).valueOf()))
         throw new ErreurDateDerniereConnexionInvalide();

--- a/src/modeles/journalMSS/evenementConnexionUtilisateur.js
+++ b/src/modeles/journalMSS/evenementConnexionUtilisateur.js
@@ -1,19 +1,13 @@
 const Evenement = require('./evenement');
-const {
-  ErreurIdentifiantUtilisateurManquant,
-  ErreurDateDerniereConnexionManquante,
-  ErreurDateDerniereConnexionInvalide,
-} = require('./erreurs');
+const { ErreurDateDerniereConnexionInvalide } = require('./erreurs');
 
 class EvenementConnexionUtilisateur extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
     const valide = () => {
-      if (!donnees.idUtilisateur)
-        throw new ErreurIdentifiantUtilisateurManquant();
-      if (!donnees.dateDerniereConnexion)
-        throw new ErreurDateDerniereConnexionManquante();
+      Evenement.valide(donnees, ['idUtilisateur', 'dateDerniereConnexion']);
+
       if (Number.isNaN(new Date(donnees.dateDerniereConnexion).valueOf()))
         throw new ErreurDateDerniereConnexionInvalide();
     };

--- a/src/modeles/journalMSS/evenementModelesMesureSpecifiqueImportes.js
+++ b/src/modeles/journalMSS/evenementModelesMesureSpecifiqueImportes.js
@@ -1,20 +1,13 @@
 const Evenement = require('./evenement');
-const { ErreurDonneeManquante } = require('./erreurs');
 
 class EvenementModelesMesureSpecifiqueImportes extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      const manque = (donnee) => typeof donnee === 'undefined';
-
-      if (manque(donnees.idUtilisateur))
-        throw new ErreurDonneeManquante('idUtilisateur');
-      if (manque(donnees.nbModelesMesureSpecifiqueImportes))
-        throw new ErreurDonneeManquante('nbModelesMesureSpecifiqueImportes');
-    };
-
-    valide();
+    Evenement.valide(donnees, [
+      'idUtilisateur',
+      'nbModelesMesureSpecifiqueImportes',
+    ]);
 
     super(
       'MODELES_MESURE_SPECIFIQUE_IMPORTES',

--- a/src/modeles/journalMSS/evenementModelesMesureSpecifiqueImportes.js
+++ b/src/modeles/journalMSS/evenementModelesMesureSpecifiqueImportes.js
@@ -4,7 +4,7 @@ class EvenementModelesMesureSpecifiqueImportes extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, [
+    Evenement.verifieProprietesRenseignees(donnees, [
       'idUtilisateur',
       'nbModelesMesureSpecifiqueImportes',
     ]);

--- a/src/modeles/journalMSS/evenementNouveauServiceCree.js
+++ b/src/modeles/journalMSS/evenementNouveauServiceCree.js
@@ -4,7 +4,10 @@ class EvenementNouveauServiceCree extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, ['idService', 'idUtilisateur']);
+    Evenement.verifieProprietesRenseignees(donnees, [
+      'idService',
+      'idUtilisateur',
+    ]);
 
     super(
       'NOUVEAU_SERVICE_CREE',

--- a/src/modeles/journalMSS/evenementNouveauServiceCree.js
+++ b/src/modeles/journalMSS/evenementNouveauServiceCree.js
@@ -1,20 +1,10 @@
 const Evenement = require('./evenement');
-const {
-  ErreurIdentifiantServiceManquant,
-  ErreurIdentifiantUtilisateurManquant,
-} = require('./erreurs');
 
 class EvenementNouveauServiceCree extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      if (!donnees.idService) throw new ErreurIdentifiantServiceManquant();
-      if (!donnees.idUtilisateur)
-        throw new ErreurIdentifiantUtilisateurManquant();
-    };
-
-    valide();
+    Evenement.valide(donnees, ['idService', 'idUtilisateur']);
 
     super(
       'NOUVEAU_SERVICE_CREE',

--- a/src/modeles/journalMSS/evenementNouvelUtilisateurInscrit.js
+++ b/src/modeles/journalMSS/evenementNouvelUtilisateurInscrit.js
@@ -4,7 +4,7 @@ class EvenementNouvelUtilisateurInscrit extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, ['idUtilisateur']);
+    Evenement.verifieProprietesRenseignees(donnees, ['idUtilisateur']);
 
     super(
       'NOUVEL_UTILISATEUR_INSCRIT',

--- a/src/modeles/journalMSS/evenementNouvelUtilisateurInscrit.js
+++ b/src/modeles/journalMSS/evenementNouvelUtilisateurInscrit.js
@@ -1,16 +1,10 @@
 const Evenement = require('./evenement');
-const { ErreurIdentifiantUtilisateurManquant } = require('./erreurs');
 
 class EvenementNouvelUtilisateurInscrit extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      if (!donnees.idUtilisateur)
-        throw new ErreurIdentifiantUtilisateurManquant();
-    };
-
-    valide();
+    Evenement.valide(donnees, ['idUtilisateur']);
 
     super(
       'NOUVEL_UTILISATEUR_INSCRIT',

--- a/src/modeles/journalMSS/evenementNouvelleHomologationCreee.js
+++ b/src/modeles/journalMSS/evenementNouvelleHomologationCreee.js
@@ -1,26 +1,14 @@
 const Evenement = require('./evenement');
-const {
-  ErreurIdentifiantServiceManquant,
-  ErreurDateHomologationManquante,
-  ErreurDureeHomologationManquante,
-} = require('./erreurs');
 
 class EvenementNouvelleHomologationCreee extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      const manque = (donnee) => typeof donnee === 'undefined';
-
-      if (manque(donnees.idService))
-        throw new ErreurIdentifiantServiceManquant();
-      if (manque(donnees.dateHomologation))
-        throw new ErreurDateHomologationManquante();
-      if (manque(donnees.dureeHomologationMois))
-        throw new ErreurDureeHomologationManquante();
-    };
-
-    valide();
+    Evenement.valide(donnees, [
+      'idService',
+      'dateHomologation',
+      'dureeHomologationMois',
+    ]);
 
     super(
       'NOUVELLE_HOMOLOGATION_CREEE',

--- a/src/modeles/journalMSS/evenementNouvelleHomologationCreee.js
+++ b/src/modeles/journalMSS/evenementNouvelleHomologationCreee.js
@@ -4,7 +4,7 @@ class EvenementNouvelleHomologationCreee extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, [
+    Evenement.verifieProprietesRenseignees(donnees, [
       'idService',
       'dateHomologation',
       'dureeHomologationMois',

--- a/src/modeles/journalMSS/evenementRetourUtilisateurMesure.js
+++ b/src/modeles/journalMSS/evenementRetourUtilisateurMesure.js
@@ -1,28 +1,15 @@
 const Evenement = require('./evenement');
-const {
-  ErreurIdentifiantServiceManquant,
-  ErreurIdentifiantUtilisateurManquant,
-  ErreurIdentifiantMesureManquant,
-  ErreurIdentifiantRetourUtilisateurManquant,
-} = require('./erreurs');
 
 class EvenementRetourUtilisateurMesure extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      const manque = (donnee) => typeof donnee === 'undefined';
-
-      if (manque(donnees.idService))
-        throw new ErreurIdentifiantServiceManquant();
-      if (manque(donnees.idUtilisateur))
-        throw new ErreurIdentifiantUtilisateurManquant();
-      if (manque(donnees.idMesure)) throw new ErreurIdentifiantMesureManquant();
-      if (manque(donnees.idRetour))
-        throw new ErreurIdentifiantRetourUtilisateurManquant();
-    };
-
-    valide();
+    Evenement.valide(donnees, [
+      'idService',
+      'idUtilisateur',
+      'idMesure',
+      'idRetour',
+    ]);
 
     super(
       'RETOUR_UTILISATEUR_MESURE_RECU',

--- a/src/modeles/journalMSS/evenementRetourUtilisateurMesure.js
+++ b/src/modeles/journalMSS/evenementRetourUtilisateurMesure.js
@@ -4,7 +4,7 @@ class EvenementRetourUtilisateurMesure extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, [
+    Evenement.verifieProprietesRenseignees(donnees, [
       'idService',
       'idUtilisateur',
       'idMesure',

--- a/src/modeles/journalMSS/evenementServiceSupprime.js
+++ b/src/modeles/journalMSS/evenementServiceSupprime.js
@@ -1,17 +1,10 @@
-const { ErreurIdentifiantServiceManquant } = require('./erreurs');
 const Evenement = require('./evenement');
 
 class EvenementServiceSupprime extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      const manque = (donnee) => typeof donnee === 'undefined';
-      if (manque(donnees.idService))
-        throw new ErreurIdentifiantServiceManquant();
-    };
-
-    valide();
+    Evenement.valide(donnees, ['idService']);
 
     super(
       'SERVICE_SUPPRIME',

--- a/src/modeles/journalMSS/evenementServiceSupprime.js
+++ b/src/modeles/journalMSS/evenementServiceSupprime.js
@@ -4,7 +4,7 @@ class EvenementServiceSupprime extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, ['idService']);
+    Evenement.verifieProprietesRenseignees(donnees, ['idService']);
 
     super(
       'SERVICE_SUPPRIME',

--- a/src/modeles/journalMSS/evenementServicesImportes.js
+++ b/src/modeles/journalMSS/evenementServicesImportes.js
@@ -4,7 +4,10 @@ class EvenementServicesImportes extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.valide(donnees, ['idUtilisateur', 'nbServicesImportes']);
+    Evenement.verifieProprietesRenseignees(donnees, [
+      'idUtilisateur',
+      'nbServicesImportes',
+    ]);
 
     super(
       'SERVICES_IMPORTES',

--- a/src/modeles/journalMSS/evenementServicesImportes.js
+++ b/src/modeles/journalMSS/evenementServicesImportes.js
@@ -1,23 +1,10 @@
 const Evenement = require('./evenement');
-const {
-  ErreurIdentifiantUtilisateurManquant,
-  ErreurNombreServicesImportes,
-} = require('./erreurs');
 
 class EvenementServicesImportes extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    const valide = () => {
-      const manque = (donnee) => typeof donnee === 'undefined';
-
-      if (manque(donnees.idUtilisateur))
-        throw new ErreurIdentifiantUtilisateurManquant();
-      if (manque(donnees.nbServicesImportes))
-        throw new ErreurNombreServicesImportes();
-    };
-
-    valide();
+    Evenement.valide(donnees, ['idUtilisateur', 'nbServicesImportes']);
 
     super(
       'SERVICES_IMPORTES',

--- a/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
+++ b/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
@@ -2,6 +2,7 @@ const expect = require('expect.js');
 const {
   ErreurIdentifiantServiceManquant,
   ErreurAutorisationsServiceManquantes,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 const {
   EvenementCollaboratifServiceModifie,
@@ -44,13 +45,10 @@ describe("Un événement de modification du collaboratif d'un service", () => {
   });
 
   const proprietesAVerifier = [
-    { propriete: 'idService', typeErreur: ErreurIdentifiantServiceManquant },
-    {
-      propriete: 'autorisations',
-      typeErreur: ErreurAutorisationsServiceManquantes,
-    },
+    { propriete: 'idService' },
+    { propriete: 'autorisations' },
   ];
-  proprietesAVerifier.forEach(({ propriete, typeErreur }) => {
+  proprietesAVerifier.forEach(({ propriete }) => {
     it(`exige que \`${propriete}\` soit renseigné`, (done) => {
       try {
         const donnees = { idService: 'abc' };
@@ -65,7 +63,7 @@ describe("Un événement de modification du collaboratif d'un service", () => {
           Error("L'instanciation de l'événement aurait dû lever une exception")
         );
       } catch (e) {
-        expect(e).to.be.an(typeErreur);
+        expect(e).to.be.an(ErreurDonneeManquante);
         done();
       }
     });

--- a/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
+++ b/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
@@ -1,7 +1,5 @@
 const expect = require('expect.js');
 const {
-  ErreurIdentifiantServiceManquant,
-  ErreurAutorisationsServiceManquantes,
   ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 const {

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -1,7 +1,7 @@
 const expect = require('expect.js');
 const ConstructeurEvenementCompletudeServiceModifiee = require('./constructeurEvenementCompletudeServiceModifiee');
 const {
-  ErreurServiceManquant,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 const { unService } = require('../../constructeurs/constructeurService');
 const Mesures = require('../../../src/modeles/mesures');
@@ -181,7 +181,7 @@ describe('Un événement de complétude modifiée', () => {
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
-      expect(e).to.be.an(ErreurServiceManquant);
+      expect(e).to.be.an(ErreurDonneeManquante);
       done();
     }
   });

--- a/test/modeles/journalMSS/evenementConnexionUtilisateur.spec.js
+++ b/test/modeles/journalMSS/evenementConnexionUtilisateur.spec.js
@@ -1,9 +1,8 @@
 const expect = require('expect.js');
 const EvenementConnexionUtilisateur = require('../../../src/modeles/journalMSS/evenementConnexionUtilisateur');
 const {
-  ErreurIdentifiantUtilisateurManquant,
-  ErreurDateDerniereConnexionManquante,
   ErreurDateDerniereConnexionInvalide,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de connexion utilisateur', () => {
@@ -45,7 +44,7 @@ describe('Un événement de connexion utilisateur', () => {
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
-      expect(e).to.be.an(ErreurIdentifiantUtilisateurManquant);
+      expect(e).to.be.an(ErreurDonneeManquante);
       done();
     }
   });
@@ -61,7 +60,7 @@ describe('Un événement de connexion utilisateur', () => {
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
-      expect(e).to.be.an(ErreurDateDerniereConnexionManquante);
+      expect(e).to.be.an(ErreurDonneeManquante);
       done();
     }
   });

--- a/test/modeles/journalMSS/evenementNouveauServiceCree.spec.js
+++ b/test/modeles/journalMSS/evenementNouveauServiceCree.spec.js
@@ -1,8 +1,7 @@
 const expect = require('expect.js');
 const EvenementNouveauServiceCree = require('../../../src/modeles/journalMSS/evenementNouveauServiceCree');
 const {
-  ErreurIdentifiantServiceManquant,
-  ErreurIdentifiantUtilisateurManquant,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de nouveau service créé', () => {
@@ -50,7 +49,7 @@ describe('Un événement de nouveau service créé', () => {
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
-      expect(e).to.be.an(ErreurIdentifiantUtilisateurManquant);
+      expect(e).to.be.an(ErreurDonneeManquante);
       done();
     }
   });
@@ -65,7 +64,7 @@ describe('Un événement de nouveau service créé', () => {
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
-      expect(e).to.be.an(ErreurIdentifiantServiceManquant);
+      expect(e).to.be.an(ErreurDonneeManquante);
       done();
     }
   });

--- a/test/modeles/journalMSS/evenementNouvelUtilisateurInscrit.spec.js
+++ b/test/modeles/journalMSS/evenementNouvelUtilisateurInscrit.spec.js
@@ -1,7 +1,7 @@
 const expect = require('expect.js');
 const EvenementNouvelUtilisateurInscrit = require('../../../src/modeles/journalMSS/evenementNouvelUtilisateurInscrit');
 const {
-  ErreurIdentifiantUtilisateurManquant,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de nouvel utilisateur inscrit', () => {
@@ -40,7 +40,7 @@ describe('Un événement de nouvel utilisateur inscrit', () => {
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
-      expect(e).to.be.an(ErreurIdentifiantUtilisateurManquant);
+      expect(e).to.be.an(ErreurDonneeManquante);
       done();
     }
   });

--- a/test/modeles/journalMSS/evenementNouvelleHomologationCreee.spec.js
+++ b/test/modeles/journalMSS/evenementNouvelleHomologationCreee.spec.js
@@ -3,9 +3,7 @@ const EvenementNouvelleHomologationCreee = require('../../../src/modeles/journal
 require('./constructeurEvenementCompletudeServiceModifiee');
 require('../../../src/modeles/journalMSS/evenementCompletudeServiceModifiee');
 const {
-  ErreurIdentifiantServiceManquant,
-  ErreurDateHomologationManquante,
-  ErreurDureeHomologationManquante,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de nouvelle homologation', () => {
@@ -48,7 +46,7 @@ describe('Un événement de nouvelle homologation', () => {
   it("exige que l'identifiant du service soit renseigné", () => {
     expect(() => new EvenementNouvelleHomologationCreee({})).to.throwError(
       (e) => {
-        expect(e).to.be.an(ErreurIdentifiantServiceManquant);
+        expect(e).to.be.an(ErreurDonneeManquante);
       }
     );
   });
@@ -57,7 +55,7 @@ describe('Un événement de nouvelle homologation', () => {
     expect(
       () => new EvenementNouvelleHomologationCreee({ idService: 'abc' })
     ).to.throwError((e) => {
-      expect(e).to.be.an(ErreurDateHomologationManquante);
+      expect(e).to.be.an(ErreurDonneeManquante);
     });
   });
 
@@ -69,7 +67,7 @@ describe('Un événement de nouvelle homologation', () => {
           dateHomologation: '2023-03-30',
         })
     ).to.throwError((e) => {
-      expect(e).to.be.an(ErreurDureeHomologationManquante);
+      expect(e).to.be.an(ErreurDonneeManquante);
     });
   });
 

--- a/test/modeles/journalMSS/evenementRetourUtilisateurMesure.spec.js
+++ b/test/modeles/journalMSS/evenementRetourUtilisateurMesure.spec.js
@@ -1,10 +1,7 @@
 const expect = require('expect.js');
 const EvenementRetourUtilisateurMesure = require('../../../src/modeles/journalMSS/evenementRetourUtilisateurMesure');
 const {
-  ErreurIdentifiantServiceManquant,
-  ErreurIdentifiantUtilisateurManquant,
-  ErreurIdentifiantMesureManquant,
-  ErreurIdentifiantRetourUtilisateurManquant,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de retour utilisateur sur une mesure', () => {
@@ -47,18 +44,12 @@ describe('Un événement de retour utilisateur sur une mesure', () => {
   });
 
   const proprietesAVerifier = [
-    { propriete: 'idService', typeErreur: ErreurIdentifiantServiceManquant },
-    {
-      propriete: 'idUtilisateur',
-      typeErreur: ErreurIdentifiantUtilisateurManquant,
-    },
-    { propriete: 'idMesure', typeErreur: ErreurIdentifiantMesureManquant },
-    {
-      propriete: 'idRetour',
-      typeErreur: ErreurIdentifiantRetourUtilisateurManquant,
-    },
+    { propriete: 'idService' },
+    { propriete: 'idUtilisateur' },
+    { propriete: 'idMesure' },
+    { propriete: 'idRetour' },
   ];
-  proprietesAVerifier.forEach(({ propriete, typeErreur }) => {
+  proprietesAVerifier.forEach(({ propriete }) => {
     it(`exige que \`${propriete}\` soit renseigné`, (done) => {
       try {
         const donnees = {
@@ -78,7 +69,7 @@ describe('Un événement de retour utilisateur sur une mesure', () => {
           Error("L'instanciation de l'événement aurait dû lever une exception")
         );
       } catch (e) {
-        expect(e).to.be.an(typeErreur);
+        expect(e).to.be.an(ErreurDonneeManquante);
         done();
       }
     });

--- a/test/modeles/journalMSS/evenementServiceSupprime.spec.js
+++ b/test/modeles/journalMSS/evenementServiceSupprime.spec.js
@@ -1,6 +1,6 @@
 const expect = require('expect.js');
 const {
-  ErreurIdentifiantServiceManquant,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 const EvenementServiceSupprime = require('../../../src/modeles/journalMSS/evenementServiceSupprime');
 
@@ -39,7 +39,7 @@ describe('Un événement de service supprimé', () => {
       );
       done("L'instanciation de l'événement aurait dû lever une exception");
     } catch (e) {
-      expect(e).to.be.an(ErreurIdentifiantServiceManquant);
+      expect(e).to.be.an(ErreurDonneeManquante);
       done();
     }
   });

--- a/test/modeles/journalMSS/evenementServicesImportes.spec.js
+++ b/test/modeles/journalMSS/evenementServicesImportes.spec.js
@@ -1,8 +1,7 @@
 const expect = require('expect.js');
 const EvenementServicesImportes = require('../../../src/modeles/journalMSS/evenementServicesImportes');
 const {
-  ErreurIdentifiantUtilisateurManquant,
-  ErreurNombreServicesImportes,
+  ErreurDonneeManquante,
 } = require('../../../src/modeles/journalMSS/erreurs');
 
 describe('Un événement de services importés', () => {
@@ -41,7 +40,7 @@ describe('Un événement de services importés', () => {
 
   it("exige que l'identifiant du service soit renseigné", () => {
     expect(() => new EvenementServicesImportes({})).to.throwError((e) => {
-      expect(e).to.be.an(ErreurIdentifiantUtilisateurManquant);
+      expect(e).to.be.an(ErreurDonneeManquante);
     });
   });
 
@@ -49,7 +48,7 @@ describe('Un événement de services importés', () => {
     expect(
       () => new EvenementServicesImportes({ idUtilisateur: 'abc' })
     ).to.throwError((e) => {
-      expect(e).to.be.an(ErreurNombreServicesImportes);
+      expect(e).to.be.an(ErreurDonneeManquante);
     });
   });
 });


### PR DESCRIPTION
On veut que chaque événement de journal puisse écrire quelque chose comme :

```js
Evenement.valide(donnees, ['idService', 'autorisations']);
```