### PR TITLE
Evite de sauter une question à cause d'une race condition

### DIFF
--- a/svelte/lib/creationV2/CreationV2.svelte
+++ b/svelte/lib/creationV2/CreationV2.svelte
@@ -13,6 +13,7 @@
   import { etapeCourante } from './etapes/etapeCourante.store';
   import { leBrouillon } from './etapes/brouillon.store';
   import { ajouteParametreAUrl } from '../outils/url';
+  import type { BrouillonSvelte } from './creationV2.types';
 
   let questionCouranteEstComplete = false;
   let enCoursDeChargement = false;
@@ -40,7 +41,15 @@
     }
 
     await metsAJourBrouillonService(idBrouillon, e.detail);
-    if ($etapeCourante.questionCourante.avecAvanceRapide)
+
+    const nomChampModifie = Object.keys(e.detail)[0] as keyof BrouillonSvelte;
+    const onEstToujoursSurLaQuestionQuiAEnvoyeLaMaj =
+      $etapeCourante.questionCourante.clesPropriete.includes(nomChampModifie);
+    // si on n'est plus sur la question mise à jour, c'est que "suivant()" a déjà été appelé
+    if (
+      onEstToujoursSurLaQuestionQuiAEnvoyeLaMaj &&
+      $etapeCourante.questionCourante.avecAvanceRapide
+    )
       navigationStore.suivant();
   };
 


### PR DESCRIPTION
On a constaté que sur une question dont la maj est envoyée au blur du champ et que ce blur est entraîné par le click sur le bouton "suivant", l'exécution de la fonction `suivant()` pouvait finir avant la ligne qui suit, et donc l'évaluation de "est-ce que l'étape courante est une étape avec avance rapide ?" porte dans ce cas sur la question suivante et non la question courante. Cela exécutait alors deux fois la fonction `suivant()`.

ex : Q1 a un champ texte et un bouton suivant, et pas d'avance rapide Q2 a une avance rapide
Q3 existe
-> remplir le champ texte de Q1 et sortir du champ en cliquant sur le bouton suivant entraîne une race condition entre `suivant` et `metsAJourBrouillonService`, les deux ayant lieu en même temps dans un ordre indéterminé.

-> Q1 est rempli, Q2 n'est pas rempli (il est sauté), Q3 est affiché