### PR TITLE
[TESTS] Ajout de `supertest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "nodemon": "^3.0.1",
         "prettier": "^3.0.3",
         "prettier-plugin-svelte": "^3.0.3",
+        "supertest": "^7.1.4",
         "svelte": "^4.2.19",
         "svelte-check": "^3.8.6",
         "svelte-eslint-parser": "^0.33.0",
@@ -1265,6 +1266,19 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1298,6 +1312,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pdf-lib/standard-fonts": {
@@ -4213,6 +4237,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4424,6 +4458,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookies": {
       "version": "0.9.1",
@@ -4754,6 +4795,17 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
       "integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -5990,6 +6042,13 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -6153,6 +6212,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -11113,6 +11190,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14458,6 +14608,12 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
+    "@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14482,6 +14638,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "requires": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "@pdf-lib/standard-fonts": {
@@ -16324,6 +16489,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
       "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="
     },
+    "component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -16490,6 +16661,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "cookies": {
       "version": "0.9.1",
@@ -16723,6 +16900,16 @@
       "version": "0.0.1413902",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
       "integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ=="
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff": {
       "version": "5.2.0",
@@ -17621,6 +17808,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -17735,6 +17928,17 @@
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "requires": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
       }
     },
     "forwarded": {
@@ -21309,6 +21513,56 @@
           "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
           "dev": true
         }
+      }
+    },
+    "superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+          "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "nodemon": "^3.0.1",
     "prettier": "^3.0.3",
     "prettier-plugin-svelte": "^3.0.3",
+    "supertest": "^7.1.4",
     "svelte": "^4.2.19",
     "svelte-check": "^3.8.6",
     "svelte-eslint-parser": "^0.33.0",

--- a/src/mss.ts
+++ b/src/mss.ts
@@ -228,7 +228,7 @@ const creeServeur = ({
     serveur.close();
   };
 
-  return { ecoute, arreteEcoute };
+  return { ecoute, arreteEcoute, app };
 };
 
 module.exports = { creeServeur };

--- a/test/aides/verifieFichierServi.js
+++ b/test/aides/verifieFichierServi.js
@@ -1,4 +1,3 @@
-const axios = require('axios');
 const expect = require('expect.js');
 const supertest = require('supertest');
 

--- a/test/aides/verifieFichierServi.js
+++ b/test/aides/verifieFichierServi.js
@@ -1,28 +1,21 @@
 const axios = require('axios');
 const expect = require('expect.js');
+const supertest = require('supertest');
 
-const verifieNomFichierServi = (url, nom, done) =>
-  axios
-    .get(url)
-    .then((reponse) =>
-      expect(reponse.headers['content-disposition']).to.contain(
-        `filename="${nom}"`
-      )
-    )
-    .then(() => done())
-    .catch(done);
+const verifieNomFichierServi = async (app, url, nom) => {
+  const reponse = await supertest(app).get(url);
+  expect(reponse.headers['content-disposition']).to.contain(
+    `filename="${nom}"`
+  );
+};
 
-const verifieTypeFichierServi = (url, done, typeFichier) =>
-  axios
-    .get(url)
-    .then((reponse) =>
-      expect(reponse.headers['content-type']).to.contain(typeFichier)
-    )
-    .then(() => done())
-    .catch(done);
+const verifieTypeFichierServi = async (app, url, typeFichier) => {
+  const reponse = await supertest(app).get(url);
+  expect(reponse.headers['content-type']).to.contain(typeFichier);
+};
 
-const verifieTypeFichierServiEstCSV = (url, done) =>
-  verifieTypeFichierServi(url, done, 'text/csv');
+const verifieTypeFichierServiEstCSV = async (app, url) =>
+  verifieTypeFichierServi(app, url, 'text/csv');
 
 const verifieTypeFichierServiEstPDF = (url, done) =>
   verifieTypeFichierServi(url, done, 'application/pdf');

--- a/test/aides/verifieFichierServi.js
+++ b/test/aides/verifieFichierServi.js
@@ -17,11 +17,11 @@ const verifieTypeFichierServi = async (app, url, typeFichier) => {
 const verifieTypeFichierServiEstCSV = async (app, url) =>
   verifieTypeFichierServi(app, url, 'text/csv');
 
-const verifieTypeFichierServiEstPDF = (url, done) =>
-  verifieTypeFichierServi(url, done, 'application/pdf');
+const verifieTypeFichierServiEstPDF = (app, url) =>
+  verifieTypeFichierServi(app, url, 'application/pdf');
 
-const verifieTypeFichierServiEstZIP = (url, done) =>
-  verifieTypeFichierServi(url, done, 'application/zip');
+const verifieTypeFichierServiEstZIP = (app, url) =>
+  verifieTypeFichierServi(app, url, 'application/zip');
 
 module.exports = {
   verifieNomFichierServi,

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -328,12 +328,12 @@ const middlewareFantaisie = {
     );
   },
 
-  verifieRequeteExigeAcceptationCGU: (...params) => {
+  verifieRequeteExigeAcceptationCGU: async (app, requete) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => verificationCGUMenee },
-      ...params
-    );
-  },
+      app,
+      requete
+    ),
 
   verifieRequeteExigeJWT: async (app, requete) =>
     verifieRequeteChangeEtat(

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -10,6 +10,8 @@ const {
 const { unService } = require('../constructeurs/constructeurService');
 const SourceAuthentification = require('../../src/modeles/sourceAuthentification');
 
+const NOMBRE_MAX_REDIRECTION_PAR_DEFAUT = 5;
+
 const verifieRequeteChangeEtat = async (donneesEtat, app, requete) => {
   const verifieEgalite = (valeurConstatee, valeurReference, ...diagnostics) => {
     expect(
@@ -23,7 +25,10 @@ const verifieRequeteChangeEtat = async (donneesEtat, app, requete) => {
   verifieEgalite(lectureEtat(), etatInitial, suffixeLectureEtat);
 
   try {
-    if (typeof requete === 'string') await supertest(app).get(requete);
+    if (typeof requete === 'string')
+      await supertest(app)
+        .get(requete)
+        .redirects(NOMBRE_MAX_REDIRECTION_PAR_DEFAUT);
     else {
       const methode = requete.method.toLowerCase();
       if (!(methode in supertest(app)))
@@ -32,7 +37,8 @@ const verifieRequeteChangeEtat = async (donneesEtat, app, requete) => {
         );
       await supertest(app)
         [requete.method.toLowerCase()](requete.url)
-        .send(requete.data);
+        .send(requete.data)
+        .redirects(NOMBRE_MAX_REDIRECTION_PAR_DEFAUT);
     }
     verifieEgalite(lectureEtat(), etatFinal, suffixeLectureEtat);
   } catch (e) {

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -30,7 +30,9 @@ const verifieRequeteChangeEtat = async (donneesEtat, app, requete) => {
         throw new Error(
           `La méthode ${methode} n'est pas un verbe HTTP correct`
         );
-      await supertest(app)[requete.method.toLowerCase()](requete.url);
+      await supertest(app)
+        [requete.method.toLowerCase()](requete.url)
+        .send(requete.data);
     }
     verifieEgalite(lectureEtat(), etatFinal, suffixeLectureEtat);
   } catch (e) {
@@ -263,16 +265,16 @@ const middlewareFantaisie = {
     expect(listeRecherche?.proprietes).to.eql(proprietesParametre);
   },
 
-  verifieAseptisationParametres: (nomsParametres, ...params) => {
+  verifieAseptisationParametres: async (nomsParametres, app, requete) =>
     verifieRequeteChangeEtat(
       {
         lectureEtat: () => parametresAseptises,
         etatInitial: [],
         etatFinal: nomsParametres,
       },
-      ...params
-    );
-  },
+      app,
+      requete
+    ),
 
   verifieAdresseIP: (listeAdressesIp, ...params) => {
     verifieRequeteChangeEtat(
@@ -374,12 +376,12 @@ const middlewareFantaisie = {
     verifieRequeteChangeEtat({ lectureEtat: () => noncePositionne }, ...params);
   },
 
-  verifieChallengeMotDePasse: (...params) => {
+  verifieChallengeMotDePasse: async (app, requete) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => challengeMotDePasseEffectue },
-      ...params
-    );
-  },
+      app,
+      requete
+    ),
 
   verifieChargementDeLaVersionBuildee: (...params) => {
     verifieRequeteChangeEtat(

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -276,59 +276,62 @@ const middlewareFantaisie = {
       requete
     ),
 
-  verifieAdresseIP: (listeAdressesIp, ...params) => {
+  verifieAdresseIP: async (listeAdressesIp, app, ...params) =>
     verifieRequeteChangeEtat(
       {
         lectureEtat: () => listeAdressesIPsAutorisee,
         etatInitial: [],
         etatFinal: listeAdressesIp,
       },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieChargementDesAutorisations: (...params) => {
+  verifieChargementDesAutorisations: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => autorisationsChargees },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieChargementDesPreferences: (...params) => {
+  verifieChargementDesPreferences: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => preferencesChargees },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieFiltrageIp: (...params) => {
+  verifieFiltrageIp: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => filtrageIpEstActif },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieProtectionTrafic: (...params) => {
-    verifieRequeteChangeEtat({ lectureEtat: () => traficProtege }, ...params);
-  },
+  verifieProtectionTrafic: async (app, ...params) =>
+    verifieRequeteChangeEtat(
+      { lectureEtat: () => traficProtege },
+      app,
+      ...params
+    ),
 
-  verifieRechercheService: (droitsAttendus, ...params) => {
+  verifieRechercheService: async (droitsAttendus, app, ...params) =>
     verifieRequeteChangeEtat(
       {
         lectureEtat: () => droitVerifie,
         etatInitial: null,
         etatFinal: droitsAttendus,
       },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieRechercheDossierCourant: (...params) => {
+  verifieRechercheDossierCourant: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => rechercheDossierCourantEffectuee },
+      app,
       ...params
-    );
-  },
+    ),
 
   verifieRequeteExigeAcceptationCGU: async (app, requete) =>
     verifieRequeteChangeEtat(
@@ -344,37 +347,40 @@ const middlewareFantaisie = {
       requete
     ),
 
-  verifieRequeteChargeEtatVisiteGuidee: (...params) => {
+  verifieRequeteChargeEtatVisiteGuidee: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => etatVisiteGuideeCharge },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieRequeteChargeActivationAgentConnect: (...params) => {
+  verifieRequeteChargeActivationAgentConnect: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => activationAgentConnectCharge },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieRequeteExigeSuppressionCookie: (...params) => {
+  verifieRequeteExigeSuppressionCookie: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => suppressionCookieEffectuee },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieRequetePositionneHeaders: (...params) => {
+  verifieRequetePositionneHeaders: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => headersPositionnes },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieRequetePositionneNonce: async (...params) => {
-    verifieRequeteChangeEtat({ lectureEtat: () => noncePositionne }, ...params);
-  },
+  verifieRequetePositionneNonce: async (app, ...params) =>
+    verifieRequeteChangeEtat(
+      { lectureEtat: () => noncePositionne },
+      app,
+      ...params
+    ),
 
   verifieChallengeMotDePasse: async (app, requete) =>
     verifieRequeteChangeEtat(
@@ -383,23 +389,23 @@ const middlewareFantaisie = {
       requete
     ),
 
-  verifieChargementDeLaVersionBuildee: (...params) => {
+  verifieChargementDeLaVersionBuildee: async (app, ...params) =>
     verifieRequeteChangeEtat(
       { lectureEtat: () => versionBuildeeChargee },
+      app,
       ...params
-    );
-  },
+    ),
 
-  verifieTypeRequeteCharge: (typeRequeteAttendu, ...params) => {
+  verifieTypeRequeteCharge: async (typeRequeteAttendu, app, ...params) =>
     verifieRequeteChangeEtat(
       {
         lectureEtat: () => typeRequeteCharge,
         etatInitial: null,
         etatFinal: typeRequeteAttendu,
       },
+      app,
       ...params
-    );
-  },
+    ),
 
   interdisLaMiseEnCache: (_requete, _reponse, suite) => {
     suite();

--- a/test/mss.spec.js
+++ b/test/mss.spec.js
@@ -1,4 +1,3 @@
-const axios = require('axios');
 const expect = require('expect.js');
 const testeurMSS = require('./routes/testeurMSS');
 const { TYPES_REQUETES } = require('../src/http/configurationServeur');
@@ -9,33 +8,27 @@ describe('Le serveur MSS', () => {
 
   beforeEach(testeur.initialise);
 
-  afterEach(testeur.arrete);
-
-  it('utilise un filtrage IP pour ne servir que les IP autorisées', (done) => {
-    testeur.middleware().verifieFiltrageIp('http://localhost:1234', done);
+  it('utilise un filtrage IP pour ne servir que les IP autorisées', async () => {
+    await testeur.middleware().verifieFiltrageIp(testeur.app(), '/');
   });
 
-  it('charge la version de build des fichiers', (done) => {
-    testeur
+  it('charge la version de build des fichiers', async () => {
+    await testeur
       .middleware()
-      .verifieChargementDeLaVersionBuildee('http://localhost:1234', done);
+      .verifieChargementDeLaVersionBuildee(testeur.app(), '/');
   });
 
   describe('quand une page est servie', () => {
-    it('positionne les headers', (done) => {
-      testeur
+    it('positionne les headers', async () => {
+      await testeur
         .middleware()
-        .verifieRequetePositionneHeaders('http://localhost:1234/', done);
+        .verifieRequetePositionneHeaders(testeur.app(), '/');
     });
 
-    it("n'affiche pas d'information sur la nature du serveur", (done) => {
-      axios
-        .get('http://localhost:1234')
-        .then((reponse) => {
-          expect(reponse.headers).to.not.have.property('x-powered-by');
-          done();
-        })
-        .catch(done);
+    it("n'affiche pas d'information sur la nature du serveur", async () => {
+      const reponse = await testeur.get('/');
+
+      expect(reponse.headers).to.not.have.property('x-powered-by');
     });
   });
 
@@ -102,16 +95,14 @@ describe('Le serveur MSS', () => {
         routeur: 'de feuilles de styles',
       },
     ].forEach(({ url, typeAttendu, routeur, callbackInitialisation }) => {
-      it(`identifie la requête comme ${typeAttendu} sur les routes ${routeur}`, (done) => {
-        callbackInitialisation?.();
-        testeur.middleware().verifieTypeRequeteCharge(
-          typeAttendu,
-          {
+      it(`identifie la requête comme ${typeAttendu} sur les routes ${routeur}`, async () => {
+        await callbackInitialisation?.();
+        await testeur
+          .middleware()
+          .verifieTypeRequeteCharge(typeAttendu, testeur.app(), {
             method: 'GET',
-            url: `http://localhost:1234${url}`,
-          },
-          done
-        );
+            url: `${url}`,
+          });
       });
     });
   });

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -1,6 +1,5 @@
 const axios = require('axios');
 const expect = require('expect.js');
-const supertest = require('supertest');
 
 const {
   verifieNomFichierServi,
@@ -93,9 +92,9 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return Promise.resolve([service]);
       };
 
-      const reponse = await supertest(testeur.app()).get('/api/services');
+      const reponse = await testeur.get('/api/services');
 
-      expect(reponse.statusCode).to.equal(200);
+      expect(reponse.status).to.equal(200);
 
       const { services } = reponse.body;
       expect(services.length).to.equal(1);
@@ -115,18 +114,18 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         ];
       };
 
-      await axios.get('http://localhost:1234/api/services');
+      await testeur.get('/api/services');
       expect(donneesPassees.idUtilisateur).to.equal('123');
     });
   });
 
   describe('quand requête GET sur `/api/services/indices-cyber`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
         .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/services/indices-cyber',
-          done
+          testeur.app(),
+          '/api/services/indices-cyber'
         );
     });
 
@@ -144,11 +143,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         ];
       };
 
-      await axios.get('http://localhost:1234/api/services/indices-cyber');
+      await testeur.get('/api/services/indices-cyber');
       expect(donneesPassees.idUtilisateur).to.equal('123');
     });
 
-    it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
+    it("interroge le dépôt de données pour récupérer les services de l'utilisateur", async () => {
       let donneesPassees = {};
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
@@ -164,28 +163,24 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return Promise.resolve([service]);
       };
 
-      axios
-        .get('http://localhost:1234/api/services/indices-cyber')
-        .then((reponse) => {
-          expect(reponse.status).to.equal(200);
+      const reponse = await testeur.get('/api/services/indices-cyber');
 
-          const { services } = reponse.data;
-          expect(services.length).to.equal(1);
-          expect(services[0].id).to.equal('456');
-          expect(donneesPassees.idUtilisateur).to.equal('123');
-          done();
-        })
-        .catch(done);
+      expect(reponse.status).to.equal(200);
+
+      const { services } = reponse.body;
+      expect(services.length).to.equal(1);
+      expect(services[0].id).to.equal('456');
+      expect(donneesPassees.idUtilisateur).to.equal('123');
     });
   });
 
   describe('quand requête GET sur `/api/services/mesures`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
         .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/services/mesures',
-          done
+          testeur.app(),
+          '/api/services/mesures'
         );
     });
 
@@ -197,7 +192,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return [];
       };
 
-      await axios.get('http://localhost:1234/api/services/mesures');
+      await testeur.get('/api/services/mesures');
 
       expect(idRecu).to.be('U1');
     });
@@ -237,12 +232,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           .construis(),
       ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/services/mesures'
-      );
+      const reponse = await testeur.get('/api/services/mesures');
 
       expect(reponse.status).to.be(200);
-      expect(reponse.data).to.eql([
+      expect(reponse.body).to.eql([
         {
           id: 'S1',
           nomService: 'Mon service',
@@ -284,12 +277,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           .construis(),
       ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/services/mesures'
-      );
+      const reponse = await testeur.get('/api/services/mesures');
 
       expect(reponse.status).to.be(200);
-      expect(reponse.data[0].mesuresSpecifiques).to.eql([
+      expect(reponse.body[0].mesuresSpecifiques).to.eql([
         {
           id: 'MS1',
           idModele: 'MOD-1',
@@ -339,13 +330,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           .construis(),
       ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/services/mesures'
-      );
+      const reponse = await testeur.get('/api/services/mesures');
 
       expect(reponse.status).to.be(200);
-      expect(reponse.data.length).to.be(1);
-      expect(reponse.data[0].id).to.be('S1');
+      expect(reponse.body.length).to.be(1);
+      expect(reponse.body[0].id).to.be('S1');
     });
 
     it("indique pour chaque service s'il peut être modifié par l'utilisateur", async () => {
@@ -389,15 +378,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           .construis(),
       ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/services/mesures'
-      );
+      const reponse = await testeur.get('/api/services/mesures');
 
       expect(reponse.status).to.be(200);
-      expect(reponse.data[0].id).to.be('S1');
-      expect(reponse.data[0].peutEtreModifie).to.be(true);
-      expect(reponse.data[1].id).to.be('S2');
-      expect(reponse.data[1].peutEtreModifie).to.be(false);
+      expect(reponse.body[0].id).to.be('S1');
+      expect(reponse.body[0].peutEtreModifie).to.be(true);
+      expect(reponse.body[1].id).to.be('S2');
+      expect(reponse.body[1].peutEtreModifie).to.be(false);
     });
 
     it('décode les entités HTML dans les données retournées', async () => {
@@ -444,21 +431,19 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           .construis(),
       ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/services/mesures'
-      );
+      const reponse = await testeur.get('/api/services/mesures');
 
-      expect(reponse.data[0].nomService).to.be("L'abricot");
-      expect(reponse.data[0].mesuresAssociees.A.modalites).to.be(
+      expect(reponse.body[0].nomService).to.be("L'abricot");
+      expect(reponse.body[0].mesuresAssociees.A.modalites).to.be(
         "L'application de A"
       );
-      expect(reponse.data[0].mesuresSpecifiques[0].modalites).to.be(
+      expect(reponse.body[0].mesuresSpecifiques[0].modalites).to.be(
         "L'ampoule"
       );
-      expect(reponse.data[0].mesuresSpecifiques[0].descriptionLongue).to.be(
+      expect(reponse.body[0].mesuresSpecifiques[0].descriptionLongue).to.be(
         "L'autre"
       );
-      expect(reponse.data[0].mesuresSpecifiques[0].description).to.be(
+      expect(reponse.body[0].mesuresSpecifiques[0].description).to.be(
         "L'arbitre"
       );
     });
@@ -469,40 +454,34 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.depotDonnees().accesAutoriseAUneListeDeService = async () => true;
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/services/mesuresGenerales/unIdDeMesure',
-        },
-        done
-      );
-    });
+    it("vérifie que l'utilisateur est authentifié", async () =>
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'put',
+        url: '/api/services/mesuresGenerales/unIdDeMesure',
+      }));
 
-    it('aseptise les données', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idsServices.*', 'id', 'statut', 'modalites'],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/services/mesuresGenerales/unIdDeMesure',
-        },
-        done
-      );
+    it('aseptise les données', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['idsServices.*', 'id', 'statut', 'modalites'],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/services/mesuresGenerales/unIdDeMesure',
+          }
+        );
     });
 
     it('jette une erreur si le statut ET les modalités ne sont pas précisés', async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/services/mesuresGenerales/unIdDeMesure',
-          {
-            statut: undefined,
-            modalites: undefined,
-          }
-        );
-        expect().fail("L'appel aurait dû lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.put(
+        '/api/services/mesuresGenerales/unIdDeMesure',
+        {
+          statut: undefined,
+          modalites: undefined,
+        }
+      );
+      expect(reponse.status).to.be(400);
     });
 
     it("jette une erreur si l'identifiant de la mesure est inconnu", async () => {
@@ -511,17 +490,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           uneMesureConnue: {},
         },
       });
-      try {
-        await axios.put(
-          'http://localhost:1234/api/services/mesuresGenerales/uneMesureInconnue',
-          {
-            statut: 'fait',
-          }
-        );
-        expect().fail("L'appel aurait dû lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.put(
+        '/api/services/mesuresGenerales/uneMesureInconnue',
+        {
+          statut: 'fait',
+        }
+      );
+      expect(reponse.status).to.be(400);
     });
 
     it('jette une erreur si le statut est inconnu', async () => {
@@ -529,17 +504,14 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         mesures: { uneMesureConnue: {} },
         statutsMesures: { unStatut: {} },
       });
-      try {
-        await axios.put(
-          'http://localhost:1234/api/services/mesuresGenerales/uneMesureConnue',
-          {
-            statut: 'unStatutInconnu',
-          }
-        );
-        expect().fail("L'appel aurait dû lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.put(
+        '/api/services/mesuresGenerales/uneMesureConnue',
+        {
+          statut: 'unStatutInconnu',
+        }
+      );
+
+      expect(reponse.status).to.be(400);
     });
 
     it("ne jette pas d'erreur si le statut est vide", async () => {
@@ -549,8 +521,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.depotDonnees().metsAJourMesureGeneraleDesServices =
         async () => {};
 
-      const reponse = await axios.put(
-        'http://localhost:1234/api/services/mesuresGenerales/uneMesureConnue',
+      const reponse = await testeur.put(
+        '/api/services/mesuresGenerales/uneMesureConnue',
         {
           statut: '',
           modalites: 'une modalité',
@@ -570,18 +542,14 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         statutsMesures: { unStatut: {} },
       });
 
-      try {
-        await axios.put(
-          'http://localhost:1234/api/services/mesuresGenerales/uneMesureConnue',
-          {
-            statut: 'unStatut',
-            idsServices: ['S1'],
-          }
-        );
-        expect().fail("L'appel aurait dû lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+      const reponse = await testeur.put(
+        '/api/services/mesuresGenerales/uneMesureConnue',
+        {
+          statut: 'unStatut',
+          idsServices: ['S1'],
+        }
+      );
+      expect(reponse.status).to.be(403);
     });
 
     it('délègue au dépôt de données la mise à jour de la mesure pour les services concernés', async () => {
@@ -603,14 +571,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         statutsMesures: { fait: {} },
       });
 
-      await axios.put(
-        'http://localhost:1234/api/services/mesuresGenerales/uneMesureConnue',
-        {
-          statut: 'fait',
-          modalites: 'une modalité',
-          idsServices: ['S1', 'S2'],
-        }
-      );
+      await testeur.put('/api/services/mesuresGenerales/uneMesureConnue', {
+        statut: 'fait',
+        modalites: 'une modalité',
+        idsServices: ['S1', 'S2'],
+      });
 
       expect(donneesRecues).to.eql({
         idUtilisateur: 'U1',
@@ -627,57 +592,50 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.depotDonnees().accesAutoriseAUneListeDeService = async () => true;
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'put',
-          url: 'http://localhost:1234/api/services/mesuresSpecifiques/unIdDeModele',
-        },
-        done
-      );
+          url: '/api/services/mesuresSpecifiques/unIdDeModele',
+        });
     });
 
