### PR TITLE
[ORGAS] Ajoute le rôle admin

### DIFF
--- a/migrations/20260504130310_creationTableAdminsOrganisations.js
+++ b/migrations/20260504130310_creationTableAdminsOrganisations.js
@@ -1,0 +1,11 @@
+const nomTable = 'admins_organisations';
+
+export const up = (knex) =>
+  knex.schema.createTable(nomTable, (table) => {
+    table.uuid('id_utilisateur').notNullable();
+    table.string('siret_hash').notNullable();
+    table.jsonb('donnees').notNullable();
+    table.primary(['id_utilisateur', 'siret_hash']);
+  });
+
+export const down = (knex) => knex.schema.dropTable(nomTable);

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -152,9 +152,10 @@ const nouvelAdaptateur = (
           donnees.simulationsMigrationReferentiel.some(
             (s) => s.idService === unService.id
           ),
-        utilisateurs: autorisationsDuService.map((a) =>
-          donnees.utilisateurs.find((u) => u.id === a.idUtilisateur)
-        ),
+        utilisateurs: autorisationsDuService.map((a) => ({
+          ...donnees.utilisateurs.find((u) => u.id === a.idUtilisateur),
+          estAdmin: a.estAdmin,
+        })),
         suggestions: donnees.suggestionsActions
           .filter((s) => s.idService === unService.id)
           .map((suggestion) => suggestion.nature),

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -693,6 +693,8 @@ const nouvelAdaptateur = (
     },
   ];
 
