### PR TITLE
[CORRECTION] Répare la fuite CSS qui touchait les activités de mesure

### DIFF
--- a/src/vues/service/pagesService.pug
+++ b/src/vues/service/pagesService.pug
@@ -6,7 +6,6 @@ block append styles
   link(href = '/statique/assets/styles/tiroir.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/modules/selectize.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/formulaire.css', rel = 'stylesheet')
-  link(href = '/statique/assets/styles/modules/validation.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/homologation/formulaire.css', rel = 'stylesheet')
   link(href = '/statique/assets/styles/homologation/mesures.css', rel = 'stylesheet')
 

--- a/svelte/lib/pagesService/pages/homologuer/Homologuer.svelte
+++ b/svelte/lib/pagesService/pages/homologuer/Homologuer.svelte
@@ -178,9 +178,49 @@
     </div>
   </dsfr-tabs>
 {/if}
+
 <ModaleEncartHomologation {idService} bind:this={modaleEncartHomologation} />
 
 <style lang="scss">
+  :global #formulaire-suppression-dossier-courant {
+    .requis {
+      position: relative;
+    }
+
+    .requis::before {
+      position: absolute;
+      left: -1em;
+      content: '*';
+      color: var(--rose-anssi);
+    }
+
+    .message-erreur {
+      position: relative;
+      display: none;
+      margin: 1em 0;
+      color: var(--rose-anssi);
+      font-weight: normal;
+      align-items: center;
+      flex-direction: row;
+      gap: 8px;
+    }
+
+    .message-erreur::before {
+      content: '';
+      display: flex;
+      flex-shrink: 0;
+      background-image: url(/statique/assets/images/icone_attention_rose.svg);
+      background-repeat: no-repeat;
+      background-size: contain;
+      width: 24px;
+      height: 24px;
+    }
+
+    :is(input, select, textarea).touche:invalid ~ .message-erreur {
+      display: flex;
+    }
+  }
+
   .conteneur-onglet {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Avant ce commit, inclure validation.css dans pagesService.pug avait un effet de bord sur l'input du tiroir d'activité de mesures, et ailleurs… Bug remonté en PROD.

Les sélecteurs de `validation.css` sont trop larges (`.requis` par exemple) pour être inclus dans la SPA service sans effets de bord.

Ici, on duplique les styles qui sont nécessaires au tiroir de suppression de dossier courant. Ce n'est pas idéal, mais on peut restreindre sur `#formulaire-suppression-dossier-courant` et éviter les fuites CSS.