-    it('aseptise les données', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idsServices.*', 'idModele', 'statut', 'modalites'],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/services/mesuresSpecifiques/unIdDeModele',
-        },
-        done
-      );
+    it('aseptise les données', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['idsServices.*', 'idModele', 'statut', 'modalites'],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/services/mesuresSpecifiques/unIdDeModele',
+          }
+        );
     });
 
     it('jette une erreur si le statut ET les modalités ne sont pas précisés', async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/services/mesuresSpecifiques/unIdDeModele',
-          {
-            statut: undefined,
-            modalites: undefined,
-          }
-        );
-        expect().fail("L'appel aurait dû lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.put(
+        '/api/services/mesuresSpecifiques/unIdDeModele',
+        {
+          statut: undefined,
+          modalites: undefined,
+        }
+      );
+      expect(reponse.status).to.be(400);
     });
 
     it("jette une erreur si l'identifiant du modèle de mesure est inconnu", async () => {
       testeur.depotDonnees().lisModelesMesureSpecifiquePourUtilisateur =
         async () => [];
 
-      try {
-        await axios.put(
-          'http://localhost:1234/api/services/mesuresSpecifiques/unModeleInconnu',
-          {
-            statut: 'fait',
-          }
-        );
-        expect().fail("L'appel aurait dû lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      const reponse = await testeur.put(
+        '/api/services/mesuresSpecifiques/unModeleInconnu',
+        {
+          statut: 'fait',
+        }
+      );
+      expect(reponse.status).to.be(404);
     });
 
     describe('lorsque le modèle de mesure est connu', () => {
@@ -699,22 +657,19 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         testeur.referentiel().recharge({
           statutsMesures: { unStatut: {} },
         });
-        try {
-          await axios.put(
-            'http://localhost:1234/api/services/mesuresSpecifiques/unModeleConnu',
-            {
-              statut: 'unStatutInconnu',
-            }
-          );
-          expect().fail("L'appel aurait dû lever une erreur.");
-        } catch (e) {
-          expect(e.response.status).to.be(400);
-        }
+        const reponse = await testeur.put(
+          '/api/services/mesuresSpecifiques/unModeleConnu',
+          {
+            statut: 'unStatutInconnu',
+          }
+        );
+
+        expect(reponse.status).to.be(400);
       });
 
       it("ne jette pas d'erreur si le statut est vide", async () => {
-        const reponse = await axios.put(
-          'http://localhost:1234/api/services/mesuresSpecifiques/unModeleConnu',
+        const reponse = await testeur.put(
+          '/api/services/mesuresSpecifiques/unModeleConnu',
           {
             statut: '',
             modalites: 'une modalité',
@@ -731,18 +686,15 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           statutsMesures: { unStatut: {} },
         });
 
-        try {
-          await axios.put(
-            'http://localhost:1234/api/services/mesuresSpecifiques/unModeleConnu',
-            {
-              statut: 'unStatut',
-              idsServices: ['S1'],
-            }
-          );
-          expect().fail("L'appel aurait dû lever une erreur.");
-        } catch (e) {
-          expect(e.response.status).to.be(403);
-        }
+        const reponse = await testeur.put(
+          '/api/services/mesuresSpecifiques/unModeleConnu',
+          {
+            statut: 'unStatut',
+            idsServices: ['S1'],
+          }
+        );
+
+        expect(reponse.status).to.be(403);
       });
 
       it('délègue au dépôt de données la mise à jour de chaque mesure pour les services concernés', async () => {
@@ -767,14 +719,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           statutsMesures: { fait: {} },
         });
 
-        await axios.put(
-          'http://localhost:1234/api/services/mesuresSpecifiques/unModeleConnu',
-          {
-            statut: 'fait',
-            modalites: 'une modalité',
-            idsServices: ['S1', 'S2'],
-          }
-        );
+        await testeur.put('/api/services/mesuresSpecifiques/unModeleConnu', {
+          statut: 'fait',
+          modalites: 'une modalité',
+          idsServices: ['S1', 'S2'],
+        });
 
         expect(donneesRecues).to.eql({
           idUtilisateur: 'U1',
@@ -803,36 +752,30 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       ];
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
         .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/services/export.csv',
-          done
+          testeur.app(),
+          '/api/services/export.csv'
         );
     });
 
-    it('aseptise les identifiants des services à exporter', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idsServices.*'],
-        {
+    it('aseptise les identifiants des services à exporter', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['idsServices.*'], testeur.app(), {
           method: 'get',
-          url: 'http://localhost:1234/api/services/export.csv',
-        },
-        done
-      );
+          url: '/api/services/export.csv',
+        });
     });
 
     describe('concernant le paramètre en query string `idsServices`', () => {
       it("retourne une erreur 400 si le paramètre n'est pas un tableau", async () => {
-        try {
-          await axios.get(
-            'http://localhost:1234/api/services/export.csv?idsServices[a]=1' // Sera interprété par express comme {a: 1}
-          );
-          expect().fail("L'appel aurait dû jeter une erreur");
-        } catch (e) {
-          expect(e.response.status).to.be(400);
-        }
+        const reponse = await testeur.get(
+          '/api/services/export.csv?idsServices[a]=1' // Sera interprété par express comme {a: 1}
+        );
+        expect(reponse.status).to.be(400);
       });
 
       it("fonctionne dans le cas où le tableau ne comporte qu'un seul élément", async () => {
@@ -841,8 +784,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         const queryString = new URLSearchParams();
         queryString.append('idsServices', '123');
 
-        const reponse = await axios.get(
-          `http://localhost:1234/api/services/export.csv?${queryString}`
+        const reponse = await testeur.get(
+          `/api/services/export.csv?${queryString}`
         );
 
         expect(reponse.status).to.be(200);
@@ -863,11 +806,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         ];
       };
 
-      await axios.get('http://localhost:1234/api/services/export.csv');
+      await testeur.get('/api/services/export.csv');
       expect(donneesPassees).to.eql({ idUtilisateur: '123' });
     });
 
-    it("interroge le dépôt de données pour récupérer les services de l'utilisateur", (done) => {
+    it("interroge le dépôt de données pour récupérer les services de l'utilisateur", async () => {
       let donneesPassees = {};
       testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
@@ -876,43 +819,37 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return Promise.resolve([service]);
       };
 
-      axios
-        .get('http://localhost:1234/api/services/export.csv')
-        .then((reponse) => {
-          expect(reponse.status).to.equal(200);
-          expect(donneesPassees.idUtilisateur).to.equal('123');
-          done();
-        })
-        .catch(done);
+      const reponse = await testeur.get('/api/services/export.csv');
+
+      expect(reponse.status).to.equal(200);
+      expect(donneesPassees.idUtilisateur).to.equal('123');
     });
 
-    it('filtre les services en fonction de la requête', (done) => {
-      testeur.depotDonnees().services = () =>
-        Promise.resolve([
-          service,
-          unService()
-            .avecId('789')
-            .avecNomService('Un deuxième service')
-            .ajouteUnContributeur(
-              unUtilisateur().avecEmail('email.proprietaire@mail.fr').donnees
-            )
-            .construis(),
-        ]);
+    it('filtre les services en fonction de la requête', async () => {
+      testeur.depotDonnees().services = async () => [
+        service,
+        unService()
+          .avecId('789')
+          .avecNomService('Un deuxième service')
+          .ajouteUnContributeur(
+            unUtilisateur().avecEmail('email.proprietaire@mail.fr').donnees
+          )
+          .construis(),
+      ];
 
-      testeur.adaptateurCsv().genereCsvServices = (donneesServices) => {
-        expect(donneesServices.length).to.be(1);
-        expect(donneesServices[0].id).to.equal('456');
-        done();
-        return Promise.resolve('Fichier CSV');
+      let donneesRecues;
+      testeur.adaptateurCsv().genereCsvServices = async (donneesServices) => {
+        donneesRecues = donneesServices;
+        return 'Fichier CSV';
       };
 
-      axios
-        .get('http://localhost:1234/api/services/export.csv?idsServices=456')
-        .catch((e) => done(e.response?.data || e));
+      await testeur.get('/api/services/export.csv?idsServices=456');
+      expect(donneesRecues.length).to.be(1);
+      expect(donneesRecues[0].id).to.equal('456');
     });
 
-    it('utilise un adaptateur de CSV pour la génération', (done) => {
-      testeur.middleware().reinitialise({ idUtilisateur: '123' });
+    it('utilise un adaptateur de CSV pour la génération', async () => {
+      await testeur.middleware().reinitialise({ idUtilisateur: '123' });
 
       testeur.depotDonnees().autorisations = async () => [
         uneAutorisation()
@@ -947,43 +884,32 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return Promise.resolve('Fichier CSV');
       };
 
-      axios
-        .get('http://localhost:1234/api/services/export.csv?idsServices=456')
-        .then(() => {
-          expect(adaptateurCsvAppele).to.be(true);
-          done();
-        })
-        .catch((e) => done(e.response?.data || e));
+      await testeur.get('/api/services/export.csv?idsServices=456');
+      expect(adaptateurCsvAppele).to.be(true);
     });
 
-    it('sert un fichier de type CSV', (done) => {
-      verifieTypeFichierServiEstCSV(
-        'http://localhost:1234/api/services/export.csv',
-        done
+    it('sert un fichier de type CSV', async () => {
+      await verifieTypeFichierServiEstCSV(
+        testeur.app(),
+        '/api/services/export.csv'
       );
     });
 
-    it('sert un fichier dont le nom contient la date du jour en format court', (done) => {
+    it('sert un fichier dont le nom contient la date du jour en format court', async () => {
       testeur.adaptateurHorloge().maintenant = () => new Date(2023, 0, 28);
 
-      verifieNomFichierServi(
-        'http://localhost:1234/api/services/export.csv',
-        'MSS_services_20230128.csv',
-        done
+      await verifieNomFichierServi(
+        testeur.app(),
+        '/api/services/export.csv',
+        'MSS_services_20230128.csv'
       );
     });
 
-    it("reste robuste en cas d'échec de génération de CSV", (done) => {
+    it("reste robuste en cas d'échec de génération de CSV", async () => {
       testeur.adaptateurCsv().genereCsvServices = () => Promise.reject();
 
-      axios
-        .get('http://localhost:1234/api/services/export.csv')
-        .then(() => done('La génération aurait dû lever une erreur'))
-        .catch((e) => {
-          expect(e.response.status).to.equal(424);
-          done();
-        })
-        .catch(done);
+      const reponse = await testeur.get('/api/services/export.csv');
+      expect(reponse.status).to.be(424);
     });
   });
 
@@ -1007,16 +933,18 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         utilisateur;
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['cguAcceptees', 'infolettreAcceptee'],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/motDePasse',
-          data: { motDePasse: 'mdp', cguAcceptees: true },
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['cguAcceptees', 'infolettreAcceptee'],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/motDePasse',
+            data: { motDePasse: 'mdp', cguAcceptees: true },
+          }
+        );
     });
 
     it('met à jour le mot de passe', async () => {
@@ -1032,7 +960,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         majMotDePasse = { idUtilisateur, motDePasse };
       };
 
-      const reponse = await axios.put('http://localhost:1234/api/motDePasse', {
+      const reponse = await testeur.put('/api/motDePasse', {
         motDePasse: 'mdp_ABC12345',
       });
 
@@ -1041,7 +969,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         motDePasse: 'mdp_ABC12345',
       });
       expect(reponse.status).to.equal(200);
-      expect(reponse.data).to.eql({ idUtilisateur: '123' });
+      expect(reponse.body).to.eql({ idUtilisateur: '123' });
     });
 
     it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", async () => {
@@ -1050,23 +978,21 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         'Mot de passe trop simple',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/motDePasse',
+          url: '/api/motDePasse',
           data: { motDePasse: '1234' },
         }
       );
     });
 
-    it('pose un nouveau cookie', (done) => {
-      axios
-        .put('http://localhost:1234/api/motDePasse', {
-          motDePasse: 'mdp_ABC12345',
-        })
-        .then((reponse) => testeur.verifieSessionDeposee(reponse, done))
-        .catch((e) => done(e.response?.data || e));
+    it('pose un nouveau cookie', async () => {
+      const reponse = await testeur.put('/api/motDePasse', {
+        motDePasse: 'mdp_ABC12345',
+      });
+      await testeur.verifieSessionDeposee(reponse);
     });
 
     it('ajoute une session utilisateur', async () => {
-      const reponse = await axios.put('http://localhost:1234/api/motDePasse', {
+      const reponse = await testeur.put('/api/motDePasse', {
         motDePasse: 'mdp_ABC12345',
       });
 
@@ -1082,7 +1008,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         inscriptionEffectuee = emailUtilisateur;
       };
 
-      await axios.put('http://localhost:1234/api/motDePasse', {
+      await testeur.put('/api/motDePasse', {
         motDePasse: 'mdp_ABC12345',
       });
 
@@ -1104,7 +1030,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         utilisateurPersiste = { idUtilisateur, donnees };
       };
 
-      await axios.put('http://localhost:1234/api/motDePasse', {
+      await testeur.put('/api/motDePasse', {
         motDePasse: 'mdp_ABC12345',
         infolettreAcceptee: 'true',
       });
@@ -1126,7 +1052,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         utilisateurQuiEstReset = u;
       };
 
-      await axios.put('http://localhost:1234/api/motDePasse', {
+      await testeur.put('/api/motDePasse', {
         motDePasse: 'mdp_ABC12345',
       });
 
@@ -1149,7 +1075,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             'CGU non acceptées',
             {
               method: 'put',
-              url: 'http://localhost:1234/api/motDePasse',
+              url: '/api/motDePasse',
               data: { motDePasse: 'mdp_12345' },
             }
           );
@@ -1162,11 +1088,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           };
 
           try {
-            await axios.put('http://localhost:1234/api/motDePasse', {
+            await testeur.put('/api/motDePasse', {
               motDePasse: 'mdp_12345',
             });
           } catch (e) {
-            expect(e.response.status).to.be(422);
+            expect(reponse.status).to.be(422);
             expect(motDePasseMisAJour).to.be(false);
           }
         });
@@ -1184,7 +1110,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             return u;
           };
 
-          await axios.put('http://localhost:1234/api/motDePasse', {
+          await testeur.put('/api/motDePasse', {
             motDePasse: 'mdp_ABC12345',
             cguAcceptees: 'true',
           });
@@ -1198,7 +1124,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             motDePasseMisAJour = true;
           };
 
-          await axios.put('http://localhost:1234/api/motDePasse', {
+          await testeur.put('/api/motDePasse', {
             motDePasse: 'mdp_ABC12345',
             cguAcceptees: 'true',
           });
@@ -1247,7 +1173,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return u;
       };
 
-      await axios.put('http://localhost:1234/api/utilisateur/acceptationCGU', {
+      await testeur.put('/api/utilisateur/acceptationCGU', {
         cguAcceptees: 'true',
       });
 
@@ -1255,10 +1181,9 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     });
 
     it('ajoute une session utilisateur', async () => {
-      const reponse = await axios.put(
-        'http://localhost:1234/api/utilisateur/acceptationCGU',
-        { cguAcceptees: 'true' }
-      );
+      const reponse = await testeur.put('/api/utilisateur/acceptationCGU', {
+        cguAcceptees: 'true',
+      });
 
       expectContenuSessionValide(reponse, 'AGENT_CONNECT', true, false);
     });
@@ -1271,14 +1196,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.depotDonnees().metsAJourMotDePasse = async () => utilisateur;
     });
 
-    it('utilise le middleware de challenge du mot de passe', (done) => {
-      testeurMSS().middleware().verifieChallengeMotDePasse(
-        {
+    it('utilise le middleware de challenge du mot de passe', async () => {
+      await testeurMSS()
+        .middleware()
+        .verifieChallengeMotDePasse(testeur.app(), {
           method: 'patch',
-          url: 'http://localhost:1234/api/motDePasse',
-        },
-        done
-      );
+          url: '/api/motDePasse',
+        });
     });
 
     it('met à jour le mot de passe', async () => {
@@ -1294,14 +1218,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return utilisateur;
       };
 
-      const reponse = await axios.patch(
-        'http://localhost:1234/api/motDePasse',
-        { motDePasse: 'mdp_ABC12345' }
-      );
+      const reponse = await testeur.patch('/api/motDePasse', {
+        motDePasse: 'mdp_ABC12345',
+      });
 
       expect(motDePasseMisAJour).to.be(true);
       expect(reponse.status).to.equal(200);
-      expect(reponse.data).to.eql({ idUtilisateur: '123' });
+      expect(reponse.body).to.eql({ idUtilisateur: '123' });
     });
 
     it("retourne une erreur HTTP 422 si le mot de passe n'est pas assez robuste", async () => {
@@ -1310,7 +1233,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         'Mot de passe trop simple',
         {
           method: 'patch',
-          url: 'http://localhost:1234/api/motDePasse',
+          url: '/api/motDePasse',
           data: { motDePasse: '1234' },
         }
       );
@@ -1345,26 +1268,28 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       depotDonnees.utilisateur = () => Promise.resolve(utilisateur);
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        [
-          'prenom',
-          'nom',
-          'telephone',
-          'cguAcceptees',
-          'infolettreAcceptee',
-          'transactionnelAccepte',
-          'postes.*',
-          'estimationNombreServices.*',
-          'siretEntite',
-        ],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/utilisateur',
-          data: donneesRequete,
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          [
+            'prenom',
+            'nom',
+            'telephone',
+            'cguAcceptees',
+            'infolettreAcceptee',
+            'transactionnelAccepte',
+            'postes.*',
+            'estimationNombreServices.*',
+            'siretEntite',
+          ],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/utilisateur',
+            data: donneesRequete,
+          }
+        );
     });
 
     it("est en erreur 422  quand les propriétés de l'utilisateur ne sont pas valides", async () => {
@@ -1375,7 +1300,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         'La mise à jour de l\'utilisateur a échoué car les paramètres sont invalides. La propriété "prenom" est requise',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/utilisateur',
+          url: '/api/utilisateur',
           data: donneesRequete,
         }
       );
@@ -1392,13 +1317,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return utilisateur;
       };
 
-      const reponse = await axios.put(
-        'http://localhost:1234/api/utilisateur',
-        donneesRequete
-      );
+      const reponse = await testeur.put('/api/utilisateur', donneesRequete);
 
       expect(reponse.status).to.equal(200);
-      expect(reponse.data).to.eql({ idUtilisateur: '123' });
+      expect(reponse.body).to.eql({ idUtilisateur: '123' });
       expect(idRecu).to.equal('123');
       expect(donneesRecues.prenom).to.equal('Jean');
       expect(donneesRecues.nom).to.equal('Dupont');
@@ -1421,10 +1343,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           return utilisateur;
         };
 
-        await axios.put(
-          'http://localhost:1234/api/utilisateur',
-          donneesRequete
-        );
+        await testeur.put('/api/utilisateur', donneesRequete);
 
         expect(versionCGURecue).to.be('v2.0');
       });
@@ -1437,10 +1356,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         };
         delete donneesRequete.cguAcceptees;
 
-        await axios.put(
-          'http://localhost:1234/api/utilisateur',
-          donneesRequete
-        );
+        await testeur.put('/api/utilisateur', donneesRequete);
 
         expect(versionCGURecue).to.be(undefined);
       });
@@ -1462,7 +1378,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       donneesRequete.infolettreAcceptee = 'true';
       donneesRequete.transactionnelAccepte = 'true';
-      await axios.put('http://localhost:1234/api/utilisateur', donneesRequete);
+      await testeur.put('/api/utilisateur', donneesRequete);
 
       expect(preferencesChangees).to.eql({
         infolettreAcceptee: true,
@@ -1484,13 +1400,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           .construis();
       };
 
-      const response = await axios.get(
-        'http://localhost:1234/api/utilisateurCourant'
-      );
+      const reponse = await testeur.get('/api/utilisateurCourant');
 
-      expect(response.status).to.equal(200);
+      expect(reponse.status).to.equal(200);
       expect(idUtilisateurRecu).to.equal('123');
-      const { utilisateur } = response.data;
+      const { utilisateur } = reponse.body;
       expect(utilisateur.prenomNom).to.equal('Marie Jeanne');
     });
 
@@ -1501,19 +1415,17 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       const depotDonnees = testeur.depotDonnees();
       depotDonnees.utilisateur = async () => unUtilisateur().construis();
 
-      const response = await axios.get(
-        'http://localhost:1234/api/utilisateurCourant'
-      );
+      const reponse = await testeur.get('/api/utilisateurCourant');
 
-      const { sourceAuthentification } = response.data;
+      const { sourceAuthentification } = reponse.body;
       expect(sourceAuthentification).to.equal('MSS');
     });
 
-    it("répond avec un code 401 quand il n'y a pas d'identifiant", (done) => {
-      testeur.middleware().reinitialise({ idUtilisateur: '' });
+    it("répond avec un code 401 quand il n'y a pas d'identifiant", async () => {
+      await testeur.middleware().reinitialise({ idUtilisateur: '' });
 
       axios
-        .get('http://localhost:1234/api/utilisateurCourant')
+        .get('/api/utilisateurCourant')
         .then(() => {
           done(new Error('La requête aurait du être en erreur'));
         })
@@ -1533,27 +1445,28 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.procedures().ajoutContributeurSurServices = async () => {};
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idServices.*', 'emailContributeur'],
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/autorisation',
-          data: { droits: tousDroitsEnEcriture() },
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['idServices.*', 'emailContributeur'],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/autorisation',
+            data: { droits: tousDroitsEnEcriture() },
+          }
+        );
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'post',
-          url: 'http://localhost:1234/api/autorisation',
+          url: '/api/autorisation',
           data: { droits: tousDroitsEnEcriture() },
-        },
-        done
-      );
+        });
     });
 
     it("appelle la procédure d'ajout de contributeur avec les droits envoyés", async () => {
@@ -1581,7 +1494,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         CONTACTS: 2,
       };
 
-      await axios.post('http://localhost:1234/api/autorisation', {
+      await testeur.post('/api/autorisation', {
         emailContributeur: 'jean.dupont@mail.fr',
         idServices: ['123'],
         droits: droitsEnvoyes,
@@ -1607,7 +1520,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         cibles = services;
       };
 
-      await axios.post('http://localhost:1234/api/autorisation', {
+      await testeur.post('/api/autorisation', {
         emailContributeur: 'jean.dupont@mail.fr',
         idServices: ['123', '456'],
         droits: tousDroitsEnEcriture(),
@@ -1627,7 +1540,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         ajout = { emailContributeur };
       };
 
-      await axios.post('http://localhost:1234/api/autorisation', {
+      await testeur.post('/api/autorisation', {
         emailContributeur: 'JEAN.DUPONT@MAIL.FR',
         idServices: ['123'],
         droits: tousDroitsEnEcriture(),
@@ -1642,20 +1555,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         throw new EchecAutorisation();
       };
 
-      try {
-        await axios.post('http://localhost:1234/api/autorisation', {
-          emailContributeur: 'jean.dupont@mail.fr',
-          idServices: ['123'],
-          droits: tousDroitsEnEcriture(),
-        });
-
-        expect().to.fail('La requête aurait dû lever une erreur HTTP 403');
-      } catch (e) {
-        expect(e.response.status).to.equal(403);
-        expect(e.response.data).to.equal(
-          "Ajout non autorisé d'un contributeur"
-        );
-      }
+      const reponse = await testeur.post('/api/autorisation', {
+        emailContributeur: 'jean.dupont@mail.fr',
+        idServices: ['123'],
+        droits: tousDroitsEnEcriture(),
+      });
+      expect(reponse.status).to.equal(403);
+      expect(reponse.text).to.equal("Ajout non autorisé d'un contributeur");
     });
 
     it('retourne une erreur HTTP 422 si la procédure a levé une `ErreurModele`', async () => {
@@ -1665,7 +1571,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
       await testeur.verifieRequeteGenereErreurHTTP(422, 'oups', {
         method: 'post',
-        url: 'http://localhost:1234/api/autorisation',
+        url: '/api/autorisation',
         data: { droits: tousDroitsEnEcriture() },
       });
     });
@@ -1676,23 +1582,20 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         { erreur: { code: 'DROITS_INCOHERENTS' } },
         {
           method: 'post',
-          url: 'http://localhost:1234/api/autorisation',
+          url: '/api/autorisation',
           data: { droits: { RUBRIQUE_INCONNUE: 2 } },
         }
       );
     });
 
     it('ne retourne pas une erreur HTTP 422 si les droits contiennent estProprietaire=false', async () => {
-      const reponse = await axios.post(
-        'http://localhost:1234/api/autorisation',
-        {
-          emailContributeur: 'jean.dupont@mail.fr',
-          idServices: ['123'],
-          droits: {
-            estProprietaire: false,
-          },
-        }
-      );
+      const reponse = await testeur.post('/api/autorisation', {
+        emailContributeur: 'jean.dupont@mail.fr',
+        idServices: ['123'],
+        droits: {
+          estProprietaire: false,
+        },
+      });
 
       expect(reponse.status).to.be(200);
     });
@@ -1706,24 +1609,23 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.depotDonnees().supprimeContributeur = async () => {};
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
         .middleware()
         .verifieAseptisationParametres(
           ['idService', 'idContributeur'],
-          { method: 'delete', url: 'http://localhost:1234/api/autorisation' },
-          done
+          testeur.app(),
+          { method: 'delete', url: '/api/autorisation' }
         );
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'delete',
-          url: 'http://localhost:1234/api/autorisation',
-        },
-        done
-      );
+          url: '/api/autorisation',
+        });
     });
 
     it("vérifie que l'utilisateur a le droit de supprimer un contributeur", async () => {
@@ -1736,9 +1638,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return uneAutorisation().deProprietaire().construis();
       };
 
-      await axios.delete('http://localhost:1234/api/autorisation', {
-        params: { idService: '123' },
-      });
+      await testeur.delete('/api/autorisation?idService=123');
 
       expect(autorisationCherchee.idUtilisateur).to.be('456');
       expect(autorisationCherchee.idService).to.be('123');
@@ -1748,17 +1648,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       const contributeurSimple = uneAutorisation().deContributeur().construis();
       testeur.depotDonnees().autorisationPour = async () => contributeurSimple;
 
-      try {
-        await axios.delete('http://localhost:1234/api/autorisation', {
-          params: { idService: '123' },
-        });
-        expect().fail('La requête aurait dû lever une erreur HTTP 403');
-      } catch (e) {
-        expect(e.response.status).to.equal(403);
-        expect(e.response.data).to.equal(
-          'Suppression non autorisé pour un contributeur'
-        );
-      }
+      const reponse = await testeur.delete('/api/autorisation?idService=123');
+      expect(reponse.status).to.equal(403);
+      expect(reponse.text).to.equal(
+        'Suppression non autorisé pour un contributeur'
+      );
     });
 
     it("utilise le dépôt de données pour supprimer l'autorisation du contributeur", async () => {
@@ -1776,12 +1670,9 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return {};
       };
 
-      await axios.delete('http://localhost:1234/api/autorisation', {
-        params: {
-          idService: 'ABC',
-          idContributeur: '999',
-        },
-      });
+      await testeur.delete(
+        '/api/autorisation?idService=ABC&idContributeur=999'
+      );
 
       expect(suppressionDemandee.idContributeur).to.be('999');
       expect(suppressionDemandee.idService).to.be('ABC');
@@ -1798,12 +1689,9 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           };
         };
 
