### PR TITLE
Suppression de toutes les utilisations de `done()`

### DIFF
--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -106,8 +106,8 @@ const middleware = (configuration = {}) => {
     return suite();
   };
 
-  const verificationAcceptationCGU = (requete, reponse, suite) => {
-    verificationJWT(requete, reponse, () => {
+  const verificationAcceptationCGU = async (requete, reponse, suite) => {
+    await verificationJWT(requete, reponse, () => {
       if (requete.estInvite) {
         return reponse.redirect(
           requete.sourceAuthentification === SourceAuthentification.MSS
@@ -123,7 +123,7 @@ const middleware = (configuration = {}) => {
     });
   };
 
-  const trouveService = (droitsRequis) => (requete, reponse, suite) => {
+  const trouveService = (droitsRequis) => async (requete, reponse, suite) => {
     const idService = requete.params.id;
 
     const droitsCoherents = verifieCoherenceDesDroits(droitsRequis);
@@ -133,7 +133,7 @@ const middleware = (configuration = {}) => {
         "L'objet de droits doit être de la forme `{ [Rubrique]: niveau }`"
       );
 
-    verificationAcceptationCGU(requete, reponse, () =>
+    await verificationAcceptationCGU(requete, reponse, () =>
       depotDonnees
         .service(idService)
         .then((service) => {

--- a/test/depotDonnees.spec.js
+++ b/test/depotDonnees.spec.js
@@ -3,37 +3,30 @@ const expect = require('expect.js');
 const { depotVide } = require('./depots/depotVide');
 
 describe('Le dépôt de données vide', () => {
-  it('ne retourne aucun service pour un utilisateur donné', (done) => {
-    depotVide()
-      .then((depot) => depot.services('456'))
-      .then((services) => expect(services).to.eql([]))
-      .then(() => done())
-      .catch(done);
+  it('ne retourne aucun service pour un utilisateur donné', async () => {
+    const depot = await depotVide();
+    const services = await depot.services('456');
+    expect(services).to.eql([]);
   });
 
-  it('ne retourne rien si on cherche un service à partir de son identifiant', (done) => {
-    depotVide()
-      .then((depot) => depot.service('123'))
-      .then((s) => expect(s).to.be(undefined))
-      .then(() => done())
-      .catch(done);
+  it('ne retourne rien si on cherche un service à partir de son identifiant', async () => {
+    const depot = await depotVide();
+    const s = await depot.service('123');
+    expect(s).to.be(undefined);
   });
 
-  it('ne retourne rien si on cherche un utilisateur à partir de son identifiant', (done) => {
-    depotVide()
-      .then((depot) => depot.utilisateur('456'))
-      .then((u) => expect(u).to.be(undefined))
-      .then(() => done())
-      .catch(done);
+  it('ne retourne rien si on cherche un utilisateur à partir de son identifiant', async () => {
+    const depot = await depotVide();
+    const u = await depot.utilisateur('456');
+    expect(u).to.be(undefined);
   });
 
-  it("n'authentifie pas l'utilisateur", (done) => {
-    depotVide()
-      .then((depot) =>
-        depot.utilisateurAuthentifie('jean.dupont@mail.fr', 'mdp_12345')
-      )
-      .then((utilisateur) => expect(utilisateur).to.be(undefined))
-      .then(() => done())
-      .catch(done);
+  it("n'authentifie pas l'utilisateur", async () => {
+    const depot = await depotVide();
+    const utilisateur = await depot.utilisateurAuthentifie(
+      'jean.dupont@mail.fr',
+      'mdp_12345'
+    );
+    expect(utilisateur).to.be(undefined);
   });
 });

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -967,7 +967,7 @@ describe('Le dépôt de données des services', () => {
       }
     });
 
-    it('lève une exception si une propriété obligatoire de la description du service est manquante', (done) => {
+    it('lève une exception si une propriété obligatoire de la description du service est manquante', async () => {
       const donneesDescriptionServiceIncompletes = uneDescriptionValide(
         referentiel
       )
@@ -975,16 +975,15 @@ describe('Le dépôt de données des services', () => {
         .construis()
         .toJSON();
 
-      depot
-        .nouveauService('123', {
+      try {
+        await depot.nouveauService('123', {
           descriptionService: donneesDescriptionServiceIncompletes,
-        })
-        .then(() =>
-          done('La création du service aurait dû lever une exception')
-        )
-        .catch((e) => expect(e).to.be.an(ErreurDonneesObligatoiresManquantes))
-        .then(() => done())
-        .catch(done);
+        });
+
+        expect().fail('La création du service aurait dû lever une exception');
+      } catch (e) {
+        expect(e).to.be.an(ErreurDonneesObligatoiresManquantes);
+      }
     });
 
     it("lève une exception si le siret de l'organisation responsable n'est pas renseigné", async () => {
@@ -1007,26 +1006,22 @@ describe('Le dépôt de données des services', () => {
       }
     });
 
-    it('lève une exception si le nom du service est déjà pris par un autre service', (done) => {
+    it('lève une exception si le nom du service est déjà pris par un autre service', async () => {
       const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('Nom service')
         .construis()
         .toJSON();
 
-      depot
-        .nouveauService('123', { descriptionService })
-        .then(() => depot.nouveauService('123', { descriptionService }))
-        .then(() =>
-          done('La création du service aurait dû lever une exception')
-        )
-        .catch((e) => {
-          expect(e).to.be.an(ErreurNomServiceDejaExistant);
-          expect(e.message).to.equal(
-            'Le nom du service "Nom service" existe déjà pour un autre service'
-          );
-          done();
-        })
-        .catch(done);
+      try {
+        await depot.nouveauService('123', { descriptionService });
+        await depot.nouveauService('123', { descriptionService });
+        expect().fail('La création du service aurait dû lever une exception');
+      } catch (e) {
+        expect(e).to.be.an(ErreurNomServiceDejaExistant);
+        expect(e.message).to.equal(
+          'Le nom du service "Nom service" existe déjà pour un autre service'
+        );
+      }
     });
   });
 
@@ -1150,7 +1145,7 @@ describe('Le dépôt de données des services', () => {
       expect(apres).to.eql([]);
     });
 
-    it('supprime les autorisations associées', (done) => {
+    it('supprime les autorisations associées', async () => {
       adaptateurPersistance = AdaptateurPersistanceMemoire.nouvelAdaptateur({
         utilisateurs: [
           { id: '999', donnees: { email: 'jean.dupont@mail.fr' } },
@@ -1180,16 +1175,14 @@ describe('Le dépôt de données des services', () => {
         adaptateurPersistance,
       });
 
-      depot
-        .supprimeService('111')
-        .then(() => depotAutorisations.autorisations('999'))
-        .then((as) => expect(as.length).to.equal(0))
-        .then(() => depotAutorisations.autorisations('000'))
-        .then((as) => expect(as.length).to.equal(1))
-        .then(() => depotAutorisations.autorisation('789'))
-        .then((a) => expect(a).to.be.ok())
-        .then(() => done())
-        .catch(done);
+      await depot.supprimeService('111');
+
+      const deUtilisateur999 = await depotAutorisations.autorisations('999');
+      expect(deUtilisateur999.length).to.equal(0);
+      const deUtilisateur000 = await depotAutorisations.autorisations('000');
+      expect(deUtilisateur000.length).to.equal(1);
+      const autorisation789 = await depotAutorisations.autorisation('789');
+      expect(autorisation789).not.to.be(undefined);
     });
 
     it('supprime les liens avec des modèles de mesure spécifique', async () => {
@@ -1246,7 +1239,7 @@ describe('Le dépôt de données des services', () => {
 
     beforeEach(() => (adaptateurUUID = { genereUUID: () => 'un UUID' }));
 
-    it('ne fait rien si un dossier courant existe déjà', (done) => {
+    it('ne fait rien si un dossier courant existe déjà', async () => {
       const donneesService = {
         id: '123',
         descriptionService: { nomService: 'Un service' },
@@ -1262,15 +1255,13 @@ describe('Le dépôt de données des services', () => {
         adaptateurUUID,
       });
 
-      depot
-        .ajouteDossierCourantSiNecessaire('123')
-        .then(() => depot.service('123'))
-        .then((s) => expect(s.nombreDossiers()).to.equal(1))
-        .then(() => done())
-        .catch(done);
+      await depot.ajouteDossierCourantSiNecessaire('123');
+
+      const s = await depot.service('123');
+      expect(s.nombreDossiers()).to.equal(1);
     });
 
-    it("ajoute le dossier s'il n'existe pas déjà", (done) => {
+    it("ajoute le dossier s'il n'existe pas déjà", async () => {
       const donneesHomologations = {
         id: '123',
         descriptionService: { nomService: 'Un service' },
@@ -1285,15 +1276,13 @@ describe('Le dépôt de données des services', () => {
         adaptateurUUID,
       });
 
-      depot
-        .ajouteDossierCourantSiNecessaire('123')
-        .then(() => depot.service('123'))
-        .then((s) => expect(s.nombreDossiers()).to.equal(1))
-        .then(() => done())
-        .catch(done);
+      await depot.ajouteDossierCourantSiNecessaire('123');
+
+      const s = await depot.service('123');
+      expect(s.nombreDossiers()).to.equal(1);
     });
 
-    it('associe un UUID au dossier créé', (done) => {
+    it('associe un UUID au dossier créé', async () => {
       const donneesService = {
         id: '123',
         descriptionService: { nomService: 'Un service' },
@@ -1309,15 +1298,13 @@ describe('Le dépôt de données des services', () => {
         adaptateurUUID,
       });
 
-      depot
-        .ajouteDossierCourantSiNecessaire('123')
-        .then(() => depot.service('123'))
-        .then((s) => expect(s.dossiers.item(0).id).to.equal('999'))
-        .then(() => done())
-        .catch(done);
+      await depot.ajouteDossierCourantSiNecessaire('123');
+
+      const s = await depot.service('123');
+      expect(s.dossiers.item(0).id).to.equal('999');
     });
 
-    it("lève une exception si le service n'existe pas", (done) => {
+    it("lève une exception si le service n'existe pas", async () => {
       const donneesService = {
         id: '123',
         descriptionService: { nomService: 'Un service' },
@@ -1326,21 +1313,17 @@ describe('Le dépôt de données des services', () => {
         AdaptateurPersistanceMemoire.nouvelAdaptateur({
           services: [donneesService],
         });
-      const depot = DepotDonneesServices.creeDepot({
-        adaptateurPersistance,
-      });
+      const depot = DepotDonneesServices.creeDepot({ adaptateurPersistance });
 
-      depot
-        .ajouteDossierCourantSiNecessaire('999')
-        .then(() =>
-          done("La tentative d'ajout de dossier aurait dû lever une exception")
-        )
-        .catch((e) => {
-          expect(e).to.be.an(ErreurServiceInexistant);
-          expect(e.message).to.equal('Service "999" non trouvé');
-          done();
-        })
-        .catch(done);
+      try {
+        await depot.ajouteDossierCourantSiNecessaire('999');
+        expect().fail(
+          "La tentative d'ajout de dossier aurait dû lever une exception"
+        );
+      } catch (e) {
+        expect(e).to.be.an(ErreurServiceInexistant);
+        expect(e.message).to.equal('Service "999" non trouvé');
+      }
     });
   });
 
@@ -1352,7 +1335,7 @@ describe('Le dépôt de données des services', () => {
 
     beforeEach(() => (adaptateurUUID = { genereUUID: () => 'un UUID' }));
 
-    it('enregistre le dossier courant', (done) => {
+    it('enregistre le dossier courant', async () => {
       const donneesService = {
         id: '123',
         descriptionService: { nomService: 'Un service' },
@@ -1378,22 +1361,16 @@ describe('Le dépôt de données des services', () => {
         referentiel
       );
 
-      depot
-        .enregistreDossier('123', dossier)
-        .then(() => depot.service('123'))
-        .then((s) => {
-          expect(s.nombreDossiers()).to.equal(1);
-          const dossierCourant = s.dossierCourant();
-          expect(dossierCourant.decision.dateHomologation).to.equal(
-            '2022-11-30'
-          );
-          expect(dossierCourant.decision.dureeValidite).to.equal('sixMois');
-          done();
-        })
-        .catch(done);
+      await depot.enregistreDossier('123', dossier);
+
+      const s = await depot.service('123');
+      expect(s.nombreDossiers()).to.equal(1);
+      const dossierCourant = s.dossierCourant();
+      expect(dossierCourant.decision.dateHomologation).to.equal('2022-11-30');
+      expect(dossierCourant.decision.dureeValidite).to.equal('sixMois');
     });
 
-    it("n'écrase pas les autres dossiers si l'ID est différent", (done) => {
+    it("n'écrase pas les autres dossiers si l'ID est différent", async () => {
       const donneesHomologations = {
         id: '123',
         donnees: {
@@ -1411,21 +1388,17 @@ describe('Le dépôt de données des services', () => {
         adaptateurUUID,
         referentiel,
       });
-      const dossier = new Dossier({ id: '999' }, referentiel);
 
-      depot
-        .enregistreDossier('123', dossier)
-        .then(() => depot.service('123'))
-        .then((s) => {
-          expect(s.nombreDossiers()).to.equal(2);
-          expect(s.dossiers.item(0).id).to.equal('888');
-          expect(s.dossiers.item(1).id).to.equal('999');
-          done();
-        })
-        .catch(done);
+      const dossier = new Dossier({ id: '999' }, referentiel);
+      await depot.enregistreDossier('123', dossier);
+
+      const s = await depot.service('123');
+      expect(s.nombreDossiers()).to.equal(2);
+      expect(s.dossiers.item(0).id).to.equal('888');
+      expect(s.dossiers.item(1).id).to.equal('999');
     });
 
-    it('écrase les données déjà stockées avec les nouvelles données', (done) => {
+    it('écrase les données déjà stockées avec les nouvelles données', async () => {
       const decision = {
         dateHomologation: '2022-12-01',
         dureeValidite: 'unAn',
@@ -1455,16 +1428,13 @@ describe('Le dépôt de données des services', () => {
         { autorite, id: '999' },
         referentiel
       );
-      depot
-        .enregistreDossier('123', seulementAutorite)
-        .then(() => depot.service('123'))
-        .then((s) => {
-          const donneesDossierCourant = s.dossierCourant().toJSON();
-          expect(donneesDossierCourant.autorite).to.eql(autorite);
-          expect(donneesDossierCourant.decision).to.eql({});
-          done();
-        })
-        .catch(done);
+
+      await depot.enregistreDossier('123', seulementAutorite);
+
+      const s = await depot.service('123');
+      const donneesDossierCourant = s.dossierCourant().toJSON();
+      expect(donneesDossierCourant.autorite).to.eql(autorite);
+      expect(donneesDossierCourant.decision).to.eql({});
     });
   });
 
@@ -1738,11 +1708,10 @@ describe('Le dépôt de données des services', () => {
     let adaptateurChiffrement;
 
     beforeEach(() => {
-      adaptateurChiffrement = {
-        dechiffre: async (objetDonnee) => objetDonnee,
-      };
+      adaptateurChiffrement = { dechiffre: async (objetDonnee) => objetDonnee };
     });
-    it("utilise l'index 1 si disponible", (done) => {
+
+    it("utilise l'index 1 si disponible", async () => {
       const referentiel = Referentiel.creeReferentielVide();
       const descriptionService = uneDescriptionValide(referentiel)
         .avecNomService('A')
@@ -1769,14 +1738,12 @@ describe('Le dépôt de données des services', () => {
         }),
       });
 
-      depot
-        .trouveIndexDisponible('999', 'A - UnSuffixe')
-        .then((index) => expect(index).to.equal(1))
-        .then(() => done())
-        .catch(done);
+      const index = await depot.trouveIndexDisponible('999', 'A - UnSuffixe');
+
+      expect(index).to.equal(1);
     });
 
-    it("incrémente l'index si nécessaire", (done) => {
+    it("incrémente l'index si nécessaire", async () => {
       const referentiel = Referentiel.creeReferentielVide();
       const copie1 = uneDescriptionValide(referentiel)
         .avecNomService('A - UnSuffixe 1')
@@ -1803,14 +1770,12 @@ describe('Le dépôt de données des services', () => {
         }),
       });
 
-      depot
-        .trouveIndexDisponible('999', 'A - UnSuffixe')
-        .then((index) => expect(index).to.equal(2))
-        .then(() => done())
-        .catch(done);
+      const index = await depot.trouveIndexDisponible('999', 'A - UnSuffixe');
+
+      expect(index).to.equal(2);
     });
 
-    it("incrémente l'index le plus élevé", (done) => {
+    it("incrémente l'index le plus élevé", async () => {
       const referentiel = Referentiel.creeReferentielVide();
       const original = uneDescriptionValide(referentiel)
         .avecNomService('A')
@@ -1845,14 +1810,12 @@ describe('Le dépôt de données des services', () => {
         }),
       });
 
-      depot
-        .trouveIndexDisponible('999', 'A - UnSuffixe')
-        .then((index) => expect(index).to.equal(3))
-        .then(() => done())
-        .catch(done);
+      const index = await depot.trouveIndexDisponible('999', 'A - UnSuffixe');
+
+      expect(index).to.equal(3);
     });
 
-    it("sait extraire l'index disponible même dans des noms contenant des parenthèses", (done) => {
+    it("sait extraire l'index disponible même dans des noms contenant des parenthèses", async () => {
       const referentiel = Referentiel.creeReferentielVide();
       const original = uneDescriptionValide(referentiel)
         .avecNomService('Service A (mairie) - Copie 1')
@@ -1879,11 +1842,12 @@ describe('Le dépôt de données des services', () => {
         }),
       });
 
-      depot
-        .trouveIndexDisponible('999', 'Service A (mairie) - Copie')
-        .then((index) => expect(index).to.equal(2))
-        .then(() => done())
-        .catch(done);
+      const index = await depot.trouveIndexDisponible(
+        '999',
+        'Service A (mairie) - Copie'
+      );
+
+      expect(index).to.equal(2);
     });
   });
 

--- a/test/modeles/descriptionService.spec.js
+++ b/test/modeles/descriptionService.spec.js
@@ -163,7 +163,7 @@ describe('La description du service', () => {
     });
   });
 
-  elle('valide la localisation des données si elle est présente', (done) => {
+  elle('valide la localisation des données si elle est présente', () => {
     const referentiel = Referentiel.creeReferentiel({
       localisationsDonnees: {
         france: { description: 'Quelque part en France' },
@@ -174,7 +174,7 @@ describe('La description du service', () => {
         { localisationDonnees: 'localisationInvalide' },
         referentiel
       );
-      done(
+      expect().fail(
         'La création de la description du service aurait dû lever une ErreurLocalisationDonneesInvalide'
       );
     } catch (e) {
@@ -182,7 +182,6 @@ describe('La description du service', () => {
       expect(e.message).to.equal(
         'La localisation des données "localisationInvalide" est invalide'
       );
-      done();
     }
   });
 

--- a/test/modeles/etapes/decision.spec.js
+++ b/test/modeles/etapes/decision.spec.js
@@ -26,36 +26,39 @@ describe('Une étape « Décision »', () => {
     });
   });
 
-  it('valide la valeur passée pour la durée de validité', (done) => {
+  it('valide la valeur passée pour la durée de validité', () => {
     try {
       new Decision({ dureeValidite: 'dureeInvalide' });
-      done("la création d'une étape date aurait dû lever une exception");
+      expect().fail(
+        "la création d'une étape date aurait dû lever une exception"
+      );
     } catch (e) {
       expect(e).to.be.a(ErreurDureeValiditeInvalide);
       expect(e.message).to.equal(
         'La durée de validité "dureeInvalide" est invalide'
       );
-      done();
     }
   });
 
-  it("valide la valeur passée pour la date d'homologation", (done) => {
+  it("valide la valeur passée pour la date d'homologation", () => {
     try {
       new Decision({ dateHomologation: '2022-13-01' });
-      done("la création d'une étape date aurait dû lever une exception");
+      expect().fail(
+        "la création d'une étape date aurait dû lever une exception"
+      );
     } catch (e) {
       expect(e).to.be.a(ErreurDateHomologationInvalide);
       expect(e.message).to.equal('La date "2022-13-01" est invalide');
-      done();
     }
   });
 
-  it("ne lève pas d'exception si la durée de validité ou la date d'homologation ne sont pas renseignées", (done) => {
+  it("ne lève pas d'exception si la durée de validité ou la date d'homologation ne sont pas renseignées", () => {
     try {
       new Decision();
-      done();
     } catch (e) {
-      done("la création d'une étape date n'aurait pas dû lever une exception");
+      expect().fail(
+        "la création d'une étape date n'aurait pas dû lever une exception"
+      );
     }
   });
 

--- a/test/modeles/journalMSS/evenementCguAcceptees.spec.js
+++ b/test/modeles/journalMSS/evenementCguAcceptees.spec.js
@@ -32,35 +32,33 @@ describe('Un événement de CGU acceptées', () => {
     });
   });
 
-  it("exige que l'identifiant utilisateur soit renseigné", (done) => {
+  it("exige que l'identifiant utilisateur soit renseigné", () => {
     try {
       new EvenementCguAcceptees(
         { cguAcceptees: '1.0' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 
-  it('exige que la version des CGU acceptées soit renseignée', (done) => {
+  it('exige que la version des CGU acceptées soit renseignée', () => {
     try {
       new EvenementCguAcceptees(
         { idUtilisateur: 'U1' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 });

--- a/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
+++ b/test/modeles/journalMSS/evenementCollaboratifServiceModifie.spec.js
@@ -47,7 +47,7 @@ describe("Un événement de modification du collaboratif d'un service", () => {
     { propriete: 'autorisations' },
   ];
   proprietesAVerifier.forEach(({ propriete }) => {
-    it(`exige que \`${propriete}\` soit renseigné`, (done) => {
+    it(`exige que \`${propriete}\` soit renseigné`, () => {
       try {
         const donnees = { idService: 'abc' };
         delete donnees[propriete];
@@ -57,12 +57,11 @@ describe("Un événement de modification du collaboratif d'un service", () => {
           adaptateurChiffrement: hacheEnMajuscules,
         });
 
-        done(
+        expect().fail(
           Error("L'instanciation de l'événement aurait dû lever une exception")
         );
       } catch (e) {
         expect(e).to.be.an(ErreurDonneeManquante);
-        done();
       }
     });
   });

--- a/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
+++ b/test/modeles/journalMSS/evenementCompletudeServiceModifiee.spec.js
@@ -173,16 +173,15 @@ describe('Un événement de complétude modifiée', () => {
     });
   });
 
-  it('exige que le service soit renseigné', (done) => {
+  it('exige que le service soit renseigné', () => {
     try {
       unEvenement().sans('service').construis();
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 });

--- a/test/modeles/journalMSS/evenementConnexionUtilisateur.spec.js
+++ b/test/modeles/journalMSS/evenementConnexionUtilisateur.spec.js
@@ -33,51 +33,48 @@ describe('Un événement de connexion utilisateur', () => {
     });
   });
 
-  it("exige que l'identifiant utilisateur soit renseigné", (done) => {
+  it("exige que l'identifiant utilisateur soit renseigné", () => {
     try {
       new EvenementConnexionUtilisateur(
         { idUtilisateur: null, dateDerniereConnexion: '2022-05-06' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 
-  it('exige que la date de dernière connexion soit renseignée', (done) => {
+  it('exige que la date de dernière connexion soit renseignée', () => {
     try {
       new EvenementConnexionUtilisateur(
         { idUtilisateur: '123', dateDerniereConnexion: null },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 
-  it('exige que la date de dernière connexion soit valide', (done) => {
+  it('exige que la date de dernière connexion soit valide', () => {
     try {
       new EvenementConnexionUtilisateur(
         { idUtilisateur: '123', dateDerniereConnexion: 'pasValide' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDateDerniereConnexionInvalide);
-      done();
     }
   });
 });

--- a/test/modeles/journalMSS/evenementNouveauServiceCree.spec.js
+++ b/test/modeles/journalMSS/evenementNouveauServiceCree.spec.js
@@ -38,34 +38,32 @@ describe('Un événement de nouveau service créé', () => {
     });
   });
 
-  it("exige que l'identifiant utilisateur associé au service soit renseigné", (done) => {
+  it("exige que l'identifiant utilisateur associé au service soit renseigné", () => {
     try {
       new EvenementNouveauServiceCree(
         { idService: 'ABC' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 
-  it("exige que l'identifiant du service créé soit renseigné", (done) => {
+  it("exige que l'identifiant du service créé soit renseigné", () => {
     try {
       new EvenementNouveauServiceCree(
         { idUtilisateur: 'DEF' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 });

--- a/test/modeles/journalMSS/evenementNouvelUtilisateurInscrit.spec.js
+++ b/test/modeles/journalMSS/evenementNouvelUtilisateurInscrit.spec.js
@@ -29,19 +29,18 @@ describe('Un événement de nouvel utilisateur inscrit', () => {
     });
   });
 
-  it("exige que l'identifiant utilisateur soit renseigné", (done) => {
+  it("exige que l'identifiant utilisateur soit renseigné", () => {
     try {
       new EvenementNouvelUtilisateurInscrit(
         {},
         { adaptateurChiffrement: hacheEnMajuscules }
       );
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 });

--- a/test/modeles/journalMSS/evenementProfilUtilisateurModifie.spec.js
+++ b/test/modeles/journalMSS/evenementProfilUtilisateurModifie.spec.js
@@ -60,18 +60,17 @@ describe('Un événement de profil utilisateur modifié', () => {
     expect(evenement.toJSON().donnees.roles).to.eql(['RSSI', 'DPO', 'Maire']);
   });
 
-  it("exige que l'utilisateur soit renseigné", (done) => {
+  it("exige que l'utilisateur soit renseigné", () => {
     try {
       new EvenementProfilUtilisateurModifie(null, {
         adaptateurChiffrement: hacheEnMajuscules,
       });
 
-      done(
+      expect().fail(
         Error("L'instanciation de l'événement aurait dû lever une exception")
       );
     } catch (e) {
       expect(e).to.be.an(ErreurUtilisateurManquant);
-      done();
     }
   });
 });

--- a/test/modeles/journalMSS/evenementRetourUtilisateurMesure.spec.js
+++ b/test/modeles/journalMSS/evenementRetourUtilisateurMesure.spec.js
@@ -50,7 +50,7 @@ describe('Un événement de retour utilisateur sur une mesure', () => {
     { propriete: 'idRetour' },
   ];
   proprietesAVerifier.forEach(({ propriete }) => {
-    it(`exige que \`${propriete}\` soit renseigné`, (done) => {
+    it(`exige que \`${propriete}\` soit renseigné`, () => {
       try {
         const donnees = {
           idService: 'abc',
@@ -65,12 +65,11 @@ describe('Un événement de retour utilisateur sur une mesure', () => {
           adaptateurChiffrement: hacheEnMajuscules,
         });
 
-        done(
+        expect().fail(
           Error("L'instanciation de l'événement aurait dû lever une exception")
         );
       } catch (e) {
         expect(e).to.be.an(ErreurDonneeManquante);
-        done();
       }
     });
   });

--- a/test/modeles/journalMSS/evenementServiceRattacheAPrestataire.spec.js
+++ b/test/modeles/journalMSS/evenementServiceRattacheAPrestataire.spec.js
@@ -29,29 +29,31 @@ describe('Un événement de service rattaché à un prestataire', () => {
     });
   });
 
-  it("exige que l'identifiant du service soit renseigné", (done) => {
+  it("exige que l'identifiant du service soit renseigné", () => {
     try {
       new EvenementServiceRattacheAPrestataire(
         { codePrestataire: 'PRESTA-1' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
-      done("L'instanciation de l'événement aurait dû lever une exception");
+      expect().fail(
+        "L'instanciation de l'événement aurait dû lever une exception"
+      );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 
-  it('exige que le code prestataire soit renseigné', (done) => {
+  it('exige que le code prestataire soit renseigné', () => {
     try {
       new EvenementServiceRattacheAPrestataire(
         { idService: 'abc' },
         { adaptateurChiffrement: hacheEnMajuscules }
       );
-      done("L'instanciation de l'événement aurait dû lever une exception");
+      expect().fail(
+        "L'instanciation de l'événement aurait dû lever une exception"
+      );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 });

--- a/test/modeles/journalMSS/evenementServiceSupprime.spec.js
+++ b/test/modeles/journalMSS/evenementServiceSupprime.spec.js
@@ -31,16 +31,17 @@ describe('Un événement de service supprimé', () => {
     });
   });
 
-  it("exige que l'identifiant du service soit renseigné", (done) => {
+  it("exige que l'identifiant du service soit renseigné", () => {
     try {
       new EvenementServiceSupprime(
         {},
         { adaptateurChiffrement: hacheEnMajuscules }
       );
-      done("L'instanciation de l'événement aurait dû lever une exception");
+      expect().fail(
+        "L'instanciation de l'événement aurait dû lever une exception"
+      );
     } catch (e) {
       expect(e).to.be.an(ErreurDonneeManquante);
-      done();
     }
   });
 });

--- a/test/modeles/mesure.spec.js
+++ b/test/modeles/mesure.spec.js
@@ -34,12 +34,11 @@ describe('Une mesure', () => {
     );
   });
 
-  elle("ne tient pas compte du statut s'il n'est pas renseigné", (done) => {
+  elle("ne tient pas compte du statut s'il n'est pas renseigné", () => {
     try {
       Mesure.valide({ statut: undefined });
-      done();
     } catch {
-      done(
+      expect.fail(
         "La validation de la mesure sans statut n'aurait pas dû lever d'exception."
       );
     }

--- a/test/modeles/mesureGenerale.spec.js
+++ b/test/modeles/mesureGenerale.spec.js
@@ -59,33 +59,31 @@ describe('Une mesure de sécurité', () => {
     });
   });
 
-  it('vérifie que la mesure est bien répertoriée', (done) => {
+  it('vérifie que la mesure est bien répertoriée', () => {
     try {
       new MesureGenerale(
         { id: 'identifiantInconnu', statut: MesureGenerale.STATUT_FAIT },
         referentiel
       );
-      done('La création de la mesure aurait dû lever une exception');
+      expect.fail('La création de la mesure aurait dû lever une exception');
     } catch (e) {
       expect(e).to.be.a(ErreurMesureInconnue);
       expect(e.message).to.equal(
         'La mesure "identifiantInconnu" n\'est pas répertoriée'
       );
-      done();
     }
   });
 
-  it('vérifie la nature du statut', (done) => {
+  it('vérifie la nature du statut', () => {
     try {
       new MesureGenerale(
         { id: 'identifiantMesure', statut: 'statutInvalide' },
         referentiel
       );
-      done('La création de la mesure aurait dû lever une exception');
+      expect.fail('La création de la mesure aurait dû lever une exception');
     } catch (e) {
       expect(e).to.be.a(ErreurStatutMesureInvalide);
       expect(e.message).to.equal('Le statut "statutInvalide" est invalide');
-      done();
     }
   });
 

--- a/test/modeles/mesureSpecifique.spec.js
+++ b/test/modeles/mesureSpecifique.spec.js
@@ -73,14 +73,13 @@ describe('Une mesure spécifique', () => {
     expect(mesure.statutSaisie()).to.equal(InformationsService.COMPLETES);
   });
 
-  it('vérifie que le statut est bien valide', (done) => {
+  it('vérifie que le statut est bien valide', () => {
     try {
       new MesureSpecifique({ statut: 'statutInconnu' });
-      done('La création de la mesure aurait dû lever une exception.');
+      expect.fail('La création de la mesure aurait dû lever une exception.');
     } catch (e) {
       expect(e).to.be.an(ErreurStatutMesureInvalide);
       expect(e.message).to.equal('Le statut "statutInconnu" est invalide');
-      done();
     }
   });
 
@@ -105,25 +104,23 @@ describe('Une mesure spécifique', () => {
     }
   });
 
-  it('vérifie que la catégorie est bien répertoriée', (done) => {
+  it('vérifie que la catégorie est bien répertoriée', () => {
     try {
       new MesureSpecifique({ categorie: 'categorieInconnue' });
-      done('La création de la mesure aurait dû lever une exception.');
+      expect().fail('La création de la mesure aurait dû lever une exception.');
     } catch (e) {
       expect(e).to.be.an(ErreurCategorieInconnue);
       expect(e.message).to.equal(
         'La catégorie "categorieInconnue" n\'est pas répertoriée'
       );
-      done();
     }
   });
 
-  it("ne tient pas compte de la catégorie si elle n'est pas renseignée", (done) => {
+  it("ne tient pas compte de la catégorie si elle n'est pas renseignée", () => {
     try {
       new MesureSpecifique();
-      done();
     } catch {
-      done(
+      expect().fail(
         "La création de la mesure sans catégorie n'aurait pas dû lever d'exception."
       );
     }

--- a/test/modeles/risque.spec.js
+++ b/test/modeles/risque.spec.js
@@ -5,16 +5,15 @@ const Referentiel = require('../../src/referentiel');
 const Risque = require('../../src/modeles/risque');
 
 describe('Un risque', () => {
-  it('vérifie que le niveau de gravité est bien répertorié', (done) => {
+  it('vérifie que le niveau de gravité est bien répertorié', () => {
     try {
       new Risque({ niveauGravite: 'niveauInconnu' });
-      done('La création du risque aurait dû lever une exception.');
+      expect().fail('La création du risque aurait dû lever une exception.');
     } catch (e) {
       expect(e).to.be.a(ErreurNiveauGraviteInconnu);
       expect(e.message).to.equal(
         'Le niveau de gravité "niveauInconnu" n\'est pas répertorié'
       );
-      done();
     }
   });
 

--- a/test/modeles/risqueGeneral.spec.js
+++ b/test/modeles/risqueGeneral.spec.js
@@ -85,16 +85,15 @@ describe('Un risque général', () => {
     });
   });
 
-  it('vérifie que le risque est bien répertorié', (done) => {
+  it('vérifie que le risque est bien répertorié', () => {
     try {
       new RisqueGeneral({ id: 'identifiantInconnu' }, referentiel);
-      done('La création du risque aurait dû lever une exception.');
+      expect().fail('La création du risque aurait dû lever une exception.');
     } catch (e) {
       expect(e).to.be.a(ErreurRisqueInconnu);
       expect(e.message).to.equal(
         'Le risque "identifiantInconnu" n\'est pas répertorié'
       );
-      done();
     }
   });
 

--- a/test/modeles/risqueSpecifique.spec.js
+++ b/test/modeles/risqueSpecifique.spec.js
@@ -59,16 +59,15 @@ describe('Un risque spécifique', () => {
     expect(risque.categoriesRisque()).to.eql(['C1', 'C2']);
   });
 
-  it('vérifie que le niveau de gravité est bien répertorié', (done) => {
+  it('vérifie que le niveau de gravité est bien répertorié', () => {
     try {
       new RisqueSpecifique({ niveauGravite: 'niveauInconnu' }, referentiel);
-      done('La création du risque aurait dû lever une exception.');
+      expect().fail('La création du risque aurait dû lever une exception.');
     } catch (e) {
       expect(e).to.be.a(ErreurNiveauGraviteInconnu);
       expect(e.message).to.equal(
         'Le niveau de gravité "niveauInconnu" n\'est pas répertorié'
       );
-      done();
     }
   });
 });

--- a/test/modeles/utilisateur.spec.js
+++ b/test/modeles/utilisateur.spec.js
@@ -175,15 +175,14 @@ describe('Un utilisateur', () => {
     expect(autreUtilisateur.accepteInfolettre()).to.be(false);
   });
 
-  it("exige que l'adresse électronique soit renseignée", (done) => {
+  it("exige que l'adresse électronique soit renseignée", () => {
     try {
       new Utilisateur({ prenom: 'Jean', nom: 'Dupont' });
-      done(
+      expect().fail(
         "La création de l'utilisateur aurait dû lever une ErreurEmailManquant"
       );
     } catch (e) {
       expect(e).to.be.a(ErreurEmailManquant);
-      done();
     }
   });
 
@@ -227,7 +226,7 @@ describe('Un utilisateur', () => {
   describe("sur une demande de validation des données d'un utilisateur", () => {
     let donnees;
 
-    const verifiePresencePropriete = (clef, nom, done) => {
+    const verifiePresencePropriete = (clef, nom) => {
       if (clef.includes('.')) {
         const clefs = clef.split('.');
         delete donnees[clefs[0]][clefs[1]];
@@ -236,13 +235,12 @@ describe('Un utilisateur', () => {
       }
       try {
         Utilisateur.valideDonnees(donnees);
-        done(
+        expect().fail(
           `La validation des données d'un utilisateur sans ${nom} aurait du lever une erreur de donnée manquante`
         );
       } catch (error) {
         expect(error).to.be.a(ErreurDonneesObligatoiresManquantes);
         expect(error.message).to.equal(`La propriété "${clef}" est requise`);
-        done();
       }
     };
 
@@ -264,55 +262,49 @@ describe('Un utilisateur', () => {
       };
     });
 
-    it('exige que le prénom soit renseigné', (done) => {
-      verifiePresencePropriete('prenom', 'prénom', done);
+    it('exige que le prénom soit renseigné', () => {
+      verifiePresencePropriete('prenom', 'prénom');
     });
 
-    it('exige que le nom soit renseigné', (done) => {
-      verifiePresencePropriete('nom', 'nom', done);
+    it('exige que le nom soit renseigné', () => {
+      verifiePresencePropriete('nom', 'nom');
     });
 
-    it("exige que l'e-mail soit renseigné quand l'utilisateur est inexistant", (done) => {
-      verifiePresencePropriete('email', 'e-mail', done);
+    it("exige que l'e-mail soit renseigné quand l'utilisateur est inexistant", () => {
+      verifiePresencePropriete('email', 'e-mail');
     });
 
-    it("n'exige pas que l'e-mail soit renseigné quand l'utilisateur existe déjà", (done) => {
+    it("n'exige pas que l'e-mail soit renseigné quand l'utilisateur existe déjà", () => {
       delete donnees.email;
       try {
         Utilisateur.valideDonnees(donnees, true);
-        done();
       } catch (erreur) {
         let messageEchec = `La validation des données d'un utilisateur existant sans email n'aurait pas du lever d'erreur : ${erreur.message}`;
         if (erreur instanceof ErreurDonneesObligatoiresManquantes) {
           messageEchec =
             "La validation des données d'un utilisateur existant sans email n'aurait pas du lever d'erreur de propriété manquante";
         }
-        done(messageEchec);
+        expect().fail(messageEchec);
       }
     });
 
-    it("exige que le SIRET de l'entité soit renseigné", (done) => {
-      verifiePresencePropriete('entite.siret', "SIRET de l'entité", done);
+    it("exige que le SIRET de l'entité soit renseigné", () => {
+      verifiePresencePropriete('entite.siret', "SIRET de l'entité");
     });
 
-    it("exige que l'estimation du nombre de services soit renseignée", (done) => {
+    it("exige que l'estimation du nombre de services soit renseignée", () => {
       verifiePresencePropriete(
         'estimationNombreServices',
-        'Estimation du nombre de services',
-        done
+        'Estimation du nombre de services'
       );
     });
 
-    it('exige que les postes soient renseignés', (done) => {
-      verifiePresencePropriete('postes', 'Postes', done);
+    it('exige que les postes soient renseignés', () => {
+      verifiePresencePropriete('postes', 'Postes');
     });
 
-    it("exige que l'information d'acceptation de l'infolettre soit renseignée", (done) => {
-      verifiePresencePropriete(
-        'infolettreAcceptee',
-        'infolettre acceptée',
-        done
-      );
+    it("exige que l'information d'acceptation de l'infolettre soit renseignée", () => {
+      verifiePresencePropriete('infolettreAcceptee', 'infolettre acceptée');
     });
   });
 


### PR DESCRIPTION
On prépare l'arrivée de `Vitest`, qui ne supporte pas `done()`.
Cette PR supprime toutes les utilisations.