### PR TITLE
Type la `Request` renvoyée par `valideBody`

### DIFF
--- a/src/http/validePayloads.ts
+++ b/src/http/validePayloads.ts
@@ -13,7 +13,7 @@ export const valideBody =
     if (!resultat.success) return reponse.sendStatus(400);
 
     // Ici on veut bel et bien ré-écrire la requête, car c'est comme ça qu'expressjs est conçu.
-    // On réassigne `body` pour que les suivants récupèrent le contenu assaini par Zod.
+    // On réassigne pour que les suivants récupèrent le contenu assaini par Zod.
     // eslint-disable-next-line no-param-reassign
     requete.body = resultat.data as TBody;
 
@@ -21,8 +21,20 @@ export const valideBody =
   };
 
 export const valideParams =
-  (objet: z.ZodType): RequestHandler =>
-  async (requete: Request, reponse: Response, suite: NextFunction) => {
+  <TZod extends z.ZodType, TParams extends z.infer<TZod>>(objet: TZod) =>
+  async (
+    requete: Request<TParams, unknown, unknown, unknown, never>,
+    reponse: Response,
+    suite: NextFunction
+  ) => {
     const resultat = objet.safeParse(requete.params);
-    return resultat.success ? suite() : reponse.sendStatus(400);
+
+    if (!resultat.success) return reponse.sendStatus(400);
+
+    // Ici on veut bel et bien ré-écrire la requête, car c'est comme ça qu'expressjs est conçu.
+    // On réassigne pour que les suivants récupèrent le contenu assaini par Zod.
+    // eslint-disable-next-line no-param-reassign
+    requete.params = resultat.data as TParams;
+
+    return suite();
   };

--- a/src/http/validePayloads.ts
+++ b/src/http/validePayloads.ts
@@ -1,11 +1,23 @@
 import * as z from 'zod';
-import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 export const valideBody =
-  (objet: z.ZodType): RequestHandler =>
-  async (requete: Request, reponse: Response, suite: NextFunction) => {
+  <TZod extends z.ZodType, TBody extends z.infer<TZod>>(objet: TZod) =>
+  async (
+    requete: Request<unknown, unknown, TBody, unknown, never>,
+    reponse: Response,
+    suite: NextFunction
+  ) => {
     const resultat = objet.safeParse(requete.body);
-    return resultat.success ? suite() : reponse.sendStatus(400);
+
+    if (!resultat.success) return reponse.sendStatus(400);
+
+    // Ici on veut bel et bien ré-écrire la requête, car c'est comme ça qu'expressjs est conçu.
+    // On réassigne `body` pour que les suivants récupèrent le contenu assaini par Zod.
+    // eslint-disable-next-line no-param-reassign
+    requete.body = resultat.data as TBody;
+
+    return suite();
   };
 
 export const valideParams =

--- a/src/routes/connecte/routesConnecteApiBrouillonService.ts
+++ b/src/routes/connecte/routesConnecteApiBrouillonService.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express from 'express';
 import * as z from 'zod';
 import { DepotDonneesBrouillonService } from '../../depots/depotDonneesBrouillonService.js';
 import { RequestRouteConnecte } from './routesConnecte.types.js';
@@ -12,15 +12,16 @@ const routesConnecteApiBrouillonService = ({
 }) => {
   const routes = express.Router();
 
-  const BrouillonHttp = z.strictObject({
-    nomService: z.string().trim().nonempty(),
-  });
   routes.post(
     '/',
-    valideBody(BrouillonHttp),
-    async (requete: Request, reponse: Response) => {
+    valideBody(
+      z.strictObject({
+        nomService: z.string().trim().nonempty(),
+      })
+    ),
+    async (requete, reponse) => {
       const { idUtilisateurCourant } = requete as RequestRouteConnecte;
-      const { nomService } = BrouillonHttp.parse(requete.body);
+      const { nomService } = requete.body;
 
       const id = await depotDonnees.nouveauBrouillonService(
         idUtilisateurCourant,

--- a/src/routes/connecte/routesConnecteApiBrouillonService.ts
+++ b/src/routes/connecte/routesConnecteApiBrouillonService.ts
@@ -35,13 +35,16 @@ const routesConnecteApiBrouillonService = ({
   routes.post(
     '/:id/finalise',
     valideParams(z.strictObject({ id: z.uuidv4() })),
-    async (requete: Request, reponse: Response) => {
-      const { idUtilisateurCourant } = requete as RequestRouteConnecte;
+    async (requete, reponse) => {
+      const { idUtilisateurCourant } =
+        requete as unknown as RequestRouteConnecte;
       const { id } = requete.params;
+
       const idService = await depotDonnees.finaliseBrouillonService(
         idUtilisateurCourant,
         id as UUID
       );
+
       return reponse.json({ idService });
     }
   );


### PR DESCRIPTION
… pour que `requete.body` soit typé dans la route qui utilise `valideBody()`. 

Inspiration : https://jakerobins.com/blog/using-zod-to-provide-typesafe-express-requests

Cette PR permet d'avoir une `requete` typée sans dupliquer l'appel à `zod` 👇 

<img width="555" alt="image" src="https://github.com/user-attachments/assets/1f0580ac-eb2f-4b45-98af-acf50a166aae" />