-      await axios.delete('http://localhost:1234/api/autorisation', {
-        params: {
-          idService: 'ABC',
-          idContributeur: '999',
-        },
-      });
+      await testeur.delete(
+        '/api/autorisation?idService=ABC&idContributeur=999'
+      );
 
       expect(suppressionDemandee.idContributeur).to.be('999');
       expect(suppressionDemandee.idService).to.be('ABC');
@@ -1814,40 +1702,31 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         throw new Error("Un message d'erreur");
       };
 
-      try {
-        await axios.delete('http://localhost:1234/api/autorisation', {
-          params: {
-            idService: '123',
-            emailContributeur: 'jean.dupont@mail.fr',
-          },
-        });
-        expect().fail('La requête aurait dû lever une erreur HTTP 424');
-      } catch (e) {
-        expect(e.response.status).to.equal(424);
-        expect(e.response.data).to.equal("Un message d'erreur");
-      }
+      const reponse = await testeur.delete(
+        '/api/autorisation?idService=123&emailContributeur=jean.dupont@mail.fr'
+      );
+      expect(reponse.status).to.equal(424);
+      expect(reponse.text).to.equal("Un message d'erreur");
     });
   });
 
   describe('quand requête GET sur `/api/annuaire/contributeurs`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
         .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/annuaire/contributeurs',
-          done
+          testeur.app(),
+          '/api/annuaire/contributeurs'
         );
     });
 
-    it('aseptise la chaine de recherche', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['recherche'],
-        {
+    it('aseptise la chaine de recherche', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['recherche'], testeur.app(), {
           method: 'get',
-          url: 'http://localhost:1234/api/annuaire/contributeurs',
-        },
-        done
-      );
+          url: '/api/annuaire/contributeurs',
+        });
     });
 
     it('retourne une erreur HTTP 400 si le terme de recherche est vide', async () => {
@@ -1856,7 +1735,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         'Le terme de recherche ne peut pas être vide',
         {
           method: 'get',
-          url: 'http://localhost:1234/api/annuaire/contributeurs',
+          url: '/api/annuaire/contributeurs',
         }
       );
     });
@@ -1879,13 +1758,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         ];
       };
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/annuaire/contributeurs?recherche=jean'
+      const reponse = await testeur.get(
+        '/api/annuaire/contributeurs?recherche=jean'
       );
 
       expect(appelDepot).to.eql({ idUtilisateur: '123', recherche: 'jean' });
       expect(reponse.status).to.be(200);
-      expect(reponse.data.suggestions).to.eql([
+      expect(reponse.body.suggestions).to.eql([
         {
           prenomNom: 'Jean Dujardin',
           email: 'jean.dujardin@beta.gouv.fr',
@@ -1901,45 +1780,44 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.depotDonnees().estSuperviseur = async () => true;
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
-        .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/supervision',
-          done
-        );
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), '/api/supervision');
     });
 
     it("retourne une erreur HTTP 401 si l'utilisateur n'est pas superviseur", async () => {
       testeur.depotDonnees().estSuperviseur = async () => false;
       await testeur.verifieRequeteGenereErreurHTTP(401, 'Unauthorized', {
         method: 'get',
-        url: 'http://localhost:1234/api/supervision',
+        url: '/api/supervision',
       });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['filtreDate', 'filtreBesoinsSecurite', 'filtreEntite'],
-        {
-          method: 'get',
-          url: 'http://localhost:1234/api/supervision',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['filtreDate', 'filtreBesoinsSecurite', 'filtreEntite'],
+          testeur.app(),
+          {
+            method: 'get',
+            url: '/api/supervision',
+          }
+        );
     });
 
     it("retourne une erreur HTTP 400 si le filtre de date n'existe pas dans le référentiel", async () => {
       await testeur.verifieRequeteGenereErreurHTTP(400, 'Bad Request', {
         method: 'get',
-        url: 'http://localhost:1234/api/supervision?filtreDate=nexistePas',
+        url: '/api/supervision?filtreDate=nexistePas',
       });
     });
 
     it('retourne une erreur HTTP 400 si le filtre de besoinsDeSecurite a une valeur inconnue', async () => {
       await testeur.verifieRequeteGenereErreurHTTP(400, 'Bad Request', {
         method: 'get',
-        url: 'http://localhost:1234/api/supervision?filtreBesoinsSecurite=nexistePas',
+        url: '/api/supervision?filtreBesoinsSecurite=nexistePas',
       });
     });
 
@@ -1951,10 +1829,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return 'https://uneURLSupervision.fr';
       };
 
-      const reponse = await axios.get('http://localhost:1234/api/supervision');
+      const reponse = await testeur.get('/api/supervision');
 
       expect(idRecu).to.be('U1');
-      expect(reponse.data.urlSupervision).to.be('https://uneURLSupervision.fr');
+      expect(reponse.body.urlSupervision).to.be('https://uneURLSupervision.fr');
     });
 
     it('transmet les filtres de date, entité et besoins de sécurité au service de supervision', async () => {
@@ -1970,8 +1848,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return 'https://uneURLSupervision.fr';
       };
 
-      await axios.get(
-        'http://localhost:1234/api/supervision?filtreDate=unFiltreDate&filtreBesoinsSecurite=niveau1&filtreEntite=unSiret'
+      await testeur.get(
+        '/api/supervision?filtreDate=unFiltreDate&filtreBesoinsSecurite=niveau1&filtreEntite=unSiret'
       );
 
       expect(filtrageRecu.filtreDate).to.be('unFiltreDate');
@@ -1981,12 +1859,12 @@ describe('Le serveur MSS des routes privées /api/*', () => {
   });
 
   describe('quand requête GET sur `/api/referentiel/mesures`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
         .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/referentiel/mesures',
-          done
+          testeur.app(),
+          '/api/referentiel/mesures'
         );
     });
 
@@ -1998,12 +1876,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         },
       });
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/referentiel/mesures'
-      );
+      const reponse = await testeur.get('/api/referentiel/mesures');
 
       expect(reponse.status).to.be(200);
-      expect(reponse.data).to.eql({
+      expect(reponse.body).to.eql({
         mesureA: 'une mesure A',
         mesureB: 'une mesure B',
       });
@@ -2011,12 +1887,12 @@ describe('Le serveur MSS des routes privées /api/*', () => {
   });
 
   describe('quand requête GET sur `/api/modeles/mesureSpecifique`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
         .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/modeles/mesureSpecifique',
-          done
+          testeur.app(),
+          '/api/modeles/mesureSpecifique'
         );
     });
 
@@ -2030,12 +1906,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         return [];
       };
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/modeles/mesureSpecifique'
-      );
+      const reponse = await testeur.get('/api/modeles/mesureSpecifique');
 
       expect(reponse.status).to.be(200);
-      expect(reponse.data).to.eql([]);
+      expect(reponse.body).to.eql([]);
       expect(idRecu).to.be('U1');
     });
 
@@ -2052,12 +1926,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           },
         ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/modeles/mesureSpecifique'
-      );
+      const reponse = await testeur.get('/api/modeles/mesureSpecifique');
 
-      expect(reponse.data[0].description).to.be("L'abricot <>");
-      expect(reponse.data[0].descriptionLongue).to.be("L'artiste");
+      expect(reponse.body[0].description).to.be("L'abricot <>");
+      expect(reponse.body[0].descriptionLongue).to.be("L'artiste");
     });
   });
 
@@ -2071,55 +1943,47 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'post',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique',
-        },
-        done
-      );
+          url: '/api/modeles/mesureSpecifique',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['description', 'descriptionLongue', 'categorie'],
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['description', 'descriptionLongue', 'categorie'],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/modeles/mesureSpecifique',
+          }
+        );
     });
 
     it('jette une erreur si la catégorie est invalide', async () => {
-      try {
-        await axios.post('http://localhost:1234/api/modeles/mesureSpecifique', {
-          description: 'une description',
-          descriptionLongue: 'une description longue',
-          categorie: 'une categorie invalide',
-        });
+      const reponse = await testeur.post('/api/modeles/mesureSpecifique', {
+        description: 'une description',
+        descriptionLongue: 'une description longue',
+        categorie: 'une categorie invalide',
+      });
 
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La catégorie est invalide');
-      }
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La catégorie est invalide');
     });
 
     it("jette une erreur si la description n'est pas renseignée", async () => {
-      try {
-        await axios.post('http://localhost:1234/api/modeles/mesureSpecifique', {
-          description: '',
-          descriptionLongue: 'une description longue',
-          categorie: 'gouvernance',
-        });
-
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La description est obligatoire');
-      }
+      const reponse = await testeur.post('/api/modeles/mesureSpecifique', {
+        description: '',
+        descriptionLongue: 'une description longue',
+        categorie: 'gouvernance',
+      });
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La description est obligatoire');
     });
 
     it("délègue au dépôt de données l'ajout du modèle de mesure spécifique", async () => {
@@ -2131,7 +1995,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesRecues = { idUtilisateur, donnees };
       };
 
-      await axios.post('http://localhost:1234/api/modeles/mesureSpecifique', {
+      await testeur.post('/api/modeles/mesureSpecifique', {
         description: 'une description',
         descriptionLongue: 'une description longue',
         categorie: 'gouvernance',
@@ -2150,31 +2014,24 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         throw new ErreurNombreLimiteModelesMesureSpecifiqueAtteint();
       };
 
-      try {
-        await axios.post('http://localhost:1234/api/modeles/mesureSpecifique', {
-          description: 'une description',
-          categorie: 'gouvernance',
-        });
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-        expect(e.response.data).to.be('Limite de création atteinte');
-      }
+      const reponse = await testeur.post('/api/modeles/mesureSpecifique', {
+        description: 'une description',
+        categorie: 'gouvernance',
+      });
+      expect(reponse.status).to.be(403);
+      expect(reponse.text).to.be('Limite de création atteinte');
     });
 
     it("retourne 201 et l'identifiant du modèle créé", async () => {
       testeur.depotDonnees().ajouteModeleMesureSpecifique = async () => 'MOD-1';
 
-      const reponse = await axios.post(
-        'http://localhost:1234/api/modeles/mesureSpecifique',
-        {
-          description: 'une description',
-          categorie: 'gouvernance',
-        }
-      );
+      const reponse = await testeur.post('/api/modeles/mesureSpecifique', {
+        description: 'une description',
+        categorie: 'gouvernance',
+      });
 
       expect(reponse.status).to.be(201);
-      expect(reponse.data).to.eql({
+      expect(reponse.body).to.eql({
         id: 'MOD-1',
       });
     });
@@ -2190,45 +2047,42 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'put',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/unIdDeModele',
-        },
-        done
-      );
+          url: '/api/modeles/mesureSpecifique/unIdDeModele',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['description', 'descriptionLongue', 'categorie'],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/unIdDeModele',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['description', 'descriptionLongue', 'categorie'],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/modeles/mesureSpecifique/unIdDeModele',
+          }
+        );
     });
 
     it("jette une erreur si le modele de mesure spécifique n'existe pas", async () => {
       testeur.depotDonnees().lisModelesMesureSpecifiquePourUtilisateur =
         async () => [];
 
-      try {
-        await axios.put(
-          'http://localhost:1234/api/modeles/mesureSpecifique/unIdInexistant',
-          {
-            description: 'une description',
-            descriptionLongue: 'une description longue',
-            categorie: 'gouvernance',
-          }
-        );
+      const reponse = await testeur.put(
+        '/api/modeles/mesureSpecifique/unIdInexistant',
+        {
+          description: 'une description',
+          descriptionLongue: 'une description longue',
+          categorie: 'gouvernance',
+        }
+      );
 
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      expect(reponse.status).to.be(404);
     });
 
     describe('quand le modèle de mesure spécifique existe', () => {
@@ -2245,39 +2099,31 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
 
       it('jette une erreur si la catégorie est invalide', async () => {
-        try {
-          await axios.put(
-            'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1',
-            {
-              description: 'une description',
-              descriptionLongue: 'une description longue',
-              categorie: 'une categorie invalide',
-            }
-          );
+        const reponse = await testeur.put(
+          '/api/modeles/mesureSpecifique/MOD-1',
+          {
+            description: 'une description',
+            descriptionLongue: 'une description longue',
+            categorie: 'une categorie invalide',
+          }
+        );
 
-          expect().fail('Aurait dû lever une erreur');
-        } catch (e) {
-          expect(e.response.status).to.be(400);
-          expect(e.response.data).to.be('La catégorie est invalide');
-        }
+        expect(reponse.status).to.be(400);
+        expect(reponse.text).to.be('La catégorie est invalide');
       });
 
       it("jette une erreur si la description n'est pas renseignée", async () => {
-        try {
-          await axios.put(
-            'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1',
-            {
-              description: '',
-              descriptionLongue: 'une description longue',
-              categorie: 'gouvernance',
-            }
-          );
+        const reponse = await testeur.put(
+          '/api/modeles/mesureSpecifique/MOD-1',
+          {
+            description: '',
+            descriptionLongue: 'une description longue',
+            categorie: 'gouvernance',
+          }
+        );
 
-          expect().fail('Aurait dû lever une erreur');
-        } catch (e) {
-          expect(e.response.status).to.be(400);
-          expect(e.response.data).to.be('La description est obligatoire');
-        }
+        expect(reponse.status).to.be(400);
+        expect(reponse.text).to.be('La description est obligatoire');
       });
 
       it('délègue au dépôt de données la mise à jour du modèle de mesure spécifique', async () => {
@@ -2290,8 +2136,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           donneesRecues = { idUtilisateur, idModele, donnees };
         };
 
-        const reponse = await axios.put(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1',
+        const reponse = await testeur.put(
+          '/api/modeles/mesureSpecifique/MOD-1',
           {
             description: 'une description',
             descriptionLongue: 'une description longue',
@@ -2327,37 +2173,34 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         ];
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'put',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services',
-        },
-        done
-      );
+          url: '/api/modeles/mesureSpecifique/MOD-1/services',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idsServicesAAssocier.*'],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['idsServicesAAssocier.*'],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/modeles/mesureSpecifique/MOD-1/services',
+          }
+        );
     });
 
     it("jette une erreur si le modele de mesure spécifique n'existe pas", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/modeles/mesureSpecifique/unIdInexistant/services'
-        );
+      const reponse = await testeur.put(
+        '/api/modeles/mesureSpecifique/unIdInexistant/services'
+      );
 
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      expect(reponse.status).to.be(404);
     });
 
     it("délègue au dépôt de données l'association des services au modèle de mesure spécifique", async () => {
@@ -2370,8 +2213,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesRecues = { idModele, idsServices, idUtilisateurAssociant };
       };
 
-      const reponse = await axios.put(
-        'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services',
+      const reponse = await testeur.put(
+        '/api/modeles/mesureSpecifique/MOD-1/services',
         {
           idsServicesAAssocier: ['S1', 'S2'],
         }
@@ -2388,15 +2231,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         async () => {
           throw new ErreurModeleDeMesureSpecifiqueDejaAssociee();
         };
-      try {
-        await axios.put(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services'
-        );
-
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.put(
+        '/api/modeles/mesureSpecifique/MOD-1/services'
+      );
+      expect(reponse.status).to.be(400);
     });
 
     it('jette une erreur si les droits de modification de services sont insuffisants', async () => {
@@ -2404,15 +2242,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         async () => {
           throw new ErreurDroitsInsuffisantsPourModelesDeMesureSpecifique();
         };
-      try {
-        await axios.put(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services'
-        );
-
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+      const reponse = await testeur.put(
+        '/api/modeles/mesureSpecifique/MOD-1/services'
+      );
+      expect(reponse.status).to.be(403);
     });
 
     it("jette une erreur si l'utilisateur ne possède pas le modèle", async () => {
@@ -2420,15 +2253,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         async () => {
           throw new ErreurAutorisationInexistante();
         };
-      try {
-        await axios.put(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services'
-        );
-
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      const reponse = await testeur.put(
+        '/api/modeles/mesureSpecifique/MOD-1/services'
+      );
+      expect(reponse.status).to.be(404);
     });
 
     it("jette une erreur si l'un des services n'existe pas", async () => {
@@ -2436,15 +2264,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         async () => {
           throw new ErreurServiceInexistant();
         };
-      try {
-        await axios.put(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services'
-        );
-
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.put(
+        '/api/modeles/mesureSpecifique/MOD-1/services'
+      );
+      expect(reponse.status).to.be(400);
     });
   });
 
@@ -2457,25 +2280,22 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         () => {};
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'delete',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1',
-        },
-        done
-      );
+          url: '/api/modeles/mesureSpecifique/MOD-1',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['detacheMesures'],
-        {
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['detacheMesures'], testeur.app(), {
           method: 'delete',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1',
-        },
-        done
-      );
+          url: '/api/modeles/mesureSpecifique/MOD-1',
+        });
     });
 
     describe('sans paramètre pour conserver les mesures associées', () => {
@@ -2486,9 +2306,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             donneesRecues = { idUtilisateur, idModele };
           };
 
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1'
-        );
+        await testeur.delete('/api/modeles/mesureSpecifique/MOD-1');
 
         expect(donneesRecues.idUtilisateur).to.be('U1');
         expect(donneesRecues.idModele).to.be('MOD-1');
@@ -2501,14 +2319,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
               'MOD-INEXISTANT'
             );
           };
-        try {
-          await axios.delete(
-            'http://localhost:1234/api/modeles/mesureSpecifique/MOD-INEXISTANT'
-          );
-          expect().fail("L'appel aurait dû lever une erreur");
-        } catch (e) {
-          expect(e.response.status).to.be(404);
-        }
+        const reponse = await testeur.delete(
+          '/api/modeles/mesureSpecifique/MOD-INEXISTANT'
+        );
+        expect(reponse.status).to.be(404);
       });
 
       it("jette une 403 si l'utilisateur ne possède pas le modèle", async () => {
@@ -2516,14 +2330,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           async () => {
             throw new ErreurAutorisationInexistante();
           };
-        try {
-          await axios.delete(
-            'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1'
-          );
-          expect().fail("L'appel aurait dû lever une erreur");
-        } catch (e) {
-          expect(e.response.status).to.be(403);
-        }
+        const reponse = await testeur.delete(
+          '/api/modeles/mesureSpecifique/MOD-1'
+        );
+        expect(reponse.status).to.be(403);
       });
 
       it("jette une 403 si l'utilisateur ne peut pas modifier tous les services associés", async () => {
@@ -2535,14 +2345,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
               {}
             );
           };
-        try {
-          await axios.delete(
-            'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1'
-          );
-          expect().fail("L'appel aurait dû lever une erreur");
-        } catch (e) {
-          expect(e.response.status).to.be(403);
-        }
+        const reponse = await testeur.delete(
+          '/api/modeles/mesureSpecifique/MOD-1'
+        );
+        expect(reponse.status).to.be(403);
       });
     });
     describe('avec paramètre pour détacher les mesures associées', () => {
@@ -2553,8 +2359,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             donneesRecues = { idUtilisateur, idModele };
           };
 
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1?detacheMesures=true'
+        await testeur.delete(
+          '/api/modeles/mesureSpecifique/MOD-1?detacheMesures=true'
         );
 
         expect(donneesRecues.idUtilisateur).to.be('U1');
@@ -2567,14 +2373,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         async () => {
           throw new ErreurModeleDeMesureSpecifiqueIntrouvable('MOD-INEXISTANT');
         };
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-INEXISTANT?detacheMesures=true'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      const reponse = await testeur.delete(
+        '/api/modeles/mesureSpecifique/MOD-INEXISTANT?detacheMesures=true'
+      );
+      expect(reponse.status).to.be(404);
     });
 
     it("jette une 403 si l'utilisateur ne possède pas le modèle", async () => {
@@ -2582,14 +2384,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         async () => {
           throw new ErreurAutorisationInexistante();
         };
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1?detacheMesures=true'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+      const reponse = await testeur.delete(
+        '/api/modeles/mesureSpecifique/MOD-1?detacheMesures=true'
+      );
+      expect(reponse.status).to.be(403);
     });
 
     it("jette une 403 si l'utilisateur ne peut pas modifier tous les services associés", async () => {
@@ -2601,14 +2399,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             {}
           );
         };
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1?detacheMesures=true'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+      const reponse = await testeur.delete(
+        '/api/modeles/mesureSpecifique/MOD-1?detacheMesures=true'
+      );
+      expect(reponse.status).to.be(403);
     });
   });
 
