### PR TITLE
[CORRECTION] N'essaie pas d'insérer si aucun modèle n'est passé

### DIFF
--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -761,13 +761,17 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
   const associeModelesMesureSpecifiqueAuService = async (
     idsModeles,
     idService
-  ) =>
-    knex('modeles_mesure_specifique_association_aux_services').insert(
+  ) => {
+    const aucunModele = idsModeles.length === 0;
+    if (aucunModele) return;
+
+    await knex('modeles_mesure_specifique_association_aux_services').insert(
       idsModeles.map((idModele) => ({
         id_modele: idModele,
         id_service: idService,
       }))
     );
+  };
 
   const verifieModeleMesureSpecifiqueExiste = async (idModele) => {
     const resultat = await knex.raw(


### PR DESCRIPTION
Dans le cas où on arrive dans `associeModelesMesureSpecifiqueAuService()` par une duplication de service qui pointe un service n'ayant aucune mesure spécifique associée à un modèle… on déclenchait `associeModelesMesureSpecifiqueAuService()` avec un tableau vide en entrée.

Ce tableau vide, côté Postgres cause une erreur "Error: The query is empty".

On protège, pour ne pas crasher.