### PR TITLE
Metabase : accepter les homologations refusées

### DIFF
--- a/src/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.js
+++ b/src/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.js
@@ -21,6 +21,7 @@ function consigneNouvelleHomologationCreeeDansJournal({
       dureeHomologationMois: referentiel.nbMoisDecalage(
         dossier.decision.dureeValidite
       ),
+      refusee: dossier.decision.refusee,
       importe,
     });
 

--- a/src/modeles/journalMSS/evenementNouvelleHomologationCreee.js
+++ b/src/modeles/journalMSS/evenementNouvelleHomologationCreee.js
@@ -4,11 +4,11 @@ class EvenementNouvelleHomologationCreee extends Evenement {
   constructor(donnees, options = {}) {
     const { date, adaptateurChiffrement } = Evenement.optionsParDefaut(options);
 
-    Evenement.verifieProprietesRenseignees(donnees, [
-      'idService',
-      'dateHomologation',
-      'dureeHomologationMois',
-    ]);
+    const proprietesRequises = donnees.refusee
+      ? ['idService', 'dateHomologation']
+      : ['idService', 'dateHomologation', 'dureeHomologationMois'];
+
+    Evenement.verifieProprietesRenseignees(donnees, proprietesRequises);
 
     super(
       'NOUVELLE_HOMOLOGATION_CREEE',
@@ -16,6 +16,7 @@ class EvenementNouvelleHomologationCreee extends Evenement {
         idService: adaptateurChiffrement.hacheSha256(donnees.idService),
         dateHomologation: donnees.dateHomologation,
         dureeHomologationMois: donnees.dureeHomologationMois,
+        ...(donnees.refusee && { refusee: true }),
         ...(donnees.importe && { importe: true }),
       },
       date

--- a/test/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.spec.js
+++ b/test/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.spec.js
@@ -52,6 +52,25 @@ describe("L'abonnement qui consigne (dans le journal MSS) la finalisation d'un d
     expect(evenementRecu.donnees.importe).to.be(true);
   });
 
+  it('peut consigner un événement de "nouvelle homologation `refusee`"', async () => {
+    let evenementRecu = {};
+    adaptateurJournal.consigneEvenement = async (evenement) => {
+      evenementRecu = evenement;
+    };
+
+    await consigneNouvelleHomologationCreeeDansJournal({
+      adaptateurJournal,
+      referentiel,
+    })({
+      idService: '123',
+      dossier: unDossier(referentiel).quiEstRefuse('2026-04-29').construis(),
+    });
+
+    expect(evenementRecu.type).to.be('NOUVELLE_HOMOLOGATION_CREEE');
+    expect(evenementRecu.donnees.dateHomologation).to.be('2026-04-29');
+    expect(evenementRecu.donnees.refusee).to.be(true);
+  });
+
   [
     { propriete: 'idService', nom: "l'ID du service" },
     { propriete: 'dossier', nom: 'le dossier' },

--- a/test/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.spec.js
+++ b/test/bus/abonnements/consigneNouvelleHomologationCreeeDansJournal.spec.js
@@ -27,7 +27,7 @@ describe("L'abonnement qui consigne (dans le journal MSS) la finalisation d'un d
       referentiel,
     })({
       idService: '123',
-      dossier: unDossier(referentiel).quiEstComplet().quiEstActif().construit(),
+      dossier: unDossier(referentiel).quiEstComplet().quiEstActif().construis(),
     });
 
     expect(evenementRecu.type).to.be('NOUVELLE_HOMOLOGATION_CREEE');
@@ -44,7 +44,7 @@ describe("L'abonnement qui consigne (dans le journal MSS) la finalisation d'un d
       referentiel,
     })({
       idService: '123',
-      dossier: unDossier(referentiel).quiEstComplet().quiEstActif().construit(),
+      dossier: unDossier(referentiel).quiEstComplet().quiEstActif().construis(),
       importe: true,
     });
 

--- a/test/bus/abonnements/sauvegardeNotificationsExpirationHomologation.spec.js
+++ b/test/bus/abonnements/sauvegardeNotificationsExpirationHomologation.spec.js
@@ -62,7 +62,7 @@ describe("L'abonnement qui sauvegarde (en base de données) les notifications d'
       referentiel,
     })({
       idService: '123',
-      dossier: unDossier(referentiel).quiEstComplet().construit(),
+      dossier: unDossier(referentiel).quiEstComplet().construis(),
     });
 
     expect(depotAppele).to.be(true);
@@ -85,7 +85,7 @@ describe("L'abonnement qui sauvegarde (en base de données) les notifications d'
       dossier: unDossier(referentiel)
         .quiEstComplet()
         .avecDecision('2024-01-01', 'unAn')
-        .construit(),
+        .construis(),
     });
 
     expect(notificationsRecus.length).to.be(2);
@@ -109,7 +109,7 @@ describe("L'abonnement qui sauvegarde (en base de données) les notifications d'
       dossier: unDossier(referentiel)
         .quiEstComplet()
         .avecDecision('2023-01-02', 'unAn')
-        .construit(),
+        .construis(),
     });
 
     expect(notificationsRecus.length).to.be(1);

