### PR TITLE
[CORRECTION] Navigue hors de la SPA pour l'export CSV des mesures

### DIFF
--- a/svelte/lib/pagesService/store/routeur.store.ts
+++ b/svelte/lib/pagesService/store/routeur.store.ts
@@ -41,6 +41,8 @@ const navigue = (
     return;
   }
 
+  if (url.includes('export.csv')) return navigueHorsSPA(url);
+
   const pageDemandee = pageDepuisURL(url) || '';
   const pageVisible = informationsService?.visible[pageDemandee];
   const versionService = informationsService?.version;

--- a/svelte/test/pagesService/store/routeur.store.spec.ts
+++ b/svelte/test/pagesService/store/routeur.store.spec.ts
@@ -142,6 +142,18 @@ describe('Le routeur des pages service', () => {
 
     it("navigue en dehors de la SPA si le routeur est en mode 'visiteGuidee'", async () => {
       const routeurStore = await leRouteur();
+      chargeInformationsService(routeurStore);
+      const navigueHorsSPA = vi.fn();
+
+      routeurStore.navigue('/service/1234/mesures/export.csv', navigueHorsSPA);
+
+      expect(navigueHorsSPA).toHaveBeenCalledWith(
+        '/service/1234/mesures/export.csv'
+      );
+    });
+
+    it("navigue en dehors de la SPA sur l'export CSV des mesures", async () => {
+      const routeurStore = await leRouteur();
       chargeInformationsService(routeurStore, {
         visible: {
           rolesResponsabilites: true,


### PR DESCRIPTION
... car il est actuellement cassé en prod, du fait que l'URL "demandée" retourne `/mesures`.