### PR TITLE
[CORRECTION] Affiche la valeur de l'indice cyber personnalisé dans son macaron

### DIFF
--- a/svelte/lib/pagesService/pages/indiceCyber/IndiceCyber.svelte
+++ b/svelte/lib/pagesService/pages/indiceCyber/IndiceCyber.svelte
@@ -198,7 +198,7 @@
       <div class="cadre-indice-cyber">
         <div class="disque-indice-cyber">
           <IndiceCyberPersonnalise
-            indiceCyberPersonnalise={indiceCyber.total}
+            indiceCyberPersonnalise={indiceCyberPersonnalise.total}
             {noteMax}
             {idService}
           />


### PR DESCRIPTION
...une erreur s'étant glissée, l'indice cyber ANSSI était affiché dans le macaron de l'onglet personnalisé