### PR TITLE
Centre l'image du bloc "Impact national"

### DIFF
--- a/public/assets/styles/home.css
+++ b/public/assets/styles/home.css
@@ -395,6 +395,7 @@ main {
 #home {
   .bloc-impact-national {
     padding-block: 3.5rem;
+    text-align: center;
 
     h3 {
       color: inherit;


### PR DESCRIPTION
... suite à une erreur de CSS dans la dernière PR.