### PR TITLE
[CORRECTION] Permet la mise à jour de nom/prénom de l'utilisateur connecté

### DIFF
--- a/src/mss.ts
+++ b/src/mss.ts
@@ -178,7 +178,6 @@ const creeServeur = ({
       lecteurDeFormData,
       adaptateurTeleversementServices,
       adaptateurTeleversementModelesMesureSpecifique,
-      adaptateurJWT,
       procedures,
       serviceAnnuaire,
       serviceGestionnaireSession,

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -15,7 +15,6 @@ const {
   ErreurModele,
   ErreurCategorieInconnue,
   ErreurModeleDeMesureSpecifiqueDejaAssociee,
-  ErreurJWTManquant,
   ErreurModeleDeMesureSpecifiqueIntrouvable,
   ErreurAutorisationInexistante,
   ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique,
@@ -61,7 +60,6 @@ const routesConnecteApi = ({
   lecteurDeFormData,
   adaptateurTeleversementServices,
   adaptateurTeleversementModelesMesureSpecifique,
-  adaptateurJWT,
   procedures,
   serviceAnnuaire,
   serviceGestionnaireSession,
@@ -452,33 +450,15 @@ const routesConnecteApi = ({
   routes.put(
     '/utilisateur',
     middleware.aseptise(
-      ...Utilisateur.nomsProprietesBase().filter(
-        (propriete) => !['prenom', 'nom', 'email'].includes(propriete)
-      ),
+      ...Utilisateur.nomsProprietesBase().filter((nom) => nom !== 'email'),
       'siretEntite'
     ),
-    async (requete, reponse, suite) => {
-      const { token } = requete.body;
-
-      let donneesToken;
-      try {
-        donneesToken = await adaptateurJWT.decode(token);
-      } catch (e) {
-        const message =
-          e instanceof ErreurJWTManquant
-            ? 'Le token est requis'
-            : 'Le token est invalide';
-        reponse.status(422).send(message);
-        return;
-      }
-
+    (requete, reponse, suite) => {
       const idUtilisateur = requete.idUtilisateurCourant;
       const donnees = obtentionDonneesDeBaseUtilisateur(
         requete.body,
         serviceCgu
       );
-      donnees.prenom = donneesToken.prenom;
-      donnees.nom = donneesToken.nom;
       const { donneesInvalides, messageErreur } =
         messageErreurDonneesUtilisateur(donnees, true);
 

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -80,7 +80,7 @@ const routesConnectePage = ({
 
       reponse.render('profil', {
         utilisateur: {
-          ...utilisateur,
+          ...utilisateur.toJSON(),
           nom: decode(utilisateur.nom),
           prenom: decode(utilisateur.prenom),
           postes: utilisateur.postes.map(decode),

--- a/svelte/lib/inscription/Inscription.svelte
+++ b/svelte/lib/inscription/Inscription.svelte
@@ -16,6 +16,10 @@
   import ChampTexte from '../ui/ChampTexte.svelte';
   import SelectionNombreServices from './SelectionNombreServices.svelte';
   import ControleFormulaire from '../ui/ControleFormulaire.svelte';
+  import {
+    finaliseInscriptionSuiteInvitation,
+    inscrisNouvelUtilisateur,
+  } from './inscription.api';
 
   export let estimationNombreServices: EstimationNombreServices[];
   export let informationsProfessionnelles: InformationsProfessionnelles;
@@ -55,9 +59,9 @@
       try {
         enCoursEnvoi = true;
         if (invite) {
-          await axios.put('/api/utilisateur', formulaireInscription);
+          await finaliseInscriptionSuiteInvitation(formulaireInscription);
         } else {
-          await axios.post('/api/utilisateur', formulaireInscription);
+          await inscrisNouvelUtilisateur(formulaireInscription);
         }
       } finally {
         enCoursEnvoi = false;
@@ -67,6 +71,8 @@
   };
 
   let formulaireInscription: FormulaireInscription = {
+    prenom: informationsProfessionnelles.prenom,
+    nom: informationsProfessionnelles.nom,
     siretEntite: informationsProfessionnelles.organisation?.siret,
     telephone: informationsProfessionnelles.telephone,
     postes: informationsProfessionnelles.domainesSpecialite,

--- a/svelte/lib/inscription/inscription.api.ts
+++ b/svelte/lib/inscription/inscription.api.ts
@@ -1,0 +1,15 @@
+import type { FormulaireInscription } from './inscription.d';
+
+export const finaliseInscriptionSuiteInvitation = (
+  formulaireInscription: FormulaireInscription
+) => {
+  const { token, ...donneesProfilInvite } = formulaireInscription;
+  return axios.put('/api/utilisateur', donneesProfilInvite);
+};
+
+export const inscrisNouvelUtilisateur = async (
+  formulaireInscription: FormulaireInscription
+) => {
+  const { prenom, nom, ...donneesNouvelleInscription } = formulaireInscription;
+  await axios.post('/api/utilisateur', donneesNouvelleInscription);
+};

--- a/svelte/lib/inscription/inscription.d.ts
+++ b/svelte/lib/inscription/inscription.d.ts
@@ -42,6 +42,8 @@ export type InscriptionProps = {
 };
 
 export type FormulaireInscription = {
+  prenom: string;
+  nom: string;
   siretEntite: string;
   telephone: string;
   postes: string[];

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -9,8 +9,6 @@ const {
   ErreurModele,
   EchecAutorisation,
   ErreurModeleDeMesureSpecifiqueDejaAssociee,
-  ErreurJWTInvalide,
-  ErreurJWTManquant,
   ErreurModeleDeMesureSpecifiqueIntrouvable,
   ErreurAutorisationInexistante,
   ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique,
@@ -1338,6 +1336,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       utilisateur = unUtilisateur().avecId('123').construis();
 
       donneesRequete = {
+        prenom: 'Jean',
+        nom: 'Dupont',
         telephone: '0100000000',
         postes: ['RSSI', "Chargé des systèmes d'informations"],
         siretEntite: '13000766900018',
@@ -1348,19 +1348,6 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         infolettreAcceptee: 'true',
         transactionnelAccepte: 'true',
         cguAcceptees: 'true',
-        token: 'unTokenValide',
-      };
-
-      testeur.adaptateurJWT().decode = (token) => {
-        if (token === 'unTokenValide')
-          return {
-            prenom: 'Jean',
-            nom: 'Dupont',
-          };
-        if (token === 'tokenInvalide') {
-          throw new ErreurJWTInvalide();
-        }
-        throw new ErreurJWTManquant();
       };
 
       testeur.referentiel().departement = () => 'Paris';
@@ -1372,6 +1359,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     it('aseptise les paramètres de la requête', (done) => {
       testeur.middleware().verifieAseptisationParametres(
         [
+          'prenom',
+          'nom',
           'telephone',
           'cguAcceptees',
           'infolettreAcceptee',
@@ -1390,11 +1379,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", async () => {
-      donneesRequete.siretEntite = '';
+      donneesRequete.prenom = '';
 
       await testeur.verifieRequeteGenereErreurHTTP(
         422,
-        'La mise à jour de l\'utilisateur a échoué car les paramètres sont invalides. La propriété "entite.siret" est requise',
+        'La mise à jour de l\'utilisateur a échoué car les paramètres sont invalides. La propriété "prenom" est requise',
         {
           method: 'put',
           url: 'http://localhost:1234/api/utilisateur',
@@ -1489,30 +1478,6 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       expect(preferencesChangees).to.eql({
         infolettreAcceptee: true,
         transactionnelAccepte: true,
-      });
-    });
-
-    it('jette une erreur si le token est invalide', async () => {
-      donneesRequete.token = 'tokenInvalide';
-
-      await testeur.verifieRequeteGenereErreurHTTP(
-        422,
-        'Le token est invalide',
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/utilisateur',
-          data: donneesRequete,
-        }
-      );
-    });
-
-    it('jette une erreur si le token est absent', async () => {
-      donneesRequete.token = '';
-
-      await testeur.verifieRequeteGenereErreurHTTP(422, 'Le token est requis', {
-        method: 'put',
-        url: 'http://localhost:1234/api/utilisateur',
-        data: donneesRequete,
       });
     });
   });


### PR DESCRIPTION
On souhaite que la finalisation d'inscription d'un utilisateur (via PUT /utilisateur) continue de prendre en compte le nom/prénom et n'utilise pas de token passé dans le corps de la requête (il est de toute façon présent dans la session, car c'est une route connectée).

Avant cette PR, la mise à jour de profil utilisateur ne fonctionne plus car le endpoint `PUT /utilisateur` s'attend, à tord, de recevoir un token dans le corps de la requête suite à https://github.com/betagouv/mon-service-securise/pull/2269 et https://github.com/betagouv/mon-service-securise/pull/2276

Bonus : j'ai remarqué que des propriétés comme "proprietesAtomiquesRequises" étaient présentes dans la payload de mise à jour de profil, car elles étaient présentes dans l'objet `donnees-profil` sur la page profil, j'ai donc nettoyé ça avec un `utilisateur.toJSON()`