### PR TITLE
[CORRECTION] Ne tente pas de charger le centre de notifications si la div conteneur n'est pas présente

### DIFF
--- a/svelte/lib/centreNotifications/centreNotifications.ts
+++ b/svelte/lib/centreNotifications/centreNotifications.ts
@@ -10,8 +10,11 @@ let app: CentreNotifications;
 const rechargeApp = async () => {
   if (app) await unmount(app);
 
+  const target = document.getElementById('centre-notifications');
+  if (!target) return;
+
   app = mount(CentreNotifications, {
-    target: document.getElementById('centre-notifications')!,
+    target: target!,
   });
 };
 


### PR DESCRIPTION

...ce qui peut arriver sur les pages publiques quand on est déconnecté, étant donné qu'on a déplacé le code de chargement du svelte du centre de notifs dans le fichier header.js qui est toujours chargé.