### PR TITLE
Reviens à un lancement classique en dev

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
-NODE_VERSION="$(cat .nvmrc)" docker compose up web --build -d
-
-docker logs -f mon-service-securise-web-1
+NODE_VERSION="$(cat .nvmrc)" docker compose \
+  up web --build


### PR DESCRIPTION
On annule 6b0609fae56bade0316554ca050d7d0121856974 car le bug des logs en double était en fait un bug Docker Compose résolu en version `2.39.2`.
Donc, inutile de démarrer en mode démon.

https://github.com/docker/compose/issues/13144