--- a/test/constructeurs/constructeurDossier.ts
+++ b/test/constructeurs/constructeurDossier.ts
@@ -160,7 +160,7 @@ class ConstructeurDossierFantaisie {
     return this;
   }
 
-  construit() {
+  construis() {
     return new Dossier(this.donnees, this.referentiel, this.adaptateurHorloge);
   }
 }

--- a/test/modeles/dossier.spec.ts
+++ b/test/modeles/dossier.spec.ts
@@ -282,7 +282,7 @@ describe("Un dossier d'homologation", () => {
     it("est « Non réalisée » si le dossier n'est pas finalisé", () => {
       const nonFinalise = unDossier(referentiel)
         .quiEstNonFinalise()
-        .construit();
+        .construis();
 
       expect(nonFinalise.statutHomologation()).toBe('nonRealisee');
     });
@@ -292,7 +292,7 @@ describe("Un dossier d'homologation", () => {
         .quiEstComplet()
         .quiEstRefuse('2023-06-01')
         .quiEstArchive()
-        .construit();
+        .construis();
 
       expect(nonFinalise.statutHomologation()).toBe('refusee');
     });
@@ -304,7 +304,7 @@ describe("Un dossier d'homologation", () => {
       const actifLeDeuxJuin = unDossier(referentiel, maintenantPremierJuin)
         .quiEstComplet()
         .avecDateHomologation(new Date('2023-06-02'))
-        .construit();
+        .construis();
 
       expect(actifLeDeuxJuin.statutHomologation()).toBe('activee');
     });
@@ -316,7 +316,7 @@ describe("Un dossier d'homologation", () => {
       const expireDansDixJours = unDossier(referentiel, maintenantPremierJuin)
         .quiEstComplet()
         .avecDecision('2022-06-11', 'unAn')
-        .construit();
+        .construis();
 
       expect(expireDansDixJours.statutHomologation()).toBe('bientotExpiree');
     });
@@ -328,7 +328,7 @@ describe("Un dossier d'homologation", () => {
       const actifAnneeComplete = unDossier(referentiel, maintenantPremierJuin)
         .quiEstComplet()
         .avecDecision('2023-01-01', 'unAn')
-        .construit();
+        .construis();
 
       expect(actifAnneeComplete.statutHomologation()).toBe('activee');
     });
@@ -340,7 +340,7 @@ describe("Un dossier d'homologation", () => {
       const finiDepuis2022 = unDossier(referentiel, maintenantPremierJuin)
         .quiEstComplet()
         .avecDecision('2021-06-15', 'unAn')
-        .construit();
+        .construis();
 
       expect(finiDepuis2022.statutHomologation()).toBe('expiree');
     });
@@ -357,13 +357,13 @@ describe("Un dossier d'homologation", () => {
     it("retourne `false` si le dossier n'est pas finalisé", () => {
       const nonFinalise = unDossier(referentiel)
         .quiEstNonFinalise()
-        .construit();
+        .construis();
 
       expect(nonFinalise.estActif()).toEqual(false);
     });
 
     it('retourne `false` si le dossier est archivé', () => {
-      const dossierArchive = unDossier(referentiel).quiEstArchive().construit();
+      const dossierArchive = unDossier(referentiel).quiEstArchive().construis();
       expect(dossierArchive.estActif()).toEqual(false);
     });
 
@@ -371,7 +371,7 @@ describe("Un dossier d'homologation", () => {
       const dossierFinaliseNonArchive = unDossier(referentiel)
         .quiEstComplet()
         .nonArchive()
-        .construit();
+        .construis();
 
       expect(dossierFinaliseNonArchive.estActif()).toEqual(true);
     });
@@ -408,7 +408,7 @@ describe("Un dossier d'homologation", () => {
       const dossierComplet = unDossier(referentiel)
         .quiEstComplet()
         .quiEstNonFinalise()
-        .construit();
+        .construis();
 
       dossierComplet.enregistreFinalisation(3.5, 4.5);
       expect(dossierComplet.finalise).toBe(true);
@@ -436,7 +436,7 @@ describe("Un dossier d'homologation", () => {
     });
 
     it("renvoie l'étape « Récapitulatif » si toutes les étapes précédentes sont complètes", () => {
-      const dossierComplet = unDossier(referentiel).quiEstComplet().construit();
+      const dossierComplet = unDossier(referentiel).quiEstComplet().construis();
 
       expect(dossierComplet.etapeCourante()).toEqual('recapitulatif');
     });
@@ -444,7 +444,7 @@ describe("Un dossier d'homologation", () => {
     it("renvoie l'étape qui suit la dernière étape complète", () => {
       const etapeUneComplete = unDossier(referentiel)
         .avecAutorite('Jean', 'RSSI')
-        .construit();
+        .construis();
 
       expect(etapeUneComplete.etapeCourante()).toEqual('avis');
     });
@@ -483,7 +483,7 @@ describe("Un dossier d'homologation", () => {
       const dossierExpirantDans30Jours = unDossier(referentiel)
         .quiEstComplet()
         .quiVaExpirer(30, 'sixMois')
-        .construit();
+        .construis();
 
       expect(dossierExpirantDans30Jours.estBientotExpire()).toBe(true);
     });
@@ -498,7 +498,7 @@ describe("Un dossier d'homologation", () => {
       const dossierExpirantDansPlusDe2Mois = unDossier(referentiel)
         .quiEstComplet()
         .quiVaExpirer(65, 'sixMois')
-        .construit();
+        .construis();
 
       expect(dossierExpirantDansPlusDe2Mois.estBientotExpire()).toBe(false);
     });
@@ -516,7 +516,7 @@ describe("Un dossier d'homologation", () => {
       const dejaExpire = unDossier(referentiel, maintenantPremierJuin)
         .quiEstComplet()
         .avecDecision('2020-01-10', 'unAn')
-        .construit();
+        .construis();
 
       expect(dejaExpire.estBientotExpire()).toBe(false);
     });
@@ -534,7 +534,7 @@ describe("Un dossier d'homologation", () => {
       const dossierExpire = unDossier(referentiel)
         .quiEstComplet()
         .quiEstExpire()
-        .construit();
+        .construis();
 
       expect(dossierExpire.estExpire()).toBe(true);
     });
@@ -543,7 +543,7 @@ describe("Un dossier d'homologation", () => {
       const dossierActif = unDossier(referentiel)
         .quiEstComplet()
         .quiEstActif()
-        .construit();
+        .construis();
 
       expect(dossierActif.estExpire()).toBe(false);
     });
@@ -552,7 +552,7 @@ describe("Un dossier d'homologation", () => {
       const dossierExpire = unDossier(referentiel)
         .quiEstComplet()
         .quiEstRefuse()
-        .construit();
+        .construis();
 
       expect(dossierExpire.estExpire()).toBe(true);
     });
@@ -562,7 +562,7 @@ describe("Un dossier d'homologation", () => {
     it("archive le dossier s'il est finalisé", () => {
       const dossierFinalise = unDossier(referentiel)
         .quiEstComplet()
-        .construit();
+        .construis();
 
       expect(dossierFinalise.archive).toBe(undefined);
       dossierFinalise.enregistreArchivage();
@@ -572,7 +572,7 @@ describe("Un dossier d'homologation", () => {
     it("jette une erreur s'il n'est pas finalisé", () => {
       const dossierFinalise = unDossier(referentiel)
         .quiEstNonFinalise()
-        .construit();
+        .construis();
 
       try {
         dossierFinalise.enregistreArchivage();

--- a/test/modeles/journalMSS/evenementNouvelleHomologationCreee.spec.js
+++ b/test/modeles/journalMSS/evenementNouvelleHomologationCreee.spec.js
@@ -57,7 +57,7 @@ describe('Un événement de nouvelle homologation', () => {
     });
   });
 
-  it("exige que la durée d'homologation soit renseignée", () => {
+  it("exige que la durée d'homologation soit renseignée si l'homologation n'est pas refusée", () => {
     expect(
       () =>
         new EvenementNouvelleHomologationCreee({
@@ -67,6 +67,17 @@ describe('Un événement de nouvelle homologation', () => {
     ).to.throwError((e) => {
       expect(e).to.be.an(ErreurDonneeManquante);
     });
+  });
+
+  it("accepte l'absence de durée d'homologation si l'homologation est refusée", () => {
+    expect(
+      () =>
+        new EvenementNouvelleHomologationCreee({
+          idService: 'abc',
+          dateHomologation: '2023-03-30',
+          refusee: true,
+        })
+    ).not.to.throwError();
   });
 
   it('peut avoir un attribut "importé"', () => {

--- a/test/modeles/notificationExpirationHomologation.spec.js
+++ b/test/modeles/notificationExpirationHomologation.spec.js
@@ -31,7 +31,7 @@ describe("Une notification d'expiration d'homologation", () => {
       const dossierRefuse = unDossier(referentiel)
         .quiEstComplet()
         .quiEstActif()
-        .construit();
+        .construis();
 
       const notifications = NotificationExpirationHomologation.pourUnDossier({
         idService: '123',
@@ -47,7 +47,7 @@ describe("Une notification d'expiration d'homologation", () => {
         .quiEstComplet()
         .quiEstActif()
         .avecDecision('2024-01-01', 'unAn')
-        .construit();
+        .construis();
 
       const notifications = NotificationExpirationHomologation.pourUnDossier({
         idService: '123',


### PR DESCRIPTION
Avant cette PR, une homologation refusée faisait crasher le constructeur de `journalMSS/EvenementNouvelleHomologationCreee`.
En effet, une homologation refusée n'a pas de propriété `dureeHomologationMois`.

Désormais, on prend en compte les homologations refusées.