@@ -2619,25 +2413,22 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         async () => {};
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'delete',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services',
-        },
-        done
-      );
+          url: '/api/modeles/mesureSpecifique/MOD-1/services',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idsServices.*'],
-        {
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['idsServices.*'], testeur.app(), {
           method: 'delete',
-          url: 'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services',
-        },
-        done
-      );
+          url: '/api/modeles/mesureSpecifique/MOD-1/services',
+        });
     });
 
     it('délègue au dépôt de données la suppression des mesures associées au modèle', async () => {
@@ -2650,10 +2441,9 @@ describe('Le serveur MSS des routes privées /api/*', () => {
         donneesRecues = { idUtilisateur, idModele, idsServices };
       };
 
-      await axios.delete(
-        'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services',
-        { data: { idsServices: ['S1'] } }
-      );
+      await testeur.delete('/api/modeles/mesureSpecifique/MOD-1/services', {
+        idsServices: ['S1'],
+      });
 
       expect(donneesRecues.idUtilisateur).to.be('U1');
       expect(donneesRecues.idModele).to.be('MOD-1');
@@ -2664,28 +2454,20 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       testeur.depotDonnees().supprimeDesMesuresAssocieesAuModele = async () => {
         throw new ErreurModeleDeMesureSpecifiqueIntrouvable('MOD-INEXISTANT');
       };
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-INEXISTANT/services'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      const reponse = await testeur.delete(
+        '/api/modeles/mesureSpecifique/MOD-INEXISTANT/services'
+      );
+      expect(reponse.status).to.be(404);
     });
 
     it("jette une 403 si l'utilisateur ne possède pas le modèle", async () => {
       testeur.depotDonnees().supprimeDesMesuresAssocieesAuModele = async () => {
         throw new ErreurAutorisationInexistante();
       };
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+      const reponse = await testeur.delete(
+        '/api/modeles/mesureSpecifique/MOD-1/services'
+      );
+      expect(reponse.status).to.be(403);
     });
 
     it("jette une 403 si l'utilisateur ne peut pas modifier tous les services passés en paramètres", async () => {
@@ -2696,28 +2478,20 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           {}
         );
       };
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+      const reponse = await testeur.delete(
+        '/api/modeles/mesureSpecifique/MOD-1/services'
+      );
+      expect(reponse.status).to.be(403);
     });
 
     it("jette une 400 si l'un des services passés en paramètres n'existe pas", async () => {
       testeur.depotDonnees().supprimeDesMesuresAssocieesAuModele = async () => {
         throw new ErreurServiceInexistant();
       };
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/modeles/mesureSpecifique/MOD-1/services'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.delete(
+        '/api/modeles/mesureSpecifique/MOD-1/services'
+      );
+      expect(reponse.status).to.be(400);
     });
   });
 });

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -1234,14 +1234,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeJWT(
-        {
-          method: 'PUT',
-          url: 'http://localhost:1234/api/utilisateur/acceptationCGU',
-        },
-        done
-      );
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur.middleware().verifieRequeteExigeJWT(testeur.app(), {
+        method: 'PUT',
+        url: '/api/utilisateur/acceptationCGU',
+      });
     });
 
     it("demande au dépôt d'enregistrer que les CGU sont acceptées", async () => {

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -47,13 +47,13 @@ describe('Le serveur MSS des routes privées /api/*', () => {
 
   beforeEach(testeur.initialise);
 
-  it("vérifie que l'utilisateur est authentifié sur toutes les routes", (done) => {
+  it("vérifie que l'utilisateur est authentifié sur toutes les routes", async () => {
     // On vérifie une seule route privée.
     // Par construction, les autres seront protégées aussi puisque la protection est ajoutée comme middleware
     // devant le routeur dédié aux routes privées.
-    testeur
+    await testeur
       .middleware()
-      .verifieRequeteExigeJWT('http://localhost:1234/api/services', done);
+      .verifieRequeteExigeJWT(testeur.app(), '/api/services');
   });
 
   describe('quand requête GET sur `/api/services`', () => {

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -66,13 +66,10 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       });
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
-        .verifieRequeteExigeAcceptationCGU(
-          'http://localhost:1234/api/services',
-          done
-        );
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), '/api/services');
     });
 
     it("interroge le dépôt de données pour récupérer les services de l'utilisateur", async () => {

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -1,4 +1,3 @@
-const axios = require('axios');
 const expect = require('expect.js');
 
 const {
@@ -1087,14 +1086,11 @@ describe('Le serveur MSS des routes privées /api/*', () => {
             motDePasseMisAJour = true;
           };
 
-          try {
-            await testeur.put('/api/motDePasse', {
-              motDePasse: 'mdp_12345',
-            });
-          } catch (e) {
-            expect(reponse.status).to.be(422);
-            expect(motDePasseMisAJour).to.be(false);
-          }
+          const reponse = await testeur.put('/api/motDePasse', {
+            motDePasse: 'mdp_12345',
+          });
+          expect(reponse.status).to.be(422);
+          expect(motDePasseMisAJour).to.be(false);
         });
       });
 
@@ -1424,15 +1420,8 @@ describe('Le serveur MSS des routes privées /api/*', () => {
     it("répond avec un code 401 quand il n'y a pas d'identifiant", async () => {
       await testeur.middleware().reinitialise({ idUtilisateur: '' });
 
-      axios
-        .get('/api/utilisateurCourant')
-        .then(() => {
-          done(new Error('La requête aurait du être en erreur'));
-        })
-        .catch((erreur) => {
-          expect(erreur.response.status).to.equal(401);
-          done();
-        });
+      const reponse = await testeur.get('/api/utilisateurCourant');
+      expect(reponse.status).to.equal(401);
     });
   });
 

--- a/test/routes/connecte/routesConnecteApiNotifications.spec.js
+++ b/test/routes/connecte/routesConnecteApiNotifications.spec.js
@@ -1,4 +1,3 @@
-const axios = require('axios');
 const expect = require('expect.js');
 const testeurMSS = require('../testeurMSS');
 const { ErreurIdentifiantTacheInconnu } = require('../../../src/erreurs');

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -1,4 +1,3 @@
-const axios = require('axios');
 const expect = require('expect.js');
 
 const testeurMSS = require('../testeurMSS');
@@ -63,7 +62,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('aseptise les paramètres', async () => {
-      await await testeur
+      await testeur
         .middleware()
         .verifieAseptisationParametres(
           [
@@ -179,12 +178,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: DECRIRE }], {
-          method: 'put',
-          url: '/api/service/456',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: DECRIRE }],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456',
+          }
+        );
     });
 
     it('aseptise les paramètres', async () => {
@@ -281,12 +284,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête GET sur `/api/service/:id/mesures', () => {
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: LECTURE, rubrique: SECURISER }], {
-          method: 'get',
-          url: '/api/service/456/mesures',
-        });
+        .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'get',
+            url: '/api/service/456/mesures',
+          }
+        );
     });
 
     it('retourne la représentation enrichie des mesures', async () => {
@@ -346,21 +353,27 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("vérifie que l'utilisateur est authentifié", async () => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
-        method: 'post',
-        url: '/api/service/456/mesuresSpecifiques',
-        data: [],
-      });
-    });
-
-    it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'post',
           url: '/api/service/456/mesuresSpecifiques',
           data: [],
         });
+    });
+
+    it('recherche le service correspondant', async () => {
+      await testeur
+        .middleware()
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/456/mesuresSpecifiques',
+            data: [],
+          }
+        );
     });
 
     it('aseptise tous les paramètres de la requête', async () => {
@@ -522,21 +535,27 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("vérifie que l'utilisateur est authentifié", async () => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
-        method: 'delete',
-        url: '/api/service/456/mesuresSpecifiques/789',
-        data: [],
-      });
-    });
-
-    it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'delete',
           url: '/api/service/456/mesuresSpecifiques/789',
           data: [],
         });
+    });
+
+    it('recherche le service correspondant', async () => {
+      await testeur
+        .middleware()
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'delete',
+            url: '/api/service/456/mesuresSpecifiques/789',
+            data: [],
+          }
+        );
     });
 
     it('délègue au dépôt de données la suppression de la mesure spécifique', async () => {
@@ -599,21 +618,27 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("vérifie que l'utilisateur est authentifié", async () => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
-        method: 'put',
-        url: '/api/service/456/mesuresSpecifiques/789',
-        data: [],
-      });
-    });
-
-    it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'put',
           url: '/api/service/456/mesuresSpecifiques/789',
           data: [],
         });
+    });
+
+    it('recherche le service correspondant', async () => {
+      await testeur
+        .middleware()
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/mesuresSpecifiques/789',
+            data: [],
+          }
+        );
     });
 
     it('aseptise tous les paramètres de la requête', async () => {
@@ -734,19 +759,25 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("vérifie que l'utilisateur a accepté les CGU", async () => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
-        method: 'put',
-        url: '/api/service/456/mesures/audit',
-      });
-    });
-
-    it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'put',
           url: '/api/service/456/mesures/audit',
         });
+    });
+
+    it('recherche le service correspondant', async () => {
+      await testeur
+        .middleware()
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/mesures/audit',
+          }
+        );
     });
 
     it('aseptise les paramètres de la requête', async () => {
@@ -880,19 +911,25 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("vérifie que l'utilisateur a accepté les CGU", async () => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
-        method: 'put',
-        url: '/api/service/S1/modeles/mesureSpecifique',
-      });
-    });
-
-    it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
           method: 'put',
           url: '/api/service/S1/modeles/mesureSpecifique',
         });
+    });
+
+    it('recherche le service correspondant', async () => {
+      await testeur
+        .middleware()
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/S1/modeles/mesureSpecifique',
+          }
+        );
     });
 
     it('aseptise les paramètres de la requête', async () => {
@@ -972,12 +1009,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: CONTACTS }], {
-          method: 'post',
-          url: '/api/service/456/rolesResponsabilites',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: CONTACTS }],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/456/rolesResponsabilites',
+          }
+        );
     });
 
     it("demande au dépôt d'associer les rôles et responsabilités au service", async () => {
@@ -1038,12 +1079,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
-          method: 'post',
-          url: '/api/service/456/risquesSpecifiques',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: RISQUES }],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/456/risquesSpecifiques',
+          }
+        );
     });
 
     it('aseptise les paramètres de la requête', async () => {
@@ -1215,12 +1260,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
-          method: 'put',
-          url: '/api/service/456/risquesSpecifiques/RS1',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: RISQUES }],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/risquesSpecifiques/RS1',
+          }
+        );
     });
 
     it('aseptise les paramètres de la requête', async () => {
@@ -1403,12 +1452,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
-          method: 'delete',
-          url: '/api/service/456/risquesSpecifiques/RS1',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: RISQUES }],
+          testeur.app(),
+          {
+            method: 'delete',
+            url: '/api/service/456/risquesSpecifiques/RS1',
+          }
+        );
     });
 
     it('délègue au dépôt de donnée la suppression du risque', async () => {
@@ -1440,12 +1493,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
-          method: 'put',
-          url: '/api/service/456/risques/unRisqueExistant',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: RISQUES }],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/risques/unRisqueExistant',
+          }
+        );
     });
 
     it('aseptise les paramètres de la requête', async () => {
@@ -1553,16 +1610,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
-          url: '/api/service/456/homologation/autorite',
-          method: 'put',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/autorite',
+            method: 'put',
+          }
+        );
     });
 
     it('recherche le dossier courant correspondant', async () => {
-      testeur.middleware().verifieRechercheDossierCourant({
+      await testeur.middleware().verifieRechercheDossierCourant(testeur.app(), {
         url: '/api/service/456/homologation/autorite',
         method: 'put',
       });
@@ -1614,16 +1675,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
-          url: '/api/service/456/homologation/decision',
-          method: 'put',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/decision',
+            method: 'put',
+          }
+        );
     });
 
     it('recherche le dossier courant correspondant', async () => {
-      testeur.middleware().verifieRechercheDossierCourant({
+      await testeur.middleware().verifieRechercheDossierCourant(testeur.app(), {
         url: '/api/service/456/homologation/decision',
         method: 'put',
       });
@@ -1643,33 +1708,27 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("renvoie une erreur 422 si la date d'homologation est invalide", async () => {
-      axios
-        .put('/api/service/456/homologation/decision', {
+      const reponse = await testeur.put(
+        '/api/service/456/homologation/decision',
+        {
           dateHomologation: 'dateInvalide',
           dureeValidite: 'unAn',
-        })
-        .then(() => done('Une erreur aurait dû être levée'))
-        .catch((e) => {
-          expect(reponse.status).to.be(422);
-          expect(reponse.data).to.be("Date d'homologation invalide");
-          done();
-        })
-        .catch((e) => done(reponse?.data || e));
+        }
+      );
+      expect(reponse.status).to.be(422);
+      expect(reponse.text).to.be("Date d'homologation invalide");
     });
 
     it('renvoie une erreur 422 si la durée de validité est inconnue du référentiel', async () => {
-      axios
-        .put('/api/service/456/homologation/decision', {
+      const reponse = await testeur.put(
+        '/api/service/456/homologation/decision',
+        {
           dateHomologation: new Date(),
           dureeValidite: 'dureeInconnue',
-        })
-        .then(() => done('Une erreur aurait dû être levée'))
-        .catch((e) => {
-          expect(reponse.status).to.be(422);
-          expect(reponse.data).to.be('Durée de validité invalide');
-          done();
-        })
-        .catch((e) => done(reponse?.data || e));
+        }
+      );
+      expect(reponse.status).to.be(422);
+      expect(reponse.text).to.be('Durée de validité invalide');
     });
 
     it("utilise le dépôt pour enregistrer la décision d'homologation", async () => {
@@ -1683,14 +1742,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return Promise.resolve();
       };
 
-      axios
-        .put('/api/service/456/homologation/decision', {
-          dateHomologation: '2023-01-01',
-          dureeValidite: 'unAn',
-        })
-        .then(() => expect(depotAppele).to.be(true))
-        .then(() => done())
-        .catch((e) => done(reponse?.data || e));
+      await testeur.put('/api/service/456/homologation/decision', {
+        dateHomologation: '2023-01-01',
+        dureeValidite: 'unAn',
+      });
+      expect(depotAppele).to.be(true);
     });
   });
 
@@ -1711,16 +1767,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
-          url: '/api/service/456/homologation/telechargement',
-          method: 'put',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/telechargement',
+            method: 'put',
+          }
+        );
     });
 
     it('recherche le dossier courant correspondant', async () => {
-      testeur.middleware().verifieRechercheDossierCourant({
+      await testeur.middleware().verifieRechercheDossierCourant(testeur.app(), {
         url: '/api/service/456/homologation/telechargement',
         method: 'put',
       });
@@ -1739,11 +1799,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return Promise.resolve();
       };
 
-      axios
-        .put('/api/service/456/homologation/telechargement')
-        .then(() => expect(depotAppele).to.be(true))
-        .then(() => done())
-        .catch((e) => done(reponse?.data || e));
+      await testeur.put('/api/service/456/homologation/telechargement');
+      expect(depotAppele).to.be(true);
     });
   });
 
@@ -1768,16 +1825,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
-          url: '/api/service/456/homologation/avis',
-          method: 'put',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/avis',
+            method: 'put',
+          }
+        );
     });
 
     it('recherche le dossier courant correspondant', async () => {
-      testeur.middleware().verifieRechercheDossierCourant({
+      await testeur.middleware().verifieRechercheDossierCourant(testeur.app(), {
         url: '/api/service/456/homologation/avis',
         method: 'put',
       });
@@ -1837,21 +1898,18 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios
-          .put('/api/service/456/homologation/avis', {
-            avis: [
-              {
-                collaborateurs: ['Jean Dupond'],
-                statut: 'favorable',
-                dureeValidite: 'unAn',
-                commentaires: 'Ok',
-              },
-            ],
-            avecAvis: 'true',
-          })
-          .then(() => expect(depotAppele).to.be(true))
-          .then(() => done())
-          .catch((e) => done(reponse?.data || e));
+        await testeur.put('/api/service/456/homologation/avis', {
+          avis: [
+            {
+              collaborateurs: ['Jean Dupond'],
+              statut: 'favorable',
+              dureeValidite: 'unAn',
+              commentaires: 'Ok',
+            },
+          ],
+          avecAvis: 'true',
+        });
+        expect(depotAppele).to.be(true);
       });
 
       it("quand il n'y a pas d'avis", async () => {
@@ -1867,14 +1925,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios
-          .put('/api/service/456/homologation/avis', {
-            avis: [],
-            avecAvis: 'false',
-          })
-          .then(() => expect(depotAppele).to.be(true))
-          .then(() => done())
-          .catch((e) => done(reponse?.data || e));
+        await testeur.put('/api/service/456/homologation/avis', {
+          avis: [],
+          avecAvis: 'false',
+        });
+        expect(depotAppele).to.be(true);
       });
     });
   });
@@ -1896,16 +1951,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
-          url: '/api/service/456/homologation/documents',
-          method: 'put',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/documents',
+            method: 'put',
+          }
+        );
     });
 
     it('recherche le dossier courant correspondant', async () => {
-      testeur.middleware().verifieRechercheDossierCourant({
+      await testeur.middleware().verifieRechercheDossierCourant(testeur.app(), {
         url: '/api/service/456/homologation/documents',
         method: 'put',
       });
@@ -1947,14 +2006,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios
-          .put('/api/service/456/homologation/documents', {
-            documents: ['unDocument'],
-            avecDocuments: 'true',
-          })
-          .then(() => expect(depotAppele).to.be(true))
-          .then(() => done())
-          .catch((e) => done(reponse?.data || e));
+        await testeur.put('/api/service/456/homologation/documents', {
+          documents: ['unDocument'],
+          avecDocuments: 'true',
+        });
+        expect(depotAppele).to.be(true);
       });
 
       it("quand il n'y a pas de document", async () => {
@@ -1970,14 +2026,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           return Promise.resolve();
         };
 
-        axios
-          .put('/api/service/456/homologation/documents', {
-            documents: [],
-            avecDocuments: 'false',
-          })
-          .then(() => expect(depotAppele).to.be(true))
-          .then(() => done())
-          .catch((e) => done(reponse?.data || e));
+        await testeur.put('/api/service/456/homologation/documents', {
+          documents: [],
+          avecDocuments: 'false',
+        });
+        expect(depotAppele).to.be(true);
       });
     });
   });
@@ -2003,12 +2056,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
-          url: '/api/service/456/homologation/finalise',
-          method: 'post',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/finalise',
+            method: 'post',
+          }
+        );
     });
 
     it("utilise le dépôt pour finaliser l'homologation", async () => {
@@ -2032,17 +2089,19 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('utilise le middleware de recherche du service', async () => {
-      testeur.middleware().verifieRechercheService([], {
+      await testeur.middleware().verifieRechercheService([], testeur.app(), {
         method: 'delete',
         url: '/api/service/123',
       });
     });
 
     it("utilise le middleware de chargement de l'autorisation", async () => {
-      testeur.middleware().verifieChargementDesAutorisations({
-        method: 'delete',
-        url: '/api/service/456',
-      });
+      await testeur
+        .middleware()
+        .verifieChargementDesAutorisations(testeur.app(), {
+          method: 'delete',
+          url: '/api/service/456',
+        });
     });
 
     it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", async () => {
@@ -2084,17 +2143,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         }
       };
 
-      axios({
-        method: 'delete',
-        url: '/api/service/123',
-      })
-        .then((reponse) => {
-          expect(serviceSupprime).to.be(true);
-          expect(reponse.status).to.equal(200);
-          expect(reponse.body).to.equal('Service supprimé');
-          done();
-        })
-        .catch((e) => done(reponse?.data || e));
+      const reponse = await testeur.delete('/api/service/123');
+      expect(serviceSupprime).to.be(true);
+      expect(reponse.status).to.equal(200);
+      expect(reponse.text).to.equal('Service supprimé');
     });
   });
 
@@ -2107,24 +2159,26 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('applique une protection de trafic', async () => {
-      testeur.middleware().verifieProtectionTrafic(testeur.app(), {
+      await testeur.middleware().verifieProtectionTrafic(testeur.app(), {
         method: 'copy',
         url: '/api/service/123',
       });
     });
 
     it('utilise le middleware de chargement du service', async () => {
-      testeur.middleware().verifieRechercheService([], {
+      await testeur.middleware().verifieRechercheService([], testeur.app(), {
         method: 'copy',
         url: '/api/service/123',
       });
     });
 
     it("utilise le middleware de chargement de l'autorisation", async () => {
-      testeur.middleware().verifieChargementDesAutorisations({
-        method: 'copy',
-        url: '/api/service/123',
-      });
+      await testeur
+        .middleware()
+        .verifieChargementDesAutorisations(testeur.app(), {
+          method: 'copy',
+          url: '/api/service/123',
+        });
     });
 
     it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", async () => {
@@ -2190,17 +2244,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         }
       };
 
-      axios({
-        method: 'copy',
-        url: '/api/service/123',
-      })
-        .then((reponse) => {
-          expect(serviceDuplique).to.be(true);
-          expect(reponse.status).to.equal(200);
-          expect(reponse.body).to.equal('Service dupliqué');
-          done();
-        })
-        .catch((e) => done(reponse?.data || e));
+      const reponse = await testeur.copy('/api/service/123');
+      expect(serviceDuplique).to.be(true);
+      expect(reponse.status).to.equal(200);
+      expect(reponse.text).to.equal('Service dupliqué');
     });
   });
 
@@ -2242,7 +2289,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur.middleware().verifieRechercheService([], {
+      await testeur.middleware().verifieRechercheService([], testeur.app(), {
         method: 'get',
         url: '/api/service/456',
       });
@@ -2317,7 +2364,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur.middleware().verifieRechercheService([], {
+      await testeur.middleware().verifieRechercheService([], testeur.app(), {
         method: 'PATCH',
         url: '/api/service/456/autorisations/uuid-1',
         data: { droits: tousDroitsEnEcriture() },
@@ -2339,11 +2386,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it("utilise le middleware de chargement de l'autorisation", async () => {
-      testeur.middleware().verifieChargementDesAutorisations({
-        method: 'PATCH',
-        url: '/api/service/456/autorisations/uuid-1',
-        data: { droits: tousDroitsEnEcriture() },
-      });
+      await testeur
+        .middleware()
+        .verifieChargementDesAutorisations(testeur.app(), {
+          method: 'PATCH',
+          url: '/api/service/456/autorisations/uuid-1',
+          data: { droits: tousDroitsEnEcriture() },
+        });
     });
 
     it("renvoie une erreur 422 si l'utilisateur courant tente de modifier ses propres droits", async () => {
@@ -2608,7 +2657,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('recherche le service correspondant', async () => {
-      testeur.middleware().verifieRechercheService([], {
+      await testeur.middleware().verifieRechercheService([], testeur.app(), {
         method: 'get',
         url: '/api/service/456/autorisations',
       });
@@ -2711,12 +2760,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête GET sur `/api/service/:id/indiceCyber', () => {
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: LECTURE, rubrique: SECURISER }], {
-          method: 'get',
-          url: '/api/service/456/indiceCyber',
-        });
+        .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'get',
+            url: '/api/service/456/indiceCyber',
+          }
+        );
     });
 
     it("aseptise l'id du service", async () => {
@@ -2743,12 +2796,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête GET sur `/api/service/:id/indiceCyberPersonnalise', () => {
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: LECTURE, rubrique: SECURISER }], {
-          method: 'get',
-          url: '/api/service/456/indiceCyberPersonnalise',
-        });
+        .verifieRechercheService(
+          [{ niveau: LECTURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'get',
+            url: '/api/service/456/indiceCyberPersonnalise',
+          }
+        );
     });
 
     it("aseptise l'id du service", async () => {
@@ -2777,12 +2834,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête POST sur `/api/service/:id/retourUtilisateurMesure', () => {
     it('recherche le service correspondant', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
-          method: 'post',
-          url: '/api/service/456/retourUtilisateurMesure',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: SECURISER }],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/456/retourUtilisateurMesure',
+          }
+        );
     });
 
     it('aseptise les données de la requête', async () => {
@@ -2860,12 +2921,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('utilise le middleware de recherche du service', async () => {
-      testeur
+      await testeur
         .middleware()
-        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
-          method: 'delete',
-          url: '/api/service/123/homologation/dossierCourant',
-        });
+        .verifieRechercheService(
+          [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
+          testeur.app(),
+          {
+            method: 'delete',
+            url: '/api/service/123/homologation/dossierCourant',
+          }
+        );
     });
 
     it("retourne une erreur HTTP 422 si le service n'a pas de dossier courant", async () => {
@@ -2908,10 +2973,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête POST sur `/api/service/estimationNiveauSecurite`', () => {
     it("vérifie que l'utilisateur est authentifié", async () => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
-        method: 'post',
-        url: '/api/service/estimationNiveauSecurite',
-      });
+      await testeur
+        .middleware()
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
+          method: 'post',
+          url: '/api/service/estimationNiveauSecurite',
+        });
     });
 
     it('aseptise les paramètres', async () => {
@@ -2976,7 +3043,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   describe('quand requête PUT sur `/api/service/:id/suggestionAction/:nature`', () => {
     it('recherche le service correspondant', async () => {
-      testeur.middleware().verifieRechercheService([], {
+      await testeur.middleware().verifieRechercheService([], testeur.app(), {
         method: 'put',
         url: '/api/service/123/suggestionAction/peuimporte',
       });

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -41,34 +41,29 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
   beforeEach(testeur.initialise);
 
-  afterEach(testeur.arrete);
-
   describe('quand requête POST sur `/api/service`', () => {
     beforeEach(() => {
       testeur.depotDonnees().nouveauService = async () => {};
     });
 
-    it('applique une protection de trafic', (done) => {
-      testeur.middleware().verifieProtectionTrafic(
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service',
-        },
-        done
-      );
+    it('applique une protection de trafic', async () => {
+      await testeur.middleware().verifieProtectionTrafic(testeur.app(), {
+        method: 'post',
+        url: '/api/service',
+      });
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      await testeur
         .middleware()
-        .verifieRequeteExigeAcceptationCGU(
-          { method: 'post', url: 'http://localhost:1234/api/service' },
-          done
-        );
+        .verifieRequeteExigeAcceptationCGU(testeur.app(), {
+          method: 'post',
+          url: '/api/service',
+        });
     });
 
-    it('aseptise les paramètres', (done) => {
-      testeur
+    it('aseptise les paramètres', async () => {
+      await await testeur
         .middleware()
         .verifieAseptisationParametres(
           [
@@ -76,13 +71,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
             'organisationsResponsables.*',
             'nombreOrganisationsUtilisatrices.*',
           ],
-          { method: 'post', url: 'http://localhost:1234/api/service' },
-          done
+          testeur.app(),
+          { method: 'post', url: '/api/service' }
         );
     });
 
     it("aseptise la liste des points d'accès ainsi que son contenu", async () => {
-      await axios.post('http://localhost:1234/api/service', {});
+      await testeur.post('/api/service', {});
 
       testeur
         .middleware()
@@ -90,7 +85,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('aseptise la liste des fonctionnalités spécifiques ainsi que son contenu', async () => {
-      await axios.post('http://localhost:1234/api/service', {});
+      await testeur.post('/api/service', {});
 
       testeur
         .middleware()
@@ -100,7 +95,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('aseptise la liste des données sensibles spécifiques ainsi que son contenu', async () => {
-      await axios.post('http://localhost:1234/api/service', {});
+      await testeur.post('/api/service', {});
 
       testeur
         .middleware()
@@ -115,7 +110,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'Le statut de déploiement "statutInvalide" est invalide',
         {
           method: 'post',
-          url: 'http://localhost:1234/api/service',
+          url: '/api/service',
           data: { statutDeploiement: 'statutInvalide' },
         }
       );
@@ -128,7 +123,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
       await testeur.verifieRequeteGenereErreurHTTP(422, 'oups', {
         method: 'post',
-        url: 'http://localhost:1234/api/service',
+        url: '/api/service',
         data: {},
       });
     });
@@ -143,7 +138,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } },
         {
           method: 'post',
-          url: 'http://localhost:1234/api/service',
+          url: '/api/service',
           data: { nomService: 'Un nom déjà existant' },
         }
       );
@@ -168,13 +163,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         return '456';
       };
 
-      const reponse = await axios.post(
-        'http://localhost:1234/api/service',
+      const reponse = await testeur.post(
+        '/api/service',
         donneesDescriptionService
       );
 
       expect(reponse.status).to.equal(200);
-      expect(reponse.data).to.eql({ idService: '456' });
+      expect(reponse.body).to.eql({ idService: '456' });
     });
   });
 
@@ -183,18 +178,17 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().ajouteDescriptionService = async () => {};
     });
 
-    it('recherche le service correspondant', (done) => {
+    it('recherche le service correspondant', async () => {
       testeur
         .middleware()
-        .verifieRechercheService(
-          [{ niveau: ECRITURE, rubrique: DECRIRE }],
-          { method: 'put', url: 'http://localhost:1234/api/service/456' },
-          done
-        );
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: DECRIRE }], {
+          method: 'put',
+          url: '/api/service/456',
+        });
     });
 
-    it('aseptise les paramètres', (done) => {
-      testeur
+    it('aseptise les paramètres', async () => {
+      await testeur
         .middleware()
         .verifieAseptisationParametres(
           [
@@ -202,13 +196,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
             'organisationsResponsables.*',
             'nombreOrganisationsUtilisatrices.*',
           ],
-          { method: 'put', url: 'http://localhost:1234/api/service/456' },
-          done
+          testeur.app(),
+          { method: 'put', url: '/api/service/456' }
         );
     });
 
     it("aseptise la liste des points d'accès ainsi que son contenu", async () => {
-      await axios.put('http://localhost:1234/api/service/456', {});
+      await testeur.put('/api/service/456', {});
 
       testeur
         .middleware()
@@ -216,7 +210,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('aseptise la liste des fonctionnalités spécifiques ainsi que son contenu', async () => {
-      await axios.put('http://localhost:1234/api/service/456', {});
+      await testeur.put('/api/service/456', {});
 
       testeur
         .middleware()
@@ -226,7 +220,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('aseptise la liste des données sensibles spécifiques ainsi que son contenu', async () => {
-      await axios.put('http://localhost:1234/api/service/456', {});
+      await testeur.put('/api/service/456', {});
 
       testeur
         .middleware()
@@ -248,12 +242,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         expect(infosGenerales.nomService).to.equal('Nouveau Nom');
       };
 
-      const reponse = await axios.put('http://localhost:1234/api/service/456', {
+      const reponse = await testeur.put('/api/service/456', {
         nomService: 'Nouveau Nom',
       });
 
       expect(reponse.status).to.equal(200);
-      expect(reponse.data).to.eql({ idService: '456' });
+      expect(reponse.body).to.eql({ idService: '456' });
     });
 
     it('retourne une erreur HTTP 422 si le validateur du modèle échoue', async () => {
@@ -262,7 +256,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'Le statut de déploiement "statutInvalide" est invalide',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456',
+          url: '/api/service/456',
           data: { statutDeploiement: 'statutInvalide' },
         }
       );
@@ -278,7 +272,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         { erreur: { code: 'NOM_SERVICE_DEJA_EXISTANT' } },
         {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456',
+          url: '/api/service/456',
           data: { nomService: 'service déjà existant' },
         }
       );
@@ -286,15 +280,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
   });
 
   describe('quand requête GET sur `/api/service/:id/mesures', () => {
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: LECTURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: LECTURE, rubrique: SECURISER }], {
           method: 'get',
-          url: 'http://localhost:1234/api/service/456/mesures',
-        },
-        done
-      );
+          url: '/api/service/456/mesures',
+        });
     });
 
     it('retourne la représentation enrichie des mesures', async () => {
@@ -317,11 +309,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           .construis(),
       });
 
-      const reponse = await axios(
-        'http://localhost:1234/api/service/456/mesures'
-      );
+      const reponse = await testeur.get('/api/service/456/mesures');
 
-      expect(reponse.data).to.eql({
+      expect(reponse.body).to.eql({
         mesuresGenerales: {
           mesureA: {
             description: 'Mesure A',
@@ -345,55 +335,54 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('retourne une réponse 201', async () => {
-      const reponse = await axios.post(
-        'http://localhost:1234/api/service/456/mesuresSpecifiques',
-        { statut: 'fait' }
+      const reponse = await testeur.post(
+        '/api/service/456/mesuresSpecifiques',
+        {
+          statut: 'fait',
+        }
       );
 
       expect(reponse.status).to.be(201);
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques',
-          data: [],
-        },
-        done
-      );
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'post',
+        url: '/api/service/456/mesuresSpecifiques',
+        data: [],
+      });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
           method: 'post',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques',
+          url: '/api/service/456/mesuresSpecifiques',
           data: [],
-        },
-        done
-      );
+        });
     });
 
-    it('aseptise tous les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        [
-          'description',
-          'categorie',
-          'statut',
-          'modalites',
-          'priorite',
-          'echeance',
-          'responsables.*',
-        ],
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques',
-          data: [],
-        },
-        done
-      );
+    it('aseptise tous les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          [
+            'description',
+            'categorie',
+            'statut',
+            'modalites',
+            'priorite',
+            'echeance',
+            'responsables.*',
+          ],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/456/mesuresSpecifiques',
+            data: [],
+          }
+        );
     });
 
     it("délègue au dépôt de données l'ajout de la mesure spécifique", async () => {
@@ -417,14 +406,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idServiceRecu = idService;
       };
 
-      await axios.post(
-        'http://localhost:1234/api/service/456/mesuresSpecifiques',
-        {
-          description: 'une description',
-          categorie: 'gouvernance',
-          statut: 'fait',
-        }
-      );
+      await testeur.post('/api/service/456/mesuresSpecifiques', {
+        description: 'une description',
+        categorie: 'gouvernance',
+        statut: 'fait',
+      });
 
       expect(idServiceRecu).to.be('456');
       expect(idUtilisateurRecu).to.be('999');
@@ -449,8 +435,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         echeance: `01${slash}01${slash}2024`,
       };
 
