### PR TITLE
Enlève l'obligation de remplissage pour les listes de champs texte côté front

### DIFF
--- a/svelte/lib/creationV2/etapes/etape1/QuestionPointsAcces.svelte
+++ b/svelte/lib/creationV2/etapes/etape1/QuestionPointsAcces.svelte
@@ -13,10 +13,7 @@
     if ($leBrouillon.pointsAcces.length === 0) ajouteValeur();
   });
 
-  // N'avoir aucun point d'accès est valide, donc on peut utiliser `every` qui renvoie `true` sur tableau vide.
-  $: estComplete = $leBrouillon.pointsAcces.every((v) =>
-    v ? v.trim().length > 0 : false
-  );
+  $: estComplete = true;
 
   const supprimeValeur = (index: number) => {
     $leBrouillon.pointsAcces = $leBrouillon.pointsAcces.filter(
@@ -29,7 +26,11 @@
   };
 
   const enregistre = () => {
-    emetEvenement('champModifie', { pointsAcces: $leBrouillon.pointsAcces });
+    emetEvenement('champModifie', {
+      pointsAcces: $leBrouillon.pointsAcces.filter(
+        (pointAcces) => pointAcces.trim().length > 0
+      ),
+    });
   };
 </script>
 

--- a/svelte/lib/creationV2/etapes/etape3/QuestionCategoriesDonneesTraitees.svelte
+++ b/svelte/lib/creationV2/etapes/etape3/QuestionCategoriesDonneesTraitees.svelte
@@ -30,11 +30,7 @@
 
   const emetEvenement = createEventDispatcher<{ champModifie: MiseAJour }>();
 
-  // Pas de condition sur categoriesDonneesTraitees car ce n'est pas obligatoire d'en sélectionner.
-  // N'avoir aucun categoriesDonneesTraiteesSupplémentaires est valide, donc on peut utiliser `every` qui renvoie `true` sur tableau vide.
-  $: estComplete = $leBrouillon.categoriesDonneesTraiteesSupplementaires.every(
-    (v) => (v ? v.trim().length > 0 : false)
-  );
+  $: estComplete = true;
 
   const supprimeValeur = (index: number) => {
     $leBrouillon.categoriesDonneesTraiteesSupplementaires =
@@ -53,7 +49,9 @@
   const enregistre = () => {
     emetEvenement('champModifie', {
       categoriesDonneesTraiteesSupplementaires:
-        $leBrouillon.categoriesDonneesTraiteesSupplementaires,
+        $leBrouillon.categoriesDonneesTraiteesSupplementaires.filter(
+          (c) => c.trim().length > 0
+        ),
     });
   };
 


### PR DESCRIPTION
...après test utilisateur, les utilisateurs ont été perturbés de ne pas pouvoir passer au suivant si un champ est vide. On filtre les champs vides avant d'envoyer la donnée au back