### PR TITLE
Ajoute un retry sur la recherche entreprise

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@tiptap/starter-kit": "^3.20.1",
     "@tiptap/suggestion": "^3.20.1",
     "axios": "^1.15.0",
+    "axios-retry": "^4.5.0",
     "bcrypt": "^6.0.0",
     "commander": "^14.0.0",
     "cookie-parser": "^1.4.7",
@@ -73,7 +74,6 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
-    "axe-core": "^4.11.2",
     "@electric-sql/pglite": "^0.4.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^9.39.4",
@@ -92,6 +92,7 @@
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "@vitest/eslint-plugin": "^1.6.12",
+    "axe-core": "^4.11.2",
     "concurrently": "^9.2.1",
     "eslint": "^9.39.4",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       axios:
         specifier: ^1.15.0
         version: 1.15.0
+      axios-retry:
+        specifier: ^4.5.0
+        version: 4.5.0(axios@1.15.0)
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1742,6 +1745,11 @@ packages:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
     engines: {node: '>=4'}
 
+  axios-retry@4.5.0:
+    resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
+    peerDependencies:
+      axios: 0.x || 1.x
+
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
@@ -2793,6 +2801,10 @@ packages:
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
+
+  is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -5846,6 +5858,11 @@ snapshots:
 
   axe-core@4.11.2: {}
 
+  axios-retry@4.5.0(axios@1.15.0):
+    dependencies:
+      axios: 1.15.0
+      is-retry-allowed: 2.2.0
+
   axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
@@ -7000,6 +7017,8 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  is-retry-allowed@2.2.0: {}
 
   is-set@2.0.3: {}
 

--- a/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
+++ b/src/adaptateurs/adaptateurRechercheEntrepriseAPI.js
@@ -1,5 +1,17 @@
 import axios from 'axios';
+import axiosRetry from 'axios-retry';
 import { fabriqueAdaptateurGestionErreur } from './fabriqueAdaptateurGestionErreur.js';
+
+axiosRetry(axios, {
+  retries: 3,
+  retryCondition: (e) => e.response?.status === 429,
+  retryDelay: (retryCount, e) => {
+    const retryAfter = e.response?.headers?.['retry-after'];
+    return retryAfter
+      ? Number(retryAfter) * 1000
+      : axiosRetry.exponentialDelay(retryCount);
+  },
+});
 
 const extraisDepartement = (commune) => {
   if (!commune) {


### PR DESCRIPTION
...afin de pouvoir réessayer sur une 429 pendant les tests d'accessibilité. En effet, contrairement à la prod qui n'a pas le même niveau de rate limit, les runners Github n'ont pas d'IP fixe donc sont sujets aux rate limit publics de l'API.