### PR TITLE
Utilise la nouvelle SPA dans la visite guidée

### DIFF
--- a/donneesReferentiel.ts
+++ b/donneesReferentiel.ts
@@ -1679,21 +1679,21 @@ const donnees = {
   departements,
   etapesVisiteGuidee: {
     DECRIRE: {
-      idEtapeSuivante: 'SECURISER',
+      idEtapeSuivante: 'MESURES',
       urlEtape: '/visiteGuidee/decrire',
     },
-    SECURISER: {
+    MESURES: {
       idEtapePrecedente: 'DECRIRE',
-      idEtapeSuivante: 'HOMOLOGUER',
-      urlEtape: '/visiteGuidee/securiser',
+      idEtapeSuivante: 'DOSSIERS',
+      urlEtape: '/visiteGuidee/mesures',
     },
-    HOMOLOGUER: {
-      idEtapePrecedente: 'SECURISER',
+    DOSSIERS: {
+      idEtapePrecedente: 'MESURES',
       idEtapeSuivante: 'PILOTER',
-      urlEtape: '/visiteGuidee/homologuer',
+      urlEtape: '/visiteGuidee/dossiers',
     },
     PILOTER: {
-      idEtapePrecedente: 'HOMOLOGUER',
+      idEtapePrecedente: 'DOSSIERS',
       urlEtape: '/visiteGuidee/piloter',
     },
   },

--- a/server.ts
+++ b/server.ts
@@ -2,7 +2,6 @@ import { fabriqueAdaptateurProfilAnssi } from './src/adaptateurs/fabriqueAdaptat
 import CmsCrisp from './src/cms/cmsCrisp.js';
 import Middleware from './src/http/middleware.js';
 import * as DepotDonnees from './src/depotDonnees.js';
-import MoteurRegles from './src/moteurRegles/v1/moteurRegles.js';
 import * as MSS from './src/mss.js';
 import { fabriqueAnnuaire } from './src/annuaire/serviceAnnuaire.js';
 import * as adaptateurCsv from './src/adaptateurs/adaptateurCsv.js';
@@ -54,7 +53,6 @@ const port = process.env.PORT || 3000;
 
 const referentiel = fabriqueReferentiel().v1();
 const referentielV2 = fabriqueReferentiel().v2();
-const moteurRegles = new MoteurRegles(referentiel);
 const serviceCgu = fabriqueServiceCgu({ referentiel });
 const depotDonnees = DepotDonnees.creeDepot({
   adaptateurChiffrement,
@@ -129,7 +127,6 @@ serviceVerificationCoherenceSels.verifieLaCoherenceDesSels().then(() => {
     middleware,
     referentiel,
     referentielV2,
-    moteurRegles,
     adaptateurMail,
     adaptateurPdf,
     adaptateurHorloge,

--- a/src/mss.js
+++ b/src/mss.js
@@ -23,7 +23,6 @@ const creeServeur = ({
   middleware,
   referentiel,
   referentielV2,
-  moteurRegles,
   adaptateurMail,
   adaptateurPdf,
   adaptateurHorloge,
@@ -112,7 +111,6 @@ const creeServeur = ({
     routesConnectePage({
       depotDonnees,
       middleware,
-      moteurRegles,
       referentiel,
       referentielV2,
       adaptateurCsv,

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -4,11 +4,9 @@ import Service from '../../modeles/service.js';
 import routesConnectePageService from './routesConnectePageService.js';
 import { questionsV2 } from '../../../donneesReferentielMesuresV2.js';
 import { VersionService } from '../../modeles/versionService.js';
-import Entite from '../../modeles/entite.js';
 
 const routesConnectePage = ({
   middleware,
-  moteurRegles,
   depotDonnees,
   referentiel,
   referentielV2,
@@ -104,12 +102,6 @@ const routesConnectePage = ({
       });
       const service = Service.creePourUnUtilisateur(utilisateurVisiteGuidee);
       service.id = 'ID-SERVICE-VISITE-GUIDEE';
-      service.descriptionService.niveauSecurite = 'niveau2';
-      service.descriptionService.nomService = 'Nom de mon service';
-      service.descriptionService.organisationResponsable = new Entite({
-        nom: 'Nom de mon entité',
-      });
-      service.versionService = VersionService.v2;
 
       const { idEtape } = requete.params;
       const idEtapeCourante = idEtape.toUpperCase();
@@ -134,23 +126,16 @@ const routesConnectePage = ({
 
       if (idEtape === 'decrire') {
         reponse.render('visiteGuidee/creationService');
-      } else if (idEtape === 'securiser') {
-        const mesures = moteurRegles.mesures(service.descriptionService);
-
-        service.indiceCyber = () => ({ total: 4.3 });
-        service.indiceCyberPersonnalise = () => ({ total: 4.6 });
-        reponse.render('service/mesures', {
+      } else if (idEtape === 'mesures') {
+        reponse.render('service/pagesService', {
           referentiel,
           service,
           etapeActive: 'mesures',
-          mesures,
         });
-      } else if (idEtape === 'homologuer') {
-        reponse.render('service/dossiers', {
+      } else if (idEtape === 'dossiers') {
+        reponse.render('service/pagesService', {
           service,
           etapeActive: 'dossiers',
-          premiereEtapeParcours: referentiel.premiereEtapeParcours(),
-          peutVoirTamponHomologation: true,
           referentiel,
         });
       } else if (idEtape === 'piloter') {

--- a/svelte/lib/pagesService/PagesService.svelte
+++ b/svelte/lib/pagesService/PagesService.svelte
@@ -2,6 +2,7 @@
   import { fade } from 'svelte/transition';
   import type {
     PagesServiceProps,
+    ServiceComplet,
     ServicePourPagesService,
   } from './pagesService.d';
   import EntetePageService from '../entetePageService/EntetePageService.svelte';
@@ -11,7 +12,6 @@
   import { routeurStore } from './store/routeur.store';
   import type { DescriptionServiceV2API } from '../decrireV2/decrireV2.d';
   import { tousRisques } from '../risques/risques';
-  import type { Risques } from '../risques/risques.d';
   import type { ContactsUtiles } from './pages/contactsUtiles/contactsUtiles.types';
   import Toaster from '../ui/Toaster.svelte';
   import BandeauReferentielV2 from '../bandeauReferentielV2/BandeauReferentielV2.svelte';
@@ -20,6 +20,7 @@
   import { pageCourante } from './store/pageCourante.store';
   import { propsPourPage } from './PagesService.props';
   import { afficheTitrePageServiceStore } from './store/afficheTitrePageService.store';
+  import { donneesVisiteGuidee } from './donneesVisiteGuidees';
 
   let props: PagesServiceProps = $props();
 
@@ -54,23 +55,28 @@
   };
 
   const rafraichisResumeService = async () => {
-    service = (
-      await axios.get<ServicePourPagesService>(
-        `/api/service/${props.idService}`
-      )
-    ).data;
+    if (props.modeVisiteGuidee) {
+      service = donneesVisiteGuidee.service;
+    } else {
+      service = (
+        await axios.get<ServicePourPagesService>(
+          `/api/service/${props.idService}`
+        )
+      ).data;
+    }
   };
 
   const rafraichisServiceComplet = async () => {
-    const serviceComplet = (
-      await axios.get<{
-        descriptionService: DescriptionServiceV2API;
-        risques: Risques;
-        contactsUtiles: ContactsUtiles;
-        indicesCyber: IndicesCyber;
-        dossiers: DossiersHomologation;
-      }>(`/api/service/${props.idService}?complet=true`)
-    ).data;
+    let serviceComplet: ServiceComplet;
+    if (props.modeVisiteGuidee) {
+      serviceComplet = donneesVisiteGuidee.serviceComplet;
+    } else {
+      serviceComplet = (
+        await axios.get<ServiceComplet>(
+          `/api/service/${props.idService}?complet=true`
+        )
+      ).data;
+    }
 
     descriptionService = serviceComplet.descriptionService;
     risques = serviceComplet.risques
@@ -87,6 +93,7 @@
     routeurStore.chargeInformationsService({
       visible: props.visible,
       version: service!.version,
+      modeVisiteGuidee: props.modeVisiteGuidee,
     });
     await rafraichisServiceComplet();
   });
@@ -103,6 +110,8 @@
       dossiers
     )
   );
+
+  $effect(() => console.log($pageCourante));
 </script>
 
 <svelte:document
@@ -151,6 +160,7 @@
             <Composant
               idService={props.idService}
               visible={props.visible}
+              modeVisiteGuidee={props.modeVisiteGuidee}
               {...propsDuComposant}
             />
           </div>

--- a/svelte/lib/pagesService/donneesVisiteGuidees.ts
+++ b/svelte/lib/pagesService/donneesVisiteGuidees.ts
@@ -1,0 +1,130 @@
+import type { ServiceComplet, ServicePourPagesService } from './pagesService.d';
+import type { VersionService } from '../../../src/modeles/versionService';
+
+const service: ServicePourPagesService = {
+  id: 'ID-SERVICE-VISITE-GUIDEE',
+  version: 'v2' as VersionService,
+  nomService: 'Nom de mon service',
+  organisationResponsable: 'Nom de mon entité',
+  documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
+};
+
+const serviceComplet: ServiceComplet = {
+  descriptionService: {
+    activitesExternalisees: ['developpementLogiciel'],
+    audienceCible: 'moyenne',
+    categoriesDonneesTraiteesSupplementaires: [],
+    dureeDysfonctionnementAcceptable: 'moinsDe4h',
+    localisationDonneesTraitees: 'UE',
+    ouvertureSysteme: 'accessibleSurInternet',
+    pointsAcces: [],
+    specificitesProjet: ['accesPhysiqueAuxBureaux'],
+    typeHebergement: 'cloud',
+    typeService: ['api'],
+    nomService: 'Service A',
+    categoriesDonneesTraitees: ['donneesSensibles'],
+    volumetrieDonneesTraitees: 'moyen',
+    statutDeploiement: 'enCours',
+    presentation: 'Le service A …',
+    niveauSecurite: 'niveau3',
+    organisationResponsable: {
+      nom: 'Mon organisation',
+      siret: '12345',
+      departement: '75',
+    },
+  },
+  dossiers: {
+    dossierCourant: undefined,
+    dossiersPasses: [],
+    aucunDossier: true,
+    dossiersRefuses: [],
+    dossierActif: undefined,
+  },
+  risques: {
+    risquesGeneraux: [],
+    risquesSpecifiques: [],
+  },
+  indicesCyber: {
+    indiceCyberAnssi: {
+      total: 4.6,
+      gouvernance: 3,
+      defense: 3,
+      protection: 3,
+      resilience: 3,
+    },
+    indiceCyberPersonnalise: {
+      total: 4.6,
+      gouvernance: 3,
+      defense: 3,
+      protection: 3,
+      resilience: 3,
+    },
+    nombreMesuresNonFait: 0,
+    nombreMesuresSpecifiques: 0,
+    referentielsMesureConcernes: 'ANSSI',
+    tranches: {
+      indiceCyber: {
+        valeurs: {
+          borneInferieure: 0,
+          borneSuperieure: 1,
+          recommandationANSSI:
+            "L'homologation du service est déconseillée ou devrait être limitée à <b>6 mois</b>.",
+          recommandationANSSIComplement:
+            "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
+          deconseillee: true,
+          dureeHomologationConseillee: '6 mois',
+          conseilHomologation: 'Homologation déconseillée',
+          description: "Très insuffisant lorsqu'il est < 1",
+        },
+        descriptions: [],
+      },
+      indiceCyberPersonnalise: {
+        valeurs: {
+          borneInferieure: 0,
+          borneSuperieure: 1,
+          recommandationANSSI:
+            "L'homologation du service est déconseillée ou devrait être limitée à <b>6 mois</b>.",
+          recommandationANSSIComplement:
+            "L'ANSSI recommande de renforcer la sécurité du service numérique avant de procéder à son homologation.",
+          deconseillee: true,
+          dureeHomologationConseillee: '6 mois',
+          conseilHomologation: 'Homologation déconseillée',
+          description: "Très insuffisant lorsqu'il est < 1",
+        },
+        descriptions: [],
+      },
+    },
+  },
+  contactsUtiles: {
+    autoriteHomologation: { nom: 'Nom', fonction: 'Fonction' },
+    acteursHomologation: [],
+    partiesPrenantesSpecifiques: [],
+    expertCybersecurite: { nom: 'Nom', fonction: 'Fonction' },
+    partiesPrenantes: {
+      Hebergement: {
+        nom: 'Nom',
+        pointContact: 'Contact',
+        natureAcces: 'Acces',
+      },
+      MaintenanceService: {
+        nom: 'Nom',
+        pointContact: 'Contact',
+        natureAcces: 'Acces',
+      },
+      SecuriteService: {
+        nom: 'Nom',
+        pointContact: 'Contact',
+        natureAcces: 'Acces',
+      },
+      DeveloppementFourniture: {
+        nom: 'Nom',
+        pointContact: 'Contact',
+        natureAcces: 'Acces',
+      },
+    },
+    delegueProtectionDonnees: { nom: 'Nom', fonction: 'Fonction' },
+    piloteProjet: { nom: 'Nom', fonction: 'Fonction' },
+  },
+};
+
+export const donneesVisiteGuidee = { service, serviceComplet };

--- a/svelte/lib/pagesService/pages/homologuer/Homologuer.svelte
+++ b/svelte/lib/pagesService/pages/homologuer/Homologuer.svelte
@@ -91,6 +91,8 @@
         label="Créer un nouveau projet d'homologation"
         kind="primary"
         size="md"
+        nom="creer-homologation"
+        id="creer-homologation"
       ></dsfr-button>
     {/if}
   </OngletVide>

--- a/svelte/lib/pagesService/pagesService.d.ts
+++ b/svelte/lib/pagesService/pagesService.d.ts
@@ -12,6 +12,11 @@ import type {
 } from '../risques/risques.d';
 import type { EtapeParcoursHomologation } from './pages/parcoursHomologation/parcoursHomologation.types';
 import type { VersionService } from '../../../src/modeles/versionService';
+import type { DescriptionServiceV2API } from '../decrireV2/decrireV2.d';
+import type { Risques } from '../risques/risques.d';
+import type { ContactsUtiles } from './pages/contactsUtiles/contactsUtiles.types';
+import type { IndicesCyber } from './pages/indiceCyber/indiceCyber.types';
+import type { DossiersHomologation } from './pages/homologuer/homologuer.types';
 
 declare global {
   interface HTMLElementEventMap {
@@ -77,4 +82,12 @@ export type ServicePourPagesService = {
   organisationResponsable: string;
   version: VersionService;
   documentsPdfDisponibles: string[];
+};
+
+export type ServiceComplet = {
+  descriptionService: DescriptionServiceV2API;
+  risques: Risques;
+  contactsUtiles: ContactsUtiles;
+  indicesCyber: IndicesCyber;
+  dossiers: DossiersHomologation;
 };

--- a/svelte/lib/pagesService/store/pageDepuisURL.ts
+++ b/svelte/lib/pagesService/store/pageDepuisURL.ts
@@ -2,6 +2,13 @@ import type { PageServiceGeree } from '../pagesServiceGerees';
 
 export const pageDepuisURL = (url: string) => {
   const { pathname } = new URL(url, window.location.origin);
-  const match = /\/service\/[0-9a-zA-Z-]*\/([a-zA-Z]*)/.exec(pathname);
+
+  let match: RegExpExecArray | null = null;
+  if (pathname.includes('service')) {
+    match = /\/service\/[0-9a-zA-Z-]*\/([a-zA-Z]*)/.exec(pathname);
+  } else if (pathname.includes('visiteGuidee')) {
+    match = /\/visiteGuidee\/([a-zA-Z]*)/.exec(pathname);
+  }
+
   return match?.[1] as PageServiceGeree;
 };

--- a/svelte/lib/pagesService/store/routeur.store.ts
+++ b/svelte/lib/pagesService/store/routeur.store.ts
@@ -8,6 +8,7 @@ import { pageDepuisURL } from './pageDepuisURL';
 export type InformationsService = {
   visible: Record<EtapeService, boolean>;
   version: VersionService;
+  modeVisiteGuidee?: boolean;
 };
 
 type RouteurStoreProps = {
@@ -34,8 +35,13 @@ const navigue = (
     window.location.href = url;
   }
 ) => {
-  const pageDemandee = pageDepuisURL(url) || '';
   const informationsService = get(routeurStore).informationsService;
+  if (informationsService?.modeVisiteGuidee) {
+    navigueHorsSPA(url);
+    return;
+  }
+
+  const pageDemandee = pageDepuisURL(url) || '';
   const pageVisible = informationsService?.visible[pageDemandee];
   const versionService = informationsService?.version;
 

--- a/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
+++ b/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
@@ -11,16 +11,17 @@
 
   let sousEtapes: SousEtape[] = $state([]);
   onMount(() => {
-    cibleNouvelleHomologation = document.getElementById(
-      'commencer-homologation'
-    )!;
+    cibleNouvelleHomologation = document.querySelector(
+      'dsfr-button[nom="creer-homologation"]'
+    ) as HTMLButtonElement;
     cibleTelechargement = document.getElementById('voir-telechargement')!;
     sousEtapes = [
       {
         cible: cibleNouvelleHomologation,
-        callbackInitialeCible: async () => {
-          const bouton = document.getElementById('commencer-homologation');
-          if (bouton) bouton.inert = true;
+        callbackInitialeCible: async (cible) => {
+          if (cible) {
+            cible.inert = true;
+          }
         },
         positionnementModale: 'BasGauche',
         titre: 'Homologuez votre service',

--- a/svelte/lib/visiteGuidee/etapes/initiale/EtapePresentationMenuNavigation.svelte
+++ b/svelte/lib/visiteGuidee/etapes/initiale/EtapePresentationMenuNavigation.svelte
@@ -19,12 +19,12 @@
           },
           {
             titre: 'Sécurisez',
-            id: 'SECURISER',
+            id: 'MESURES',
             icone: '/statique/assets/images/actionsSaisie/mesures.svg',
           },
           {
             titre: 'Homologuez',
-            id: 'HOMOLOGUER',
+            id: 'DOSSIERS',
             icone: '/statique/assets/images/actionsSaisie/dossiers.svg',
           },
           {

--- a/svelte/lib/visiteGuidee/kit/MenuNavigationVisiteGuidee.svelte
+++ b/svelte/lib/visiteGuidee/kit/MenuNavigationVisiteGuidee.svelte
@@ -49,15 +49,15 @@
       },
       {
         titre: 'Sécurisez',
-        id: 'SECURISER',
+        id: 'MESURES',
         icone: '/statique/assets/images/actionsSaisie/mesures.svg',
-        lien: '/visiteGuidee/securiser',
+        lien: '/visiteGuidee/mesures',
       },
       {
         titre: 'Homologuez',
-        id: 'HOMOLOGUER',
+        id: 'DOSSIERS',
         icone: '/statique/assets/images/actionsSaisie/dossiers.svg',
-        lien: '/visiteGuidee/homologuer',
+        lien: '/visiteGuidee/dossiers',
       },
       {
         titre: 'Pilotez vos services',

--- a/svelte/lib/visiteGuidee/visiteGuidee.d.ts
+++ b/svelte/lib/visiteGuidee/visiteGuidee.d.ts
@@ -22,8 +22,8 @@ export type EtapeVisiteGuidee =
   | 'BIENVENUE'
   | 'PRESENTATION_MENU_NAV'
   | 'DECRIRE'
-  | 'SECURISER'
-  | 'HOMOLOGUER'
+  | 'MESURES'
+  | 'DOSSIERS'
   | 'PILOTER'
   | 'MASQUE';
 

--- a/svelte/lib/visiteGuidee/visiteGuidee.store.ts
+++ b/svelte/lib/visiteGuidee/visiteGuidee.store.ts
@@ -85,9 +85,9 @@ export const composantVisiteGuidee = derived(
         return EtapePresentationMenuNavigation;
       case 'DECRIRE':
         return EtapeDecrireV2;
-      case 'SECURISER':
+      case 'MESURES':
         return EtapeSecuriser;
-      case 'HOMOLOGUER':
+      case 'DOSSIERS':
         return EtapeHomologuer;
       case 'PILOTER':
         return EtapePiloter;

--- a/svelte/test/pagesService/store/routeur.store.spec.ts
+++ b/svelte/test/pagesService/store/routeur.store.spec.ts
@@ -139,6 +139,28 @@ describe('Le routeur des pages service', () => {
         '/service/1234/descriptionService'
       );
     });
+
+    it("navigue en dehors de la SPA si le routeur est en mode 'visiteGuidee'", async () => {
+      const routeurStore = await leRouteur();
+      chargeInformationsService(routeurStore, {
+        visible: {
+          rolesResponsabilites: true,
+          risques: true,
+          descriptionService: true,
+          mesures: true,
+          dossiers: true,
+          indiceCyber: true,
+          homologation: true,
+        },
+        version: 'v1' as VersionService,
+        modeVisiteGuidee: true,
+      });
+      const navigueHorsSPA = vi.fn();
+
+      routeurStore.navigue('/visiteGuidee/mesures', navigueHorsSPA);
+
+      expect(navigueHorsSPA).toHaveBeenCalledWith('/visiteGuidee/mesures');
+    });
   });
 
   describe('concernant la page courante', () => {

--- a/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
+++ b/test/routes/connecte/routesConnecteApiVisiteGuidee.spec.js
@@ -23,8 +23,8 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
     beforeEach(() => {
       testeur.referentiel().recharge({
         etapesVisiteGuidee: {
-          DECRIRE: { idEtapeSuivante: 'SECURISER' },
-          SECURISER: { urlEtape: '/visiteGuidee/securiser' },
+          DECRIRE: { idEtapeSuivante: 'MESURES' },
+          MESURES: { urlEtape: '/visiteGuidee/mesures' },
         },
       });
     });
@@ -60,11 +60,11 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
     it("renvoi l'URL de l'étape suivante", async () => {
       const reponse = await testeur.post('/api/visiteGuidee/DECRIRE/termine');
 
-      expect(reponse.body.urlEtapeSuivante).to.be('/visiteGuidee/securiser');
+      expect(reponse.body.urlEtapeSuivante).to.be('/visiteGuidee/mesures');
     });
 
     it("renvoi une URL `null` s'il n'y a pas d'étape suivante", async () => {
-      const reponse = await testeur.post('/api/visiteGuidee/SECURISER/termine');
+      const reponse = await testeur.post('/api/visiteGuidee/MESURES/termine');
 
       expect(reponse.body.urlEtapeSuivante).to.be(null);
     });
@@ -73,7 +73,7 @@ describe('Le serveur MSS des routes privées /api/visiteGuidee/*', () => {
   describe('quand requête POST sur /visiteGuidee/termine', () => {
     beforeEach(() => {
       testeur.referentiel().recharge({
-        etapesVisiteGuidee: { DECRIRE: { idEtapeSuivante: 'SECURISER' } },
+        etapesVisiteGuidee: { DECRIRE: { idEtapeSuivante: 'MESURES' } },
       });
     });
 

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -18,8 +18,8 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
     '/profil',
     '/tableauDeBord',
     '/visiteGuidee/decrire',
-    '/visiteGuidee/securiser',
-    '/visiteGuidee/homologuer',
+    '/visiteGuidee/mesures',
+    '/visiteGuidee/dossiers',
     '/visiteGuidee/piloter',
     '/mesures',
   ].forEach((route) => {
@@ -79,7 +79,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
         .middleware()
         .verifieChargementDeLExplicationDesRisquesV2(
           testeur.app(),
-          '/visiteGuidee/securiser'
+          '/visiteGuidee/mesures'
         );
     });
 
@@ -88,18 +88,6 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
         const reponse = await testeur.get('/visiteGuidee/decrire');
 
         expect(reponse.text).to.contain('id="visite-guidee-creation-service"');
-      });
-    });
-
-    describe("concernant la version du 'faux' service utilisé", () => {
-      it('sert un service v2 par défaut', async () => {
-        const reponse = await testeur.get('/visiteGuidee/securiser');
-
-        const versionService = donneesPartagees(
-          reponse.text,
-          'version-service'
-        );
-        expect(versionService).to.be('v2');
       });
     });
   });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -2,7 +2,6 @@ import expect from 'expect.js';
 import supertest from 'supertest';
 import { depotVide } from '../depots/depotVide.js';
 import * as adaptateurMailMemoire from '../../src/adaptateurs/adaptateurMailMemoire.js';
-import MoteurRegles from '../../src/moteurRegles/v1/moteurRegles.js';
 import * as MSS from '../../src/mss.js';
 import * as Referentiel from '../../src/referentiel.js';
 import middleware from '../mocks/middleware.js';
@@ -168,8 +167,6 @@ const testeurMss = () => {
       extraisDonneesTeleversees: async () => {},
     };
     busEvenements = fabriqueBusPourLesTests();
-
-    moteurRegles = new MoteurRegles(referentiel);
     try {
       depotDonnees = await depotVide();
       inscriptionUtilisateur = fabriqueInscriptionUtilisateur({
@@ -182,7 +179,6 @@ const testeurMss = () => {
         middleware,
         referentiel,
         referentielV2,
-        moteurRegles,
         adaptateurMail,
         adaptateurPdf,
         adaptateurHorloge,


### PR DESCRIPTION
... en utilisant tout de même une navigation entre page, afin de ne pas avoir à modifier la logique d'affichage des modales.

On pourra par la suite faire un gros ménage sur tous les anciens fichiers `pug`, `css` et `mjs` qui traite des anciennes pages de service.