-      await axios.post(
-        'http://localhost:1234/api/service/456/mesuresSpecifiques',
+      await testeur.post(
+        '/api/service/456/mesuresSpecifiques',
         mesureSpecifique
       );
 
@@ -465,7 +451,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'La catégorie "MAUVAISE_CATEGORIE" n\'est pas répertoriée',
         {
           method: 'post',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques',
+          url: '/api/service/456/mesuresSpecifiques',
           data: {
             description: 'une description',
             categorie: 'MAUVAISE_CATEGORIE',
@@ -480,18 +466,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: '',
       };
 
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/mesuresSpecifiques',
-          mesure
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le statut de la mesure est obligatoire.'
-        );
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/mesuresSpecifiques',
+        mesure
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('Le statut de la mesure est obligatoire.');
     });
 
     it('renvoie une erreur 400 si la mesure est invalide à cause du statut', async () => {
@@ -499,16 +479,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: 'invalide',
       };
 
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/mesuresSpecifiques',
-          mesure
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La mesure est invalide.');
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/mesuresSpecifiques',
+        mesure
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La mesure est invalide.');
     });
 
     it('renvoie une erreur 400 si la mesure est invalide à cause de la priorité', async () => {
@@ -517,16 +493,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: 'enCours',
       };
 
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/mesuresSpecifiques',
-          mesure
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La mesure est invalide.');
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/mesuresSpecifiques',
+        mesure
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La mesure est invalide.');
     });
 
     it("renvoie une erreur 400 si la mesure est invalide à cause de l'échéance", async () => {
@@ -535,16 +507,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: 'enCours',
       };
 
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/mesuresSpecifiques',
-          mesure
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La mesure est invalide.');
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/mesuresSpecifiques',
+        mesure
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La mesure est invalide.');
     });
   });
 
@@ -553,27 +521,22 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().supprimeMesureSpecifiqueDuService = async () => {};
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
-          method: 'delete',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques/789',
-          data: [],
-        },
-        done
-      );
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'delete',
+        url: '/api/service/456/mesuresSpecifiques/789',
+        data: [],
+      });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
           method: 'delete',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques/789',
+          url: '/api/service/456/mesuresSpecifiques/789',
           data: [],
-        },
-        done
-      );
+        });
     });
 
     it('délègue au dépôt de données la suppression de la mesure spécifique', async () => {
@@ -599,9 +562,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       };
 
       expect(serviceARenvoyer.nombreMesuresSpecifiques()).to.eql(1);
-      await axios.delete(
-        'http://localhost:1234/api/service/456/mesuresSpecifiques/M1'
-      );
+      await testeur.delete('/api/service/456/mesuresSpecifiques/M1');
 
       expect(idServiceRecu).to.be('456');
       expect(idUtilisateurRecu).to.be('999');
@@ -613,14 +574,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         throw new ErreurSuppressionImpossible();
       };
 
-      try {
-        await axios.delete(
-          'http://localhost:1234/api/service/456/mesuresSpecifiques/M1'
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.delete(
+        '/api/service/456/mesuresSpecifiques/M1'
+      );
+      expect(reponse.status).to.be(400);
     });
   });
 
@@ -641,47 +598,44 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques/789',
-          data: [],
-        },
-        done
-      );
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'put',
+        url: '/api/service/456/mesuresSpecifiques/789',
+        data: [],
+      });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques/789',
+          url: '/api/service/456/mesuresSpecifiques/789',
           data: [],
-        },
-        done
-      );
+        });
     });
 
-    it('aseptise tous les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        [
-          'description',
-          'categorie',
-          'statut',
-          'modalites',
-          'priorite',
-          'echeance',
-          'responsables.*',
-        ],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques/789',
-          data: [],
-        },
-        done
-      );
+    it('aseptise tous les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          [
+            'description',
+            'categorie',
+            'statut',
+            'modalites',
+            'priorite',
+            'echeance',
+            'responsables.*',
+          ],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/mesuresSpecifiques/789',
+            data: [],
+          }
+        );
     });
 
     it('délègue au dépôt de données la mise à jour de la mesure spécifique', async () => {
@@ -698,15 +652,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         mesureRecue = mesure;
       };
 
-      await axios.put(
-        'http://localhost:1234/api/service/456/mesuresSpecifiques/M1',
-        {
-          description: 'une description',
-          categorie: 'gouvernance',
-          statut: 'fait',
-          echeance: '01&#x2F;01&#x2F;2024',
-        }
-      );
+      await testeur.put('/api/service/456/mesuresSpecifiques/M1', {
+        description: 'une description',
+        categorie: 'gouvernance',
+        statut: 'fait',
+        echeance: '01&#x2F;01&#x2F;2024',
+      });
 
       expect(idServiceRecu).to.be('456');
       expect(idUtilisateurRecu).to.be('999');
@@ -727,7 +678,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'La mesure est introuvable',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques/INTROUVABLE',
+          url: '/api/service/456/mesuresSpecifiques/INTROUVABLE',
           data: {
             description: 'une description',
             categorie: 'gouvernance',
@@ -743,7 +694,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'La catégorie "MAUVAISE_CATEGORIE" n\'est pas répertoriée',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesuresSpecifiques/M1',
+          url: '/api/service/456/mesuresSpecifiques/M1',
           data: {
             description: 'une description',
             categorie: 'MAUVAISE_CATEGORIE',
@@ -754,22 +705,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('renvoi une erreur 400 si le statut est vide', async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/mesuresSpecifiques/M1',
-          {
-            description: 'une description',
-            categorie: 'gouvernance',
-            statut: '',
-          }
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le statut de la mesure est obligatoire.'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/mesuresSpecifiques/M1',
+        {
+          description: 'une description',
+          categorie: 'gouvernance',
+          statut: '',
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('Le statut de la mesure est obligatoire.');
     });
   });
 
@@ -788,36 +733,33 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         Promise.resolve();
     });
 
-    it("vérifie que l'utilisateur a accepté les CGU", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesures/audit',
-        },
-        done
-      );
+    it("vérifie que l'utilisateur a accepté les CGU", async () => {
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'put',
+        url: '/api/service/456/mesures/audit',
+      });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesures/audit',
-        },
-        done
-      );
+          url: '/api/service/456/mesures/audit',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['statut', 'modalites', 'priorite', 'echeance', 'responsables.*'],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/456/mesures/audit',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['statut', 'modalites', 'priorite', 'echeance', 'responsables.*'],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/mesures/audit',
+          }
+        );
     });
 
     it('jette une erreur 400 si le statut est vide', async () => {
@@ -825,18 +767,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: '',
       };
 
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/mesures/audit',
-          mesureGenerale
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le statut de la mesure est obligatoire.'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/mesures/audit',
+        mesureGenerale
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('Le statut de la mesure est obligatoire.');
     });
 
     it('délègue au dépôt de données la mise à jour des mesures générales', async () => {
@@ -857,10 +793,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: 'fait',
       };
 
-      await axios.put(
-        'http://localhost:1234/api/service/456/mesures/audit',
-        mesureGenerale
-      );
+      await testeur.put('/api/service/456/mesures/audit', mesureGenerale);
 
       expect(idServiceRecu).to.equal('456');
       expect(idUtilisateurRecu).to.equal('123');
@@ -873,16 +806,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: 'invalide',
       };
 
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/mesures/audit',
-          mesureGenerale
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La mesure est invalide.');
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/mesures/audit',
+        mesureGenerale
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La mesure est invalide.');
     });
 
     it('renvoie une erreur 400 si la mesure est invalide à cause de la priorité', async () => {
@@ -891,16 +820,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: 'enCours',
       };
 
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/mesures/audit',
-          mesureGenerale
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La mesure est invalide.');
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/mesures/audit',
+        mesureGenerale
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La mesure est invalide.');
     });
 
     it("renvoie une erreur 400 si la mesure est invalide à cause de l'échéance", async () => {
@@ -909,16 +834,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         statut: 'enCours',
       };
 
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/mesures/audit',
-          mesureGenerale
-        );
-        expect().fail("L'appel aurait du lever une erreur.");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be('La mesure est invalide.');
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/mesures/audit',
+        mesureGenerale
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('La mesure est invalide.');
     });
 
     it("décode les 'slash' de la date d'échéance ", async () => {
@@ -937,10 +858,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         echeance: `01${slash}01${slash}2024`,
       };
 
-      await axios.put(
-        'http://localhost:1234/api/service/456/mesures/audit',
-        mesureGenerale
-      );
+      await testeur.put('/api/service/456/mesures/audit', mesureGenerale);
 
       expect(donneesRecues.echeance.getTime()).to.equal(
         new Date('01/01/2024').getTime()
@@ -961,36 +879,29 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it("vérifie que l'utilisateur a accepté les CGU", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/S1/modeles/mesureSpecifique',
-        },
-        done
-      );
+    it("vérifie que l'utilisateur a accepté les CGU", async () => {
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'put',
+        url: '/api/service/S1/modeles/mesureSpecifique',
+      });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
           method: 'put',
-          url: 'http://localhost:1234/api/service/S1/modeles/mesureSpecifique',
-        },
-        done
-      );
+          url: '/api/service/S1/modeles/mesureSpecifique',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idsModeles.*'],
-        {
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['idsModeles.*'], testeur.app(), {
           method: 'put',
-          url: 'http://localhost:1234/api/service/S1/modeles/mesureSpecifique',
-        },
-        done
-      );
+          url: '/api/service/S1/modeles/mesureSpecifique',
+        });
     });
 
     it("délègue au dépôt de données l'association des modèles au service", async () => {
@@ -1003,12 +914,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         donnesRecues = { idsModeles, idService, idUtilisateur };
       };
 
-      await axios.put(
-        'http://localhost:1234/api/service/S1/modeles/mesureSpecifique',
-        {
-          idsModeles: ['MOD-1', 'MOD-2'],
-        }
-      );
+      await testeur.put('/api/service/S1/modeles/mesureSpecifique', {
+        idsModeles: ['MOD-1', 'MOD-2'],
+      });
 
       expect(donnesRecues.idsModeles).to.eql(['MOD-1', 'MOD-2']);
       expect(donnesRecues.idService).to.be('S1');
@@ -1020,14 +928,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         async () => {
           throw new ErreurModeleDeMesureSpecifiqueIntrouvable();
         };
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/S1/modeles/mesureSpecifique'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+
+      const reponse = await testeur.put(
+        '/api/service/S1/modeles/mesureSpecifique'
+      );
+      expect(reponse.status).to.be(403);
     });
 
     it("jette une 403 si l'utilisateur ne peut pas modifier tous les services passés en paramètres", async () => {
@@ -1039,14 +944,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
             {}
           );
         };
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/S1/modeles/mesureSpecifique'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(403);
-      }
+      const reponse = await testeur.put(
+        '/api/service/S1/modeles/mesureSpecifique'
+      );
+      expect(reponse.status).to.be(403);
     });
 
     it("jette une 400 si le service est déjà associé à l'un des modèles", async () => {
@@ -1054,14 +955,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         async () => {
           throw new ErreurModeleDeMesureSpecifiqueDejaAssociee();
         };
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/S1/modeles/mesureSpecifique'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+
+      const reponse = await testeur.put(
+        '/api/service/S1/modeles/mesureSpecifique'
+      );
+      expect(reponse.status).to.be(400);
     });
   });
 
@@ -1073,15 +971,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         Promise.resolve();
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: CONTACTS }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: CONTACTS }], {
           method: 'post',
-          url: 'http://localhost:1234/api/service/456/rolesResponsabilites',
-        },
-        done
-      );
+          url: '/api/service/456/rolesResponsabilites',
+        });
     });
 
     it("demande au dépôt d'associer les rôles et responsabilités au service", async () => {
@@ -1096,21 +992,18 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         rolesResponsabilitesAjoutees = true;
       };
 
-      const reponse = await axios.post(
-        'http://localhost:1234/api/service/456/rolesResponsabilites',
+      const reponse = await testeur.post(
+        '/api/service/456/rolesResponsabilites',
         { autoriteHomologation: 'Jean Dupont' }
       );
 
       expect(rolesResponsabilitesAjoutees).to.be(true);
       expect(reponse.status).to.equal(200);
-      expect(reponse.data).to.eql({ idService: '456' });
+      expect(reponse.body).to.eql({ idService: '456' });
     });
 
     it("aseptise la liste des acteurs de l'homologation ainsi que son contenu", async () => {
-      await axios.post(
-        'http://localhost:1234/api/service/456/rolesResponsabilites',
-        {}
-      );
+      await testeur.post('/api/service/456/rolesResponsabilites', {});
 
       testeur
         .middleware()
@@ -1122,10 +1015,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     });
 
     it('aseptise la liste des parties prenantes ainsi que son contenu', async () => {
-      await axios.post(
-        'http://localhost:1234/api/service/456/rolesResponsabilites',
-        {}
-      );
+      await testeur.post('/api/service/456/rolesResponsabilites', {});
 
       testeur
         .middleware()
@@ -1147,116 +1037,104 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().ajouteRisqueSpecifiqueAService = async () => {};
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: RISQUES }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
           method: 'post',
-          url: 'http://localhost:1234/api/service/456/risquesSpecifiques',
-        },
-        done
-      );
+          url: '/api/service/456/risquesSpecifiques',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        [
-          'niveauGravite',
-          'niveauVraisemblance',
-          'commentaire',
-          'description',
-          'intitule',
-          'categories.*',
-        ],
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service/456/risquesSpecifiques',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          [
+            'niveauGravite',
+            'niveauVraisemblance',
+            'commentaire',
+            'description',
+            'intitule',
+            'categories.*',
+          ],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/456/risquesSpecifiques',
+          }
+        );
     });
 
     it("retourne une erreur 400 si le niveau de gravité n'existe pas", async () => {
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/risquesSpecifiques',
-          {
-            niveauGravite: 'inexistant',
-            intitule: 'risque',
-            categories: ['C1'],
-          }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le niveau de gravité &quot;inexistant&quot; n&apos;est pas répertorié'
-        );
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/risquesSpecifiques',
+        {
+          niveauGravite: 'inexistant',
+          intitule: 'risque',
+          categories: ['C1'],
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'Le niveau de gravité &quot;inexistant&quot; n&apos;est pas répertorié'
+      );
     });
 
     it("retourne une erreur 400 si le niveau de vraisemblance n'existe pas", async () => {
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/risquesSpecifiques',
-          {
-            niveauVraisemblance: 'inexistant',
-            intitule: 'risque',
-            categories: ['C1'],
-          }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le niveau de vraisemblance &quot;inexistant&quot; n&apos;est pas répertorié'
-        );
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/risquesSpecifiques',
+        {
+          niveauVraisemblance: 'inexistant',
+          intitule: 'risque',
+          categories: ['C1'],
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'Le niveau de vraisemblance &quot;inexistant&quot; n&apos;est pas répertorié'
+      );
     });
 
     it("retourne une erreur 400 si l'intitulé est vide", async () => {
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/risquesSpecifiques',
-          { categories: ['C1'] }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'L&apos;intitulé du risque est obligatoire.'
-        );
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/risquesSpecifiques',
+        {
+          categories: ['C1'],
+        }
+      );
+
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('L&apos;intitulé du risque est obligatoire.');
     });
 
     it("retourne une erreur 400 si la catégorie n'existe pas", async () => {
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/risquesSpecifiques',
-          { categories: ['inexistante'], intitule: 'un risque' }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'La catégorie &quot;inexistante&quot; n&apos;est pas répertoriée'
-        );
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/risquesSpecifiques',
+        {
+          categories: ['inexistante'],
+          intitule: 'un risque',
+        }
+      );
+
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'La catégorie &quot;inexistante&quot; n&apos;est pas répertoriée'
+      );
     });
 
     it("assaini le message avec de retourner l'erreur 400", async () => {
-      try {
-        await axios.post(
-          'http://localhost:1234/api/service/456/risquesSpecifiques',
-          { categories: ['<script>'], intitule: 'un risque' }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'La catégorie &quot;&lt;script&gt;&quot; n&apos;est pas répertoriée'
-        );
-      }
+      const reponse = await testeur.post(
+        '/api/service/456/risquesSpecifiques',
+        {
+          categories: ['<script>'],
+          intitule: 'un risque',
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'La catégorie &quot;&lt;script&gt;&quot; n&apos;est pas répertoriée'
+      );
     });
 
     it("délègue au dépôt de donnée l'ajout du risque", async () => {
@@ -1271,16 +1149,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         donnees.id = 'RS1';
       };
 
-      await axios.post(
-        'http://localhost:1234/api/service/456/risquesSpecifiques',
-        {
-          intitule: 'un risque important',
-          niveauGravite: 'unNiveau',
-          niveauVraisemblance: 'unNiveauVraisemblance',
-          commentaire: "c'est important",
-          categories: ['C1'],
-        }
-      );
+      await testeur.post('/api/service/456/risquesSpecifiques', {
+        intitule: 'un risque important',
+        niveauGravite: 'unNiveau',
+        niveauVraisemblance: 'unNiveauVraisemblance',
+        commentaire: "c'est important",
+        categories: ['C1'],
+      });
 
       expect(idServiceRecu).to.be('456');
       expect(donneesRecues.intitule).to.eql('un risque important');
@@ -1298,8 +1173,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         risque.identifiantNumerique = 'RS1';
       };
 
-      const reponse = await axios.post(
-        'http://localhost:1234/api/service/456/risquesSpecifiques',
+      const reponse = await testeur.post(
+        '/api/service/456/risquesSpecifiques',
         {
           intitule: 'un risque important',
           niveauGravite: 'unNiveau',
@@ -1309,8 +1184,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         }
       );
 
-      expect(reponse.data.id).to.be('abcd');
-      expect(reponse.data.identifiantNumerique).to.be('RS1');
+      expect(reponse.body.id).to.be('abcd');
+      expect(reponse.body.identifiantNumerique).to.be('RS1');
     });
   });
 
@@ -1339,119 +1214,105 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: RISQUES }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-        },
-        done
-      );
+          url: '/api/service/456/risquesSpecifiques/RS1',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        [
-          'niveauGravite',
-          'niveauVraisemblance',
-          'commentaire',
-          'description',
-          'intitule',
-          'categories.*',
-        ],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          [
+            'niveauGravite',
+            'niveauVraisemblance',
+            'commentaire',
+            'description',
+            'intitule',
+            'categories.*',
+          ],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/risquesSpecifiques/RS1',
+          }
+        );
     });
 
     it("retourne une erreur 400 si le niveau de gravité n'existe pas", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-          {
-            niveauGravite: 'inexistant',
-            intitule: 'risque',
-            categories: ['C1'],
-          }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le niveau de gravité &quot;inexistant&quot; n&apos;est pas répertorié'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risquesSpecifiques/RS1',
+        {
+          niveauGravite: 'inexistant',
+          intitule: 'risque',
+          categories: ['C1'],
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'Le niveau de gravité &quot;inexistant&quot; n&apos;est pas répertorié'
+      );
     });
 
     it("retourne une erreur 400 si le niveau de vraisemblance n'existe pas", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-          {
-            niveauVraisemblance: 'inexistant',
-            intitule: 'risque',
-            categories: ['C1'],
-          }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le niveau de vraisemblance &quot;inexistant&quot; n&apos;est pas répertorié'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risquesSpecifiques/RS1',
+        {
+          niveauVraisemblance: 'inexistant',
+          intitule: 'risque',
+          categories: ['C1'],
+        }
+      );
+
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'Le niveau de vraisemblance &quot;inexistant&quot; n&apos;est pas répertorié'
+      );
     });
 
     it("retourne une erreur 400 si l'intitulé est vide", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-          { categories: ['C1'] }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'L&apos;intitulé du risque est obligatoire.'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risquesSpecifiques/RS1',
+        {
+          categories: ['C1'],
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be('L&apos;intitulé du risque est obligatoire.');
     });
 
     it("retourne une erreur 400 si la catégorie n'existe pas", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-          { categories: ['inexistante'], intitule: 'un risque' }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'La catégorie &quot;inexistante&quot; n&apos;est pas répertoriée'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risquesSpecifiques/RS1',
+        {
+          categories: ['inexistante'],
+          intitule: 'un risque',
+        }
+      );
+
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'La catégorie &quot;inexistante&quot; n&apos;est pas répertoriée'
+      );
     });
 
     it("assaini le message avant de retourner l'erreur 400", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-          {
-            categories: ['<script></script>'],
-            intitule: 'un risque',
-          }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'La catégorie &quot;&lt;script&gt;&lt;/script&gt;&quot; n&apos;est pas répertoriée'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risquesSpecifiques/RS1',
+        {
+          categories: ['<script></script>'],
+          intitule: 'un risque',
+        }
+      );
+
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'La catégorie &quot;&lt;script&gt;&lt;/script&gt;&quot; n&apos;est pas répertoriée'
+      );
     });
 
     it('renvoi une erreur 404 si le risque est introuvable', async () => {
@@ -1463,7 +1324,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'Le risque est introuvable',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/risquesSpecifiques/INTROUVABLE',
+          url: '/api/service/456/risquesSpecifiques/INTROUVABLE',
           data: {
             intitule: 'un risque important',
             categories: ['C1'],
@@ -1481,7 +1342,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'Le risque &lt;script&gt; est introuvable',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/risquesSpecifiques/INTROUVABLE',
+          url: '/api/service/456/risquesSpecifiques/INTROUVABLE',
           data: {
             intitule: 'un risque important',
             categories: ['C1'],
@@ -1501,16 +1362,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         donneesRecues = donnees;
       };
 
-      await axios.put(
-        'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-        {
-          intitule: 'un risque important',
-          niveauGravite: 'unNiveau',
-          niveauVraisemblance: 'unNiveauVraisemblance',
-          commentaire: "c'est important",
-          categories: ['C1'],
-        }
-      );
+      await testeur.put('/api/service/456/risquesSpecifiques/RS1', {
+        intitule: 'un risque important',
+        niveauGravite: 'unNiveau',
+        niveauVraisemblance: 'unNiveauVraisemblance',
+        commentaire: "c'est important",
+        categories: ['C1'],
+      });
 
       expect(idServiceRecu).to.be('456');
       expect(donneesRecues.id).to.eql('RS1');
@@ -1524,8 +1382,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().metsAJourRisqueSpecifiqueDuService =
         async () => {};
 
-      const reponse = await axios.put(
-        'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
+      const reponse = await testeur.put(
+        '/api/service/456/risquesSpecifiques/RS1',
         {
           intitule: 'un risque important',
           niveauGravite: 'unNiveau',
@@ -1535,7 +1393,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         }
       );
 
-      expect(reponse.data.intitule).to.be('un risque important');
+      expect(reponse.body.intitule).to.be('un risque important');
     });
   });
 
@@ -1544,15 +1402,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().supprimeRisqueSpecifiqueDuService = async () => {};
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: RISQUES }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
           method: 'delete',
-          url: 'http://localhost:1234/api/service/456/risquesSpecifiques/RS1',
-        },
-        done
-      );
+          url: '/api/service/456/risquesSpecifiques/RS1',
+        });
     });
 
     it('délègue au dépôt de donnée la suppression du risque', async () => {
@@ -1566,9 +1422,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idRisqueRecu = idRisque;
       };
 
-      await axios.delete(
-        'http://localhost:1234/api/service/456/risquesSpecifiques/RS1'
-      );
+      await testeur.delete('/api/service/456/risquesSpecifiques/RS1');
 
       expect(idServiceRecu).to.be('456');
       expect(idRisqueRecu).to.be('RS1');
@@ -1585,74 +1439,62 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: RISQUES }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: RISQUES }], {
           method: 'put',
-          url: 'http://localhost:1234/api/service/456/risques/unRisqueExistant',
-        },
-        done
-      );
+          url: '/api/service/456/risques/unRisqueExistant',
+        });
     });
 
