### PR TITLE
[API] Ajoute la possibilité de renvoyer la représentation complète d'un Service

### DIFF
--- a/src/modeles/autorisations/autorisation.ts
+++ b/src/modeles/autorisations/autorisation.ts
@@ -57,7 +57,7 @@ export class Autorisation extends Base {
     return this.droits[rubrique] >= niveau;
   }
 
-  aLesPermissions(droits: Droits) {
+  aLesPermissions(droits: Partial<Droits>) {
     return Object.entries(droits).every(([rubrique, niveau]) =>
       this.aLaPermission(niveau, rubrique as Rubrique)
     );

--- a/src/modeles/objetsApi/objetGetServiceComplet.ts
+++ b/src/modeles/objetsApi/objetGetServiceComplet.ts
@@ -1,5 +1,9 @@
 import Service from '../service.js';
 import { Autorisation } from '../autorisations/autorisation.js';
+import * as objetGetMesures from './objetGetMesures.js';
+import { Droits } from '../autorisations/gestionDroits.js';
+
+const { DROITS_VOIR_DESCRIPTION, DROITS_VOIR_MESURES } = Autorisation;
 
 export class ObjetGetServiceComplet {
   constructor(
@@ -7,13 +11,21 @@ export class ObjetGetServiceComplet {
     private readonly autorisation: Autorisation
   ) {}
 
-  donnees(): { descriptionService?: Record<string, unknown> } {
+  donnees(): {
+    descriptionService?: Record<string, unknown>;
+    mesures?: Record<string, unknown>;
+  } {
     return {
-      descriptionService: this.autorisation.aLesPermissions(
-        Autorisation.DROITS_VOIR_DESCRIPTION
-      )
-        ? this.service.descriptionService.toJSON()
-        : undefined,
+      ...(this.peut(DROITS_VOIR_DESCRIPTION) && {
+        descriptionService: this.service.descriptionService.toJSON(),
+      }),
+      ...(this.peut(DROITS_VOIR_MESURES) && {
+        mesures: objetGetMesures.donnees(this.service),
+      }),
     };
+  }
+
+  private peut(droits: Partial<Droits>) {
+    return this.autorisation.aLesPermissions(droits);
   }
 }

--- a/src/modeles/objetsApi/objetGetServiceComplet.ts
+++ b/src/modeles/objetsApi/objetGetServiceComplet.ts
@@ -1,0 +1,19 @@
+import Service from '../service.js';
+import { Autorisation } from '../autorisations/autorisation.js';
+
+export class ObjetGetServiceComplet {
+  constructor(
+    private readonly service: Service,
+    private readonly autorisation: Autorisation
+  ) {}
+
+  donnees(): { descriptionService?: Record<string, unknown> } {
+    return {
+      descriptionService: this.autorisation.aLesPermissions(
+        Autorisation.DROITS_VOIR_DESCRIPTION
+      )
+        ? this.service.descriptionService.toJSON()
+        : undefined,
+    };
+  }
+}

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -17,7 +17,11 @@ import routesConnecteApiServiceActivitesMesure from './routesConnecteApiServiceA
 import { Autorisation } from '../../modeles/autorisations/autorisation.js';
 import routesConnecteApiSimulationMigrationReferentiel from './routesConnecteApiSimulationMigrationReferentiel.js';
 import { schemaSuggestionAction } from '../../http/schemas/suggestionAction.schema.js';
-import { valideBody, valideParams } from '../../http/validePayloads.js';
+import {
+  valideBody,
+  valideParams,
+  valideQuery,
+} from '../../http/validePayloads.js';
 import { schemaPutRisqueGeneral } from './routesConnecteApiService.schema.js';
 import { schemaAutorisation } from '../../http/schemas/autorisation.schema.js';
 import { routesConnecteApiServiceMesuresSpecifiques } from './routesConnecteApiServiceMesuresSpecifiques.js';
@@ -29,6 +33,7 @@ import { routesConnecteApiServiceMesuresGenerales } from './routesConnecteApiSer
 import { routesConnecteApiServiceDescription } from './routesConnecteApiServiceDescription.js';
 import { routesConnecteApiServiceRolesReponsaibilites } from './routesConnecteApiServiceRolesReponsabilites.js';
 import routesConnecteApiServiceRisquesV2 from './routesConnecteApiServiceRisquesV2.js';
+import { ObjetGetServiceComplet } from '../../modeles/objetsApi/objetGetServiceComplet.js';
 
 const { ECRITURE, LECTURE } = Permissions;
 const { SECURISER, RISQUES } = Rubriques;
@@ -134,13 +139,24 @@ const routesConnecteApiService = ({
     '/:id',
     middleware.trouveService({}),
     middleware.chargeAutorisationsService,
+    valideQuery(z.strictObject({ complet: z.literal('true').optional() })),
     async (requete, reponse) => {
-      const donnees = objetGetService.donnees(
-        requete.service,
-        requete.autorisationService,
-        referentiel
-      );
-      reponse.json(donnees);
+      const { complet } = requete.query;
+
+      if (complet) {
+        const donnees = new ObjetGetServiceComplet(
+          requete.service,
+          requete.autorisationService
+        ).donnees();
+        reponse.json(donnees);
+      } else {
+        const donnees = objetGetService.donnees(
+          requete.service,
+          requete.autorisationService,
+          referentiel
+        );
+        reponse.json(donnees);
+      }
     }
   );
 

--- a/test/modeles/objetsApi/objetGetServiceComplet.spec.ts
+++ b/test/modeles/objetsApi/objetGetServiceComplet.spec.ts
@@ -1,0 +1,36 @@
+import { unServiceV2 } from '../../constructeurs/constructeurService.js';
+import { ObjetGetServiceComplet } from '../../../src/modeles/objetsApi/objetGetServiceComplet.ts';
+import { uneAutorisation } from '../../constructeurs/constructeurAutorisation.js';
+import {
+  Permissions,
+  Rubriques,
+} from '../../../src/modeles/autorisations/gestionDroits.ts';
+
+describe("Sur demande de la représentation API complète d'un service", () => {
+  describe('concernant la description du service', () => {
+    it('retourne la représentation JSON de la description', () => {
+      const serviceV2 = unServiceV2().avecNomService('Mon service').construis();
+
+      const donnees = new ObjetGetServiceComplet(
+        serviceV2,
+        uneAutorisation().deProprietaire('U1', 'S1').construis()
+      ).donnees();
+
+      expect(donnees.descriptionService!.nomService).toBe('Mon service');
+    });
+
+    it('ne retourne pas la représentation de la description si les droits sont insuffisants', () => {
+      const serviceV2 = unServiceV2().avecNomService('Mon service').construis();
+      const autorisation = uneAutorisation()
+        .avecDroits({ [Rubriques.DECRIRE]: Permissions.INVISIBLE })
+        .construis();
+
+      const donnees = new ObjetGetServiceComplet(
+        serviceV2,
+        autorisation
+      ).donnees();
+
+      expect(donnees.descriptionService).toBeUndefined();
+    });
+  });
+});

--- a/test/modeles/objetsApi/objetGetServiceComplet.spec.ts
+++ b/test/modeles/objetsApi/objetGetServiceComplet.spec.ts
@@ -7,13 +7,17 @@ import {
 } from '../../../src/modeles/autorisations/gestionDroits.ts';
 
 describe("Sur demande de la représentation API complète d'un service", () => {
+  const autorisationProprietaire = uneAutorisation()
+    .deProprietaire('U1', 'S1')
+    .construis();
+
   describe('concernant la description du service', () => {
     it('retourne la représentation JSON de la description', () => {
       const serviceV2 = unServiceV2().avecNomService('Mon service').construis();
 
       const donnees = new ObjetGetServiceComplet(
         serviceV2,
-        uneAutorisation().deProprietaire('U1', 'S1').construis()
+        autorisationProprietaire
       ).donnees();
 
       expect(donnees.descriptionService!.nomService).toBe('Mon service');
@@ -31,6 +35,34 @@ describe("Sur demande de la représentation API complète d'un service", () => {
       ).donnees();
 
       expect(donnees.descriptionService).toBeUndefined();
+    });
+  });
+
+  describe('concernant la liste des mesures du service', () => {
+    it('retourne la représentation JSON des mesures', () => {
+      const serviceV2 = unServiceV2().construis();
+
+      const donnees = new ObjetGetServiceComplet(
+        serviceV2,
+        autorisationProprietaire
+      ).donnees();
+
+      expect(donnees.mesures!.mesuresGenerales).toBeDefined();
+      expect(donnees.mesures!.mesuresSpecifiques).toBeDefined();
+    });
+
+    it('ne retourne pas la représentation des mesures si les droits sont insuffisants', () => {
+      const serviceV2 = unServiceV2().avecNomService('Mon service').construis();
+      const autorisation = uneAutorisation()
+        .avecDroits({ [Rubriques.SECURISER]: Permissions.INVISIBLE })
+        .construis();
+
+      const donnees = new ObjetGetServiceComplet(
+        serviceV2,
+        autorisation
+      ).donnees();
+
+      expect(donnees.mesures).toBeUndefined();
     });
   });
 });

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -357,7 +357,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         .verifieChargementDesAutorisations(testeur.app(), '/api/service/456');
     });
 
-    it('retourne la représentation du service grâce à `objetGetService`', async () => {
+    it('retourne la représentation du service', async () => {
       const reponse = await testeur.get('/api/service/456');
 
       expect(reponse.body).to.eql({
@@ -394,6 +394,19 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         niveauSecurite: 'niveau1',
         pourcentageCompletude: 0,
       });
+    });
+
+    it('retourne la représentation complète du service si le paramètre `complet` vaut `true`', async () => {
+      const reponse = await testeur.get('/api/service/456?complet=true');
+
+      expect(reponse.body.descriptionService).not.to.be(undefined);
+      expect(reponse.body.mesures).not.to.be(undefined);
+    });
+
+    it('jette une erreur si le paramètre `complet` est invalide', async () => {
+      const { status } = await testeur.get('/api/service/456?complet=1234');
+
+      expect(status).to.be(400);
     });
   });
 


### PR DESCRIPTION
...via la route API actuelle et un paramètre `complet=true`.