### PR TITLE
[CORRECTION] Assigne `estComplete` en mode "réactif", afin de l'évaluer au montage

### DIFF
--- a/svelte/lib/creationV2/etapes/etape1/QuestionStatutDeploiement.svelte
+++ b/svelte/lib/creationV2/etapes/etape1/QuestionStatutDeploiement.svelte
@@ -8,13 +8,10 @@
   const metsAJourValeur = () => {
     if (valeur) {
       dispatch('champModifie', valeur);
-      estComplete = true;
     }
   };
 
-  $: {
-    if (valeur) estComplete = true;
-  }
+  $: estComplete = !!valeur;
 </script>
 
 <label for="statut-deploiement">


### PR DESCRIPTION
… du composant.