-    it('aseptise les paramètres de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['niveauGravite', 'niveauVraisemblance', 'commentaire', 'desactive'],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/456/risques/unRisqueExistant',
-        },
-        done
-      );
+    it('aseptise les paramètres de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['niveauGravite', 'niveauVraisemblance', 'commentaire', 'desactive'],
+          testeur.app(),
+          {
+            method: 'put',
+            url: '/api/service/456/risques/unRisqueExistant',
+          }
+        );
     });
 
     it('retourne une erreur 400 si les données sont invalides', async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risques/unRisqueInexistant'
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le risque &quot;unRisqueInexistant&quot; n&apos;est pas répertorié'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risques/unRisqueInexistant'
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'Le risque &quot;unRisqueInexistant&quot; n&apos;est pas répertorié'
+      );
     });
 
     it("retourne une erreur 400 si le niveau de vraisemblance n'existe pas", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risques/unRisqueExistant',
-          {
-            niveauVraisemblance: 'inexistant',
-          }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le niveau de vraisemblance &quot;inexistant&quot; n&apos;est pas répertorié'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risques/unRisqueExistant',
+        {
+          niveauVraisemblance: 'inexistant',
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'Le niveau de vraisemblance &quot;inexistant&quot; n&apos;est pas répertorié'
+      );
     });
 
     it("assaini le message avec de retourner l'erreur 400", async () => {
-      try {
-        await axios.put(
-          'http://localhost:1234/api/service/456/risques/unRisqueExistant',
-          {
-            niveauVraisemblance: '<script>',
-          }
-        );
-        expect().fail('Aurait du lever une exception');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-        expect(e.response.data).to.be(
-          'Le niveau de vraisemblance &quot;&lt;script&gt;&quot; n&apos;est pas répertorié'
-        );
-      }
+      const reponse = await testeur.put(
+        '/api/service/456/risques/unRisqueExistant',
+        {
+          niveauVraisemblance: '<script>',
+        }
+      );
+      expect(reponse.status).to.be(400);
+      expect(reponse.text).to.be(
+        'Le niveau de vraisemblance &quot;&lt;script&gt;&quot; n&apos;est pas répertorié'
+      );
     });
 
     it('délègue au dépôt de donnée la mise à jour du risque', async () => {
@@ -1666,15 +1508,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         donneesRecues = donnees;
       };
 
-      await axios.put(
-        'http://localhost:1234/api/service/456/risques/unRisqueExistant',
-        {
-          niveauGravite: 'unNiveau',
-          commentaire: "c'est important",
-          niveauVraisemblance: 'unNiveauVraisemblance',
-          desactive: 'true',
-        }
-      );
+      await testeur.put('/api/service/456/risques/unRisqueExistant', {
+        niveauGravite: 'unNiveau',
+        commentaire: "c'est important",
+        niveauVraisemblance: 'unNiveauVraisemblance',
+        desactive: 'true',
+      });
 
       expect(idServiceRecu).to.be('456');
       expect(donneesRecues.niveauGravite).to.eql('unNiveau');
@@ -1687,8 +1526,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
     it('retourne la représentation du risque modifié', async () => {
       testeur.depotDonnees().ajouteRisqueGeneralAService = async () => {};
 
-      const reponse = await axios.put(
-        'http://localhost:1234/api/service/456/risques/unRisqueExistant',
+      const reponse = await testeur.put(
+        '/api/service/456/risques/unRisqueExistant',
         {
           niveauGravite: 'unNiveau',
           niveauVraisemblance: 'unNiveauVraisemblance',
@@ -1696,7 +1535,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         }
       );
 
-      expect(reponse.data.niveauVraisemblance).to.be('unNiveauVraisemblance');
+      expect(reponse.body.niveauVraisemblance).to.be('unNiveauVraisemblance');
     });
   });
 
@@ -1713,36 +1552,29 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().enregistreDossier = async () => {};
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/autorite',
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
+          url: '/api/service/456/homologation/autorite',
           method: 'put',
-        },
-        done
-      );
+        });
     });
 
-    it('recherche le dossier courant correspondant', (done) => {
-      testeur.middleware().verifieRechercheDossierCourant(
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/autorite',
-          method: 'put',
-        },
-        done
-      );
+    it('recherche le dossier courant correspondant', async () => {
+      testeur.middleware().verifieRechercheDossierCourant({
+        url: '/api/service/456/homologation/autorite',
+        method: 'put',
+      });
     });
 
-    it('aseptise les paramètres reçus', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['nom', 'fonction'],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/autorite',
+    it('aseptise les paramètres reçus', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['nom', 'fonction'], testeur.app(), {
+          url: '/api/service/456/homologation/autorite',
           method: 'put',
-        },
-        done
-      );
+        });
     });
 
     it("utilise le dépôt pour enregistrer l'autorité d'homologation", async () => {
@@ -1758,10 +1590,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         expect(dossier.autorite.fonction).to.equal('RSSI');
       };
 
-      await axios.put(
-        'http://localhost:1234/api/service/456/homologation/autorite',
-        { nom: 'Jean Dupond', fonction: 'RSSI' }
-      );
+      await testeur.put('/api/service/456/homologation/autorite', {
+        nom: 'Jean Dupond',
+        fonction: 'RSSI',
+      });
 
       expect(depotAppele).to.be(true);
     });
@@ -1781,69 +1613,66 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.referentiel().recharge({ echeancesRenouvellement: { unAn: {} } });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/decision',
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
+          url: '/api/service/456/homologation/decision',
           method: 'put',
-        },
-        done
-      );
+        });
     });
 
-    it('recherche le dossier courant correspondant', (done) => {
-      testeur.middleware().verifieRechercheDossierCourant(
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/decision',
-          method: 'put',
-        },
-        done
-      );
+    it('recherche le dossier courant correspondant', async () => {
+      testeur.middleware().verifieRechercheDossierCourant({
+        url: '/api/service/456/homologation/decision',
+        method: 'put',
+      });
     });
 
-    it('aseptise les paramètres reçus', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['dateHomologation', 'dureeValidite'],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/decision',
-          method: 'put',
-        },
-        done
-      );
+    it('aseptise les paramètres reçus', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['dateHomologation', 'dureeValidite'],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/decision',
+            method: 'put',
+          }
+        );
     });
 
-    it("renvoie une erreur 422 si la date d'homologation est invalide", (done) => {
+    it("renvoie une erreur 422 si la date d'homologation est invalide", async () => {
       axios
-        .put('http://localhost:1234/api/service/456/homologation/decision', {
+        .put('/api/service/456/homologation/decision', {
           dateHomologation: 'dateInvalide',
           dureeValidite: 'unAn',
         })
         .then(() => done('Une erreur aurait dû être levée'))
         .catch((e) => {
-          expect(e.response.status).to.be(422);
-          expect(e.response.data).to.be("Date d'homologation invalide");
+          expect(reponse.status).to.be(422);
+          expect(reponse.data).to.be("Date d'homologation invalide");
           done();
         })
-        .catch((e) => done(e.response?.data || e));
+        .catch((e) => done(reponse?.data || e));
     });
 
-    it('renvoie une erreur 422 si la durée de validité est inconnue du référentiel', (done) => {
+    it('renvoie une erreur 422 si la durée de validité est inconnue du référentiel', async () => {
       axios
-        .put('http://localhost:1234/api/service/456/homologation/decision', {
+        .put('/api/service/456/homologation/decision', {
           dateHomologation: new Date(),
           dureeValidite: 'dureeInconnue',
         })
         .then(() => done('Une erreur aurait dû être levée'))
         .catch((e) => {
-          expect(e.response.status).to.be(422);
-          expect(e.response.data).to.be('Durée de validité invalide');
+          expect(reponse.status).to.be(422);
+          expect(reponse.data).to.be('Durée de validité invalide');
           done();
         })
-        .catch((e) => done(e.response?.data || e));
+        .catch((e) => done(reponse?.data || e));
     });
 
-    it("utilise le dépôt pour enregistrer la décision d'homologation", (done) => {
+    it("utilise le dépôt pour enregistrer la décision d'homologation", async () => {
       let depotAppele = false;
 
       testeur.depotDonnees().enregistreDossier = (idHomologation, dossier) => {
@@ -1855,13 +1684,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       };
 
       axios
-        .put('http://localhost:1234/api/service/456/homologation/decision', {
+        .put('/api/service/456/homologation/decision', {
           dateHomologation: '2023-01-01',
           dureeValidite: 'unAn',
         })
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
-        .catch((e) => done(e.response?.data || e));
+        .catch((e) => done(reponse?.data || e));
     });
   });
 
@@ -1881,28 +1710,23 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .recharge({ documentsHomologation: { decision: {} } });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/telechargement',
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
+          url: '/api/service/456/homologation/telechargement',
           method: 'put',
-        },
-        done
-      );
+        });
     });
 
-    it('recherche le dossier courant correspondant', (done) => {
-      testeur.middleware().verifieRechercheDossierCourant(
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/telechargement',
-          method: 'put',
-        },
-        done
-      );
+    it('recherche le dossier courant correspondant', async () => {
+      testeur.middleware().verifieRechercheDossierCourant({
+        url: '/api/service/456/homologation/telechargement',
+        method: 'put',
+      });
     });
 
-    it('utilise le dépôt pour enregistrer la date du téléchargement', (done) => {
+    it('utilise le dépôt pour enregistrer la date du téléchargement', async () => {
       let depotAppele = false;
       const maintenant = new Date('2023-02-21');
 
@@ -1916,12 +1740,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       };
 
       axios
-        .put(
-          'http://localhost:1234/api/service/456/homologation/telechargement'
-        )
+        .put('/api/service/456/homologation/telechargement')
         .then(() => expect(depotAppele).to.be(true))
         .then(() => done())
-        .catch((e) => done(e.response?.data || e));
+        .catch((e) => done(reponse?.data || e));
     });
   });
 
@@ -1945,71 +1767,58 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/avis',
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
+          url: '/api/service/456/homologation/avis',
           method: 'put',
-        },
-        done
+        });
+    });
+
+    it('recherche le dossier courant correspondant', async () => {
+      testeur.middleware().verifieRechercheDossierCourant({
+        url: '/api/service/456/homologation/avis',
+        method: 'put',
+      });
+    });
+
+    it('aseptise la liste des avis', async () => {
+      await testeur.put('/api/service/456/homologation/avis', {
+        avis: [],
+      });
+      testeur
+        .middleware()
+        .verifieAseptisationListe('avis', [
+          'statut',
+          'dureeValidite',
+          'commentaires',
+        ]);
+    });
+
+    it('aseptise les collaborateurs mentionnés dans les avis et le paramètres "avecAvis"', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['avis.*.collaborateurs.*', 'avecAvis'],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/avis',
+            method: 'put',
+          }
+        );
+    });
+
+    it("renvoie une 400 si aucun avis n'est envoyé", async () => {
+      const reponse = await testeur.put(
+        '/api/service/456/homologation/avis',
+        {}
       );
-    });
-
-    it('recherche le dossier courant correspondant', (done) => {
-      testeur.middleware().verifieRechercheDossierCourant(
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/avis',
-          method: 'put',
-        },
-        done
-      );
-    });
-
-    it('aseptise la liste des avis', (done) => {
-      axios
-        .put('http://localhost:1234/api/service/456/homologation/avis', {
-          avis: [],
-        })
-        .then(() => {
-          testeur
-            .middleware()
-            .verifieAseptisationListe('avis', [
-              'statut',
-              'dureeValidite',
-              'commentaires',
-            ]);
-          done();
-        })
-        .catch(done);
-    });
-
-    it('aseptise les collaborateurs mentionnés dans les avis et le paramètres "avecAvis"', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['avis.*.collaborateurs.*', 'avecAvis'],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/avis',
-          method: 'put',
-        },
-        done
-      );
-    });
-
-    it("renvoie une 400 si aucun avis n'est envoyé", (done) => {
-      axios
-        .put('http://localhost:1234/api/service/456/homologation/avis', {})
-        .then(() => {
-          done('Une erreur aurait du être renvoyée');
-        })
-        .catch((e) => {
-          expect(e.response.status).to.be(400);
-          done();
-        })
-        .catch(done);
+      expect(reponse.status).to.be(400);
     });
 
     describe('utilise le dépôt pour enregistrer les avis', () => {
-      it('quand il y a des avis', (done) => {
+      it('quand il y a des avis', async () => {
         let depotAppele = false;
         testeur.depotDonnees().enregistreDossier = (
           idHomologation,
@@ -2029,7 +1838,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         };
 
         axios
-          .put('http://localhost:1234/api/service/456/homologation/avis', {
+          .put('/api/service/456/homologation/avis', {
             avis: [
               {
                 collaborateurs: ['Jean Dupond'],
@@ -2042,10 +1851,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
-          .catch((e) => done(e.response?.data || e));
+          .catch((e) => done(reponse?.data || e));
       });
 
-      it("quand il n'y a pas d'avis", (done) => {
+      it("quand il n'y a pas d'avis", async () => {
         let depotAppele = false;
         testeur.depotDonnees().enregistreDossier = (
           idHomologation,
@@ -2059,13 +1868,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         };
 
         axios
-          .put('http://localhost:1234/api/service/456/homologation/avis', {
+          .put('/api/service/456/homologation/avis', {
             avis: [],
             avecAvis: 'false',
           })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
-          .catch((e) => done(e.response?.data || e));
+          .catch((e) => done(reponse?.data || e));
       });
     });
   });
@@ -2086,51 +1895,45 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().enregistreDossier = () => Promise.resolve();
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/documents',
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
+          url: '/api/service/456/homologation/documents',
           method: 'put',
-        },
-        done
-      );
+        });
     });
 
-    it('recherche le dossier courant correspondant', (done) => {
-      testeur.middleware().verifieRechercheDossierCourant(
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/documents',
-          method: 'put',
-        },
-        done
-      );
+    it('recherche le dossier courant correspondant', async () => {
+      testeur.middleware().verifieRechercheDossierCourant({
+        url: '/api/service/456/homologation/documents',
+        method: 'put',
+      });
     });
 
-    it('aseptise la liste des documents et le paramètres "avecDocuments"', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['documents.*', 'avecDocuments'],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/documents',
-          method: 'put',
-        },
-        done
-      );
+    it('aseptise la liste des documents et le paramètres "avecDocuments"', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['documents.*', 'avecDocuments'],
+          testeur.app(),
+          {
+            url: '/api/service/456/homologation/documents',
+            method: 'put',
+          }
+        );
     });
 
-    it("renvoie une 400 si aucun document n'est envoyé", (done) => {
-      axios
-        .put('http://localhost:1234/api/service/456/homologation/documents', {})
-        .then(() => done('Une erreur aurait du être renvoyée'))
-        .catch((e) => {
-          expect(e.response.status).to.be(400);
-          done();
-        })
-        .catch(done);
+    it("renvoie une 400 si aucun document n'est envoyé", async () => {
+      const reponse = await testeur.put(
+        '/api/service/456/homologation/documents',
+        {}
+      );
+      expect(reponse.status).to.be(400);
     });
 
     describe('utilise le dépôt pour enregistrer les documents', () => {
-      it('quand il y a des documents', (done) => {
+      it('quand il y a des documents', async () => {
         let depotAppele = false;
         testeur.depotDonnees().enregistreDossier = (
           idHomologation,
@@ -2145,16 +1948,16 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         };
 
         axios
-          .put('http://localhost:1234/api/service/456/homologation/documents', {
+          .put('/api/service/456/homologation/documents', {
             documents: ['unDocument'],
             avecDocuments: 'true',
           })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
-          .catch((e) => done(e.response?.data || e));
+          .catch((e) => done(reponse?.data || e));
       });
 
-      it("quand il n'y a pas de document", (done) => {
+      it("quand il n'y a pas de document", async () => {
         let depotAppele = false;
         testeur.depotDonnees().enregistreDossier = (
           idHomologation,
@@ -2168,13 +1971,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         };
 
         axios
-          .put('http://localhost:1234/api/service/456/homologation/documents', {
+          .put('/api/service/456/homologation/documents', {
             documents: [],
             avecDocuments: 'false',
           })
           .then(() => expect(depotAppele).to.be(true))
           .then(() => done())
-          .catch((e) => done(e.response?.data || e));
+          .catch((e) => done(reponse?.data || e));
       });
     });
   });
@@ -2199,15 +2002,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().finaliseDossierCourant = () => Promise.resolve();
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
-        {
-          url: 'http://localhost:1234/api/service/456/homologation/finalise',
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
+          url: '/api/service/456/homologation/finalise',
           method: 'post',
-        },
-        done
-      );
+        });
     });
 
     it("utilise le dépôt pour finaliser l'homologation", async () => {
@@ -2216,9 +2017,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         servicePasse = service;
       };
 
-      await axios.post(
-        'http://localhost:1234/api/service/456/homologation/finalise'
-      );
+      await testeur.post('/api/service/456/homologation/finalise');
 
       expect(servicePasse.id).to.equal('456');
     });
@@ -2232,24 +2031,18 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().supprimeService = () => Promise.resolve();
     });
 
-    it('utilise le middleware de recherche du service', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [],
-        {
-          method: 'delete',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
-      );
+    it('utilise le middleware de recherche du service', async () => {
+      testeur.middleware().verifieRechercheService([], {
+        method: 'delete',
+        url: '/api/service/123',
+      });
     });
 
-    it("utilise le middleware de chargement de l'autorisation", (done) => {
-      testeur
-        .middleware()
-        .verifieChargementDesAutorisations(
-          { method: 'delete', url: 'http://localhost:1234/api/service/456' },
-          done
-        );
+    it("utilise le middleware de chargement de l'autorisation", async () => {
+      testeur.middleware().verifieChargementDesAutorisations({
+        method: 'delete',
+        url: '/api/service/456',
+      });
     });
 
     it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", async () => {
@@ -2261,7 +2054,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour supprimer le service',
-        { method: 'delete', url: 'http://localhost:1234/api/service/123' }
+        { method: 'delete', url: '/api/service/123' }
       );
     });
 
@@ -2273,11 +2066,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour supprimer le service',
-        { method: 'delete', url: 'http://localhost:1234/api/service/123' }
+        { method: 'delete', url: '/api/service/123' }
       );
     });
 
-    it('demande au dépôt de supprimer le service', (done) => {
+    it('demande au dépôt de supprimer le service', async () => {
       let serviceSupprime = false;
 
       testeur.depotDonnees().supprimeService = (idService) => {
@@ -2293,15 +2086,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
       axios({
         method: 'delete',
-        url: 'http://localhost:1234/api/service/123',
+        url: '/api/service/123',
       })
         .then((reponse) => {
           expect(serviceSupprime).to.be(true);
           expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.equal('Service supprimé');
+          expect(reponse.body).to.equal('Service supprimé');
           done();
         })
-        .catch((e) => done(e.response?.data || e));
+        .catch((e) => done(reponse?.data || e));
     });
   });
 
@@ -2313,33 +2106,25 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('applique une protection de trafic', (done) => {
-      testeur
-        .middleware()
-        .verifieProtectionTrafic(
-          { method: 'copy', url: 'http://localhost:1234/api/service/123' },
-          done
-        );
+    it('applique une protection de trafic', async () => {
+      testeur.middleware().verifieProtectionTrafic(testeur.app(), {
+        method: 'copy',
+        url: '/api/service/123',
+      });
     });
 
-    it('utilise le middleware de chargement du service', (done) => {
-      testeur
-        .middleware()
-        .verifieRechercheService(
-          [],
-          { method: 'copy', url: 'http://localhost:1234/api/service/123' },
-          done
-        );
+    it('utilise le middleware de chargement du service', async () => {
+      testeur.middleware().verifieRechercheService([], {
+        method: 'copy',
+        url: '/api/service/123',
+      });
     });
 
-    it("utilise le middleware de chargement de l'autorisation", (done) => {
-      testeur.middleware().verifieChargementDesAutorisations(
-        {
-          method: 'copy',
-          url: 'http://localhost:1234/api/service/123',
-        },
-        done
-      );
+    it("utilise le middleware de chargement de l'autorisation", async () => {
+      testeur.middleware().verifieChargementDesAutorisations({
+        method: 'copy',
+        url: '/api/service/123',
+      });
     });
 
     it("retourne une erreur HTTP 403 si l'utilisateur courant n'a pas accès au service", async () => {
@@ -2351,7 +2136,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour dupliquer le service',
-        { method: 'copy', url: 'http://localhost:1234/api/service/123' }
+        { method: 'copy', url: '/api/service/123' }
       );
     });
 
@@ -2363,7 +2148,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       await testeur.verifieRequeteGenereErreurHTTP(
         403,
         'Droits insuffisants pour dupliquer le service',
-        { method: 'copy', url: 'http://localhost:1234/api/service/123' }
+        { method: 'copy', url: '/api/service/123' }
       );
     });
 
@@ -2381,11 +2166,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           message:
             'La duplication a échoué car certaines données obligatoires ne sont pas renseignées',
         },
-        { method: 'copy', url: 'http://localhost:1234/api/service/123' }
+        { method: 'copy', url: '/api/service/123' }
       );
     });
 
