### PR TITLE
[CORRECTION] Ne passe pas le département s'il est vide

### DIFF
--- a/svelte/lib/inscription/SelectionOrganisation.svelte
+++ b/svelte/lib/inscription/SelectionOrganisation.svelte
@@ -64,7 +64,9 @@
     const reponse = await axios.get('/api/annuaire/organisations', {
       params: {
         recherche: saisie,
-        departement: filtreDepartement?.code,
+        ...(filtreDepartement?.code
+          ? { departement: filtreDepartement?.code }
+          : {}),
       },
     });
 


### PR DESCRIPTION
... car l'API n'autorise pas le paramètre vide.