### PR TITLE
Ajoute la version "v1" par défaut sur les Services

### DIFF
--- a/donneesReferentiel.js
+++ b/donneesReferentiel.js
@@ -1709,4 +1709,5 @@ export default {
   modelesMesureSpecifique: {
     nombreMaximumParUtilisateur: 40,
   },
+  versionServiceParDefaut: 'v1',
 };

--- a/migrations/20250902085307_ajoutColonneVersionService.js
+++ b/migrations/20250902085307_ajoutColonneVersionService.js
@@ -1,0 +1,9 @@
+export const up = (knex) =>
+  knex.schema.alterTable('services', (table) => {
+    table.string('version_service').defaultTo('v1').notNullable();
+  });
+
+export const down = (knex) =>
+  knex.schema.alterTable('services', (table) =>
+    table.dropColumn('version_service')
+  );

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -27,13 +27,15 @@ const nouvelAdaptateur = (
     id,
     donneesService,
     nomServiceHash,
-    siretHash
+    siretHash,
+    versionService
   ) => {
     donnees.services.push({
       id,
       donnees: donneesService,
       nomServiceHash,
       siretHash,
+      version: versionService,
     });
   };
 
@@ -97,7 +99,6 @@ const nouvelAdaptateur = (
       );
       return {
         ...unService,
-        version: 'v1',
         utilisateurs: autorisationsDuService.map((a) =>
           donnees.utilisateurs.find((u) => u.id === a.idUtilisateur)
         ),
@@ -148,11 +149,23 @@ const nouvelAdaptateur = (
     else Object.assign(dejaConnue, { ...donneesAutorisation });
   };
 
-  const sauvegardeService = (id, donneesService, nomServiceHash, siretHash) => {
+  const sauvegardeService = (
+    id,
+    donneesService,
+    nomServiceHash,
+    siretHash,
+    versionService
+  ) => {
     const dejaConnu = donnees.services.find((s) => s.id === id) !== undefined;
     return dejaConnu
       ? metsAJourService(id, donneesService, nomServiceHash, siretHash)
-      : ajouteService(id, donneesService, nomServiceHash, siretHash);
+      : ajouteService(
+          id,
+          donneesService,
+          nomServiceHash,
+          siretHash,
+          versionService
+        );
   };
 
   const supprimeService = (...params) =>

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -97,6 +97,7 @@ const nouvelAdaptateur = (
       );
       return {
         ...unService,
+        version: 'v1',
         utilisateurs: autorisationsDuService.map((a) =>
           donnees.utilisateurs.find((u) => u.id === a.idUtilisateur)
         ),

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -35,7 +35,7 @@ const nouvelAdaptateur = (
       donnees: donneesService,
       nomServiceHash,
       siretHash,
-      version: versionService,
+      versionService,
     });
   };
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -74,12 +74,19 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
   const supprimeEnregistrement = (nomTable, id) =>
     knex(nomTable).where({ id }).del();
 
-  const ajouteService = async (id, donnees, nomServiceHash, siretHash) =>
+  const ajouteService = async (
+    id,
+    donnees,
+    nomServiceHash,
+    siretHash,
+    versionService
+  ) =>
     knex('services').insert({
       id,
       donnees,
       nom_service_hash: nomServiceHash,
       siret_hash: siretHash,
+      version_service: versionService,
     });
 
   const ajouteUtilisateur = (id, donnees, emailHash) =>
@@ -318,7 +325,13 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
       .whereRaw("(donnees->>'estProprietaire')::boolean=true")
       .then(([{ count }]) => parseInt(count, 10));
 
-  const sauvegardeService = (id, donneesService, nomServiceHash, siretHash) => {
+  const sauvegardeService = (
+    id,
+    donneesService,
+    nomServiceHash,
+    siretHash,
+    versionService
+  ) => {
     const testExistence = knex('services')
       .where('id', id)
       .select({ id: 'id' })
@@ -328,7 +341,13 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
     return testExistence.then((dejaConnu) =>
       dejaConnu
         ? metsAJourService(id, donneesService, nomServiceHash, siretHash)
-        : ajouteService(id, donneesService, nomServiceHash, siretHash)
+        : ajouteService(
+            id,
+            donneesService,
+            nomServiceHash,
+            siretHash,
+            versionService
+          )
     );
   };
 

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -203,7 +203,7 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
 
     return requete.rows.map((s) => ({
       ...s,
-      version: s.version_service,
+      versionService: s.version_service,
       modelesDisponiblesDeMesureSpecifique:
         s.modelesDisponiblesDeMesureSpecifique.map(
           // eslint-disable-next-line camelcase

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -196,6 +196,7 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
 
     return requete.rows.map((s) => ({
       ...s,
+      version: s.version_service,
       modelesDisponiblesDeMesureSpecifique:
         s.modelesDisponiblesDeMesureSpecifique.map(
           // eslint-disable-next-line camelcase

--- a/src/bus/abonnements/consigneNouveauServiceDansJournal.js
+++ b/src/bus/abonnements/consigneNouveauServiceDansJournal.js
@@ -16,6 +16,7 @@ function consigneNouveauServiceDansJournal({ adaptateurJournal }) {
     const creation = new EvenementNouveauServiceCree({
       idService: service.id,
       idUtilisateur: utilisateur.id,
+      versionService: service.version(),
     });
 
     await adaptateurJournal.consigneEvenement(creation.toJSON());

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -133,7 +133,7 @@ const fabriquePersistance = (
       },
     },
     sauvegarde: async (id, donneesService) => {
-      const { version, ...donneesMetier } = donneesService;
+      const { versionService, ...donneesMetier } = donneesService;
       const donneesChiffrees = await chiffre.donneesService(donneesMetier);
 
       const nomServiceHash = adaptateurChiffrement.hacheSha256(
@@ -149,7 +149,7 @@ const fabriquePersistance = (
         donneesChiffrees,
         nomServiceHash,
         siretHash,
-        version
+        versionService
       );
     },
     supprime: async (idService) => {

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -356,6 +356,9 @@ const creeDepot = (config = {}) => {
 
     await completeDescriptionService(donneesService.descriptionService);
 
+    if (!donneesService.versionService)
+      donneesService.versionService = referentiel.versionServiceParDefaut();
+
     await p.sauvegarde(idService, donneesService);
 
     const proprietaire = Autorisation.NouvelleAutorisationProprietaire({

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -133,7 +133,8 @@ const fabriquePersistance = (
       },
     },
     sauvegarde: async (id, donneesService) => {
-      const donneesChiffrees = await chiffre.donneesService(donneesService);
+      const { version, ...donneesMetier } = donneesService;
+      const donneesChiffrees = await chiffre.donneesService(donneesMetier);
 
       const nomServiceHash = adaptateurChiffrement.hacheSha256(
         donneesService.descriptionService.nomService
@@ -147,7 +148,8 @@ const fabriquePersistance = (
         id,
         donneesChiffrees,
         nomServiceHash,
-        siretHash
+        siretHash,
+        version
       );
     },
     supprime: async (idService) => {

--- a/src/modeles/journalMSS/evenementNouveauServiceCree.js
+++ b/src/modeles/journalMSS/evenementNouveauServiceCree.js
@@ -7,6 +7,7 @@ class EvenementNouveauServiceCree extends Evenement {
     Evenement.verifieProprietesRenseignees(donnees, [
       'idService',
       'idUtilisateur',
+      'versionService',
     ]);
 
     super(
@@ -14,6 +15,7 @@ class EvenementNouveauServiceCree extends Evenement {
       {
         idService: adaptateurChiffrement.hacheSha256(donnees.idService),
         idUtilisateur: adaptateurChiffrement.hacheSha256(donnees.idUtilisateur),
+        versionService: donnees.versionService,
       },
       date
     );

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -30,7 +30,7 @@ class Service {
   ) {
     const {
       id = '',
-      version,
+      versionService,
       contributeurs = [],
       descriptionService = {},
       dossiers = [],
@@ -44,7 +44,7 @@ class Service {
     } = donnees;
 
     this.id = id;
-    this.versionService = version;
+    this.versionService = versionService;
     this.prochainIdNumeriqueDeRisqueSpecifique =
       prochainIdNumeriqueDeRisqueSpecifique;
     this.contributeurs = contributeurs.map((c) => new Contributeur(c));

--- a/src/modeles/service.js
+++ b/src/modeles/service.js
@@ -30,6 +30,7 @@ class Service {
   ) {
     const {
       id = '',
+      version,
       contributeurs = [],
       descriptionService = {},
       dossiers = [],
@@ -43,6 +44,7 @@ class Service {
     } = donnees;
 
     this.id = id;
+    this.versionService = version;
     this.prochainIdNumeriqueDeRisqueSpecifique =
       prochainIdNumeriqueDeRisqueSpecifique;
     this.contributeurs = contributeurs.map((c) => new Contributeur(c));
@@ -75,6 +77,10 @@ class Service {
     );
 
     this.referentiel = referentiel;
+  }
+
+  version() {
+    return this.versionService;
   }
 
   autoriteHomologation() {

--- a/src/referentiel.js
+++ b/src/referentiel.js
@@ -442,6 +442,8 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
   const nombreMaximumDeModelesMesureSpecifiqueParUtilisateur = () =>
     donnees.modelesMesureSpecifique.nombreMaximumParUtilisateur;
 
+  const versionServiceParDefaut = () => donnees.versionServiceParDefaut;
+
   valideDonnees();
 
   return {
@@ -546,6 +548,7 @@ const creeReferentiel = (donneesReferentiel = donneesParDefaut) => {
     typeServiceParDescription,
     typesService,
     verifieCategoriesMesuresSontRepertoriees,
+    versionServiceParDefaut,
     etapePrecedenteVisiteGuidee,
     etapeSuivanteVisiteGuidee,
     etapeVisiteGuidee,

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -2,7 +2,8 @@
 
 ## TODO
 
-- [ ] Un nouveau service est persité en `v1`
+- [ ] C'est MSS qui met explicitement v1, pas Postgres
+- [ ] L'attribut s'appelle `versionService` et pas `version`
 - [ ] Côté Metabase : un LÉGO des versions de service.
   - Ce légo n'existe pas encore
   - L'absence de version veut dire `v1`
@@ -11,6 +12,7 @@
 
 ## DONE
 
+- [x] Un nouveau service est persité en `v1`
 - [x] La version d'un service est lue depuis la persistance
 - [x] Un service connaît sa version
 - [x] Une colonne dédiée `version_service` dans la table `services`

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -5,9 +5,12 @@
 - [ ] Une colonne dédiée `version_service` dans la table `services`
   - Avec valeur par défaut à `v1`, comme ça pas de migration.
 - [ ] Un nouveau service est persité en `v1`
-- [ ] Un service connaît sa version
 - [ ] Côté Metabase : un LÉGO des versions de service.
   - Ce légo n'existe pas encore
   - L'absence de version veut dire `v1`
   - On imagine que dans `NOUVEAU_SERVICE_CREE` on aura un champ `versionService: "v2"` sur lequel il pourra se baser
   - Au moment du switch, on imagine un nouvel event `SERVICE_A_ETE_MIGRE` qui dit `versionCible: "v2"`
+
+## DONE
+
+- [x] Un service connaît sa version

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -2,7 +2,6 @@
 
 ## TODO
 
-- [ ] C'est MSS qui met explicitement v1, pas Postgres
 - [ ] Côté Metabase : un LÉGO des versions de service.
   - Ce légo n'existe pas encore
   - L'absence de version veut dire `v1`
@@ -11,6 +10,7 @@
 
 ## DONE
 
+- [x] C'est MSS qui met explicitement v1, pas Postgres
 - [x] L'attribut s'appelle `versionService` et pas `version`
 - [x] Un nouveau service est persité en `v1`
 - [x] La version d'un service est lue depuis la persistance

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -5,7 +5,7 @@
 - [ ] Côté Metabase : un LÉGO des versions de service.
   - Ce légo n'existe pas encore
   - L'absence de version veut dire `v1`
-  - On imagine que dans `NOUVEAU_SERVICE_CREE` on aura un champ `versionService: "v2"` sur lequel il pourra se baser
+  - [x] On imagine que dans `NOUVEAU_SERVICE_CREE` on aura un champ `versionService: "v2"` sur lequel il pourra se baser
   - Au moment du switch, on imagine un nouvel event `SERVICE_A_ETE_MIGRE` qui dit `versionCible: "v2"`
 
 ## DONE

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -2,8 +2,6 @@
 
 ## TODO
 
-- [ ] Une colonne dédiée `version_service` dans la table `services`
-  - Avec valeur par défaut à `v1`, comme ça pas de migration.
 - [ ] Un nouveau service est persité en `v1`
 - [ ] Côté Metabase : un LÉGO des versions de service.
   - Ce légo n'existe pas encore
@@ -14,3 +12,5 @@
 ## DONE
 
 - [x] Un service connaît sa version
+- [x] Une colonne dédiée `version_service` dans la table `services`
+  - Avec valeur par défaut à `v1`, comme ça pas de migration.

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -3,7 +3,6 @@
 ## TODO
 
 - [ ] C'est MSS qui met explicitement v1, pas Postgres
-- [ ] L'attribut s'appelle `versionService` et pas `version`
 - [ ] Côté Metabase : un LÉGO des versions de service.
   - Ce légo n'existe pas encore
   - L'absence de version veut dire `v1`
@@ -12,6 +11,7 @@
 
 ## DONE
 
+- [x] L'attribut s'appelle `versionService` et pas `version`
 - [x] Un nouveau service est persité en `v1`
 - [x] La version d'un service est lue depuis la persistance
 - [x] Un service connaît sa version

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -11,6 +11,7 @@
 
 ## DONE
 
+- [x] La version d'un service est lue depuis la persistance
 - [x] Un service connaît sa version
 - [x] Une colonne dédiée `version_service` dans la table `services`
   - Avec valeur par défaut à `v1`, comme ça pas de migration.

--- a/tdd/les_services_actuels_sont_des_v1.md
+++ b/tdd/les_services_actuels_sont_des_v1.md
@@ -1,0 +1,13 @@
+# Les services actuels sont des V1
+
+## TODO
+
+- [ ] Une colonne dédiée `version_service` dans la table `services`
+  - Avec valeur par défaut à `v1`, comme ça pas de migration.
+- [ ] Un nouveau service est persité en `v1`
+- [ ] Un service connaît sa version
+- [ ] Côté Metabase : un LÉGO des versions de service.
+  - Ce légo n'existe pas encore
+  - L'absence de version veut dire `v1`
+  - On imagine que dans `NOUVEAU_SERVICE_CREE` on aura un champ `versionService: "v2"` sur lequel il pourra se baser
+  - Au moment du switch, on imagine un nouvel event `SERVICE_A_ETE_MIGRE` qui dit `versionCible: "v2"`

--- a/test/adaptateurs/adaptateurPostgres.spec.js
+++ b/test/adaptateurs/adaptateurPostgres.spec.js
@@ -135,6 +135,16 @@ describe("L'adaptateur persistance Postgres", () => {
         },
       ]);
     });
+
+    it('sait lire la version du service', async () => {
+      const idService = await insereService();
+      const idUtilisateur = await insereUtilisateur();
+      await insereAutorisation(idUtilisateur, idService);
+
+      const services = await persistance.servicesComplets({ idService });
+
+      expect(services[0].version).to.be('v1');
+    });
   });
 
   describe('concernant la lecture des modèles de mesure spécifique', () => {

--- a/test/adaptateurs/adaptateurPostgres.spec.js
+++ b/test/adaptateurs/adaptateurPostgres.spec.js
@@ -143,7 +143,7 @@ describe("L'adaptateur persistance Postgres", () => {
 
       const services = await persistance.servicesComplets({ idService });
 
-      expect(services[0].version).to.be('v1');
+      expect(services[0].versionService).to.be('v1');
     });
   });
 

--- a/test/constructeurs/constructeurService.js
+++ b/test/constructeurs/constructeurService.js
@@ -7,6 +7,7 @@ class ConstructeurService {
   constructor(referentiel) {
     this.donnees = {
       id: '',
+      versionService: 'versionParDefaut',
       descriptionService: uneDescriptionValide(referentiel).donnees,
       contributeurs: [],
       suggestionsActions: [],

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -896,6 +896,28 @@ describe('Le dépôt de données des services', () => {
       });
       expect(donnees.siretHash).to.be('unSIRET-haché256');
     });
+    /**/
+    it('stocke la version du service sans la chiffrer', async () => {
+      let chiffrementFait;
+      adaptateurChiffrement.chiffre = async (donneesAChiffrer) => {
+        expect(donneesAChiffrer.version).to.be(undefined);
+        chiffrementFait = true;
+        return { ...donneesAChiffrer, chiffre: true };
+      };
+
+      const idNouveau = await depot.nouveauService('123', {
+        version: 'v4',
+        descriptionService: uneDescriptionValide(referentiel)
+          .construis()
+          .donneesSerialisees(),
+      });
+
+      const [donnees] = await adaptateurPersistance.servicesComplets({
+        idService: idNouveau,
+      });
+      expect(donnees.version).to.be('v4');
+      expect(chiffrementFait).to.be(true);
+    });
 
     it("déclare un accès en écriture entre l'utilisateur et le service", async () => {
       const depotAutorisations = DepotDonneesAutorisations.creeDepot({

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -900,13 +900,13 @@ describe('Le dépôt de données des services', () => {
     it('stocke la version du service sans la chiffrer', async () => {
       let chiffrementFait;
       adaptateurChiffrement.chiffre = async (donneesAChiffrer) => {
-        expect(donneesAChiffrer.version).to.be(undefined);
+        expect(donneesAChiffrer.versionService).to.be(undefined);
         chiffrementFait = true;
         return { ...donneesAChiffrer, chiffre: true };
       };
 
       const idNouveau = await depot.nouveauService('123', {
-        version: 'v4',
+        versionService: 'v4',
         descriptionService: uneDescriptionValide(referentiel)
           .construis()
           .donneesSerialisees(),
@@ -915,7 +915,7 @@ describe('Le dépôt de données des services', () => {
       const [donnees] = await adaptateurPersistance.servicesComplets({
         idService: idNouveau,
       });
-      expect(donnees.version).to.be('v4');
+      expect(donnees.versionService).to.be('v4');
       expect(chiffrementFait).to.be(true);
     });
 

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -770,7 +770,9 @@ describe('Le dépôt de données des services', () => {
         )
         .construis();
       adaptateurUUID = { genereUUID: () => 'unUUID' };
-      referentiel = Referentiel.creeReferentielVide();
+      referentiel = Referentiel.creeReferentiel({
+        versionServiceParDefaut: 'vTest',
+      });
       adaptateurRechercheEntite = fauxAdaptateurRechercheEntreprise();
 
       depot = unDepotDeDonneesServices()
@@ -896,7 +898,7 @@ describe('Le dépôt de données des services', () => {
       });
       expect(donnees.siretHash).to.be('unSIRET-haché256');
     });
-    /**/
+
     it('stocke la version du service sans la chiffrer', async () => {
       let chiffrementFait;
       adaptateurChiffrement.chiffre = async (donneesAChiffrer) => {
@@ -917,6 +919,20 @@ describe('Le dépôt de données des services', () => {
       });
       expect(donnees.versionService).to.be('v4');
       expect(chiffrementFait).to.be(true);
+    });
+
+    it("utilise la version par défaut du référentiel ('v1' en Production) si aucune version n'est indiquée", async () => {
+      const donneesSansVersion = {
+        descriptionService: uneDescriptionValide(referentiel)
+          .construis()
+          .donneesSerialisees(),
+      };
+      const idNouveau = await depot.nouveauService('123', donneesSansVersion);
+
+      const [donnees] = await adaptateurPersistance.servicesComplets({
+        idService: idNouveau,
+      });
+      expect(donnees.versionService).to.be('vTest');
     });
 
     it("déclare un accès en écriture entre l'utilisateur et le service", async () => {

--- a/test/modeles/journalMSS/evenementNouveauServiceCree.spec.js
+++ b/test/modeles/journalMSS/evenementNouveauServiceCree.spec.js
@@ -7,7 +7,7 @@ describe('Un événement de nouveau service créé', () => {
 
   it("chiffre l'identifiant du service qui lui est donné", () => {
     const evenement = new EvenementNouveauServiceCree(
-      { idService: 'abc', idUtilisateur: 'def' },
+      { idService: 'abc', idUtilisateur: 'def', versionService: 'v1' },
       { adaptateurChiffrement: hacheEnMajuscules }
     );
 
@@ -16,7 +16,7 @@ describe('Un événement de nouveau service créé', () => {
 
   it("chiffre l'identifiant utilisateur qui lui est donné", () => {
     const evenement = new EvenementNouveauServiceCree(
-      { idService: 'abc', idUtilisateur: 'def' },
+      { idService: 'abc', idUtilisateur: 'def', versionService: 'v1' },
       { adaptateurChiffrement: hacheEnMajuscules }
     );
 
@@ -25,43 +25,37 @@ describe('Un événement de nouveau service créé', () => {
 
   it('sait se convertir en JSON', () => {
     const evenement = new EvenementNouveauServiceCree(
-      { idService: 'abc', idUtilisateur: 'def' },
+      { idService: 'abc', idUtilisateur: 'def', versionService: 'v1' },
       { date: '17/11/2022', adaptateurChiffrement: hacheEnMajuscules }
     );
 
     expect(evenement.toJSON()).to.eql({
       type: 'NOUVEAU_SERVICE_CREE',
-      donnees: { idService: 'ABC', idUtilisateur: 'DEF' },
+      donnees: { idService: 'ABC', idUtilisateur: 'DEF', versionService: 'v1' },
       date: '17/11/2022',
     });
   });
 
-  it("exige que l'identifiant utilisateur associé au service soit renseigné", () => {
-    try {
-      new EvenementNouveauServiceCree(
-        { idService: 'ABC' },
-        { adaptateurChiffrement: hacheEnMajuscules }
-      );
+  it.each(['idUtilisateur', 'idService', 'versionService'])(
+    'exige que %s soit renseigné',
+    (proprieteRequise) => {
+      const donneesTest = {
+        idService: 'S1',
+        idUtilisateur: 'U1',
+        versionService: 'v1',
+      };
+      delete donneesTest[proprieteRequise];
+      try {
+        new EvenementNouveauServiceCree(donneesTest, {
+          adaptateurChiffrement: hacheEnMajuscules,
+        });
 
-      expect().fail(
-        Error("L'instanciation de l'événement aurait dû lever une exception")
-      );
-    } catch (e) {
-      expect(e).to.be.an(ErreurDonneeManquante);
+        expect().fail(
+          Error("L'instanciation de l'événement aurait dû lever une exception")
+        );
+      } catch (e) {
+        expect(e).to.be.an(ErreurDonneeManquante);
+      }
     }
-  });
-
-  it("exige que l'identifiant du service créé soit renseigné", () => {
-    try {
-      new EvenementNouveauServiceCree(
-        { idUtilisateur: 'DEF' },
-        { adaptateurChiffrement: hacheEnMajuscules }
-      );
-      expect().fail(
-        Error("L'instanciation de l'événement aurait dû lever une exception")
-      );
-    } catch (e) {
-      expect(e).to.be.an(ErreurDonneeManquante);
-    }
-  });
+  );
 });

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -33,6 +33,14 @@ describe('Un service', () => {
     expect(service.nomService()).to.equal('Super Service');
   });
 
+  it('connaît sa version', () => {
+    const serviceV1 = new Service({
+      version: 'v1',
+    });
+
+    expect(serviceV1.version()).to.be('v1');
+  });
+
   it('connaît ses contributrices et contributeurs', () => {
     const service = unService()
       .avecId('123')

--- a/test/modeles/service.spec.js
+++ b/test/modeles/service.spec.js
@@ -34,9 +34,7 @@ describe('Un service', () => {
   });
 
   it('connaît sa version', () => {
-    const serviceV1 = new Service({
-      version: 'v1',
-    });
+    const serviceV1 = new Service({ versionService: 'v1' });
 
     expect(serviceV1.version()).to.be('v1');
   });


### PR DESCRIPTION
... afin de préparer le terrain pour l'apparition de la version V2.

Cette PR permet de fixer la version à "v1" sur tous les services existants, et les nouveaux services créés.