-    it('demande au dépôt de dupliquer le service', (done) => {
+    it('demande au dépôt de dupliquer le service', async () => {
       let serviceDuplique = false;
 
       testeur.middleware().reinitialise({
@@ -2407,15 +2192,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
       axios({
         method: 'copy',
-        url: 'http://localhost:1234/api/service/123',
+        url: '/api/service/123',
       })
         .then((reponse) => {
           expect(serviceDuplique).to.be(true);
           expect(reponse.status).to.equal(200);
-          expect(reponse.data).to.equal('Service dupliqué');
+          expect(reponse.body).to.equal('Service dupliqué');
           done();
         })
-        .catch((e) => done(e.response?.data || e));
+        .catch((e) => done(reponse?.data || e));
     });
   });
 
@@ -2456,39 +2241,32 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur
-        .middleware()
-        .verifieRechercheService(
-          [],
-          { method: 'get', url: 'http://localhost:1234/api/service/456' },
-          done
-        );
+    it('recherche le service correspondant', async () => {
+      testeur.middleware().verifieRechercheService([], {
+        method: 'get',
+        url: '/api/service/456',
+      });
     });
 
-    it("aseptise l'id du service", (done) => {
-      testeur
+    it("aseptise l'id du service", async () => {
+      await testeur
         .middleware()
-        .verifieAseptisationParametres(
-          ['id'],
-          { method: 'get', url: 'http://localhost:1234/api/service/456' },
-          done
-        );
+        .verifieAseptisationParametres(['id'], testeur.app(), {
+          method: 'get',
+          url: '/api/service/456',
+        });
     });
 
-    it("utilise le middleware de chargement de l'autorisation", (done) => {
-      testeur
+    it("utilise le middleware de chargement de l'autorisation", async () => {
+      await testeur
         .middleware()
-        .verifieChargementDesAutorisations(
-          'http://localhost:1234/api/service/456',
-          done
-        );
+        .verifieChargementDesAutorisations(testeur.app(), '/api/service/456');
     });
 
     it('retourne la représentation du service grâce à `objetGetService`', async () => {
-      const reponse = await axios('http://localhost:1234/api/service/456');
+      const reponse = await testeur.get('/api/service/456');
 
-      expect(reponse.data).to.eql({
+      expect(reponse.body).to.eql({
         id: '456',
         nomService: 'Nom service',
         organisationResponsable: 'ANSSI',
@@ -2538,39 +2316,34 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().sauvegardeAutorisation = async () => {};
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [],
-        {
-          method: 'PATCH',
-          url: 'http://localhost:1234/api/service/456/autorisations/uuid-1',
-          data: { droits: tousDroitsEnEcriture() },
-        },
-        done
-      );
+    it('recherche le service correspondant', async () => {
+      testeur.middleware().verifieRechercheService([], {
+        method: 'PATCH',
+        url: '/api/service/456/autorisations/uuid-1',
+        data: { droits: tousDroitsEnEcriture() },
+      });
     });
 
-    it("aseptise l'id du service et de l'autorisation", (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['id', 'idAutorisation'],
-        {
-          method: 'PATCH',
-          url: 'http://localhost:1234/api/service/456/autorisations/uuid-1',
-          data: { droits: tousDroitsEnEcriture() },
-        },
-        done
-      );
+    it("aseptise l'id du service et de l'autorisation", async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['id', 'idAutorisation'],
+          testeur.app(),
+          {
+            method: 'PATCH',
+            url: '/api/service/456/autorisations/uuid-1',
+            data: { droits: tousDroitsEnEcriture() },
+          }
+        );
     });
 
-    it("utilise le middleware de chargement de l'autorisation", (done) => {
-      testeur.middleware().verifieChargementDesAutorisations(
-        {
-          method: 'PATCH',
-          url: 'http://localhost:1234/api/service/456/autorisations/uuid-1',
-          data: { droits: tousDroitsEnEcriture() },
-        },
-        done
-      );
+    it("utilise le middleware de chargement de l'autorisation", async () => {
+      testeur.middleware().verifieChargementDesAutorisations({
+        method: 'PATCH',
+        url: '/api/service/456/autorisations/uuid-1',
+        data: { droits: tousDroitsEnEcriture() },
+      });
     });
 
     it("renvoie une erreur 422 si l'utilisateur courant tente de modifier ses propres droits", async () => {
@@ -2584,17 +2357,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
       testeur.depotDonnees().autorisation = async () => monAutorisation;
 
-      try {
-        await axios.patch(
-          'http://localhost:1234/api/service/456/autorisations/uuid-1',
-          { droits: tousDroitsEnEcriture() }
-        );
+      const reponse = await testeur.patch(
+        '/api/service/456/autorisations/uuid-1',
+        {
+          droits: tousDroitsEnEcriture(),
+        }
+      );
 
-        expect().to.fail('La requête aurait dû lever une erreur HTTP 422');
-      } catch (e) {
-        expect(e.response.status).to.equal(422);
-        expect(e.response.data).to.eql({ code: 'AUTO-MODIFICATION_INTERDITE' });
-      }
+      expect(reponse.status).to.equal(422);
+      expect(reponse.body).to.eql({ code: 'AUTO-MODIFICATION_INTERDITE' });
     });
 
     it("renvoie une erreur 422 si l'utilisateur tente de modifier une autorisation qui n'appartient pas au service ciblé", async () => {
@@ -2614,21 +2385,14 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .construis();
       testeur.depotDonnees().autorisation = async () => autorisationSurDEF;
 
-      try {
-        const leroyVeutModifierDEF =
-          'http://localhost:1234/api/service/456/autorisations/uuid-appartenant-a-DEF';
-        await axios.patch(leroyVeutModifierDEF, {
-          droits: tousDroitsEnEcriture(),
-        });
+      const leroyVeutModifierDEF =
+        '/api/service/456/autorisations/uuid-appartenant-a-DEF';
+      const reponse = await testeur.patch(leroyVeutModifierDEF, {
+        droits: tousDroitsEnEcriture(),
+      });
 
-        expect().to.fail(
-          "La requête aurait dû lever une erreur HTTP 422 car Leroy tente d'utiliser le service ABC pour modifier chez DEF"
-        );
-      } catch (e) {
-        if (!e.response) throw e;
-        expect(e.response.status).to.equal(422);
-        expect(e.response.data).to.eql({ code: 'LIEN_INCOHERENT' });
-      }
+      expect(reponse.status).to.equal(422);
+      expect(reponse.body).to.eql({ code: 'LIEN_INCOHERENT' });
     });
 
     it("renvoie une erreur 403 si l'utilisateur courant n'a pas le droit de gérer les contributeurs sur le service", async () => {
@@ -2636,17 +2400,15 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         autorisationACharger: { peutGererContributeurs: () => false },
       });
 
-      try {
-        await axios.patch(
-          'http://localhost:1234/api/service/456/autorisations/uuid-1',
-          { droits: tousDroitsEnEcriture() }
-        );
+      const reponse = await testeur.patch(
+        '/api/service/456/autorisations/uuid-1',
+        {
+          droits: tousDroitsEnEcriture(),
+        }
+      );
 
-        expect().to.fail('La requête aurait dû lever une erreur HTTP 403');
-      } catch (e) {
-        expect(e.response.status).to.equal(403);
-        expect(e.response.data).to.eql({ code: 'INTERDIT' });
-      }
+      expect(reponse.status).to.equal(403);
+      expect(reponse.body).to.eql({ code: 'INTERDIT' });
     });
 
     it("récupère l'autorisation cible et lui applique les droits demandés puis persiste la modification", async () => {
@@ -2668,10 +2430,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         RISQUES: 0,
         CONTACTS: 2,
       };
-      await axios.patch(
-        'http://localhost:1234/api/service/456/autorisations/uuid-1',
-        { droits: droitsCible }
-      );
+      await testeur.patch('/api/service/456/autorisations/uuid-1', {
+        droits: droitsCible,
+      });
 
       expect(autorisationCiblee).to.be('uuid-1');
       expect(autorisationPersistee.droits).to.eql(droitsCible);
@@ -2704,10 +2465,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           RISQUES: 0,
           CONTACTS: 2,
         };
-        await axios.patch(
-          'http://localhost:1234/api/service/S1/autorisations/A1',
-          { droits: droitsCible }
-        );
+        await testeur.patch('/api/service/S1/autorisations/A1', {
+          droits: droitsCible,
+        });
 
         expect(donneesRecues).to.eql({ idUtilisateur: 'U1', idService: 'S1' });
       });
@@ -2731,10 +2491,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           RISQUES: 0,
           CONTACTS: 2,
         };
-        await axios.patch(
-          'http://localhost:1234/api/service/S1/autorisations/A1',
-          { droits: droitsCible }
-        );
+        await testeur.patch('/api/service/S1/autorisations/A1', {
+          droits: droitsCible,
+        });
 
         expect(depotAppele).to.be(false);
       });
@@ -2758,10 +2517,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           RISQUES: 0,
           CONTACTS: 2,
         };
-        await axios.patch(
-          'http://localhost:1234/api/service/S1/autorisations/A1',
-          { droits: droitsCible }
-        );
+        await testeur.patch('/api/service/S1/autorisations/A1', {
+          droits: droitsCible,
+        });
 
         expect(depotAppele).to.be(false);
       });
@@ -2779,12 +2537,12 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         CONTACTS: 2,
       };
 
-      const reponse = await axios.patch(
-        'http://localhost:1234/api/service/456/autorisations/uuid-1',
+      const reponse = await testeur.patch(
+        '/api/service/456/autorisations/uuid-1',
         { droits: droitsCible }
       );
 
-      expect(reponse.data).to.eql({
+      expect(reponse.body).to.eql({
         idAutorisation: 'uuid-1',
         idUtilisateur: '888',
         resumeNiveauDroit: 'PERSONNALISE',
@@ -2798,7 +2556,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         { code: 'DROITS_INCOHERENTS' },
         {
           method: 'PATCH',
-          url: 'http://localhost:1234/api/service/456/autorisations/uuid-1',
+          url: '/api/service/456/autorisations/uuid-1',
           data: { droits: { MAUVAISE_RUBRIQUE: 1 } },
         }
       );
@@ -2808,8 +2566,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       testeur.depotDonnees().autorisation = async (id) =>
         uneAutorisation().avecId(id).deContributeur('888', '456').construis();
 
-      const reponse = await axios.patch(
-        'http://localhost:1234/api/service/456/autorisations/uuid-1',
+      const reponse = await testeur.patch(
+        '/api/service/456/autorisations/uuid-1',
         {
           droits: { estProprietaire: false },
         }
@@ -2827,10 +2585,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         autorisationPersistee = autorisation;
       };
 
-      await axios.patch(
-        'http://localhost:1234/api/service/456/autorisations/uuid-1',
-        { droits: { estProprietaire: true } }
-      );
+      await testeur.patch('/api/service/456/autorisations/uuid-1', {
+        droits: { estProprietaire: true },
+      });
 
       expect(autorisationPersistee.estProprietaire).to.be(true);
     });
@@ -2850,26 +2607,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       ];
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [],
-        {
-          method: 'get',
-          url: 'http://localhost:1234/api/service/456/autorisations',
-        },
-        done
-      );
+    it('recherche le service correspondant', async () => {
+      testeur.middleware().verifieRechercheService([], {
+        method: 'get',
+        url: '/api/service/456/autorisations',
+      });
     });
 
-    it("aseptise l'id du service", (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['id'],
-        {
+    it("aseptise l'id du service", async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['id'], testeur.app(), {
           method: 'get',
-          url: 'http://localhost:1234/api/service/456/autorisations',
-        },
-        done
-      );
+          url: '/api/service/456/autorisations',
+        });
     });
 
     it('utilise le depot pour récupérer toutes les autorisations du service', async () => {
@@ -2888,7 +2639,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         idUtilisateur: 'AAA',
       });
 
-      await axios.get('http://localhost:1234/api/service/456/autorisations');
+      await testeur.get('/api/service/456/autorisations');
 
       expect(donneesPassees).to.eql({ idService: '456' });
     });
@@ -2901,11 +2652,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
           .construis(),
       ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/service/456/autorisations'
-      );
+      const reponse = await testeur.get('/api/service/456/autorisations');
 
-      expect(reponse.data).to.eql([
+      expect(reponse.body).to.eql([
         {
           idAutorisation: 'uuid-a',
           idUtilisateur: 'AAA',
@@ -2931,11 +2680,9 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         uneAutorisation().deContributeur('GHI', '456').construis(),
       ];
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/service/456/autorisations'
-      );
+      const reponse = await testeur.get('/api/service/456/autorisations');
 
-      expect(reponse.data.length).to.be(3 + 1);
+      expect(reponse.body.length).to.be(3 + 1);
     });
 
     it("renvoie uniquement le créateur et l'utilisateur s'il n'est pas créateur", async () => {
@@ -2954,37 +2701,31 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         uneAutorisation().deContributeur('GHI', '456').construis(),
       ];
 
-      const { data } = await axios.get(
-        'http://localhost:1234/api/service/456/autorisations'
-      );
+      const reponse = await testeur.get('/api/service/456/autorisations');
 
-      expect(data.length).to.be(2);
-      expect(data[0].idUtilisateur).to.equal('AAA');
-      expect(data[1].idUtilisateur).to.equal('DEF');
+      expect(reponse.body.length).to.be(2);
+      expect(reponse.body[0].idUtilisateur).to.equal('AAA');
+      expect(reponse.body[1].idUtilisateur).to.equal('DEF');
     });
   });
 
   describe('quand requête GET sur `/api/service/:id/indiceCyber', () => {
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: LECTURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: LECTURE, rubrique: SECURISER }], {
           method: 'get',
-          url: 'http://localhost:1234/api/service/456/indiceCyber',
-        },
-        done
-      );
+          url: '/api/service/456/indiceCyber',
+        });
     });
 
-    it("aseptise l'id du service", (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['id'],
-        {
+    it("aseptise l'id du service", async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['id'], testeur.app(), {
           method: 'get',
-          url: 'http://localhost:1234/api/service/456/indiceCyber',
-        },
-        done
-      );
+          url: '/api/service/456/indiceCyber',
+        });
     });
 
     it("renvoie l'indice cyber du service", async () => {
@@ -2994,35 +2735,29 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         serviceARenvoyer,
       });
 
-      const { data } = await axios.get(
-        'http://localhost:1234/api/service/456/indiceCyber'
-      );
+      const reponse = await testeur.get('/api/service/456/indiceCyber');
 
-      expect(data.total).to.be(1.5);
+      expect(reponse.body.total).to.be(1.5);
     });
   });
 
   describe('quand requête GET sur `/api/service/:id/indiceCyberPersonnalise', () => {
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: LECTURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: LECTURE, rubrique: SECURISER }], {
           method: 'get',
-          url: 'http://localhost:1234/api/service/456/indiceCyberPersonnalise',
-        },
-        done
-      );
+          url: '/api/service/456/indiceCyberPersonnalise',
+        });
     });
 
-    it("aseptise l'id du service", (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['id'],
-        {
+    it("aseptise l'id du service", async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['id'], testeur.app(), {
           method: 'get',
-          url: 'http://localhost:1234/api/service/456/indiceCyberPersonnalise',
-        },
-        done
-      );
+          url: '/api/service/456/indiceCyberPersonnalise',
+        });
     });
 
     it("renvoie l'indice cyber personnalisé du service", async () => {
@@ -3032,35 +2767,35 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         serviceARenvoyer,
       });
 
-      const { data } = await axios.get(
-        'http://localhost:1234/api/service/456/indiceCyberPersonnalise'
+      const reponse = await testeur.get(
+        '/api/service/456/indiceCyberPersonnalise'
       );
 
-      expect(data.total).to.be(2.5);
+      expect(reponse.body.total).to.be(2.5);
     });
   });
 
   describe('quand requête POST sur `/api/service/:id/retourUtilisateurMesure', () => {
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: SECURISER }],
-        {
+    it('recherche le service correspondant', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: SECURISER }], {
           method: 'post',
-          url: 'http://localhost:1234/api/service/456/retourUtilisateurMesure',
-        },
-        done
-      );
+          url: '/api/service/456/retourUtilisateurMesure',
+        });
     });
 
-    it('aseptise les données de la requête', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['id', 'idMesure', 'idRetour', 'commentaire'],
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service/456/retourUtilisateurMesure',
-        },
-        done
-      );
+    it('aseptise les données de la requête', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          ['id', 'idMesure', 'idRetour', 'commentaire'],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/456/retourUtilisateurMesure',
+          }
+        );
     });
 
     it("retourne une erreur HTTP 424 si l'id du retour utilisateur est inconnu", async () => {
@@ -3072,7 +2807,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         },
         {
           method: 'post',
-          url: 'http://localhost:1234/api/service/456/retourUtilisateurMesure',
+          url: '/api/service/456/retourUtilisateurMesure',
           data: { idRetour: 'idRetourInconnu' },
         }
       );
@@ -3090,7 +2825,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         },
         {
           method: 'post',
-          url: 'http://localhost:1234/api/service/456/retourUtilisateurMesure',
+          url: '/api/service/456/retourUtilisateurMesure',
           data: { idMesure: 'idMesureInconnu', idRetour: 'idRetour' },
         }
       );
@@ -3107,14 +2842,11 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         evenementRecu = donnees;
       };
 
-      await axios.post(
-        'http://localhost:1234/api/service/456/retourUtilisateurMesure',
-        {
-          idMesure: 'implementerMfa',
-          idRetour: 'bonneMesure',
-          commentaire: 'un commentaire',
-        }
-      );
+      await testeur.post('/api/service/456/retourUtilisateurMesure', {
+        idMesure: 'implementerMfa',
+        idRetour: 'bonneMesure',
+        commentaire: 'un commentaire',
+      });
 
       expect(evenementRecu.type).to.equal('RETOUR_UTILISATEUR_MESURE_RECU');
     });
@@ -3127,15 +2859,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
       });
     });
 
-    it('utilise le middleware de recherche du service', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [{ niveau: ECRITURE, rubrique: HOMOLOGUER }],
-        {
+    it('utilise le middleware de recherche du service', async () => {
+      testeur
+        .middleware()
+        .verifieRechercheService([{ niveau: ECRITURE, rubrique: HOMOLOGUER }], {
           method: 'delete',
-          url: 'http://localhost:1234/api/service/123/homologation/dossierCourant',
-        },
-        done
-      );
+          url: '/api/service/123/homologation/dossierCourant',
+        });
     });
 
     it("retourne une erreur HTTP 422 si le service n'a pas de dossier courant", async () => {
@@ -3147,7 +2877,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'Les dossiers ne comportent pas de dossier courant',
         {
           method: 'delete',
-          url: 'http://localhost:1234/api/service/123/homologation/dossierCourant',
+          url: '/api/service/123/homologation/dossierCourant',
         }
       );
     });
@@ -3170,44 +2900,39 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         serviceMisAJour = s;
       };
 