+  const lisAdminsPour = async () => [];
+
   return {
     activitesMesure,
     ajouteActiviteMesure,
@@ -716,6 +718,7 @@ const nouvelAdaptateur = (
     contributeursDesServicesDe,
     estJwtRevoque,
     estSuperviseur,
+    lisAdminsPour,
     lisBrouillonsService,
     lisModelesMesureSpecifiquePourUtilisateur,
     lisNotificationsExpirationHomologationDansIntervalle,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -154,7 +154,7 @@ const nouvelAdaptateur = (
           ),
         utilisateurs: autorisationsDuService.map((a) => ({
           ...donnees.utilisateurs.find((u) => u.id === a.idUtilisateur),
-          estAdmin: a.estAdmin,
+          estAdmin: !!a.estAdmin,
         })),
         suggestions: donnees.suggestionsActions
           .filter((s) => s.idService === unService.id)

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -24,6 +24,7 @@ const nouvelAdaptateur = (
   donnees.brouillonsServices ||= [];
   donnees.simulationsMigrationReferentiel ||= [];
   donnees.revocationsJwt ||= [];
+  donnees.adminsOrganisations ||= [];
 
   const ajouteTeleversementServices = async (
     idUtilisateur,
@@ -693,7 +694,10 @@ const nouvelAdaptateur = (
     },
   ];
 
-  const lisAdminsPour = async () => [];
+  const lisAdminsPour = async (siret) =>
+    donnees.adminsOrganisations
+      .filter((a) => a.siretHash === siret)
+      .map((a) => a.idUtilisateur);
 
   return {
     activitesMesure,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -984,7 +984,12 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
       .where({ hash_jwt_revoque: jwtHashe })
       .first()) !== undefined;
 
-  const lisAdminsPour = async (_siret) => [];
+  const lisAdminsPour = async (siret) =>
+    (
+      await knex('admins_organisations')
+        .where({ siret_hash: siret })
+        .select('id_utilisateur')
+    ).map((admin) => admin.id_utilisateur);
 
   return {
     activitesMesure,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -984,6 +984,8 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
       .where({ hash_jwt_revoque: jwtHashe })
       .first()) !== undefined;
 
+  const lisAdminsPour = async (_siret) => [];
+
   return {
     activitesMesure,
     ajouteActiviteMesure,
@@ -1009,6 +1011,7 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
     contributeursDesServicesDe,
     estJwtRevoque,
     estSuperviseur,
+    lisAdminsPour,
     lisBrouillonsService,
     lisDernierIndiceCyber,
     lisModelesMesureSpecifiquePourUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -4,6 +4,7 @@ import config from '../../knexfile.js';
 const CORRESPONDANCE_COLONNES_PROPRIETES = {
   date_creation: 'dateCreation',
   email_hash: 'emailHash',
+  est_admin: 'estAdmin',
 };
 
 const nouvelAdaptateur = ({ env, knexSurcharge }) => {
@@ -446,6 +447,7 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
           JOIN utilisateurs AS u
         ON u.id::TEXT = a.donnees->>'idUtilisateur'
         WHERE a.donnees->>'idService' IN (SELECT "ids_services" FROM mes_services)
+          AND a.donnees->>'estAdmin' <> 'true'
           AND a.donnees->>'idUtilisateur' != ?
       `,
       [idProprietaire, idProprietaire]

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -222,7 +222,10 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
                           WHERE date_acquittement IS NULL
                           GROUP BY id_service) suggestions_du_service ON suggestions_du_service.id_service = s.id
 
-               LEFT JOIN (SELECT (a.donnees ->>'idService')::uuid AS id_service, json_agg(u.*) AS utilisateurs
+               LEFT JOIN (SELECT (a.donnees ->>'idService')::uuid AS id_service,
+                          json_agg(
+                                to_jsonb(u) || jsonb_build_object('estAdmin', (a.donnees ->>'estAdmin')::boolean)
+                          ) AS utilisateurs
                           FROM autorisations a
                                  JOIN utilisateurs u ON (a.donnees ->>'idUtilisateur')::uuid = u.id
                           GROUP BY id_service) utilisateurs_du_service ON utilisateurs_du_service.id_service = s.id

--- a/src/bus/abonnements/modifieRattachementServiceEtAdmins.ts
+++ b/src/bus/abonnements/modifieRattachementServiceEtAdmins.ts
@@ -1,0 +1,29 @@
+import Service from '../../modeles/service.js';
+import DescriptionService from '../../modeles/descriptionService.js';
+import { DescriptionServiceV2 } from '../../modeles/descriptionServiceV2.js';
+import { ServiceAdministrationOrganisations } from '../../supervision/serviceAdministrationOrganisations.js';
+
+function modifieRattachementServiceEtAdmins({
+  serviceAdministrationOrganisations,
+}: {
+  serviceAdministrationOrganisations: ServiceAdministrationOrganisations;
+}) {
+  return async ({
+    service,
+    ancienneDescription,
+  }: {
+    service: Service;
+    ancienneDescription: DescriptionService | DescriptionServiceV2;
+  }) => {
+    if (
+      service.siretDeOrganisation() ===
+      ancienneDescription.organisationResponsable.siret
+    )
+      return;
+    await serviceAdministrationOrganisations.rattacheLesAdministrateursDe(
+      service
+    );
+  };
+}
+
+export { modifieRattachementServiceEtAdmins };

--- a/src/bus/abonnements/rattacheServiceEtAdmins.ts
+++ b/src/bus/abonnements/rattacheServiceEtAdmins.ts
@@ -1,0 +1,16 @@
+import Service from '../../modeles/service.js';
+import { ServiceAdministrationOrganisations } from '../../supervision/serviceAdministrationOrganisations.js';
+
+function rattacheServiceEtAdmins({
+  serviceAdministrationOrganisations,
+}: {
+  serviceAdministrationOrganisations: ServiceAdministrationOrganisations;
+}) {
+  return async ({ service }: { service: Service }) => {
+    await serviceAdministrationOrganisations.rattacheLesAdministrateursDe(
+      service
+    );
+  };
+}
+
+export { rattacheServiceEtAdmins };

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -58,6 +58,8 @@ import { consigneServiceV1MigreEnV2 } from './abonnements/consigneServiceV1Migre
 import EvenementServiceV1MigreEnV2 from './evenementServiceV1MigreEnV2.js';
 import EvenementSimulationMigrationReferentielCreee from './evenementSimulationMigrationReferentielCreee.js';
 import { consigneSimulationMigrationReferentielCreee } from './abonnements/consigneSimulationMigrationReferentielCreeeDansJournal.js';
+import { rattacheServiceEtAdmins } from './abonnements/rattacheServiceEtAdmins.js';
+import { ServiceAdministrationOrganisations } from '../supervision/serviceAdministrationOrganisations.js';
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -80,6 +82,8 @@ const cableTousLesAbonnes = (
     adaptateurSupervision,
     depotDonnees,
   });
+  const serviceAdministrationOrganisations =
+    new ServiceAdministrationOrganisations({ depotDonnees });
 
   busEvenements.abonnePlusieurs(EvenementNouveauServiceCree, [
     consigneNouveauServiceDansJournal({ adaptateurJournal }),
@@ -94,6 +98,7 @@ const cableTousLesAbonnes = (
       depotDonnees,
     }),
     relieServiceEtSuperviseurs({ serviceSupervision }),
+    rattacheServiceEtAdmins({ serviceAdministrationOrganisations }),
   ]);
 
   busEvenements.abonne(

--- a/src/bus/cablage.js
+++ b/src/bus/cablage.js
@@ -60,6 +60,7 @@ import EvenementSimulationMigrationReferentielCreee from './evenementSimulationM
 import { consigneSimulationMigrationReferentielCreee } from './abonnements/consigneSimulationMigrationReferentielCreeeDansJournal.js';
 import { rattacheServiceEtAdmins } from './abonnements/rattacheServiceEtAdmins.js';
 import { ServiceAdministrationOrganisations } from '../supervision/serviceAdministrationOrganisations.js';
+import { modifieRattachementServiceEtAdmins } from './abonnements/modifieRattachementServiceEtAdmins.js';
 
 const cableTousLesAbonnes = (
   busEvenements,
@@ -134,6 +135,7 @@ const cableTousLesAbonnes = (
     }),
     envoieTrackingCompletude({ adaptateurTracking, depotDonnees }),
     modifieLienServiceEtSuperviseurs({ serviceSupervision }),
+    modifieRattachementServiceEtAdmins({ serviceAdministrationOrganisations }),
   ]);
 
   busEvenements.abonnePlusieurs(EvenementAutorisationsServiceModifiees, [

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -22,6 +22,7 @@ import { fabriqueAdaptateurProfilAnssi } from './adaptateurs/fabriqueAdaptateurP
 import * as depotDonneesBrouillonService from './depots/depotDonneesBrouillonService.js';
 import * as depotSimulationMigrationReferentiel from './depots/depotDonneesSimulationMigrationReferentiel.js';
 import * as depotDonneesSession from './depots/depotDonneesSession.js';
+import * as depotDonneesAdministrationOrganisations from './depots/depotDonneesAdministrationOrganisations.js';
 
 const creeDepot = (config = {}) => {
   const {
@@ -160,6 +161,12 @@ const creeDepot = (config = {}) => {
     persistance: adaptateurPersistance,
     decodeJwt: adaptateurJWT.decode,
   });
+
+  const depotAdministrationOragnisations =
+    depotDonneesAdministrationOrganisations.creeDepot({
+      chiffrement: adaptateurChiffrement,
+      persistance: adaptateurPersistance,
+    });
 
   const {
     ajouteDescriptionService,
@@ -322,6 +329,8 @@ const creeDepot = (config = {}) => {
 
   const { estJwtRevoque, revoqueJwt } = depotSession;
 
+  const { lisAdminsPour } = depotAdministrationOragnisations;
+
   return {
     accesAutorise,
     accesAutoriseAUneListeDeService,
@@ -361,6 +370,7 @@ const creeDepot = (config = {}) => {
     enregistreDossier,
     finaliseDossierCourant,
     lisActivitesMesure,
+    lisAdminsPour,
     lisBrouillonService,
     lisBrouillonsService,
     lisDernierIndiceCyber,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -226,6 +226,7 @@ const creeDepot = (config = {}) => {
     autorisations,
     autorisationsDuService,
     sauvegardeAutorisation,
+    supprimeAutorisationsAdminPour,
     supprimeContributeur,
   } = depotAutorisations;
 
@@ -421,6 +422,7 @@ const creeDepot = (config = {}) => {
     sauvegardeNotificationsExpirationHomologation,
     sauvegardeSimulationMigrationReferentiel,
     superviseur,
+    supprimeAutorisationsAdminPour,
     supprimeBrouillonService,
     supprimeContributeur,
     supprimeDesMesuresAssocieesAuModele,

--- a/src/depots/depotDonneesAdministrationOrganisations.ts
+++ b/src/depots/depotDonneesAdministrationOrganisations.ts
@@ -1,0 +1,18 @@
+import { AdaptateurPersistance } from '../adaptateurs/adaptateurPersistance.interface.js';
+import { UUID } from '../typesBasiques.js';
+import { AdaptateurChiffrement } from '../adaptateurs/adaptateurChiffrement.interface.js';
+
+export const creeDepot = ({
+  persistance,
+  chiffrement,
+}: {
+  persistance: AdaptateurPersistance;
+  chiffrement: AdaptateurChiffrement;
+}) => {
+  const lisAdminsPour = async (siret: string): Promise<Array<UUID>> => {
+    const siretHache = chiffrement.hacheSha256(siret);
+    return persistance.lisAdminsPour(siretHache);
+  };
+
+  return { lisAdminsPour };
+};

--- a/src/depots/depotDonneesAutorisations.interface.ts
+++ b/src/depots/depotDonneesAutorisations.interface.ts
@@ -1,0 +1,3 @@
+import { creeDepot } from './depotDonneesAutorisations.js';
+
+export type DepotDonneesAutorisation = ReturnType<typeof creeDepot>;

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -5,8 +5,8 @@ import {
   ErreurAutorisationExisteDeja,
   ErreurAutorisationInexistante,
   ErreurServiceInexistant,
-  ErreurUtilisateurInexistant,
   ErreurSuppressionImpossible,
+  ErreurUtilisateurInexistant,
 } from '../erreurs.js';
 
 import * as FabriqueAutorisation from '../modeles/autorisations/fabriqueAutorisation.js';
@@ -144,10 +144,17 @@ const creeDepot = (config = {}) => {
     };
 
     const verifieSuppressionPermise = async () => {
-      const impossible = idContributeur === idUtilisateurCourant;
-      if (impossible)
+      const estLuiMeme = idContributeur === idUtilisateurCourant;
+      if (estLuiMeme)
         throw new ErreurSuppressionImpossible(
           `L'utilisateur "${idUtilisateurCourant}" ne peut pas supprimer sa propre autorisation`
+        );
+      const cibleEstAdmin = (
+        await autorisationPour(idContributeur, idService)
+      ).estUnAdmin();
+      if (cibleEstAdmin)
+        throw new ErreurSuppressionImpossible(
+          `L'utilisateur "${idContributeur}" ne peut pas être supprimé`
         );
     };
 

--- a/src/depots/depotDonneesAutorisations.js
+++ b/src/depots/depotDonneesAutorisations.js
@@ -179,6 +179,27 @@ const creeDepot = (config = {}) => {
     );
   };
 
+  const supprimeAutorisationsAdminPour = async (idService) => {
+    const duService = await autorisationsDuService(idService);
+    const idAdmins = duService
+      .filter((a) => a.estAdmin)
+      .map((a) => a.idUtilisateur);
+
+    if (idAdmins.length === 0) return;
+
+    await Promise.all(
+      idAdmins.map((idUtilisateur) =>
+        adaptateurPersistance.supprimeAutorisation(idUtilisateur, idService)
+      )
+    );
+    await Promise.all(
+      idAdmins.map((idUtilisateur) =>
+        depotServices.supprimeContributeur(idService, idUtilisateur)
+      )
+    );
+    await publieAutorisationsDuService(idService);
+  };
+
   return {
     accesAutorise,
     accesAutoriseAUneListeDeService,
@@ -190,6 +211,7 @@ const creeDepot = (config = {}) => {
     autorisations,
     autorisationsDuService,
     sauvegardeAutorisation,
+    supprimeAutorisationsAdminPour,
     supprimeContributeur,
   };
 };

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -55,7 +55,7 @@ const fabriquePersistance = (
 
     serviceEnClair.contributeurs = await Promise.all(
       serviceEnClair.utilisateurs.map((d) =>
-        depotDonneesUtilisateurs.dechiffreUtilisateur(d)
+        depotDonneesUtilisateurs.dechiffreDonneesContributeur(d)
       )
     );
     delete serviceEnClair.utilisateurs;

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -70,6 +70,7 @@ function fabriquePersistance({
     return {
       ...donneesEnClair,
       id: donneesContributeur.id,
+      estAdmin: donneesContributeur.estAdmin,
     };
   };
 

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -62,9 +62,22 @@ function fabriquePersistance({
     });
   };
 
+  const dechiffreDonneesContributeur = async (donneesContributeur) => {
+    if (!donneesContributeur) return undefined;
+    const donneesEnClair = await dechiffre.donneesUtilisateur(
+      donneesContributeur.donnees
+    );
+    return {
+      ...donneesEnClair,
+      id: donneesContributeur.id,
+    };
+  };
+
   return {
     dechiffreUtilisateur: async (donneesUtilisateur) =>
       dechiffreUtilisateur(donneesUtilisateur),
+    dechiffreDonneesContributeur: async (donneesContributeur) =>
+      dechiffreDonneesContributeur(donneesContributeur),
     lis: {
       donnees: {
         de: async (idUtilisateur) => {
@@ -156,6 +169,9 @@ const creeDepot = (config = {}) => {
 
   const dechiffreUtilisateur = async (donneesUtilisateur) =>
     p.dechiffreUtilisateur(donneesUtilisateur);
+
+  const dechiffreDonneesContributeur = async (donneesUtilisateur) =>
+    p.dechiffreDonneesContributeur(donneesUtilisateur);
 
   const utilisateur = async (identifiant) => p.lis.un(identifiant);
 
@@ -307,6 +323,7 @@ const creeDepot = (config = {}) => {
 
   return {
     dechiffreUtilisateur,
+    dechiffreDonneesContributeur,
     metsAJourUtilisateur,
     nouvelUtilisateur,
     rafraichisProfilUtilisateurLocal,

--- a/src/modeles/autorisations/autorisation.ts
+++ b/src/modeles/autorisations/autorisation.ts
@@ -16,6 +16,7 @@ const { LECTURE, ECRITURE } = Permissions;
 
 export type DonneesAutorisation = {
   estProprietaire: boolean;
+  estAdmin?: boolean;
   id: UUID;
   idUtilisateur: UUID;
   idService: UUID;
@@ -35,6 +36,7 @@ export class Autorisation extends Base {
         'idService',
         'droits',
       ],
+      proprietesAtomiquesFacultatives: ['estAdmin'],
     });
     this.renseigneProprietes(donnees);
   }
@@ -50,6 +52,19 @@ export class Autorisation extends Base {
       ...donnees,
       droits: tousDroitsEnEcriture(),
       estProprietaire: true,
+    });
+
+  static NouvelleAutorisationAdmin = (
+    donnees: Omit<
+      DonneesAutorisation,
+      'droits' | 'estProprietaire' | 'estAdmin'
+    >
+  ) =>
+    new Autorisation({
+      ...donnees,
+      droits: tousDroitsEnEcriture(),
+      estProprietaire: true,
+      estAdmin: true,
     });
 
   aLaPermission(niveau: NiveauPermission, rubrique: Rubrique) {

--- a/src/modeles/autorisations/autorisation.ts
+++ b/src/modeles/autorisations/autorisation.ts
@@ -24,6 +24,8 @@ export type DonneesAutorisation = {
 };
 
 export class Autorisation extends Base {
+  readonly estAdmin?: boolean;
+
   // @ts-expect-error La propriétés est définie dans `this.renseigneProprietes`
   droits: Partial<Droits>;
 
@@ -126,6 +128,7 @@ export class Autorisation extends Base {
   donneesAPersister() {
     return {
       estProprietaire: this.estProprietaire,
+      estAdmin: this.estUnAdmin(),
       id: this.id,
       idService: this.idService,
       idUtilisateur: this.idUtilisateur,
@@ -226,5 +229,9 @@ export class Autorisation extends Base {
       return this.peutGererContributeurs();
 
     return this.aLesPermissions(actionRecommandee.droitsNecessaires as Droits);
+  }
+
+  estUnAdmin() {
+    return !!this.estAdmin;
   }
 }

--- a/src/modeles/autorisations/autorisation.ts
+++ b/src/modeles/autorisations/autorisation.ts
@@ -99,6 +99,7 @@ export class Autorisation extends Base {
   resumeNiveauDroit() {
     const { RESUME_NIVEAU_DROIT } = Autorisation;
 
+    if (this.estAdmin) return RESUME_NIVEAU_DROIT.ADMIN;
     if (this.estProprietaire) return RESUME_NIVEAU_DROIT.PROPRIETAIRE;
 
     const tousNiveaux = Object.values(Permissions).reduce(
@@ -137,6 +138,7 @@ export class Autorisation extends Base {
   }
 
   static RESUME_NIVEAU_DROIT = {
+    ADMIN: 'ADMIN',
     PROPRIETAIRE: 'PROPRIETAIRE',
     ECRITURE: 'ECRITURE',
     LECTURE: 'LECTURE',

--- a/src/modeles/autorisations/autorisation.ts
+++ b/src/modeles/autorisations/autorisation.ts
@@ -24,6 +24,7 @@ export type DonneesAutorisation = {
 };
 
 export class Autorisation extends Base {
+  readonly id!: UUID;
   readonly estAdmin?: boolean;
 
   // @ts-expect-error La propriétés est définie dans `this.renseigneProprietes`

--- a/src/modeles/autorisations/fabriqueAutorisation.ts
+++ b/src/modeles/autorisations/fabriqueAutorisation.ts
@@ -1,6 +1,10 @@
 import { Autorisation, type DonneesAutorisation } from './autorisation.js';
 
-export const fabrique = (donnees: DonneesAutorisation) =>
-  donnees.estProprietaire
+export const fabrique = (donnees: DonneesAutorisation) => {
+  if (donnees.estAdmin) {
+    return Autorisation.NouvelleAutorisationAdmin(donnees);
+  }
+  return donnees.estProprietaire
     ? Autorisation.NouvelleAutorisationProprietaire(donnees)
     : Autorisation.NouvelleAutorisationContributeur(donnees);
+};

--- a/src/modeles/contributeur.ts
+++ b/src/modeles/contributeur.ts
@@ -7,16 +7,19 @@ export type DonneesContributeur = {
   prenom: string;
   nom: string;
   postes: string[];
+  estAdmin: boolean;
 };
 
 class Contributeur {
   public readonly idUtilisateur: UUID;
   private readonly identite: Identite;
+  public readonly estAdmin: boolean;
 
   constructor(donnees: DonneesContributeur) {
     const { id, email, prenom, nom, postes } = donnees;
     this.idUtilisateur = id;
     this.identite = new Identite({ email, prenom, nom, postes });
+    this.estAdmin = donnees.estAdmin;
   }
 
   prenomNom() {

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -22,13 +22,28 @@ const donnees = (service, autorisation, referentiel) => {
     nomService: service.nomService(),
     organisationResponsable:
       service.descriptionService.organisationResponsable.nom ?? '',
-    contributeurs: service.contributeurs.map((c) => ({
-      id: c.idUtilisateur,
-      prenomNom: c.prenomNom(),
-      initiales: c.initiales(),
-      poste: c.posteDetaille(),
-      estUtilisateurCourant: autorisation.designeUtilisateur(c.idUtilisateur),
-    })),
+    contributeurs: service.contributeurs.map((c) => {
+      const designeLuiMeme = autorisation.designeUtilisateur(c.idUtilisateur);
+      const doitMasquerPourConfidentialite = c.estAdmin && !designeLuiMeme;
+
+      if (doitMasquerPourConfidentialite)
+        return {
+          estAdmin: true,
+          estUtilisateurCourant: false,
+          id: c.idUtilisateur,
+          prenomNom: 'Administrateur',
+          initiales: 'A',
+          poste: '',
+        };
+
+      return {
+        id: c.idUtilisateur,
+        prenomNom: c.prenomNom(),
+        initiales: c.initiales(),
+        poste: c.posteDetaille(),
+        estUtilisateurCourant: designeLuiMeme,
+      };
+    }),
     ...(autorisation.aLesPermissions(DROITS_VOIR_STATUT_HOMOLOGATION) && {
       statutHomologation: {
         id: service.dossiers.statutHomologation(),

--- a/src/modeles/objetsApi/objetGetService.js
+++ b/src/modeles/objetsApi/objetGetService.js
@@ -41,6 +41,7 @@ const donnees = (service, autorisation, referentiel) => {
       },
     }),
     nombreContributeurs: service.contributeurs.length,
+    estAdmin: autorisation.estUnAdmin(),
     estProprietaire: autorisation.estProprietaire,
     documentsPdfDisponibles: service.documentsPdfDisponibles(autorisation),
     permissions: {

--- a/src/routes/connecte/routesConnecteApiService.js
+++ b/src/routes/connecte/routesConnecteApiService.js
@@ -299,6 +299,11 @@ const routesConnecteApiService = ({
       }
 
       const ciblee = await depotDonnees.autorisation(idAutorisation);
+      if (ciblee.estUnAdmin()) {
+        reponse.sendStatus(403);
+        return;
+      }
+
       if (ciblee.idUtilisateur === idUtilisateurCourant) {
         reponse.status(422).json({ code: 'AUTO-MODIFICATION_INTERDITE' });
         return;

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -1,0 +1,43 @@
+import { UUID } from '../typesBasiques.js';
+import Service from '../modeles/service.js';
+import { Autorisation } from '../modeles/autorisations/autorisation.js';
+import { AdaptateurUUID } from '../adaptateurs/adaptateurUUID.js';
+
+type DepotDonneesPourServiceAdmin = {
+  lisAdminsPour: (siret: string) => Promise<Array<UUID>>;
+  sauvegardeAutorisation: (autorisation: Autorisation) => Promise<void>;
+};
+
+export class ServiceAdministrationOrganisations {
+  private readonly depotDonnees: DepotDonneesPourServiceAdmin;
+  private readonly adaptateurUUID: AdaptateurUUID;
+
+  constructor({
+    depotDonnees,
+    adaptateurUUID,
+  }: {
+    depotDonnees: DepotDonneesPourServiceAdmin;
+    adaptateurUUID: AdaptateurUUID;
+  }) {
+    this.depotDonnees = depotDonnees;
+    this.adaptateurUUID = adaptateurUUID;
+  }
+
+  async rattacheLesAdministrateursDe(service: Service) {
+    const lesAdmins = await this.depotDonnees.lisAdminsPour(
+      service.siretDeOrganisation()
+    );
+
+    const nouvellesAutorisations = lesAdmins.map((idAdmin) =>
+      Autorisation.NouvelleAutorisationAdmin({
+        id: this.adaptateurUUID.genereUUID(),
+        idService: service.id,
+        idUtilisateur: idAdmin,
+      })
+    );
+
+    await Promise.all(
+      nouvellesAutorisations.map(this.depotDonnees.sauvegardeAutorisation)
+    );
+  }
+}

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -31,12 +31,20 @@ export class ServiceAdministrationOrganisations {
   async rattacheLesAdministrateursDe(service: Service) {
     await this.depotDonnees.supprimeAutorisationsAdminPour(service.id);
 
+    const nouvellesAutorisations =
+      await this.fabriqueAutorisationsAdmin(service);
+
+    await this.sauvegardeAutorisations(nouvellesAutorisations);
+  }
+
+  private async fabriqueAutorisationsAdmin(service: Service) {
     const lesAdmins = await this.depotDonnees.lisAdminsPour(
       service.siretDeOrganisation()
     );
     const autorisationsExistantes =
       await this.depotDonnees.autorisationsDuService(service.id);
-    const nouvellesAutorisations = lesAdmins.map((idAdmin) => {
+
+    return lesAdmins.map((idAdmin) => {
       const existante = autorisationsExistantes.find((a) =>
         a.designeUtilisateur(idAdmin)
       );
@@ -47,6 +55,11 @@ export class ServiceAdministrationOrganisations {
         idUtilisateur: idAdmin,
       });
     });
+  }
+
+  private async sauvegardeAutorisations(
+    nouvellesAutorisations: Autorisation[]
+  ) {
     await Promise.all(
       nouvellesAutorisations.map(this.depotDonnees.sauvegardeAutorisation)
     );

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -1,7 +1,10 @@
 import { UUID } from '../typesBasiques.js';
 import Service from '../modeles/service.js';
 import { Autorisation } from '../modeles/autorisations/autorisation.js';
-import { AdaptateurUUID } from '../adaptateurs/adaptateurUUID.js';
+import {
+  AdaptateurUUID,
+  fabriqueAdaptateurUUID,
+} from '../adaptateurs/adaptateurUUID.js';
 
 type DepotDonneesPourServiceAdmin = {
   lisAdminsPour: (siret: string) => Promise<Array<UUID>>;
@@ -14,7 +17,7 @@ export class ServiceAdministrationOrganisations {
 
   constructor({
     depotDonnees,
-    adaptateurUUID,
+    adaptateurUUID = fabriqueAdaptateurUUID(),
   }: {
     depotDonnees: DepotDonneesPourServiceAdmin;
     adaptateurUUID: AdaptateurUUID;

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -9,6 +9,7 @@ import {
 type DepotDonneesPourServiceAdmin = {
   lisAdminsPour: (siret: string) => Promise<Array<UUID>>;
   sauvegardeAutorisation: (autorisation: Autorisation) => Promise<void>;
+  supprimeAutorisationsAdminPour: (id: UUID) => Promise<void>;
 };
 
 export class ServiceAdministrationOrganisations {
@@ -27,10 +28,11 @@ export class ServiceAdministrationOrganisations {
   }
 
   async rattacheLesAdministrateursDe(service: Service) {
+    await this.depotDonnees.supprimeAutorisationsAdminPour(service.id);
+
     const lesAdmins = await this.depotDonnees.lisAdminsPour(
       service.siretDeOrganisation()
     );
-
     const nouvellesAutorisations = lesAdmins.map((idAdmin) =>
       Autorisation.NouvelleAutorisationAdmin({
         id: this.adaptateurUUID.genereUUID(),
@@ -38,7 +40,6 @@ export class ServiceAdministrationOrganisations {
         idUtilisateur: idAdmin,
       })
     );
-
     await Promise.all(
       nouvellesAutorisations.map(this.depotDonnees.sauvegardeAutorisation)
     );

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -7,6 +7,7 @@ import {
 } from '../adaptateurs/adaptateurUUID.js';
 
 type DepotDonneesPourServiceAdmin = {
+  autorisationsDuService: (id: UUID) => Promise<Array<Autorisation>>;
   lisAdminsPour: (siret: string) => Promise<Array<UUID>>;
   sauvegardeAutorisation: (autorisation: Autorisation) => Promise<void>;
   supprimeAutorisationsAdminPour: (id: UUID) => Promise<void>;
@@ -33,13 +34,19 @@ export class ServiceAdministrationOrganisations {
     const lesAdmins = await this.depotDonnees.lisAdminsPour(
       service.siretDeOrganisation()
     );
-    const nouvellesAutorisations = lesAdmins.map((idAdmin) =>
-      Autorisation.NouvelleAutorisationAdmin({
-        id: this.adaptateurUUID.genereUUID(),
+    const autorisationsExistantes =
+      await this.depotDonnees.autorisationsDuService(service.id);
+    const nouvellesAutorisations = lesAdmins.map((idAdmin) => {
+      const existante = autorisationsExistantes.find((a) =>
+        a.designeUtilisateur(idAdmin)
+      );
+
+      return Autorisation.NouvelleAutorisationAdmin({
+        id: existante ? existante.id : this.adaptateurUUID.genereUUID(),
         idService: service.id,
         idUtilisateur: idAdmin,
-      })
-    );
+      });
+    });
     await Promise.all(
       nouvellesAutorisations.map(this.depotDonnees.sauvegardeAutorisation)
     );

--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -43,9 +43,14 @@
     <ul class="liste-contributeurs contributeurs-actifs">
       {#if $serviceUnique}
         {#each $serviceUnique.contributeurs as contributeur (contributeur.id)}
+          {@const contributeurPasSoiMeme = !contributeur.estUtilisateurCourant}
+          {@const utilisateurPeutGererLesContributeurs =
+            $serviceUnique.permissions.gestionContributeurs}
+          {@const contributeurPasUnAdmin = !contributeur.estAdmin}
           <LigneContributeur
-            droitsModifiables={!contributeur.estUtilisateurCourant &&
-              $serviceUnique.permissions.gestionContributeurs}
+            droitsModifiables={contributeurPasSoiMeme &&
+              utilisateurPeutGererLesContributeurs &&
+              contributeurPasUnAdmin}
             utilisateur={contributeur}
           />
         {/each}

--- a/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
+++ b/svelte/lib/gestionContributeurs/gestionContributeurs.d.ts
@@ -35,6 +35,7 @@ export type Utilisateur = {
   poste: string;
   email: string;
   estUtilisateurCourant: boolean;
+  estAdmin?: boolean;
 };
 
 type Invisible = 0;

--- a/svelte/lib/gestionContributeurs/kit/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/kit/LigneContributeur.svelte
@@ -41,11 +41,6 @@
 
     storeAutorisations.remplace(autorisationMAJ);
   };
-
-  let peutEtreModifie = derived(
-    autorisation,
-    ($a) => droitsModifiables && $a?.resumeNiveauDroit !== 'ADMIN'
-  );
 </script>
 
 <li class="ligne-contributeur">
@@ -65,14 +60,14 @@
     {#if afficheDroits && $autorisation?.resumeNiveauDroit && estUtilisateur(utilisateur)}
       <TagNiveauDroit
         niveau={$autorisation.resumeNiveauDroit}
-        droitsModifiables={$peutEtreModifie}
+        {droitsModifiables}
         onDroitsChange={(nouveauxDroits) => changeDroits(nouveauxDroits)}
         onChoixPersonnalisation={() =>
           store.navigation.affichePersonnalisationContributeur(utilisateur)}
       />
     {/if}
 
-    {#if $peutEtreModifie && estUtilisateur(utilisateur)}
+    {#if droitsModifiables && estUtilisateur(utilisateur)}
       <BoutonSuppressionContributeur
         onclick={() => store.navigation.afficheEtapeSuppression(utilisateur)}
       />

--- a/svelte/lib/gestionContributeurs/kit/LigneContributeur.svelte
+++ b/svelte/lib/gestionContributeurs/kit/LigneContributeur.svelte
@@ -41,6 +41,11 @@
 
     storeAutorisations.remplace(autorisationMAJ);
   };
+
+  let peutEtreModifie = derived(
+    autorisation,
+    ($a) => droitsModifiables && $a?.resumeNiveauDroit !== 'ADMIN'
+  );
 </script>
 
 <li class="ligne-contributeur">
@@ -60,14 +65,14 @@
     {#if afficheDroits && $autorisation?.resumeNiveauDroit && estUtilisateur(utilisateur)}
       <TagNiveauDroit
         niveau={$autorisation.resumeNiveauDroit}
-        {droitsModifiables}
+        droitsModifiables={$peutEtreModifie}
         onDroitsChange={(nouveauxDroits) => changeDroits(nouveauxDroits)}
         onChoixPersonnalisation={() =>
           store.navigation.affichePersonnalisationContributeur(utilisateur)}
       />
     {/if}
 
-    {#if droitsModifiables && estUtilisateur(utilisateur)}
+    {#if $peutEtreModifie && estUtilisateur(utilisateur)}
       <BoutonSuppressionContributeur
         onclick={() => store.navigation.afficheEtapeSuppression(utilisateur)}
       />

--- a/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
+++ b/svelte/lib/gestionContributeurs/kit/TagNiveauDroit.svelte
@@ -3,6 +3,7 @@
   import type { ResumeNiveauDroit } from '../../ui/types';
 
   const STATUS_DROITS: Record<ResumeNiveauDroit, string> = {
+    ADMIN: 'Admin',
     PROPRIETAIRE: 'Propriétaire',
     ECRITURE: 'Édition',
     LECTURE: 'Lecture',
@@ -157,6 +158,11 @@
   }
   .role-propose:hover .description {
     font-weight: 500;
+  }
+
+  .ADMIN {
+    background: var(--background-contrast-blue-cumulus);
+    color: var(--text-label-blue-cumulus);
   }
 
   .PROPRIETAIRE {

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -211,7 +211,14 @@
               title="Ouvrir la page du service"
             >
               <span class="denomination-service">
-                {#if service.estProprietaire}
+                {#if service.estAdmin}
+                  <dsfr-badge
+                    label="Admin"
+                    type="accent"
+                    accent="blue-cumulus"
+                    size="sm"
+                  ></dsfr-badge>
+                {:else if service.estProprietaire}
                   <EtiquetteProprietaire />
                 {/if}
                 <span class="nom-service">{service.nomService}</span>

--- a/svelte/lib/tableauDeBord/elementsDeService/EtiquetteProprietaire.svelte
+++ b/svelte/lib/tableauDeBord/elementsDeService/EtiquetteProprietaire.svelte
@@ -1,31 +1,6 @@
-<span>
-  <img
-    src="/statique/assets/images/icone_etoile.svg"
-    alt="Icône de propriétaire"
-  />
-  Propriétaire
-</span>
-
-<style>
-  span {
-    text-transform: uppercase;
-    padding: 0 6px;
-    display: flex;
-    gap: 4px;
-    background: #feecc2;
-    color: #716043;
-    font-size: 12px;
-    font-style: normal;
-    font-weight: 700;
-    line-height: 20px;
-    border-radius: 4px;
-    width: fit-content;
-    align-items: center;
-    justify-content: center;
-  }
-
-  img {
-    width: 12px;
-    height: 12px;
-  }
-</style>
+<dsfr-badge
+  label="Propriétaire"
+  type="accent"
+  accent="yellow-tournesol"
+  size="sm"
+></dsfr-badge>

--- a/svelte/lib/tableauDeBord/tableauDeBord.d.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.d.ts
@@ -37,6 +37,7 @@ export type Service = {
   };
   nombreContributeurs: number;
   estProprietaire: boolean;
+  estAdmin: boolean;
   documentsPdfDisponibles: string[];
   permissions: {
     gestionContributeurs: boolean;

--- a/svelte/lib/tableauDeBord/tableauDeBord.ts
+++ b/svelte/lib/tableauDeBord/tableauDeBord.ts
@@ -57,6 +57,7 @@ export const donneesVisiteGuidee = {
       },
       nombreContributeurs: 3,
       estProprietaire: true,
+      estAdmin: false,
       documentsPdfDisponibles: ['annexes', 'syntheseSecurite'],
       permissions: {
         gestionContributeurs: true,

--- a/svelte/lib/ui/Initiales.svelte
+++ b/svelte/lib/ui/Initiales.svelte
@@ -46,6 +46,14 @@
       hue-rotate(176deg) brightness(102%) contrast(91%);
   }
 
+  .ADMIN {
+    background: var(--background-contrast-blue-cumulus);
+  }
+
+  .initiales.ADMIN {
+    color: var(--text-label-blue-cumulus);
+  }
+
   .PROPRIETAIRE {
     background: var(--role-proprietaire);
   }

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -49,6 +49,7 @@ export type LibellePriorite = {
 export type EcheanceMesure = string;
 
 export type ResumeNiveauDroit =
+  | 'ADMIN'
   | 'PROPRIETAIRE'
   | 'ECRITURE'
   | 'LECTURE'

--- a/test/adaptateurs/adaptateurPostgres.spec.js
+++ b/test/adaptateurs/adaptateurPostgres.spec.js
@@ -77,6 +77,18 @@ describe("L'adaptateur persistance Postgres", () => {
     );
   }
 
+  async function insereAutorisationContributeur(idUtilisateur, idService) {
+    const idAutorisation = genereUUID();
+    const autorisation = Autorisation.NouvelleAutorisationContributeur({
+      idUtilisateur,
+      idService,
+    });
+    await persistance.ajouteAutorisation(
+      idAutorisation,
+      autorisation.donneesAPersister()
+    );
+  }
+
   async function insereAutorisationAdmin(idUtilisateur, idService) {
     const idAutorisation = genereUUID();
     const autorisation = Autorisation.NouvelleAutorisationAdmin({
@@ -321,6 +333,40 @@ describe("L'adaptateur persistance Postgres", () => {
 
       expect(admins.length).to.be(1);
       expect(admins[0]).to.be(id);
+    });
+  });
+
+  describe("concernant la recherche des contributeurs des services d'un propriétaire", () => {
+    it('retourne les contributeurs de tous les services', async () => {
+      const idService = await insereService();
+      const idServicePasProprietaire = await insereService();
+      const proprietaire = await insereUtilisateur();
+      const autreContributeur = await insereUtilisateur();
+      await insereAutorisation(proprietaire, idService);
+      await insereAutorisation(autreContributeur, idService);
+      await insereAutorisationContributeur(
+        proprietaire,
+        idServicePasProprietaire
+      );
+
+      const lesContributeurs =
+        await persistance.contributeursDesServicesDe(proprietaire);
+
+      expect(lesContributeurs.length).to.be(1);
+      expect(lesContributeurs[0].id).to.be(autreContributeur);
+    });
+
+    it('exclue les autorisations admin dans un souci de confidentialité', async () => {
+      const idService = await insereService();
+      const proprietaire = await insereUtilisateur();
+      await insereAutorisation(proprietaire, idService);
+      const admin = await insereUtilisateur();
+      await insereAutorisationAdmin(admin, idService);
+
+      const lesContributeurs =
+        await persistance.contributeursDesServicesDe(proprietaire);
+
+      expect(lesContributeurs.length).to.be(0);
     });
   });
 });

--- a/test/adaptateurs/adaptateurPostgres.spec.js
+++ b/test/adaptateurs/adaptateurPostgres.spec.js
@@ -28,6 +28,7 @@ describe("L'adaptateur persistance Postgres", () => {
         'autorisations',
         'modeles_mesure_specifique',
         'modeles_mesure_specifique_association_aux_services',
+        'admins_organisations',
       ].map((table) => knex(table).truncate())
     );
   });
@@ -279,6 +280,22 @@ describe("L'adaptateur persistance Postgres", () => {
       } catch {
         assert.fail("L'appel n'aurait pas dû lever d'exception");
       }
+    });
+  });
+
+  describe("concernant les administrateurs d'organisations", () => {
+    it("peut lire les admins d'un siret haché", async () => {
+      const id = genereUUID();
+      await knex('admins_organisations').insert({
+        id_utilisateur: id,
+        siret_hash: 'siret-haché256',
+        donnees: {},
+      });
+
+      const admins = await persistance.lisAdminsPour('siret-haché256');
+
+      expect(admins.length).to.be(1);
+      expect(admins[0]).to.be(id);
     });
   });
 });

--- a/test/adaptateurs/adaptateurPostgres.spec.js
+++ b/test/adaptateurs/adaptateurPostgres.spec.js
@@ -77,6 +77,18 @@ describe("L'adaptateur persistance Postgres", () => {
     );
   }
 
+  async function insereAutorisationAdmin(idUtilisateur, idService) {
+    const idAutorisation = genereUUID();
+    const autorisation = Autorisation.NouvelleAutorisationAdmin({
+      idUtilisateur,
+      idService,
+    });
+    await persistance.ajouteAutorisation(
+      idAutorisation,
+      autorisation.donneesAPersister()
+    );
+  }
+
   describe('concernant la lecture complète de service', () => {
     it("sait lire les suggestions d'action d'un service", async () => {
       const idService = await insereService();
@@ -100,6 +112,19 @@ describe("L'adaptateur persistance Postgres", () => {
       const proprietaire = services[0].utilisateurs[0];
       expect(proprietaire.id).to.be(idUtilisateur);
       expect(proprietaire.email_hash).to.be('email');
+      expect(proprietaire.estAdmin).to.be(false);
+    });
+
+    it("sait dire qu'un contributeur est admin", async () => {
+      const idService = await insereService();
+      const idUtilisateur = await insereUtilisateur();
+      await insereAutorisationAdmin(idUtilisateur, idService);
+
+      const services = await persistance.servicesComplets({ idService });
+
+      const proprietaire = services[0].utilisateurs[0];
+      expect(proprietaire.id).to.be(idUtilisateur);
+      expect(proprietaire.estAdmin).to.be(true);
     });
 
     it('sait lire les modèles de mesure spécifique disponible pour un service', async () => {

--- a/test/bus/abonnements/modifieRattachementServiceEtAdmins.spec.ts
+++ b/test/bus/abonnements/modifieRattachementServiceEtAdmins.spec.ts
@@ -1,0 +1,59 @@
+import { unService } from '../../constructeurs/constructeurService.js';
+import uneDescriptionValide from '../../constructeurs/constructeurDescriptionService.js';
+import { ServiceAdministrationOrganisations } from '../../../src/supervision/serviceAdministrationOrganisations.ts';
+import { modifieRattachementServiceEtAdmins } from '../../../src/bus/abonnements/modifieRattachementServiceEtAdmins.ts';
+
+describe("L'abonné en charge de modifier le rattachement entre un service modifié et ses admins", () => {
+  let serviceAdministrationOrganisations: ServiceAdministrationOrganisations;
+
+  beforeEach(() => {
+    serviceAdministrationOrganisations = {
+      rattacheLesAdministrateursDe: vi.fn(),
+    } as unknown as ServiceAdministrationOrganisations;
+  });
+
+  it("ne fait rien si le SIRET n'a pas changé", async () => {
+    const service = unService()
+      .avecOrganisationResponsable({
+        siret: 'unSIRET',
+      })
+      .construis();
+    const ancienneDescription = uneDescriptionValide()
+      .deLOrganisation({ siret: 'unSIRET' })
+      .construis();
+
+    await modifieRattachementServiceEtAdmins({
+      serviceAdministrationOrganisations,
+    })({
+      service,
+      ancienneDescription,
+    });
+
+    expect(
+      serviceAdministrationOrganisations.rattacheLesAdministrateursDe
+    ).not.toHaveBeenCalled();
+  });
+
+  it("délègue au service d'administration des organisations la modification du rattachement si le SIRET a changé", async () => {
+    const service = unService()
+      .avecId('S1')
+      .avecOrganisationResponsable({
+        siret: 'unSIRET',
+      })
+      .construis();
+    const ancienneDescription = uneDescriptionValide()
+      .deLOrganisation({ siret: 'unAutreSIRET' })
+      .construis();
+
+    await modifieRattachementServiceEtAdmins({
+      serviceAdministrationOrganisations,
+    })({
+      service,
+      ancienneDescription,
+    });
+
+    expect(
+      serviceAdministrationOrganisations.rattacheLesAdministrateursDe
+    ).toHaveBeenCalledWith(service);
+  });
+});

--- a/test/bus/abonnements/rattacheServiceEtAdmins.spec.ts
+++ b/test/bus/abonnements/rattacheServiceEtAdmins.spec.ts
@@ -1,0 +1,23 @@
+import { unService } from '../../constructeurs/constructeurService.js';
+import Service from '../../../src/modeles/service.js';
+import { ServiceAdministrationOrganisations } from '../../../src/supervision/serviceAdministrationOrganisations.ts';
+import { rattacheServiceEtAdmins } from '../../../src/bus/abonnements/rattacheServiceEtAdmins.ts';
+
+describe("L'abonné en charge de rattacher un nouveau service à ses administrateurs", () => {
+  it("délègue le rattachement au service d'administration des organisations", async () => {
+    let serviceRecu;
+    const serviceAdministrationOrganisations = {
+      rattacheLesAdministrateursDe: async (service: Service) => {
+        serviceRecu = service;
+      },
+    } as ServiceAdministrationOrganisations;
+
+    const service = unService().avecId('S1').construis();
+
+    await rattacheServiceEtAdmins({ serviceAdministrationOrganisations })({
+      service,
+    });
+
+    expect(serviceRecu!.id).toEqual('S1');
+  });
+});

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -24,6 +24,13 @@ class ConstructeurAutorisation {
     return this;
   }
 
+  dAdmin(idUtilisateur, idService) {
+    this.donnees.estAdmin = true;
+    this.donnees.idUtilisateur = idUtilisateur;
+    this.donnees.idService = idService;
+    return this;
+  }
+
   deContributeur(idUtilisateur, idService) {
     this.donnees.estProprietaire = false;
     this.donnees.idUtilisateur = idUtilisateur;

--- a/test/depots/depotDonneesAdministrationOrganisations.spec.ts
+++ b/test/depots/depotDonneesAdministrationOrganisations.spec.ts
@@ -1,0 +1,27 @@
+import { creeDepot } from '../../src/depots/depotDonneesAdministrationOrganisations.ts';
+import fauxAdaptateurChiffrement from '../mocks/adaptateurChiffrement.js';
+import { AdaptateurPersistance } from '../../src/adaptateurs/adaptateurPersistance.interface.ts';
+import { AdaptateurChiffrement } from '../../src/adaptateurs/adaptateurChiffrement.interface.ts';
+
+describe("Le dépôt de données d'admin des organisations", () => {
+  describe("concernant la lecture des admins d'une organisation", () => {
+    it('appelle la persistance avec un SIRET haché', async () => {
+      let siretPersistance;
+
+      const depot = creeDepot({
+        persistance: {
+          lisAdminsPour: (siret: string) => {
+            siretPersistance = siret;
+            return [];
+          },
+        } as unknown as AdaptateurPersistance,
+        chiffrement:
+          fauxAdaptateurChiffrement() as unknown as AdaptateurChiffrement,
+      });
+
+      await depot.lisAdminsPour('SIRET');
+
+      expect(siretPersistance).toBe('SIRET-haché256');
+    });
+  });
+});

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -121,6 +121,29 @@ describe('Le dépôt de données des autorisations', () => {
       expect(a.idService).to.equal('123');
     });
 
+    it("peut instancier une autorisation d'admin", async () => {
+      const adaptateurPersistance = unePersistanceMemoire()
+        .ajouteUnUtilisateur({ id: '999', email: 'jean.dupont@mail.fr' })
+        .ajouteUnService({
+          id: '123',
+          descriptionService: { nomService: 'Un service' },
+        })
+        .ajouteUneAutorisation(
+          uneAutorisation().avecId('456').dAdmin('999', '123').donnees
+        )
+        .construis();
+
+      const depot = creeDepot(adaptateurPersistance);
+
+      const a = await depot.autorisation('456');
+
+      expect(a.estAdmin).to.be(true);
+      expect(a.estProprietaire).to.be(true);
+      expect(a.id).to.equal('456');
+      expect(a.idUtilisateur).to.equal('999');
+      expect(a.idService).to.equal('123');
+    });
+
     it("retourne `undefined` si l'autorisation est inexistante", async () => {
       const depot = await depotVide();
       const autorisation = await depot.autorisation('123');

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -375,6 +375,26 @@ describe('Le dépôt de données des autorisations', () => {
       }
     });
 
+    it("empêche l'utilisateur de supprimer un admin", async () => {
+      const autorisationPourABC = unePersistanceMemoire()
+        .ajouteUneAutorisation(uneAutorisation().dAdmin('A1', 'ABC').donnees)
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('P1', 'ABC').donnees
+        )
+        .construis();
+      const depot = creeDepot(autorisationPourABC);
+
+      try {
+        await depot.supprimeContributeur('A1', 'ABC', 'P1');
+        expect().to.fail('La demande aurait dû lever une erreur');
+      } catch (e) {
+        expect(e).to.be.an(ErreurSuppressionImpossible);
+        expect(e.message).to.equal(
+          'L\'utilisateur "A1" ne peut pas être supprimé'
+        );
+      }
+    });
+
     it('supprime le contributeur', async () => {
       const avecUneAutorisation = unePersistanceMemoire()
         .ajouteUnService(

--- a/test/depots/depotDonneesAutorisations.spec.js
+++ b/test/depots/depotDonneesAutorisations.spec.js
@@ -664,4 +664,86 @@ describe('Le dépôt de données des autorisations', () => {
       expect(resultat[0].domaineEmailUtilisateur).to.be('le-domaine.fr');
     });
   });
+
+  describe("sur demande de suppression des autorisations administrateur d'un service", () => {
+    it('supprime les autorisations administrateur du service', async () => {
+      const avecAutorisations = unePersistanceMemoire()
+        .ajouteUnService(
+          unService().avecId('S1').avecDescription({ nom: 'S1' }).donnees
+        )
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U3').donnees)
+        .ajouteUneAutorisation(uneAutorisation().dAdmin('U1', 'S1').donnees)
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('U2', 'S1').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deContributeur('U3', 'S1').donnees
+        )
+        .construis();
+      const depot = creeDepot(avecAutorisations);
+
+      await depot.supprimeAutorisationsAdminPour('S1');
+
+      const autorisations = await depot.autorisationsDuService('S1');
+      expect(autorisations.length).to.be(2);
+    });
+
+    it('demande au dépôt données service de supprimer le contributeur', async () => {
+      const avecUneAutorisation = unePersistanceMemoire()
+        .ajouteUneAutorisation(uneAutorisation().dAdmin('U1', 'S1').donnees)
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('U2', 'S1').donnees
+        )
+        .construis();
+
+      let idServiceRecu;
+      let idUtilisateurRecu;
+      const depotServices = {
+        supprimeContributeur: async (idService, idUtilisateur) => {
+          idServiceRecu = idService;
+          idUtilisateurRecu = idUtilisateur;
+        },
+      };
+      const depot = creeDepot(
+        avecUneAutorisation,
+        {},
+        fabriqueBusPourLesTests(),
+        depotServices
+      );
+
+      await depot.supprimeAutorisationsAdminPour('S1');
+
+      expect(idServiceRecu).to.be('S1');
+      expect(idUtilisateurRecu).to.be('U1');
+    });
+
+    it("publie les autorisations à jour sur le bus d'événements", async () => {
+      const bus = fabriqueBusPourLesTests();
+      const avecDeuxExistantes = unePersistanceMemoire()
+        .ajouteUnService(
+          unService().avecId('S1').avecDescription({ nom: 'S1' }).donnees
+        )
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
+        .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
+        .ajouteUneAutorisation(
+          uneAutorisation().avecId('A1').dAdmin('U1', 'S1').donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().avecId('A2').deProprietaire('U2', 'S1').donnees
+        )
+        .construis();
+      const depot = creeDepot(avecDeuxExistantes, null, bus);
+
+      await depot.supprimeAutorisationsAdminPour('S1');
+
+      expect(
+        bus.recupereEvenement(EvenementAutorisationsServiceModifiees)
+      ).to.eql({
+        idService: 'S1',
+        autorisations: [{ droit: 'PROPRIETAIRE', idUtilisateur: 'U2' }],
+      });
+    });
+  });
 });

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -228,9 +228,7 @@ describe('Le dépôt de données des services', () => {
         .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
         .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
         .ajouteUnService(unService(r).avecId('S1').donnees)
-        .ajouteUneAutorisation(
-          uneAutorisation().deProprietaire('U1', 'S1').donnees
-        )
+        .ajouteUneAutorisation(uneAutorisation().dAdmin('U1', 'S1').donnees)
         .ajouteUneAutorisation(
           uneAutorisation().deContributeur('U2', 'S1').donnees
         );
@@ -244,7 +242,9 @@ describe('Le dépôt de données des services', () => {
       const { contributeurs } = service;
       expect(contributeurs.length).to.equal(2);
       expect(contributeurs[0].idUtilisateur).to.equal('U1');
+      expect(contributeurs[0].estAdmin).to.be(true);
       expect(contributeurs[1].idUtilisateur).to.equal('U2');
+      expect(contributeurs[1].estAdmin).to.be(false);
     });
 
     it("délègue au dépôt d'utilisateurs de déchiffrer les contributeurs", async () => {

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -61,6 +61,7 @@ import {
 import { VersionService } from '../../src/modeles/versionService.js';
 import { creeReferentielV2 } from '../../src/referentielV2.js';
 import EvenementServiceV1MigreEnV2 from '../../src/bus/evenementServiceV1MigreEnV2.js';
+import { unAdaptateurChiffrementQuiWrap } from '../mocks/adaptateurChiffrementQuiWrap.js';
 
 const { DECRIRE, SECURISER, HOMOLOGUER, CONTACTS, RISQUES } = Rubriques;
 const { ECRITURE } = Permissions;
@@ -248,38 +249,45 @@ describe('Le dépôt de données des services', () => {
 
     it("délègue au dépôt d'utilisateurs de déchiffrer les contributeurs", async () => {
       const r = Referentiel.creeReferentielVide();
+      const chiffrement = unAdaptateurChiffrementQuiWrap();
       const persistance = unePersistanceMemoire()
-        .ajouteUnUtilisateur(unUtilisateur().avecId('U1').donnees)
-        .ajouteUnUtilisateur(unUtilisateur().avecId('U2').donnees)
-        .ajouteUnService(unService(r).avecId('S1').donnees)
         .ajouteUneAutorisation(
           uneAutorisation().deProprietaire('U1', 'S1').donnees
         )
         .ajouteUneAutorisation(
           uneAutorisation().deContributeur('U2', 'S1').donnees
-        );
-      const unDepotUtilisateur = {
-        dechiffreUtilisateur: async (donneesUtilisateur) => {
-          donneesUtilisateur.donnees.nom = `${donneesUtilisateur.id}-déchiffré`;
-          return new Utilisateur(
-            {
-              id: donneesUtilisateur.id,
-              ...donneesUtilisateur.donnees,
-            },
-            { adaptateurJWT: {} }
-          );
-        },
-      };
+        )
+        .construis();
+      const u1 = await chiffrement.chiffre(
+        unUtilisateur().avecId('U1').avecEmail('u1@societe.fr').donnees
+      );
+      const u2 = await chiffrement.chiffre(
+        unUtilisateur().avecId('U2').avecEmail('u2@societe.fr').donnees
+      );
+      await persistance.ajouteUtilisateur('U1', u1);
+      await persistance.ajouteUtilisateur('U2', u2);
+
+      await persistance.sauvegardeService(
+        'S1',
+        await chiffrement.chiffre(unService(r).avecId('S1').donnees)
+      );
+
+      const unDepotUtilisateur = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurPersistance: persistance,
+        adaptateurChiffrement: chiffrement,
+      });
+
       const depot = unDepotDeDonneesServices()
+        .avecAdaptateurChiffrement(chiffrement)
         .avecDepotDonneesUtilisateurs(unDepotUtilisateur)
         .avecReferentiel(r)
-        .avecConstructeurDePersistance(persistance)
+        .avecAdaptateurPersistance(persistance)
         .construis();
 
       const service = await depot.service('S1');
 
-      expect(service.contributeurs[0].prenomNom()).to.equal('U1-déchiffré');
-      expect(service.contributeurs[1].prenomNom()).to.equal('U2-déchiffré');
+      expect(service.contributeurs[0].prenomNom()).to.equal('u1@societe.fr');
+      expect(service.contributeurs[1].prenomNom()).to.equal('u2@societe.fr');
     });
 
     it('associe ses suggestions d’actions au service', async () => {

--- a/test/modeles/autorisations/autorisation.spec.ts
+++ b/test/modeles/autorisations/autorisation.spec.ts
@@ -370,4 +370,20 @@ describe('Une autorisation', () => {
       });
     });
   });
+
+  describe('pour un administrateur', () => {
+    const donnees = {
+      id: unUUID('a'),
+      idService: unUUID('s'),
+      idUtilisateur: unUUID('u'),
+    };
+
+    it('a la propriété estAdmin et estProprietaire à true', () => {
+      const nouvelleAutorisationAdmin =
+        Autorisation.NouvelleAutorisationAdmin(donnees);
+
+      expect(nouvelleAutorisationAdmin.estAdmin).toBe(true);
+      expect(nouvelleAutorisationAdmin.estProprietaire).toBe(true);
+    });
+  });
 });

--- a/test/modeles/autorisations/autorisation.spec.ts
+++ b/test/modeles/autorisations/autorisation.spec.ts
@@ -264,6 +264,7 @@ describe('Une autorisation', () => {
         });
 
       expect(autorisationContributeur.donneesAPersister()).to.eql({
+        estAdmin: false,
         estProprietaire: false,
         id: unUUID('a'),
         idService: unUUID('s'),
@@ -289,6 +290,7 @@ describe('Une autorisation', () => {
 
       expect(autorisationProprietaire.donneesAPersister()).to.eql({
         estProprietaire: true,
+        estAdmin: false,
         id: unUUID('a'),
         idService: unUUID('s'),
         idUtilisateur: unUUID('u'),

--- a/test/modeles/autorisations/autorisation.spec.ts
+++ b/test/modeles/autorisations/autorisation.spec.ts
@@ -158,6 +158,15 @@ describe('Une autorisation', () => {
   });
 
   describe('sur demande de résumé de niveau de droit', () => {
+    it("retourne 'ADMIN' si l'utilisateur est admin du service", async () => {
+      const autorisationProprietaire =
+        Autorisation.NouvelleAutorisationAdmin(donneesAutorisation);
+
+      expect(autorisationProprietaire.resumeNiveauDroit()).toBe(
+        Autorisation.RESUME_NIVEAU_DROIT.ADMIN
+      );
+    });
+
     it("retourne 'PROPRIETAIRE' si l'utilisateur est propriétaire du service", async () => {
       const autorisationProprietaire =
         Autorisation.NouvelleAutorisationProprietaire(donneesAutorisation);
@@ -263,7 +272,7 @@ describe('Une autorisation', () => {
           droits: tousDroitsEnEcriture(),
         });
 
-      expect(autorisationContributeur.donneesAPersister()).to.eql({
+      expect(autorisationContributeur.donneesAPersister()).toEqual({
         estAdmin: false,
         estProprietaire: false,
         id: unUUID('a'),
@@ -288,7 +297,7 @@ describe('Une autorisation', () => {
           idUtilisateur: unUUID('u'),
         });
 
-      expect(autorisationProprietaire.donneesAPersister()).to.eql({
+      expect(autorisationProprietaire.donneesAPersister()).toEqual({
         estProprietaire: true,
         estAdmin: false,
         id: unUUID('a'),
@@ -302,6 +311,17 @@ describe('Une autorisation', () => {
           SECURISER: 2,
         },
       });
+    });
+
+    it('connaît ses données pour une autorisation de admin', () => {
+      const autorisationAdmin = Autorisation.NouvelleAutorisationAdmin({
+        ...donneesAutorisation,
+        id: unUUID('a'),
+        idService: unUUID('s'),
+        idUtilisateur: unUUID('u'),
+      });
+
+      expect(autorisationAdmin.donneesAPersister().estAdmin).toBe(true);
     });
   });
 

--- a/test/modeles/contributeur.spec.ts
+++ b/test/modeles/contributeur.spec.ts
@@ -11,6 +11,7 @@ describe('Un contributeur', () => {
     prenom: 'Jean',
     nom: 'Dujardin',
     postes: [],
+    estAdmin: false,
     ...surcharge,
   });
 
@@ -45,5 +46,15 @@ describe('Un contributeur', () => {
     );
 
     expect(contributeur.posteDetaille()).toEqual('RSSI, DPO et Maire');
+  });
+
+  it("sait s'il est admin", () => {
+    const contributeur = new Contributeur(
+      donneesContributeur({
+        estAdmin: true,
+      })
+    );
+
+    expect(contributeur.estAdmin).toBe(true);
   });
 });

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -107,6 +107,7 @@ describe("L'objet d'API de `GET /service`", () => {
       },
       nombreContributeurs: 1 + 1,
       estProprietaire: false,
+      estAdmin: false,
       documentsPdfDisponibles: ['syntheseSecurite'],
       permissions: { gestionContributeurs: false },
       aUneSuggestionAction: true,

--- a/test/modeles/objetsApi/objetGetService.spec.js
+++ b/test/modeles/objetsApi/objetGetService.spec.js
@@ -215,6 +215,45 @@ describe("L'objet d'API de `GET /service`", () => {
     expect(donnees.statutHomologation.etapeCourante).to.be('autorite');
   });
 
+  describe('concernant les contributeurs admin', () => {
+    const serviceAvecAdminA = unService(referentiel)
+      .ajouteUnContributeur({
+        ...unUtilisateur().avecId('ADMIN').quiSAppelle('Jean Dupont').donnees,
+        estAdmin: true,
+      })
+      .construis();
+
+    it('masque leurs informations, dans un soucis de confidentialité', () => {
+      const pointDeVueDuNonAdmin = objetGetService.donnees(
+        serviceAvecAdminA,
+        uneAutorisation().deProprietaire('B', '123').construis(),
+        referentiel
+      );
+
+      const [admin] = pointDeVueDuNonAdmin.contributeurs;
+      expect(admin).to.eql({
+        estAdmin: true,
+        estUtilisateurCourant: false,
+        id: 'ADMIN',
+        initiales: 'A',
+        poste: '',
+        prenomNom: 'Administrateur',
+      });
+    });
+
+    it("donne quand même les informations de l'admin s'il s'agit de l'utilisateur courant", () => {
+      const pointDeVueDeAdminLuiMeme = objetGetService.donnees(
+        serviceAvecAdminA,
+        uneAutorisation().dAdmin('ADMIN', '123').construis(),
+        referentiel
+      );
+
+      const [admin] = pointDeVueDeAdminLuiMeme.contributeurs;
+      expect(admin.id).to.be('ADMIN');
+      expect(admin.prenomNom).to.be('Jean Dupont');
+    });
+  });
+
   describe('sur demande des permissions', () => {
     it("autorise la gestion de contributeurs si l'utilisateur est propriétaire", () => {
       const unServiceDontAestCreateur = unService()

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -462,6 +462,28 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         });
     });
 
+    it("renvoie une erreur 403 si l'utilisateur courant tente de modifier les droits d'un admin", async () => {
+      const monAutorisation = uneAutorisation()
+        .deProprietaire('p1', 'ABC')
+        .construis();
+      const autorisationAdmin = uneAutorisation()
+        .dAdmin('a1', 'ABC')
+        .construis();
+
+      testeur.middleware().reinitialise({
+        idUtilisateur: '123',
+        autorisationACharger: monAutorisation,
+      });
+      testeur.depotDonnees().autorisation = async () => autorisationAdmin;
+
+      const reponse = await testeur.patch(
+        `/api/service/456/autorisations/${unUUIDRandom()}`,
+        { droits: tousDroitsEnEcriture() }
+      );
+
+      expect(reponse.status).to.equal(403);
+    });
+
     it("renvoie une erreur 422 si l'utilisateur courant tente de modifier ses propres droits", async () => {
       const monAutorisation = uneAutorisation()
         .deProprietaire('123', 'ABC')

--- a/test/routes/connecte/routesConnecteApiService.spec.js
+++ b/test/routes/connecte/routesConnecteApiService.spec.js
@@ -388,6 +388,7 @@ describe('Le serveur MSS des routes /api/service/*', () => {
         },
         nombreContributeurs: 2,
         estProprietaire: false,
+        estAdmin: false,
         documentsPdfDisponibles: ['syntheseSecurite'],
         permissions: { gestionContributeurs: false },
         aUneSuggestionAction: false,

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -1,0 +1,38 @@
+import * as DepotDonneesAutorisations from '../../src/depots/depotDonneesAutorisations.js';
+import { unePersistanceMemoire } from '../constructeurs/constructeurAdaptateurPersistanceMemoire.js';
+import { unUUID } from '../constructeurs/UUID.ts';
+import { unServiceV2 } from '../constructeurs/constructeurService.js';
+import { ServiceAdministrationOrganisations } from '../../src/supervision/serviceAdministrationOrganisations.js';
+import { fabriqueAdaptateurUUID } from '../../src/adaptateurs/adaptateurUUID.ts';
+import { fabriqueBusPourLesTests } from '../bus/aides/busPourLesTests.js';
+
+describe("Le service de gestion des admins d'organisation", () => {
+  describe("sur demande de rattachement d'un service à ses admins", () => {
+    const depotAutorisations = DepotDonneesAutorisations.creeDepot({
+      adaptateurPersistance: unePersistanceMemoire().construis(),
+      busEvenements: fabriqueBusPourLesTests(),
+    });
+
+    it('crée les autorisations admins correspondantes', async () => {
+      const unService = unServiceV2()
+        .avecId(unUUID('s'))
+        .avecOrganisationResponsable({ siret: '1234' })
+        .construis();
+      const administrationOrganisations =
+        new ServiceAdministrationOrganisations({
+          adaptateurUUID: fabriqueAdaptateurUUID(),
+          depotDonnees: {
+            ...depotAutorisations,
+            lisAdminsPour: async () => [unUUID('u1')],
+          },
+        });
+
+      await administrationOrganisations.rattacheLesAdministrateursDe(unService);
+
+      const autorisationsDuService =
+        await depotAutorisations.autorisationsDuService(unUUID('s'));
+      const [admin] = autorisationsDuService;
+      expect(admin.idUtilisateur).toBe(unUUID('u1'));
+    });
+  });
+});

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -24,6 +24,7 @@ describe("Le service de gestion des admins d'organisation", () => {
           depotDonnees: {
             ...depotAutorisations,
             lisAdminsPour: async () => [unUUID('u1')],
+            supprimeAutorisationsAdminPour: async () => {},
           },
         });
 
@@ -33,6 +34,29 @@ describe("Le service de gestion des admins d'organisation", () => {
         await depotAutorisations.autorisationsDuService(unUUID('s'));
       const [admin] = autorisationsDuService;
       expect(admin.idUtilisateur).toBe(unUUID('u1'));
+    });
+
+    it('délègue au dépôt la suppression des autorisations admins pré-existantes', async () => {
+      const constructeurService = unServiceV2()
+        .avecId(unUUID('s'))
+        .avecOrganisationResponsable({ siret: '1234' });
+
+      const mockSupprimeAutorisations = vi.fn();
+      const administrationOrganisations =
+        new ServiceAdministrationOrganisations({
+          adaptateurUUID: fabriqueAdaptateurUUID(),
+          depotDonnees: {
+            sauvegardeAutorisation: async () => {},
+            lisAdminsPour: async () => [unUUID('u1')],
+            supprimeAutorisationsAdminPour: mockSupprimeAutorisations,
+          },
+        });
+
+      await administrationOrganisations.rattacheLesAdministrateursDe(
+        constructeurService.construis()
+      );
+
+      expect(mockSupprimeAutorisations).toHaveBeenCalledWith(unUUID('s'));
     });
   });
 });

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -1,16 +1,21 @@
-import * as DepotDonneesAutorisations from '../../src/depots/depotDonneesAutorisations.js';
+import { creeDepot } from '../../src/depots/depotDonneesAutorisations.js';
 import { unePersistanceMemoire } from '../constructeurs/constructeurAdaptateurPersistanceMemoire.js';
 import { unUUID } from '../constructeurs/UUID.ts';
 import { unServiceV2 } from '../constructeurs/constructeurService.js';
 import { ServiceAdministrationOrganisations } from '../../src/supervision/serviceAdministrationOrganisations.js';
 import { fabriqueAdaptateurUUID } from '../../src/adaptateurs/adaptateurUUID.ts';
 import { fabriqueBusPourLesTests } from '../bus/aides/busPourLesTests.js';
+import { uneAutorisation } from '../constructeurs/constructeurAutorisation.js';
+import { DepotDonneesAutorisation } from '../../src/depots/depotDonneesAutorisations.interface.ts';
 
 describe("Le service de gestion des admins d'organisation", () => {
   describe("sur demande de rattachement d'un service à ses admins", () => {
-    const depotAutorisations = DepotDonneesAutorisations.creeDepot({
-      adaptateurPersistance: unePersistanceMemoire().construis(),
-      busEvenements: fabriqueBusPourLesTests(),
+    let depotAutorisations: DepotDonneesAutorisation;
+    beforeEach(() => {
+      depotAutorisations = creeDepot({
+        adaptateurPersistance: unePersistanceMemoire().construis(),
+        busEvenements: fabriqueBusPourLesTests(),
+      });
     });
 
     it('crée les autorisations admins correspondantes', async () => {
@@ -36,6 +41,34 @@ describe("Le service de gestion des admins d'organisation", () => {
       expect(admin.idUtilisateur).toBe(unUUID('u1'));
     });
 
+    it("élève les droits au rôle d'admin si l'admin est un contributeur existant", async () => {
+      const idService = unUUID('s');
+      const idProprietaire = unUUID('u1');
+      const unService = unServiceV2()
+        .avecId(idService)
+        .avecOrganisationResponsable({ siret: '1234' })
+        .construis();
+      await depotAutorisations.sauvegardeAutorisation(
+        uneAutorisation().deProprietaire(idProprietaire, idService).construis()
+      );
+      const administrationOrganisations =
+        new ServiceAdministrationOrganisations({
+          adaptateurUUID: fabriqueAdaptateurUUID(),
+          depotDonnees: {
+            ...depotAutorisations,
+            lisAdminsPour: async () => [idProprietaire],
+            supprimeAutorisationsAdminPour: async () => {},
+          },
+        });
+
+      await administrationOrganisations.rattacheLesAdministrateursDe(unService);
+
+      const autorisationsDuService =
+        await depotAutorisations.autorisationsDuService(idService);
+      expect(autorisationsDuService).toHaveLength(1);
+      expect(autorisationsDuService[0].estAdmin).toBe(true);
+    });
+
     it('délègue au dépôt la suppression des autorisations admins pré-existantes', async () => {
       const constructeurService = unServiceV2()
         .avecId(unUUID('s'))
@@ -46,6 +79,7 @@ describe("Le service de gestion des admins d'organisation", () => {
         new ServiceAdministrationOrganisations({
           adaptateurUUID: fabriqueAdaptateurUUID(),
           depotDonnees: {
+            ...depotAutorisations,
             sauvegardeAutorisation: async () => {},
             lisAdminsPour: async () => [unUUID('u1')],
             supprimeAutorisationsAdminPour: mockSupprimeAutorisations,


### PR DESCRIPTION
...en s'appuyant sur le modèle d'autorisations actuel.

Un admin est également propriétaire. Il ne peut pas être modifié/supprimé dans la gestion des contributeurs.
Lors de la création/mise à jour d'un service, le rattachement avec les admins est mis à jour.