### PR TITLE
Page admin pour les entités

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -72,6 +72,7 @@ CHIFFREMENT_SEL_DE_HASHAGE_1= # Sel à utiliser pour le hachage SHA256
 
 # Feature Flags
 FEATURE_FLAG_AVEC_RISQUES_V2= # Active la version "V2" des risques, pour les services "V2"
+FEATURE_FLAG_AVEC_GESTION_ORGANISATIONS= # Active la gestion des organisations par les superviseurs et admins
 
 # Crisp
 CRISP_ID_SITE= # L'identifiant "WebsiteID" de MonServiceSécurisé

--- a/public/admin/entites.mjs
+++ b/public/admin/entites.mjs
@@ -1,3 +1,0 @@
-$(() => {
-  document.body.dispatchEvent(new CustomEvent('svelte-recharge-admin-entites'));
-});

--- a/public/admin/entites.mjs
+++ b/public/admin/entites.mjs
@@ -1,0 +1,3 @@
+$(() => {
+  document.body.dispatchEvent(new CustomEvent('svelte-recharge-admin-entites'));
+});

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -81,6 +81,8 @@ const chiffrement = () => ({
 const featureFlag = () => ({
   avecServiceMonProfilAnssi: () => process.env.PROFIL_ANSSI_ACTIF === 'true',
   avecRisquesV2: () => process.env.FEATURE_FLAG_AVEC_RISQUES_V2 === 'true',
+  avecGestionDesOrganisations: () =>
+    process.env.FEATURE_FLAG_AVEC_GESTION_ORGANISATIONS === 'true',
 });
 
 const versionDeBuild = () => {

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -700,12 +700,25 @@ const nouvelAdaptateur = (
       .filter((a) => a.siretHash === siret)
       .map((a) => a.idUtilisateur);
 
+  const ajouteEntiteAAdmin = async (idAdmin, siretHash, donneesChiffrees) =>
+    donnees.adminsOrganisations.push({
+      idUtilisateur: idAdmin,
+      donnees: donneesChiffrees,
+      siretHash,
+    });
+
+  const lisEntitesAdministreesPar = async (idAdmin) =>
+    donnees.adminsOrganisations
+      .filter((a) => a.idUtilisateur === idAdmin)
+      .map((a) => a.donnees);
+
   return {
     activitesMesure,
     ajouteActiviteMesure,
     ajouteActivitesMesure,
     ajouteAutorisation,
     ajouteBrouillonService,
+    ajouteEntiteAAdmin,
     ajouteEntiteAuSuperviseur,
     ajouteModeleMesureSpecifique,
     ajoutePlusieursModelesMesureSpecifique,
@@ -725,6 +738,7 @@ const nouvelAdaptateur = (
     estSuperviseur,
     lisAdminsPour,
     lisBrouillonsService,
+    lisEntitesAdministreesPar,
     lisModelesMesureSpecifiquePourUtilisateur,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -996,12 +996,27 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
         .select('id_utilisateur')
     ).map((admin) => admin.id_utilisateur);
 
+  const ajouteEntiteAAdmin = async (idAdmin, siretHash, donnees) =>
+    knex('admins_organisations').insert({
+      id_utilisateur: idAdmin,
+      siret_hash: siretHash,
+      donnees,
+    });
+
+  const lisEntitesAdministreesPar = async (idAdmin) =>
+    (
+      await knex('admins_organisations')
+        .where({ id_utilisateur: idAdmin })
+        .select('donnees')
+    ).map((a) => a.donnees);
+
   return {
     activitesMesure,
     ajouteActiviteMesure,
     ajouteActivitesMesure,
     ajouteAutorisation,
     ajouteBrouillonService,
+    ajouteEntiteAAdmin,
     ajouteEntiteAuSuperviseur,
     ajouteModeleMesureSpecifique,
     ajouteParrainage,
@@ -1024,6 +1039,7 @@ const nouvelAdaptateur = ({ env, knexSurcharge }) => {
     lisAdminsPour,
     lisBrouillonsService,
     lisDernierIndiceCyber,
+    lisEntitesAdministreesPar,
     lisModelesMesureSpecifiquePourUtilisateur,
     lisNotificationsExpirationHomologationDansIntervalle,
     lisParcoursUtilisateur,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -164,6 +164,7 @@ const creeDepot = (config = {}) => {
 
   const depotAdministrationOragnisations =
     depotDonneesAdministrationOrganisations.creeDepot({
+      depotSuperviseurs,
       chiffrement: adaptateurChiffrement,
       persistance: adaptateurPersistance,
     });
@@ -330,7 +331,7 @@ const creeDepot = (config = {}) => {
 
   const { estJwtRevoque, revoqueJwt } = depotSession;
 
-  const { lisAdminsPour, entitesDansPerimetreDe } =
+  const { lisAdminsPour, entitesAdministreesPar } =
     depotAdministrationOragnisations;
 
   return {
@@ -363,7 +364,7 @@ const creeDepot = (config = {}) => {
     confirmeTeleversementModelesMesureSpecifique,
     dissocieTousModelesMesureSpecifiqueDeUtilisateurSurService,
     dupliqueService,
-    entitesDansPerimetreDe,
+    entitesAdministreesPar,
     estJwtRevoque,
     estSuperviseur,
     finaliseBrouillonService,

--- a/src/depotDonnees.js
+++ b/src/depotDonnees.js
@@ -330,7 +330,8 @@ const creeDepot = (config = {}) => {
 
   const { estJwtRevoque, revoqueJwt } = depotSession;
 
-  const { lisAdminsPour } = depotAdministrationOragnisations;
+  const { lisAdminsPour, entitesDansPerimetreDe } =
+    depotAdministrationOragnisations;
 
   return {
     accesAutorise,
@@ -362,6 +363,7 @@ const creeDepot = (config = {}) => {
     confirmeTeleversementModelesMesureSpecifique,
     dissocieTousModelesMesureSpecifiqueDeUtilisateurSurService,
     dupliqueService,
+    entitesDansPerimetreDe,
     estJwtRevoque,
     estSuperviseur,
     finaliseBrouillonService,

--- a/src/depots/depotDonneesAdministrationOrganisations.interface.ts
+++ b/src/depots/depotDonneesAdministrationOrganisations.interface.ts
@@ -1,7 +1,7 @@
 import { UUID } from '../typesBasiques.js';
 import Entite from '../modeles/entite.js';
 
-export type DepotDonneesAdministrationOrganisationsInterface = {
+export type DepotDonneesAdministrationOrganisations = {
   lisAdminsPour: (siret: string) => Promise<Array<UUID>>;
-  entitesDansPerimetreDe: (idUtilisateur: UUID) => Promise<Array<Entite>>;
+  entitesAdministreesPar: (idUtilisateur: UUID) => Promise<Array<Entite>>;
 };

--- a/src/depots/depotDonneesAdministrationOrganisations.interface.ts
+++ b/src/depots/depotDonneesAdministrationOrganisations.interface.ts
@@ -1,0 +1,7 @@
+import { UUID } from '../typesBasiques.js';
+import Entite from '../modeles/entite.js';
+
+export type DepotDonneesAdministrationOrganisationsInterface = {
+  lisAdminsPour: (siret: string) => Promise<Array<UUID>>;
+  entitesDansPerimetreDe: (idUtilisateur: UUID) => Promise<Array<Entite>>;
+};

--- a/src/depots/depotDonneesAdministrationOrganisations.ts
+++ b/src/depots/depotDonneesAdministrationOrganisations.ts
@@ -1,30 +1,40 @@
 import { AdaptateurPersistance } from '../adaptateurs/adaptateurPersistance.interface.js';
 import { UUID } from '../typesBasiques.js';
 import { AdaptateurChiffrement } from '../adaptateurs/adaptateurChiffrement.interface.js';
-import { DepotDonneesAdministrationOrganisationsInterface } from './depotDonneesAdministrationOrganisations.interface.js';
-import Entite from '../modeles/entite.js';
+import { DepotDonneesAdministrationOrganisations } from './depotDonneesAdministrationOrganisations.interface.js';
+import Entite, { DonneesEntite } from '../modeles/entite.js';
+import { DepotDonneesSuperviseurs } from './depotDonneesSuperviseurs.interface.js';
 
 export const creeDepot = ({
   persistance,
   chiffrement,
+  depotSuperviseurs,
 }: {
   persistance: AdaptateurPersistance;
   chiffrement: AdaptateurChiffrement;
-}): DepotDonneesAdministrationOrganisationsInterface => {
+  depotSuperviseurs: DepotDonneesSuperviseurs;
+}): DepotDonneesAdministrationOrganisations => {
   const lisAdminsPour = async (siret: string): Promise<Array<UUID>> => {
     const siretHache = chiffrement.hacheSha256(siret);
     return persistance.lisAdminsPour(siretHache);
   };
 
-  const entitesDansPerimetreDe = async (
+  const entitesAdministreesPar = async (
     idUtilisateur: UUID
-  ): Promise<Array<Entite>> => [
-    new Entite({
-      siret: '123',
-      nom: `Une entite dans le périmètre de ${idUtilisateur}`,
-      departement: '33',
-    }),
-  ];
+  ): Promise<Array<Entite>> => {
+    const estSuperviseur =
+      await depotSuperviseurs.estSuperviseur(idUtilisateur);
+    if (estSuperviseur) {
+      const superviseur = await depotSuperviseurs.superviseur(idUtilisateur);
+      return superviseur.entitesSupervisees;
+    }
 
-  return { lisAdminsPour, entitesDansPerimetreDe };
+    const donneesEntites =
+      await persistance.lisEntitesAdministreesPar(idUtilisateur);
+    return donneesEntites.map(
+      (donneesEntite: DonneesEntite) => new Entite(donneesEntite)
+    );
+  };
+
+  return { lisAdminsPour, entitesAdministreesPar };
 };

--- a/src/depots/depotDonneesAdministrationOrganisations.ts
+++ b/src/depots/depotDonneesAdministrationOrganisations.ts
@@ -1,6 +1,8 @@
 import { AdaptateurPersistance } from '../adaptateurs/adaptateurPersistance.interface.js';
 import { UUID } from '../typesBasiques.js';
 import { AdaptateurChiffrement } from '../adaptateurs/adaptateurChiffrement.interface.js';
+import { DepotDonneesAdministrationOrganisationsInterface } from './depotDonneesAdministrationOrganisations.interface.js';
+import Entite from '../modeles/entite.js';
 
 export const creeDepot = ({
   persistance,
@@ -8,11 +10,21 @@ export const creeDepot = ({
 }: {
   persistance: AdaptateurPersistance;
   chiffrement: AdaptateurChiffrement;
-}) => {
+}): DepotDonneesAdministrationOrganisationsInterface => {
   const lisAdminsPour = async (siret: string): Promise<Array<UUID>> => {
     const siretHache = chiffrement.hacheSha256(siret);
     return persistance.lisAdminsPour(siretHache);
   };
 
-  return { lisAdminsPour };
+  const entitesDansPerimetreDe = async (
+    idUtilisateur: UUID
+  ): Promise<Array<Entite>> => [
+    new Entite({
+      siret: '123',
+      nom: `Une entite dans le périmètre de ${idUtilisateur}`,
+      departement: '33',
+    }),
+  ];
+
+  return { lisAdminsPour, entitesDansPerimetreDe };
 };

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -41,6 +41,7 @@ import { schemaMesureGenerale } from '../../http/schemas/mesure.schema.js';
 import routesConnecteApiModeleMesureSpecifique from './routesConnecteApiModeleMesureSpecifique.js';
 import { routesConnecteApiUtilisateur } from './routesConnecteApiUtilisateur.js';
 import { routesConnecteApiExplicationRisquesV2 } from './routesConnecteApiExplicationRisquesV2.js';
+import { routesConnecteApiAdmin } from './routesConnecteApiAdmin.js';
 
 const { ECRITURE, LECTURE } = Permissions;
 const { SECURISER } = Rubriques;
@@ -416,6 +417,13 @@ const routesConnecteApi = ({
       referentielV2,
     })
   );
+
+  routes.use(
+    '/admin',
+    middleware.verificationAcceptationCGU,
+    routesConnecteApiAdmin()
+  );
+
   routes.post(
     '/autorisation',
     middleware.verificationAcceptationCGU,

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -421,7 +421,7 @@ const routesConnecteApi = ({
   routes.use(
     '/admin',
     middleware.verificationAcceptationCGU,
-    routesConnecteApiAdmin()
+    routesConnecteApiAdmin({ depotDonnees })
   );
 
   routes.post(

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 import { RequestRouteConnecte } from './routesConnecte.types.js';
-import { DepotDonneesAdministrationOrganisationsInterface } from '../../depots/depotDonneesAdministrationOrganisations.interface.js';
+import { DepotDonneesAdministrationOrganisations } from '../../depots/depotDonneesAdministrationOrganisations.interface.js';
 
 type Configuration = {
-  depotDonnees: DepotDonneesAdministrationOrganisationsInterface;
+  depotDonnees: DepotDonneesAdministrationOrganisations;
 };
 
 const routesConnecteApiAdmin = ({ depotDonnees }: Configuration) => {
@@ -13,7 +13,7 @@ const routesConnecteApiAdmin = ({ depotDonnees }: Configuration) => {
     const { idUtilisateurCourant } = requete as RequestRouteConnecte;
 
     const entites =
-      await depotDonnees.entitesDansPerimetreDe(idUtilisateurCourant);
+      await depotDonnees.entitesAdministreesPar(idUtilisateurCourant);
 
     reponse.json(entites.map((entite) => entite.toJSON()));
   });

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+
+const routesConnecteApiAdmin = () => {
+  const routes = express.Router();
+
+  routes.get('/entites', async (_requete, reponse) => {
+    reponse.json([{ siret: '123', nom: 'Une entite', departement: '33' }]);
+  });
+
+  return routes;
+};
+
+export { routesConnecteApiAdmin };

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -1,10 +1,21 @@
 import express from 'express';
+import { RequestRouteConnecte } from './routesConnecte.types.js';
+import { DepotDonneesAdministrationOrganisationsInterface } from '../../depots/depotDonneesAdministrationOrganisations.interface.js';
 
-const routesConnecteApiAdmin = () => {
+type Configuration = {
+  depotDonnees: DepotDonneesAdministrationOrganisationsInterface;
+};
+
+const routesConnecteApiAdmin = ({ depotDonnees }: Configuration) => {
   const routes = express.Router();
 
-  routes.get('/entites', async (_requete, reponse) => {
-    reponse.json([{ siret: '123', nom: 'Une entite', departement: '33' }]);
+  routes.get('/entites', async (requete, reponse) => {
+    const { idUtilisateurCourant } = requete as RequestRouteConnecte;
+
+    const entites =
+      await depotDonnees.entitesDansPerimetreDe(idUtilisateurCourant);
+
+    reponse.json(entites.map((entite) => entite.toJSON()));
   });
 
   return routes;

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -224,7 +224,7 @@ const routesConnectePage = ({
   routes.use(
     '/admin',
     middleware.verificationAcceptationCGU,
-    routesConnectePageAdmin()
+    routesConnectePageAdmin({ adaptateurEnvironnement })
   );
 
   return routes;

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -5,6 +5,7 @@ import routesConnectePageService from './routesConnectePageService.js';
 import { questionsV2 } from '../../../donneesReferentielMesuresV2.js';
 import { VersionService } from '../../modeles/versionService.js';
 import { adaptateurJWT } from '../../adaptateurs/adaptateurJWT.js';
+import { routesConnectePageAdmin } from './routesConnectePageAdmin.js';
 
 const routesConnectePage = ({
   middleware,
@@ -218,6 +219,12 @@ const routesConnectePage = ({
       adaptateurHorloge,
       adaptateurEnvironnement,
     })
+  );
+
+  routes.use(
+    '/admin',
+    middleware.verificationAcceptationCGU,
+    routesConnectePageAdmin()
   );
 
   return routes;

--- a/src/routes/connecte/routesConnectePageAdmin.ts
+++ b/src/routes/connecte/routesConnectePageAdmin.ts
@@ -1,9 +1,24 @@
 import express from 'express';
+import { AdaptateurEnvironnement } from '../../adaptateurs/adaptateurEnvironnement.interface.js';
 
-const routesConnectePageAdmin = () => {
+type Configuration = {
+  adaptateurEnvironnement: AdaptateurEnvironnement;
+};
+
+const routesConnectePageAdmin = ({
+  adaptateurEnvironnement,
+}: Configuration) => {
   const routes = express.Router();
 
-  routes.get('/entites', async (requete, reponse) => {
+  routes.use((_requete, reponse, suite) => {
+    if (!adaptateurEnvironnement.featureFlag().avecGestionDesOrganisations()) {
+      reponse.status(404).render('404');
+      return;
+    }
+    suite();
+  });
+
+  routes.get('/entites', async (_requete, reponse) => {
     reponse.render('admin/entites');
   });
 

--- a/src/routes/connecte/routesConnectePageAdmin.ts
+++ b/src/routes/connecte/routesConnectePageAdmin.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+
+const routesConnectePageAdmin = () => {
+  const routes = express.Router();
+
+  routes.get('/entites', async (requete, reponse) => {
+    reponse.render('admin/entites');
+  });
+
+  return routes;
+};
+
+export { routesConnectePageAdmin };

--- a/src/vues/admin/entites.pug
+++ b/src/vues/admin/entites.pug
@@ -1,0 +1,4 @@
+extends ../mssConnecte
+
+block main
+  h1 les entités

--- a/src/vues/admin/entites.pug
+++ b/src/vues/admin/entites.pug
@@ -1,4 +1,8 @@
 extends ../mssConnecte
 
+block append scripts
+  +composantSvelte('adminEntites.js')
+  script(type = 'module', src = '/statique/admin/entites.mjs')
+
 block main
-  h1 les entités
+  #conteneur-admin-entites

--- a/src/vues/admin/entites.pug
+++ b/src/vues/admin/entites.pug
@@ -2,7 +2,6 @@ extends ../mssConnecte
 
 block append scripts
   +composantSvelte('adminEntites.js')
-  script(type = 'module', src = '/statique/admin/entites.mjs')
 
 block main
   #conteneur-admin-entites

--- a/svelte/lib/adminEntites/AdminEntites.svelte
+++ b/svelte/lib/adminEntites/AdminEntites.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  // eslint-disable-next-line no-empty-pattern
+  let {} = $props();
+</script>
+
+<h1>Entités</h1>
+
+<style lang="scss">
+  :global(#conteneur-admin-entites) {
+    text-align: left;
+    background: #fff;
+    width: 100%;
+    padding: 32px 48px;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    line-height: 3rem;
+    margin: 0;
+  }
+</style>

--- a/svelte/lib/adminEntites/AdminEntites.svelte
+++ b/svelte/lib/adminEntites/AdminEntites.svelte
@@ -1,9 +1,25 @@
 <script lang="ts">
-  // eslint-disable-next-line no-empty-pattern
-  let {} = $props();
+  import { onMount } from 'svelte';
+  import type { Entite } from '../ui/types';
+  import { api } from './adminEntites.api';
+
+  let mesEntites: Entite[] = $state([]);
+
+  onMount(async () => {
+    mesEntites = await api.entitesDansMonPerimetre();
+  });
 </script>
 
 <h1>Entités</h1>
+
+<dsfr-table
+  columns={[
+    { key: 'siret', label: 'SIRET' },
+    { key: 'nom', label: 'Nom' },
+    { key: 'departement', label: 'Département' },
+  ]}
+  rows={mesEntites}
+></dsfr-table>
 
 <style lang="scss">
   :global(#conteneur-admin-entites) {

--- a/svelte/lib/adminEntites/adminEntites.api.ts
+++ b/svelte/lib/adminEntites/adminEntites.api.ts
@@ -1,0 +1,6 @@
+import type { Entite } from '../ui/types';
+
+export const api = {
+  entitesDansMonPerimetre: async (): Promise<Entite[]> =>
+    (await axios.get<Entite[]>('/api/admin/entites')).data,
+};

--- a/svelte/lib/adminEntites/adminEntites.d.ts
+++ b/svelte/lib/adminEntites/adminEntites.d.ts
@@ -1,5 +1,0 @@
-declare global {
-  interface HTMLElementEventMap {
-    'svelte-recharge-admin-entites': CustomEvent;
-  }
-}

--- a/svelte/lib/adminEntites/adminEntites.d.ts
+++ b/svelte/lib/adminEntites/adminEntites.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  interface HTMLElementEventMap {
+    'svelte-recharge-admin-entites': CustomEvent;
+  }
+}

--- a/svelte/lib/adminEntites/adminEntites.ts
+++ b/svelte/lib/adminEntites/adminEntites.ts
@@ -1,0 +1,18 @@
+import AdminEntites from './AdminEntites.svelte';
+import { mount, unmount } from 'svelte';
+
+document.body.addEventListener(
+  'svelte-recharge-admin-entites',
+  async () => await rechargeApp()
+);
+
+let app: AdminEntites;
+const rechargeApp = async () => {
+  if (app) await unmount(app);
+
+  app = mount(AdminEntites, {
+    target: document.getElementById('conteneur-admin-entites')!,
+  });
+};
+
+export default app!;

--- a/svelte/lib/adminEntites/adminEntites.ts
+++ b/svelte/lib/adminEntites/adminEntites.ts
@@ -1,18 +1,8 @@
 import AdminEntites from './AdminEntites.svelte';
-import { mount, unmount } from 'svelte';
+import { mount } from 'svelte';
 
-document.body.addEventListener(
-  'svelte-recharge-admin-entites',
-  async () => await rechargeApp()
-);
+const app = mount(AdminEntites, {
+  target: document.getElementById('conteneur-admin-entites')!,
+});
 
-let app: AdminEntites;
-const rechargeApp = async () => {
-  if (app) await unmount(app);
-
-  app = mount(AdminEntites, {
-    target: document.getElementById('conteneur-admin-entites')!,
-  });
-};
-
-export default app!;
+export default app;

--- a/test/depots/depotDonneesAdministrationOrganisations.spec.ts
+++ b/test/depots/depotDonneesAdministrationOrganisations.spec.ts
@@ -2,6 +2,14 @@ import { creeDepot } from '../../src/depots/depotDonneesAdministrationOrganisati
 import fauxAdaptateurChiffrement from '../mocks/adaptateurChiffrement.js';
 import { AdaptateurPersistance } from '../../src/adaptateurs/adaptateurPersistance.interface.ts';
 import { AdaptateurChiffrement } from '../../src/adaptateurs/adaptateurChiffrement.interface.ts';
+import { AdaptateurRechercheEntreprise } from '../../src/adaptateurs/adaptateurRechercheEntreprise.interface.ts';
+import fauxAdaptateurRechercheEntreprise from '../mocks/adaptateurRechercheEntreprise.js';
+import { unePersistanceMemoire } from '../constructeurs/constructeurAdaptateurPersistanceMemoire.js';
+import * as depotDonneesSuperviseurs from '../../src/depots/depotDonneesSuperviseurs.ts';
+import { DepotDonneesAdministrationOrganisations } from '../../src/depots/depotDonneesAdministrationOrganisations.interface.ts';
+import { unUUID } from '../constructeurs/UUID.ts';
+import Entite from '../../src/modeles/entite.ts';
+import { DepotDonneesSuperviseurs } from '../../src/depots/depotDonneesSuperviseurs.interface.ts';
 
 describe("Le dépôt de données d'admin des organisations", () => {
   describe("concernant la lecture des admins d'une organisation", () => {
@@ -17,11 +25,76 @@ describe("Le dépôt de données d'admin des organisations", () => {
         } as unknown as AdaptateurPersistance,
         chiffrement:
           fauxAdaptateurChiffrement() as unknown as AdaptateurChiffrement,
+        depotSuperviseurs: {} as unknown as DepotDonneesSuperviseurs,
       });
 
       await depot.lisAdminsPour('SIRET');
 
       expect(siretPersistance).toBe('SIRET-haché256');
+    });
+  });
+
+  describe('concernant la lecture des entités administrées par un utilisateur', () => {
+    let depot: DepotDonneesAdministrationOrganisations;
+    let depotSuperviseurs: DepotDonneesSuperviseurs;
+    let adaptateurPersistance: AdaptateurPersistance;
+    let adaptateurRechercheEntite: AdaptateurRechercheEntreprise;
+
+    beforeEach(() => {
+      adaptateurRechercheEntite = fauxAdaptateurRechercheEntreprise();
+      adaptateurPersistance =
+        unePersistanceMemoire().construis() as AdaptateurPersistance;
+      depotSuperviseurs = depotDonneesSuperviseurs.creeDepot({
+        adaptateurPersistance,
+        adaptateurRechercheEntite,
+      });
+      depot = creeDepot({
+        persistance: adaptateurPersistance,
+        chiffrement: fauxAdaptateurChiffrement(),
+        depotSuperviseurs,
+      });
+    });
+
+    it("utilise le dépôt des superviseurs pour lister les entités d'un superviseur", async () => {
+      const idSuperviseur = unUUID('1');
+      await adaptateurPersistance.ajouteEntiteAuSuperviseur(idSuperviseur, {
+        nom: 'NomEntite',
+        siret: 'SIRET-123',
+        departement: '75',
+      });
+
+      const entites = await depot.entitesAdministreesPar(idSuperviseur);
+
+      expect(entites).toEqual([
+        new Entite({
+          nom: 'NomEntite',
+          siret: 'SIRET-123',
+          departement: '75',
+        }),
+      ]);
+    });
+
+    it("utilise la persistance pour lister les entités d'un admin", async () => {
+      const idAdmin = unUUID('1');
+      await adaptateurPersistance.ajouteEntiteAAdmin(
+        idAdmin,
+        'SIRET-123-haché',
+        {
+          nom: 'NomEntite',
+          siret: 'SIRET-123',
+          departement: '75',
+        }
+      );
+
+      const entites = await depot.entitesAdministreesPar(idAdmin);
+
+      expect(entites).toEqual([
+        new Entite({
+          nom: 'NomEntite',
+          siret: 'SIRET-123',
+          departement: '75',
+        }),
+      ]);
     });
   });
 });

--- a/test/mocks/adaptateurChiffrement.js
+++ b/test/mocks/adaptateurChiffrement.js
@@ -4,6 +4,7 @@ const fauxAdaptateurChiffrement = () => ({
   hacheBCrypt: (chaine) => Promise.resolve(chaine ? `${chaine}-haché` : chaine),
   hacheSha256: (chaine) => `${chaine}-haché256`,
   hacheSha256AvecUnSeulSel: (chaine, _sel) => `${chaine}-haché256`,
+  hacheSha256SansSel: (chaine) => `${chaine}-haché256`,
   compareBCrypt: (enClair, chiffreeReference) =>
     fauxAdaptateurChiffrement()
       .hacheBCrypt(enClair)

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -1,5 +1,6 @@
 import testeurMSS from '../testeurMSS.js';
-import { DonneesEntite } from '../../../src/modeles/entite.ts';
+import Entite, { DonneesEntite } from '../../../src/modeles/entite.ts';
+import { UUID } from '../../../src/typesBasiques.ts';
 
 describe('Le serveur MSS des routes /api/admin/*', () => {
   const testeur = testeurMSS();
@@ -20,8 +21,20 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
 
   describe('quand requête GET sur `/api/admin/entites`', () => {
     it("retourne la liste des entités dans le périmètre de l'utilisateur courant", async () => {
+      let idAdmin;
+      testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
+      testeur.depotDonnees().entitesDansPerimetreDe = async (
+        idUtilisateur: UUID
+      ) => {
+        idAdmin = idUtilisateur;
+        return [
+          new Entite({ siret: '123', nom: 'Une entite', departement: '33' }),
+        ];
+      };
+
       const reponse = await testeur.get('/api/admin/entites');
 
+      expect(idAdmin).toBe('U1');
       expect(reponse.body).toEqual<DonneesEntite[]>([
         { siret: '123', nom: 'Une entite', departement: '33' },
       ]);

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -1,0 +1,30 @@
+import testeurMSS from '../testeurMSS.js';
+import { DonneesEntite } from '../../../src/modeles/entite.ts';
+
+describe('Le serveur MSS des routes /api/admin/*', () => {
+  const testeur = testeurMSS();
+
+  beforeEach(() => testeur.initialise());
+
+  it("vérifie que l'utilisateur est authentifié sur toutes les routes", async () => {
+    // On vérifie une seule route privée.
+    // Par construction, les autres seront protégées aussi puisque la protection est ajoutée comme middleware
+    // devant le routeur dédié aux routes de la visite guidée.
+    await testeur
+      .middleware()
+      .verifieRequeteExigeAcceptationCGU(testeur.app(), {
+        method: 'get',
+        url: '/api/admin/entites',
+      });
+  });
+
+  describe('quand requête GET sur `/api/admin/entites`', () => {
+    it("retourne la liste des entités dans le périmètre de l'utilisateur courant", async () => {
+      const reponse = await testeur.get('/api/admin/entites');
+
+      expect(reponse.body).toEqual<DonneesEntite[]>([
+        { siret: '123', nom: 'Une entite', departement: '33' },
+      ]);
+    });
+  });
+});

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -23,7 +23,7 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
     it("retourne la liste des entités dans le périmètre de l'utilisateur courant", async () => {
       let idAdmin;
       testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
-      testeur.depotDonnees().entitesDansPerimetreDe = async (
+      testeur.depotDonnees().entitesAdministreesPar = async (
         idUtilisateur: UUID
       ) => {
         idAdmin = idUtilisateur;

--- a/test/routes/connecte/routesConnectePageAdmin.spec.ts
+++ b/test/routes/connecte/routesConnectePageAdmin.spec.ts
@@ -1,0 +1,30 @@
+import testeurMSS from '../testeurMSS.js';
+import { unUtilisateur } from '../../constructeurs/constructeurUtilisateur.js';
+
+describe("Le serveur MSS des pages d'admin", () => {
+  const testeur = testeurMSS();
+
+  beforeEach(() => testeur.initialise());
+
+  ['/admin/entites'].forEach((route) => {
+    describe(`quand GET sur ${route}`, () => {
+      beforeEach(() => {
+        const utilisateur = unUtilisateur().construis();
+        testeur.depotDonnees().utilisateur = async () => utilisateur;
+      });
+
+      it("vérifie que l'utilisateur a accepté les CGU", async () => {
+        await testeur
+          .middleware()
+          .verifieRequeteExigeAcceptationCGU(testeur.app(), `${route}`);
+      });
+
+      it('sert le contenu HTML de la page', async () => {
+        const reponse = await testeur.get(`${route}`);
+
+        expect(reponse.status).to.equal(200);
+        expect(reponse.headers['content-type']).to.contain('text/html');
+      });
+    });
+  });
+});

--- a/test/routes/connecte/routesConnectePageAdmin.spec.ts
+++ b/test/routes/connecte/routesConnectePageAdmin.spec.ts
@@ -25,6 +25,16 @@ describe("Le serveur MSS des pages d'admin", () => {
         expect(reponse.status).to.equal(200);
         expect(reponse.headers['content-type']).to.contain('text/html');
       });
+
+      it("jette une erreur 404 si le feature flag de gestion des orgas n'est pas activé", async () => {
+        testeur.adaptateurEnvironnement().featureFlag = () => ({
+          avecGestionDesOrganisations: () => false,
+        });
+
+        const reponse = await testeur.get(`${route}`);
+
+        expect(reponse.status).to.equal(404);
+      });
     });
   });
 });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -122,6 +122,7 @@ const testeurMss = () => {
       trustProxy: () => 0,
       featureFlag: () => ({
         avecRisquesV2: () => true,
+        avecGestionDesOrganisations: () => true,
       }),
       oidc: () => ({ fournisseursAvecMFA: () => [] }),
     };


### PR DESCRIPTION
Cette PR rajoute une page `/admin/entites` qui servira à lister les entités dans le périmètre d'admin de l'utilisateur courant.

Ici on démarre en mode coquille 👇 

<img width="550" alt="image" src="https://github.com/user-attachments/assets/42696b12-3590-4351-80f7-a16438e9eb33" />


Mais on traverse Navigation > pug > Svelte > API > Dépôt


> [!IMPORTANT]
> `FEATURE_FLAG_AVEC_GESTION_ORGANISATIONS=true` pour activer la feature