-      await axios.delete(
-        'http://localhost:1234/api/service/123/homologation/dossierCourant'
-      );
+      await testeur.delete('/api/service/123/homologation/dossierCourant');
 
       expect(serviceMisAJour.id).to.be('123');
     });
   });
 
   describe('quand requête POST sur `/api/service/estimationNiveauSecurite`', () => {
-    it("vérifie que l'utilisateur est authentifié", (done) => {
-      testeur.middleware().verifieRequeteExigeAcceptationCGU(
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service/estimationNiveauSecurite',
-        },
-        done
-      );
+    it("vérifie que l'utilisateur est authentifié", async () => {
+      testeur.middleware().verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'post',
+        url: '/api/service/estimationNiveauSecurite',
+      });
     });
 
-    it('aseptise les paramètres', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        [
-          'nomService',
-          'organisationsResponsables.*',
-          'nombreOrganisationsUtilisatrices.*',
-        ],
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/service/estimationNiveauSecurite',
-        },
-        done
-      );
+    it('aseptise les paramètres', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(
+          [
+            'nomService',
+            'organisationsResponsables.*',
+            'nombreOrganisationsUtilisatrices.*',
+          ],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/api/service/estimationNiveauSecurite',
+          }
+        );
     });
 
     it('aseptise les listes de paramètres ainsi que leur contenu', async () => {
-      await axios.post(
-        'http://localhost:1234/api/service/estimationNiveauSecurite'
-      );
+      await testeur.post('/api/service/estimationNiveauSecurite');
 
       testeur
         .middleware()
@@ -3226,13 +2951,13 @@ describe('Le serveur MSS des routes /api/service/*', () => {
 
     it("retourne l'estimation du niveau de sécurité pour la description donnée", async () => {
       const donneesDescriptionNiveau1 = { nomService: 'Mon service' };
-      const resultat = await axios.post(
-        'http://localhost:1234/api/service/estimationNiveauSecurite',
+      const resultat = await testeur.post(
+        '/api/service/estimationNiveauSecurite',
         donneesDescriptionNiveau1
       );
 
       expect(resultat.status).to.be(200);
-      expect(resultat.data.niveauDeSecuriteMinimal).to.be('niveau1');
+      expect(resultat.body.niveauDeSecuriteMinimal).to.be('niveau1');
     });
 
     it('retourne une erreur HTTP 400 si les données de description de service sont invalides', async () => {
@@ -3242,7 +2967,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'La description du service est invalide',
         {
           method: 'post',
-          url: 'http://localhost:1234/api/service/estimationNiveauSecurite',
+          url: '/api/service/estimationNiveauSecurite',
           data: donneesInvalides,
         }
       );
@@ -3250,26 +2975,20 @@ describe('Le serveur MSS des routes /api/service/*', () => {
   });
 
   describe('quand requête PUT sur `/api/service/:id/suggestionAction/:nature`', () => {
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
-        [],
-        {
-          method: 'put',
-          url: 'http://localhost:1234/api/service/123/suggestionAction/peuimporte',
-        },
-        done
-      );
+    it('recherche le service correspondant', async () => {
+      testeur.middleware().verifieRechercheService([], {
+        method: 'put',
+        url: '/api/service/123/suggestionAction/peuimporte',
+      });
     });
 
-    it('aseptise les paramètres', (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['id', 'nature'],
-        {
+    it('aseptise les paramètres', async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['id', 'nature'], testeur.app(), {
           method: 'put',
-          url: 'http://localhost:1234/api/service/123/suggestionAction/peuimporte',
-        },
-        done
-      );
+          url: '/api/service/123/suggestionAction/peuimporte',
+        });
     });
 
     it('utilise le dépôt de données pour acquitter la suggestion', async () => {
@@ -3286,8 +3005,8 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         },
       });
 
-      const resultat = await axios.put(
-        'http://localhost:1234/api/service/123/suggestionAction/niveauRetrograde'
+      const resultat = await testeur.put(
+        '/api/service/123/suggestionAction/niveauRetrograde'
       );
 
       expect(donneesDepotAppele).to.be.an('object');
@@ -3302,7 +3021,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         'La nature de la suggestion d’action est inconnue',
         {
           method: 'put',
-          url: 'http://localhost:1234/api/service/123/suggestionAction/inconnue',
+          url: '/api/service/123/suggestionAction/inconnue',
         }
       );
     });

--- a/test/routes/connecte/routesConnecteApiServicePdf.spec.js
+++ b/test/routes/connecte/routesConnecteApiServicePdf.spec.js
@@ -1,5 +1,4 @@
 const expect = require('expect.js');
-const axios = require('axios');
 
 const testeurMSS = require('../testeurMSS');
 const {
@@ -24,25 +23,23 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
 
   beforeEach(testeur.initialise);
 
-  afterEach(testeur.arrete);
-
   describe('quand requête GET sur `/api/service/:id/pdf/annexes.pdf`', () => {
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
+    it('recherche le service correspondant', async () => {
+      await testeur.middleware().verifieRechercheService(
         [
           { niveau: LECTURE, rubrique: DECRIRE },
           { niveau: LECTURE, rubrique: SECURISER },
           { niveau: LECTURE, rubrique: RISQUES },
         ],
-        'http://localhost:1234/api/service/456/pdf/annexes.pdf',
-        done
+        testeur.app(),
+        '/api/service/456/pdf/annexes.pdf'
       );
     });
 
-    it('sert un fichier de type pdf', (done) => {
-      verifieTypeFichierServiEstPDF(
-        'http://localhost:1234/api/service/456/pdf/annexes.pdf',
-        done
+    it('sert un fichier de type pdf', async () => {
+      await verifieTypeFichierServiEstPDF(
+        testeur.app(),
+        '/api/service/456/pdf/annexes.pdf'
       );
     });
 
@@ -53,7 +50,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         return 'Pdf annexes';
       };
 
-      await axios.get('http://localhost:1234/api/service/456/pdf/annexes.pdf');
+      await testeur.get('/api/service/456/pdf/annexes.pdf');
 
       expect(adaptateurPdfAppele).to.be(true);
     });
@@ -90,29 +87,29 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur
+    it('recherche le service correspondant', async () => {
+      await testeur
         .middleware()
         .verifieRechercheService(
           [{ niveau: LECTURE, rubrique: HOMOLOGUER }],
-          'http://localhost:1234/api/service/456/pdf/dossierDecision.pdf',
-          done
+          testeur.app(),
+          '/api/service/456/pdf/dossierDecision.pdf'
         );
     });
 
-    it('recherche le dossier courant correspondant', (done) => {
-      testeur
+    it('recherche le dossier courant correspondant', async () => {
+      await testeur
         .middleware()
         .verifieRechercheDossierCourant(
-          'http://localhost:1234/api/service/456/pdf/dossierDecision.pdf',
-          done
+          testeur.app(),
+          '/api/service/456/pdf/dossierDecision.pdf'
         );
     });
 
-    it('sert un fichier de type pdf', (done) => {
-      verifieTypeFichierServiEstPDF(
-        'http://localhost:1234/api/service/456/pdf/dossierDecision.pdf',
-        done
+    it('sert un fichier de type pdf', async () => {
+      await verifieTypeFichierServiEstPDF(
+        testeur.app(),
+        '/api/service/456/pdf/dossierDecision.pdf'
       );
     });
 
@@ -125,9 +122,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         return 'Pdf dossier décision';
       };
 
-      await axios.get(
-        'http://localhost:1234/api/service/456/pdf/dossierDecision.pdf'
-      );
+      await testeur.get('/api/service/456/pdf/dossierDecision.pdf');
 
       expect(donneesDossier.nomService).to.equal('un service');
       expect(donneesDossier.nomPrenomAutorite).to.equal('Jean Dupond');
@@ -161,21 +156,21 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
+    it('recherche le service correspondant', async () => {
+      await testeur.middleware().verifieRechercheService(
         [
           { niveau: LECTURE, rubrique: SECURISER },
           { niveau: LECTURE, rubrique: DECRIRE },
         ],
-        'http://localhost:1234/api/service/456/pdf/syntheseSecurite.pdf',
-        done
+        testeur.app(),
+        '/api/service/456/pdf/syntheseSecurite.pdf'
       );
     });
 
-    it('sert un fichier de type pdf', (done) => {
-      verifieTypeFichierServiEstPDF(
-        'http://localhost:1234/api/service/456/pdf/syntheseSecurite.pdf',
-        done
+    it('sert un fichier de type pdf', async () => {
+      await verifieTypeFichierServiEstPDF(
+        testeur.app(),
+        '/api/service/456/pdf/syntheseSecurite.pdf'
       );
     });
 
@@ -187,9 +182,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         return 'Pdf synthèse sécurité';
       };
 
-      await axios.get(
-        'http://localhost:1234/api/service/456/pdf/syntheseSecurite.pdf'
-      );
+      await testeur.get('/api/service/456/pdf/syntheseSecurite.pdf');
 
       expect(donneesSynthese.service).to.eql(serviceARenvoyer);
       expect(donneesSynthese.referentiel).to.eql(testeur.referentiel());
@@ -217,39 +210,39 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur
+    it('recherche le service correspondant', async () => {
+      await testeur
         .middleware()
         .verifieRechercheService(
           [],
-          'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip',
-          done
+          testeur.app(),
+          '/api/service/456/pdf/documentsHomologation.zip'
         );
     });
 
-    it('sert un fichier de type zip', (done) => {
-      verifieTypeFichierServiEstZIP(
-        'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip',
-        done
+    it('sert un fichier de type zip', async () => {
+      await verifieTypeFichierServiEstZIP(
+        testeur.app(),
+        '/api/service/456/pdf/documentsHomologation.zip'
       );
     });
 
-    it('sert un fichier dont le nom contient la date du jour en format court', (done) => {
+    it('sert un fichier dont le nom contient la date du jour en format court', async () => {
       testeur.adaptateurHorloge().maintenant = () => new Date(2023, 0, 28);
 
-      verifieNomFichierServi(
-        'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip',
-        'MSS_decision_20230128.zip',
-        done
+      await verifieNomFichierServi(
+        testeur.app(),
+        '/api/service/456/pdf/documentsHomologation.zip',
+        'MSS_decision_20230128.zip'
       );
     });
 
-    it("utilise le middleware de chargement de l'autorisation", (done) => {
-      testeur
+    it("utilise le middleware de chargement de l'autorisation", async () => {
+      await testeur
         .middleware()
         .verifieChargementDesAutorisations(
-          'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip',
-          done
+          testeur.app(),
+          '/api/service/456/pdf/documentsHomologation.zip'
         );
     });
 
@@ -273,9 +266,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         fichiersZipes = fichiers;
       };
 
-      await axios.get(
-        'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip'
-      );
+      await testeur.get('/api/service/456/pdf/documentsHomologation.zip');
 
       expect(fichiersZipes.length).to.be(1);
       expect(fichiersZipes[0]).to.eql({ nom: 'Annexes.pdf', buffer: 'PDF A' });
@@ -288,9 +279,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         return new Date();
       };
 
-      await axios.get(
-        'http://localhost:1234/api/service/456/pdf/documentsHomologation.zip'
-      );
+      await testeur.get('/api/service/456/pdf/documentsHomologation.zip');
       expect(adaptateurHorlogeAppele).to.be(true);
     });
   });
@@ -312,31 +301,31 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       testeur.middleware().reinitialise({ serviceARenvoyer });
     });
 
-    it('recherche le service correspondant', (done) => {
-      testeur.middleware().verifieRechercheService(
+    it('recherche le service correspondant', async () => {
+      await testeur.middleware().verifieRechercheService(
         [
           { niveau: LECTURE, rubrique: HOMOLOGUER },
           { niveau: LECTURE, rubrique: DECRIRE },
         ],
-        'http://localhost:1234/api/service/456/archive/tamponHomologation.zip',
-        done
+        testeur.app(),
+        '/api/service/456/archive/tamponHomologation.zip'
       );
     });
 
-    it('sert un fichier de type zip', (done) => {
-      verifieTypeFichierServiEstZIP(
-        'http://localhost:1234/api/service/456/archive/tamponHomologation.zip',
-        done
+    it('sert un fichier de type zip', async () => {
+      await verifieTypeFichierServiEstZIP(
+        testeur.app(),
+        '/api/service/456/archive/tamponHomologation.zip'
       );
     });
 
-    it("sert un fichier qui porte le nom de l'archive", (done) => {
+    it("sert un fichier qui porte le nom de l'archive", async () => {
       testeur.adaptateurHorloge().maintenant = () => new Date(2023, 0, 28);
 
-      verifieNomFichierServi(
-        'http://localhost:1234/api/service/456/archive/tamponHomologation.zip',
-        'MSS_tampon_homologation.zip',
-        done
+      await verifieNomFichierServi(
+        testeur.app(),
+        '/api/service/456/archive/tamponHomologation.zip',
+        'MSS_tampon_homologation.zip'
       );
     });
 
@@ -355,7 +344,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         "Le service n'a pas d'homologation active",
         {
           method: 'get',
-          url: 'http://localhost:1234/api/service/456/archive/tamponHomologation.zip',
+          url: '/api/service/456/archive/tamponHomologation.zip',
         }
       );
     });
@@ -367,9 +356,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         return [];
       };
 
-      await axios.get(
-        'http://localhost:1234/api/service/456/archive/tamponHomologation.zip'
-      );
+      await testeur.get('/api/service/456/archive/tamponHomologation.zip');
       expect(adaptateurPdfAppele).to.be(true);
     });
 
@@ -380,9 +367,7 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
         return [];
       };
 
-      await axios.get(
-        'http://localhost:1234/api/service/456/archive/tamponHomologation.zip'
-      );
+      await testeur.get('/api/service/456/archive/tamponHomologation.zip');
       expect(adaptateurZipAppele).to.be(true);
     });
   });

--- a/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
+++ b/test/routes/connecte/routesConnecteApiTeleversement.modelesMesureSpecifique.spec.js
@@ -1,4 +1,3 @@
-const axios = require('axios');
 const expect = require('expect.js');
 const testeurMSS = require('../testeurMSS');
 const {
@@ -11,27 +10,22 @@ const TeleversementModelesMesureSpecifique = require('../../../src/modeles/telev
 describe('Les routes connecté de téléversement des modèles de mesure spécifique', () => {
   const testeur = testeurMSS();
   beforeEach(testeur.initialise);
-  afterEach(testeur.arrete);
 
-  it("vérifie que l'utilisateur est authentifié, 1 seul test suffit car le middleware est placé au niveau de l'instanciation du routeur", (done) => {
-    testeur.middleware().verifieRequeteExigeAcceptationCGU(
-      {
+  it("vérifie que l'utilisateur est authentifié, 1 seul test suffit car le middleware est placé au niveau de l'instanciation du routeur", async () => {
+    await testeur
+      .middleware()
+      .verifieRequeteExigeAcceptationCGU(testeur.app(), {
         method: 'post',
-        url: 'http://localhost:1234/api/televersement/modelesMesureSpecifique',
-      },
-      done
-    );
+        url: '/api/televersement/modelesMesureSpecifique',
+      });
   });
 
   describe('quand requête POST sur `/api/televersement/modelesMesureSpecifique`', () => {
-    it('applique une protection de trafic', (done) => {
-      testeur.middleware().verifieProtectionTrafic(
-        {
-          method: 'post',
-          url: 'http://localhost:1234/api/televersement/modelesMesureSpecifique',
-        },
-        done
-      );
+    it('applique une protection de trafic', async () => {
+      await testeur.middleware().verifieProtectionTrafic(testeur.app(), {
+        method: 'post',
+        url: '/api/televersement/modelesMesureSpecifique',
+      });
     });
 
     it("délègue la vérification de surface à l'adaptateur de vérification de fichier", async () => {
@@ -42,9 +36,7 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
         requeteRecue = requete;
       };
 
-      await axios.post(
-        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
-      );
+      await testeur.post('/api/televersement/modelesMesureSpecifique');
 
       expect(adaptateurAppele).to.be(true);
       expect(requeteRecue).not.to.be(undefined);
@@ -55,14 +47,11 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
         throw new ErreurFichierXlsInvalide();
       };
 
-      try {
-        await axios.post(
-          'http://localhost:1234/api/televersement/modelesMesureSpecifique'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.post(
+        '/api/televersement/modelesMesureSpecifique'
+      );
+
+      expect(reponse.status).to.be(400);
     });
 
     it("délègue la conversion du contenu à l'adaptateur de lecture de données téléversées", async () => {
@@ -74,9 +63,7 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
           bufferRecu = buffer;
         };
 
-      await axios.post(
-        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
-      );
+      await testeur.post('/api/televersement/modelesMesureSpecifique');
 
       expect(adaptateurAppele).to.be(true);
       expect(bufferRecu).not.to.be(undefined);
@@ -95,9 +82,7 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
           donneesRecues = donnees;
         };
 
-      await axios.post(
-        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
-      );
+      await testeur.post('/api/televersement/modelesMesureSpecifique');
 
       expect(idUtilisateurQuiTeleverse).to.equal('123');
       expect(donneesRecues).to.eql([{ description: 'Mesure téléversée' }]);
@@ -118,9 +103,7 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
         return new TeleversementModelesMesureSpecifique([], {});
       };
 
-      await axios.get(
-        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
-      );
+      await testeur.get('/api/televersement/modelesMesureSpecifique');
 
       expect(idDemande).to.be('U1');
     });
@@ -139,12 +122,13 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
             {}
           );
 
-      const reponse = await axios.get(
-        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
+      const reponse = await testeur.get(
+        '/api/televersement/modelesMesureSpecifique'
       );
 
       const { descriptionLongue, description } =
-        reponse.data.modelesTeleverses[0].modele;
+        reponse.body.modelesTeleverses[0].modele;
+
       expect(description).to.be("L'abricot");
       expect(descriptionLongue).to.be("L'autre");
     });
@@ -153,14 +137,11 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
       testeur.depotDonnees().lisTeleversementModelesMesureSpecifique =
         async () => undefined;
 
-      try {
-        await axios.get(
-          'http://localhost:1234/api/televersement/modelesMesureSpecifique'
-        );
-        expect().fail("L'appel aurait dû lever une erreur");
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      const reponse = await testeur.get(
+        '/api/televersement/modelesMesureSpecifique'
+      );
+
+      expect(reponse.status).to.be(404);
     });
   });
 
@@ -173,9 +154,7 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
         };
       testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
 
-      await axios.delete(
-        'http://localhost:1234/api/televersement/modelesMesureSpecifique'
-      );
+      await testeur.delete('/api/televersement/modelesMesureSpecifique');
 
       expect(idRecu).to.be('U1');
     });
@@ -201,14 +180,11 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
           throw new ErreurTeleversementInexistant();
         };
 
-      try {
-        await axios.post(
-          'http://localhost:1234/api/televersement/modelesMesureSpecifique/confirme'
-        );
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(404);
-      }
+      const reponse = await testeur.post(
+        '/api/televersement/modelesMesureSpecifique/confirme'
+      );
+
+      expect(reponse.status).to.be(404);
     });
 
     it('renvoie une erreur 400 si le téléversement en cours est invalide', async () => {
@@ -217,14 +193,11 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
           throw new ErreurTeleversementInvalide();
         };
 
-      try {
-        await axios.post(
-          'http://localhost:1234/api/televersement/modelesMesureSpecifique/confirme'
-        );
-        expect().fail('Aurait dû lever une erreur');
-      } catch (e) {
-        expect(e.response.status).to.be(400);
-      }
+      const reponse = await testeur.post(
+        '/api/televersement/modelesMesureSpecifique/confirme'
+      );
+
+      expect(reponse.status).to.be(400);
     });
 
     it('délègue au dépôt de données la confirmation du téléversement', async () => {
@@ -234,9 +207,7 @@ describe('Les routes connecté de téléversement des modèles de mesure spécif
           idUtilisateurRecu = idUtilisateur;
         };
 
-      await axios.post(
-        'http://localhost:1234/api/televersement/modelesMesureSpecifique/confirme'
-      );
+      await testeur.post('/api/televersement/modelesMesureSpecifique/confirme');
 
       expect(idUtilisateurRecu).to.be('U1');
     });

--- a/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
+++ b/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
@@ -1,4 +1,3 @@
-const axios = require('axios');
 const expect = require('expect.js');
 
 const testeurMSS = require('../testeurMSS');
@@ -9,19 +8,16 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
 
   beforeEach(testeur.initialise);
 
-  afterEach(testeur.arrete);
-
-  it("vérifie que l'utilisateur est authentifié sur toutes les routes", (done) => {
+  it("vérifie que l'utilisateur est authentifié sur toutes les routes", async () => {
     // On vérifie une seule route privée.
     // Par construction, les autres seront protégées aussi puisque la protection est ajoutée comme middleware
     // devant le routeur dédié aux routes de la visite guidée.
-    testeur.middleware().verifieRequeteExigeAcceptationCGU(
-      {
+    await testeur
+      .middleware()
+      .verifieRequeteExigeAcceptationCGU(testeur.app(), {
         method: 'post',
-        url: 'http://localhost:1234/api/visiteGuidee/termine',
-      },
-      done
-    );
+        url: '/api/visiteGuidee/termine',
+      });
   });
 
   describe('quand requête POST sur /visiteGuidee/:idEtape/termine', () => {
@@ -34,15 +30,13 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
       });
     });
 
-    it("aseptise l'identifiant d'étape", (done) => {
-      testeur.middleware().verifieAseptisationParametres(
-        ['idEtape'],
-        {
+    it("aseptise l'identifiant d'étape", async () => {
+      await testeur
+        .middleware()
+        .verifieAseptisationParametres(['idEtape'], testeur.app(), {
           method: 'post',
-          url: 'http://localhost:1234/api/visiteGuidee/DECRIRE/termine',
-        },
-        done
-      );
+          url: '/api/visiteGuidee/DECRIRE/termine',
+        });
     });
 
     it("retourne une erreur HTTP 400 si l'ID d'étape n'existe pas", async () => {
@@ -51,7 +45,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
         "Identifiant d'étape inconnu",
         {
           method: 'POST',
-          url: 'http://localhost:1234/api/visiteGuidee/MAUVAIS_ID/termine',
+          url: '/api/visiteGuidee/MAUVAIS_ID/termine',
         }
       );
     });
@@ -71,9 +65,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
         parcoursUtilisateurPasse = parcoursUtilisateur;
       };
 
-      await axios.post(
-        'http://localhost:1234/api/visiteGuidee/DECRIRE/termine'
-      );
+      await testeur.post('/api/visiteGuidee/DECRIRE/termine');
 
       expect(parcoursUtilisateurPasse.etatVisiteGuidee.etapesVues).to.eql([
         'DECRIRE',
@@ -81,19 +73,15 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
     });
 
     it("renvoi l'URL de l'étape suivante", async () => {
-      const reponse = await axios.post(
-        'http://localhost:1234/api/visiteGuidee/DECRIRE/termine'
-      );
+      const reponse = await testeur.post('/api/visiteGuidee/DECRIRE/termine');
 
-      expect(reponse.data.urlEtapeSuivante).to.be('/visiteGuidee/securiser');
+      expect(reponse.body.urlEtapeSuivante).to.be('/visiteGuidee/securiser');
     });
 
     it("renvoi une URL `null` s'il n'y a pas d'étape suivante", async () => {
-      const reponse = await axios.post(
-        'http://localhost:1234/api/visiteGuidee/SECURISER/termine'
-      );
+      const reponse = await testeur.post('/api/visiteGuidee/SECURISER/termine');
 
-      expect(reponse.data.urlEtapeSuivante).to.be(null);
+      expect(reponse.body.urlEtapeSuivante).to.be(null);
     });
   });
 
@@ -121,7 +109,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
         parcoursUtilisateurPasse = parcoursUtilisateur;
       };
 
-      await axios.post('http://localhost:1234/api/visiteGuidee/termine');
+      await testeur.post('/api/visiteGuidee/termine');
 
       expect(parcoursUtilisateurPasse.etatVisiteGuidee.toJSON()).to.eql({
         dejaTerminee: true,
@@ -145,7 +133,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
         parcoursUtilisateurPasse = parcoursUtilisateur;
       };
 
-      await axios.post('http://localhost:1234/api/visiteGuidee/metsEnPause');
+      await testeur.post('/api/visiteGuidee/metsEnPause');
 
       expect(parcoursUtilisateurPasse.etatVisiteGuidee.enPause).to.be(true);
     });
@@ -167,7 +155,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
         parcoursUtilisateurPasse = parcoursUtilisateur;
       };
 
-      await axios.post('http://localhost:1234/api/visiteGuidee/reprends');
+      await testeur.post('/api/visiteGuidee/reprends');
 
       expect(parcoursUtilisateurPasse.etatVisiteGuidee.enPause).to.be(false);
     });
@@ -188,7 +176,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
       parcoursUtilisateurPasse = parcoursUtilisateur;
     };
 
-    await axios.post('http://localhost:1234/api/visiteGuidee/reinitialise');
+    await testeur.post('/api/visiteGuidee/reinitialise');
 
     expect(parcoursUtilisateurPasse.etatVisiteGuidee.dejaTerminee).to.be(false);
   });

--- a/test/routes/connecte/routesConnecteOidc.spec.js
+++ b/test/routes/connecte/routesConnecteOidc.spec.js
@@ -1,5 +1,4 @@
 const expect = require('expect.js');
-const { requeteSansRedirection } = require('../../aides/http');
 const testeurMSS = require('../testeurMSS');
 const { enObjet } = require('../../aides/cookie');
 
@@ -10,7 +9,6 @@ describe('Le serveur MSS des routes connectées /oidc/*', () => {
     testeur.initialise();
   });
 
-  afterEach(testeur.arrete);
   describe('quand requête GET sur /oidc/deconnexion', () => {
     let idTokenAgentConnect;
     beforeEach(() => {
@@ -27,9 +25,7 @@ describe('Le serveur MSS des routes connectées /oidc/*', () => {
     });
 
     it('redirige vers la page de déconnexion', async () => {
-      const reponse = await requeteSansRedirection(
-        'http://localhost:1234/oidc/deconnexion'
-      );
+      const reponse = await testeur.get('/oidc/deconnexion');
 
       expect(reponse.status).to.be(302);
       expect(reponse.headers.location).to.be('http');
@@ -37,9 +33,7 @@ describe('Le serveur MSS des routes connectées /oidc/*', () => {
     });
 
     it('dépose un cookie avec le state', async () => {
-      const reponse = await requeteSansRedirection(
-        'http://localhost:1234/oidc/deconnexion'
-      );
+      const reponse = await testeur.get('/oidc/deconnexion');
 
       const headerCookie = reponse.headers['set-cookie'];
       const cookie = enObjet(headerCookie[0]).AgentConnectInfo;

--- a/test/routes/connecte/routesConnectePageService.spec.js
+++ b/test/routes/connecte/routesConnectePageService.spec.js
@@ -188,7 +188,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
           const reponse = await testeur.get('/service/456');
 
-          expect(reponse.headers['location']).to.contain(redirectionAttendue);
+          expect(reponse.headers.location).to.contain(redirectionAttendue);
         });
       });
 
@@ -215,7 +215,7 @@ describe('Le serveur MSS des routes /service/*', () => {
 
         const reponse = await testeur.get('/service/456');
 
-        expect(reponse.headers['location']).to.contain(
+        expect(reponse.headers.location).to.contain(
           '/service/456/descriptionService?etape=3'
         );
       });
@@ -716,7 +716,7 @@ describe('Le serveur MSS des routes /service/*', () => {
         '/service/456/homologation/edition/etape/deuxieme'
       );
 
-      expect(reponse.headers['location']).to.contain('dateTelechargement');
+      expect(reponse.headers.location).to.contain('dateTelechargement');
     });
 
     it("redirige vers la dernière étape disponible si l'étape demandée n'est pas accessible pour l'utilisateur", async () => {
@@ -734,7 +734,7 @@ describe('Le serveur MSS des routes /service/*', () => {
         '/service/456/homologation/edition/etape/deuxieme'
       );
 
-      expect(reponse.headers['location']).to.contain('dateTelechargement');
+      expect(reponse.headers.location).to.contain('dateTelechargement');
     });
   });
 });

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.js
@@ -62,14 +62,14 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
 
     it('applique une protection de trafic', async () => {
-      testeur.middleware().verifieProtectionTrafic({
+      await testeur.middleware().verifieProtectionTrafic(testeur.app(), {
         method: 'post',
         url: '/api/utilisateur',
       });
     });
 
     it('aseptise les paramètres de la requête', async () => {
-      testeur
+      await testeur
         .middleware()
         .verifieAseptisationParametres(
           [
@@ -81,6 +81,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
             'estimationNombreServices.*',
             'siretEntite',
           ],
+          testeur.app(),
           {
             method: 'post',
             url: '/api/utilisateur',

--- a/test/routes/nonConnecte/routesNonConnecteApiBibliotheques.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApiBibliotheques.spec.js
@@ -5,15 +5,13 @@ describe('Le serveur MSS des routes /bibliotheques/*', () => {
 
   beforeEach(testeur.initialise);
 
-  afterEach(testeur.arrete);
-
   it('retourne une erreur HTTP 404 si la bibliothèque est inconnue', async () => {
     await testeur.verifieRequeteGenereErreurHTTP(
       404,
       'Bibliothèque inconnue : bibliothequeInconnue.js',
       {
         method: 'get',
-        url: 'http://localhost:1234/bibliotheques/bibliothequeInconnue.js',
+        url: '/bibliotheques/bibliothequeInconnue.js',
       }
     );
   });

--- a/test/routes/nonConnecte/routesNonConnecteApiStyles.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteApiStyles.spec.js
@@ -5,13 +5,11 @@ describe('Le serveur MSS des routes /styles/*', () => {
 
   beforeEach(testeur.initialise);
 
-  afterEach(testeur.arrete);
-
   it('retourne une erreur HTTP 404 si la feuille de style est inconnue', async () => {
     await testeur.verifieRequeteGenereErreurHTTP(
       404,
       'Feuille de style inconnue',
-      { method: 'get', url: 'http://localhost:1234/styles/stylesInconnu.css' }
+      { method: 'get', url: '/styles/stylesInconnu.css' }
     );
   });
 });

--- a/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
+++ b/test/routes/nonConnecte/routesNonConnecteOidc.spec.js
@@ -13,9 +13,7 @@ const { donneesPartagees } = require('../../aides/http');
 describe('Le serveur MSS des routes publiques /oidc/*', () => {
   const testeur = testeurMSS();
 
-  beforeEach(() => {
-    testeur.initialise();
-  });
+  beforeEach(testeur.initialise);
 
   describe('quand requête GET sur `/oidc/connexion`', () => {
     beforeEach(() => {
@@ -452,6 +450,7 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
         },
       });
     });
+
     it('redirige vers la page de connexion', async () => {
       const reponse = await testeur.get(
         '/oidc/apres-deconnexion?state=unState'
@@ -462,9 +461,10 @@ describe('Le serveur MSS des routes publiques /oidc/*', () => {
     });
 
     it("supprime la session de l'utilisateur via la page /connexion", async () => {
-      testeur
+      await testeur
         .middleware()
         .verifieRequeteExigeSuppressionCookie(
+          testeur.app(),
           '/oidc/apres-deconnexion?state=unState'
         );
     });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -73,7 +73,7 @@ const testeurMss = () => {
       [requete.method.toLowerCase()](requete.url)
       .send(requete.data);
     expect(reponse.status).to.equal(status);
-    if (reponse.type === 'text/html')
+    if (reponse.type === 'text/html' || reponse.type === 'text/plain')
       expect(reponse.text).to.eql(messageErreur);
     else expect(reponse.body).to.eql(messageErreur);
   };

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const expect = require('expect.js');
 
+const supertest = require('supertest');
 const { depotVide } = require('../depots/depotVide');
 const adaptateurGestionErreurVide = require('../../src/adaptateurs/adaptateurGestionErreurVide');
 const adaptateurMailMemoire = require('../../src/adaptateurs/adaptateurMailMemoire');
@@ -203,6 +204,15 @@ const testeurMss = () => {
 
   const arrete = () => serveur.arreteEcoute();
 
+  const get = async (url) => supertest(app).get(url);
+  const patch = async (url, donnees = {}) =>
+    supertest(app).patch(url).send(donnees);
+  const post = async (url, donnees = {}) =>
+    supertest(app).post(url).send(donnees);
+  const put = async (url, donnees = {}) =>
+    supertest(app).put(url).send(donnees);
+  const del = async (url) => supertest(app).delete(url);
+
   return {
     app: () => app,
     serviceAnnuaire: () => serviceAnnuaire,
@@ -235,6 +245,11 @@ const testeurMss = () => {
     initialise,
     verifieRequeteGenereErreurHTTP,
     verifieSessionDeposee,
+    get,
+    patch,
+    put,
+    post,
+    delete: del,
   };
 };
 

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -220,6 +220,8 @@ const testeurMss = () => {
     supertest(app).put(url).send(donnees);
   const del = async (url, donnees = {}) =>
     supertest(app).delete(url).send(donnees);
+  const copy = async (url, donnees = {}) =>
+    supertest(app).copy(url).send(donnees);
 
   return {
     app: () => app,
@@ -253,6 +255,7 @@ const testeurMss = () => {
     initialise,
     verifieRequeteGenereErreurHTTP,
     verifieSessionDeposee,
+    copy,
     get,
     patch,
     put,

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -52,6 +52,7 @@ const testeurMss = () => {
   let busEvenements;
   let cmsCrisp;
   let serveur;
+  let app;
 
   const verifieSessionDeposee = (reponse, suite) => {
     const valeurHeader = reponse.headers['set-cookie'][0];
@@ -75,7 +76,7 @@ const testeurMss = () => {
     }
   };
 
-  const initialise = (done) => {
+  const initialise = async () => {
     serviceAnnuaire = {};
     serviceSupervision = {};
     adaptateurHorloge = {
@@ -154,55 +155,56 @@ const testeurMss = () => {
     busEvenements = fabriqueBusPourLesTests();
 
     moteurRegles = new MoteurRegles(referentiel);
-    depotVide()
-      .then((depot) => {
-        depotDonnees = depot;
-        inscriptionUtilisateur = fabriqueInscriptionUtilisateur({
-          adaptateurMail,
-          adaptateurTracking,
-          depotDonnees,
-        });
-        serveur = MSS.creeServeur({
-          depotDonnees,
-          middleware,
-          referentiel,
-          moteurRegles,
-          adaptateurMail,
-          adaptateurPdf,
-          adaptateurHorloge,
-          adaptateurGestionErreur,
-          serviceAnnuaire,
-          adaptateurCsv,
-          adaptateurZip,
-          adaptateurTracking,
-          adaptateurProtection,
-          adaptateurJournal,
-          adaptateurOidc,
-          adaptateurEnvironnement,
-          adaptateurStatistiques,
-          adaptateurJWT,
-          adaptateurProfilAnssi,
-          lecteurDeFormData,
-          adaptateurTeleversementServices,
-          adaptateurTeleversementModelesMesureSpecifique,
-          cmsCrisp,
-          serviceSupervision,
-          serviceGestionnaireSession,
-          serviceCgu,
-          procedures,
-          inscriptionUtilisateur,
-          busEvenements,
-          avecCookieSecurise: false,
-          avecPageErreur: false,
-        });
-        serveur.ecoute(1234, done);
-      })
-      .catch(done);
+    try {
+      depotDonnees = await depotVide();
+      inscriptionUtilisateur = fabriqueInscriptionUtilisateur({
+        adaptateurMail,
+        adaptateurTracking,
+        depotDonnees,
+      });
+      serveur = MSS.creeServeur({
+        depotDonnees,
+        middleware,
+        referentiel,
+        moteurRegles,
+        adaptateurMail,
+        adaptateurPdf,
+        adaptateurHorloge,
+        adaptateurGestionErreur,
+        serviceAnnuaire,
+        adaptateurCsv,
+        adaptateurZip,
+        adaptateurTracking,
+        adaptateurProtection,
+        adaptateurJournal,
+        adaptateurOidc,
+        adaptateurEnvironnement,
+        adaptateurStatistiques,
+        adaptateurJWT,
+        adaptateurProfilAnssi,
+        lecteurDeFormData,
+        adaptateurTeleversementServices,
+        adaptateurTeleversementModelesMesureSpecifique,
+        cmsCrisp,
+        serviceSupervision,
+        serviceGestionnaireSession,
+        serviceCgu,
+        procedures,
+        inscriptionUtilisateur,
+        busEvenements,
+        avecCookieSecurise: false,
+        avecPageErreur: false,
+      });
+      app = serveur.app;
+    } catch (e) {
+      expect().fail("Erreur à l'initialisation du testeur MSS.");
+    }
   };
 
   const arrete = () => serveur.arreteEcoute();
 
   return {
+    app: () => app,
     serviceAnnuaire: () => serviceAnnuaire,
     serviceGestionnaireSession: () => serviceGestionnaireSession,
     serviceSupervision: () => serviceSupervision,

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -66,12 +66,18 @@ const testeurMss = () => {
     messageErreur,
     requete
   ) => {
-    const methode = requete.method.toLowerCase();
+    let url;
+    let methode;
+    if (typeof requete === 'string') {
+      url = requete;
+      methode = 'get';
+    } else {
+      url = requete.url;
+      methode = requete.method?.toLowerCase();
+    }
     if (!(methode in supertest(app)))
       throw new Error(`La méthode ${methode} n'est pas un verbe HTTP correct`);
-    const reponse = await supertest(app)
-      [requete.method.toLowerCase()](requete.url)
-      .send(requete.data);
+    const reponse = await supertest(app)[methode](url).send(requete.data);
     expect(reponse.status).to.equal(status);
     if (reponse.type === 'text/html' || reponse.type === 'text/plain')
       expect(reponse.text).to.eql(messageErreur);


### PR DESCRIPTION
... afin de tester nos routes dans une configuration "in memory".

Cela permet de faciliter la transition vers Typescript, Vitest, etc...