### PR TITLE
[CORRECTION] Calcule correctement l'indice cyber personnalisé même avec que du « non fait »

### DIFF
--- a/src/modeles/indiceCyber.js
+++ b/src/modeles/indiceCyber.js
@@ -58,7 +58,9 @@ class IndiceCyber {
       0
     );
     const indiceCyberNoteMax = referentiel.indiceCyberNoteMax();
-    const indiceTotal = indiceCyberNoteMax * (totalPondere / nbTotalMesures);
+    const indiceTotal = nbTotalMesures
+      ? indiceCyberNoteMax * (totalPondere / nbTotalMesures)
+      : 0;
 
     this.scoreToutesCategories = toutesCategories.reduce(
       (acc, categorie) => ({

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -2341,6 +2341,10 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         documentsPdfDisponibles: ['syntheseSecurite'],
         permissions: { gestionContributeurs: false },
         aUneSuggestionAction: false,
+        actionRecommandee: {
+          autorisee: false,
+          id: 'augmenterIndiceCyber',
+        },
         niveauSecurite: 'niveau1',
         pourcentageCompletude: 0,
       });


### PR DESCRIPTION
En PROD nous avons eu des Sentry sur 

> TypeError
> Cannot read properties of null (reading 'toFixed')

<img width="550" alt="image" src="https://github.com/user-attachments/assets/8949ca89-b50a-40d2-96c7-5ea1dce07164" />

En analysant, on trouve un bug dans le code lorsque toutes les mesures sont en « Non faite » : à ce moment là MSS ne parvient pas à calculer l'IC personnalisé.
En effet de bord, cela insère `total: null` dans la colonne `indice_cyber_personnalise` table `evolutions_indice_cyber`. 
C'est cet effet de bord qui est remonté par le Sentry.