### PR TITLE
Corrige l'encodage des modèles de mesure spécifique

### DIFF
--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -134,7 +134,7 @@ const routesConnecteApi = ({
                   idMesure,
                   {
                     ...(statut && { statut }),
-                    ...(modalites && { modalites }),
+                    ...(modalites && { modalites: decode(modalites) }),
                   },
                 ];
               }
@@ -143,11 +143,18 @@ const routesConnecteApi = ({
 
           return {
             id: service.id,
-            nomService: service.nomService(),
+            nomService: decode(service.nomService()),
             organisationResponsable:
               service.descriptionService.organisationResponsable.nom,
             mesuresAssociees,
-            mesuresSpecifiques,
+            mesuresSpecifiques: mesuresSpecifiques.map((ms) => ({
+              ...ms,
+              ...(ms.description && { description: decode(ms.description) }),
+              ...(ms.descriptionLongue && {
+                descriptionLongue: decode(ms.descriptionLongue),
+              }),
+              ...(ms.modalites && { modalites: decode(ms.modalites) }),
+            })),
             peutEtreModifie: autorisations
               .find((a) => a.idService === service.id)
               .aLesPermissions({ [SECURISER]: ECRITURE }),

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -1,3 +1,4 @@
+const { decode } = require('html-entities');
 const express = require('express');
 
 const { valeurBooleenne } = require('../../utilitaires/aseptisation');
@@ -674,7 +675,13 @@ const routesConnecteApi = ({
           requete.idUtilisateurCourant
         );
 
-      reponse.json(modeles);
+      reponse.json(
+        modeles.map((m) => ({
+          ...m,
+          description: decode(m.description),
+          descriptionLongue: decode(m.descriptionLongue),
+        }))
+      );
     }
   );
 

--- a/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
+++ b/src/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { decode } = require('html-entities');
 const {
   ErreurFichierXlsInvalide,
   ErreurTeleversementInexistant,
@@ -43,7 +44,18 @@ const routesConnecteApiTeleversementModelesMesureSpecifique = ({
 
     if (!televersement) return reponse.sendStatus(404);
 
-    return reponse.json(televersement.rapportDetaille());
+    const rapportDetaille = televersement.rapportDetaille();
+    rapportDetaille.modelesTeleverses = rapportDetaille.modelesTeleverses.map(
+      (m) => ({
+        ...m,
+        modele: {
+          ...m.modele,
+          description: decode(m.modele.description),
+          descriptionLongue: decode(m.modele.descriptionLongue),
+        },
+      })
+    );
+    return reponse.json(rapportDetaille);
   });
 
   routes.delete('/', async (requete, reponse) => {

--- a/svelte/lib/listeMesures/kit/TableauSelectionServices.svelte
+++ b/svelte/lib/listeMesures/kit/TableauSelectionServices.svelte
@@ -66,7 +66,7 @@
     {#if colonne.cle === 'nom'}
       <div class="contenu-nom-service">
         <div class="intitule-service" class:desactive>
-          <span class="nom">{decode(donnee.nomService)}</span>
+          <span class="nom">{donnee.nomService}</span>
           <span class="organisation">{donnee.organisationResponsable}</span>
         </div>
         {#if !donnee.peutEtreModifie}
@@ -86,7 +86,7 @@
         <slot name="infoStatutMesure" {donnee} />
       </div>
     {:else if colonne.cle === 'modalites'}
-      {@const contenu = decode(donnee.mesure.modalites)}
+      {@const contenu = donnee.mesure.modalites ?? ''}
       {@const contenuTropLong = contenu.length > 90}
       <div class="precision">
         <span>{contenuTropLong ? contenu.slice(0, 90) + '...' : contenu}</span>

--- a/svelte/lib/listeMesures/mesureSpecifique/ServicesAssociesModeleMesureSpecifique.svelte
+++ b/svelte/lib/listeMesures/mesureSpecifique/ServicesAssociesModeleMesureSpecifique.svelte
@@ -136,7 +136,7 @@
     {#if colonne.cle === 'nom'}
       <div class="contenu-nom-service">
         <div class="intitule-service" class:desactive>
-          <span class="nom">{decode(donnee.nomService)}</span>
+          <span class="nom">{donnee.nomService}</span>
           <span class="organisation">{donnee.organisationResponsable}</span>
         </div>
         {#if desactive}

--- a/svelte/lib/listeMesures/mesureSpecifique/modification/ConfirmationModificationModeleMesureSpecifique.svelte
+++ b/svelte/lib/listeMesures/mesureSpecifique/modification/ConfirmationModificationModeleMesureSpecifique.svelte
@@ -55,7 +55,7 @@
     {#if colonne.cle === 'nom'}
       <div class="contenu-nom-service">
         <div class="intitule-service">
-          <span class="nom">{decode(donnee.nomService)}</span>
+          <span class="nom">{donnee.nomService}</span>
           <span class="organisation">{donnee.organisationResponsable}</span>
         </div>
       </div>

--- a/svelte/lib/listeMesures/servicesAssocies/TableauServicesAssocies.svelte
+++ b/svelte/lib/listeMesures/servicesAssocies/TableauServicesAssocies.svelte
@@ -41,12 +41,12 @@
           class="intitule-service intitule-service-cliquable"
           href={urlSecuriserService}
         >
-          <span class="nom">{decode(donnee.nomService)}</span>
+          <span class="nom">{donnee.nomService}</span>
           <span class="organisation">{donnee.organisationResponsable}</span>
         </a>
       {:else}
         <div class="intitule-service">
-          <span class="nom">{decode(donnee.nomService)}</span>
+          <span class="nom">{donnee.nomService}</span>
           <span class="organisation">{donnee.organisationResponsable}</span>
         </div>
       {/if}
@@ -67,7 +67,7 @@
         <TagStatutMesure {referentielStatuts} statut={donnee.mesure.statut} />
       </div>
     {:else if colonne.cle === 'modalites'}
-      {@const contenu = decode(donnee.mesure.modalites)}
+      {@const contenu = donnee.mesure.modalites ?? ''}
       {@const contenuTropLong = contenu.length > 90}
       <div class="precision">
         <span>{contenuTropLong ? contenu.slice(0, 90) + '...' : contenu}</span>

--- a/svelte/lib/listeMesures/televersement/LigneDeRapport.svelte
+++ b/svelte/lib/listeMesures/televersement/LigneDeRapport.svelte
@@ -34,12 +34,12 @@
   </th>
   <CelluleDonnee contenu={ligne.numeroLigne.toString()} />
   <CelluleDonnee
-    contenu={decode(ligne.modele.description)}
+    contenu={ligne.modele.description}
     enErreur={contientErreur('INTITULE_MANQUANT') ||
       contientErreur('MESURE_DUPLIQUEE')}
     gras
   />
-  <CelluleDonnee contenu={decode(ligne.modele.descriptionLongue)} />
+  <CelluleDonnee contenu={ligne.modele.descriptionLongue} />
   <CelluleDonnee enErreur={contientErreur('CATEGORIE_INCONNUE')}>
     <lab-anssi-tag
       class="tag-categorie"

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.api.ts
@@ -15,6 +15,7 @@ const decodeEntitesHtml = (mesures: Mesures) => {
     (m: MesureSpecifique) => ({
       ...m,
       description: decode(m.description),
+      descriptionLongue: decode(m.descriptionLongue),
       modalites: decode(m.modalites),
     })
   );

--- a/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
+++ b/svelte/lib/tableauDesMesures/tableauDesMesures.d.ts
@@ -42,6 +42,7 @@ export type MesureSpecifique = {
   idModele?: string;
   categorie: string;
   description: string;
+  descriptionLongue?: string;
   statut: StatutMesure;
   modalites: string;
   identifiantNumerique: string;

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -2021,6 +2021,27 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       expect(reponse.data).to.eql([]);
       expect(idRecu).to.be('U1');
     });
+
+    it('décode les entités HTML dans le contenu renvoyé', async () => {
+      testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
+      testeur.depotDonnees().lisModelesMesureSpecifiquePourUtilisateur =
+        async () => [
+          {
+            id: 'MOD-1',
+            idsServicesAssocies: [],
+            description: 'L&#x27;abricot &lt;&gt;',
+            descriptionLongue: 'L&#x27;artiste',
+            categorie: 'gouvernance',
+          },
+        ];
+
+      const reponse = await axios.get(
+        'http://localhost:1234/api/modeles/mesureSpecifique'
+      );
+
+      expect(reponse.data[0].description).to.be("L'abricot <>");
+      expect(reponse.data[0].descriptionLongue).to.be("L'artiste");
+    });
   });
 
   describe('quand requête POST sur `/api/modeles/mesureSpecifique`', () => {

--- a/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
+++ b/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
@@ -125,6 +125,30 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
       expect(idDemande).to.be('U1');
     });
 
+    it('décode les entités HTML dans les données renvoyées', async () => {
+      testeur.depotDonnees().lisTeleversementModelesMesureSpecifique =
+        async () =>
+          new TeleversementModelesMesureSpecifique(
+            [
+              {
+                description: 'L&apos;abricot',
+                descriptionLongue: 'L&apos;autre',
+                categorie: 'Gouvernance',
+              },
+            ],
+            {}
+          );
+
+      const reponse = await axios.get(
+        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
+      );
+
+      const { descriptionLongue, description } =
+        reponse.data.modelesTeleverses[0].modele;
+      expect(description).to.be("L'abricot");
+      expect(descriptionLongue).to.be("L'autre");
+    });
+
     it("renvoie une erreur 404 si l'utilisateur n'a pas de téléversement en cours", async () => {
       testeur.depotDonnees().lisTeleversementModelesMesureSpecifique =
         async () => undefined;


### PR DESCRIPTION
Décode les données de mesure spécifique côté API pour éviter de dupliquer le décode partout côté front