### PR TITLE
[CORRECTION] Rafraîchis correctement l'onglet indice cyber

### DIFF
--- a/svelte/lib/pagesService/PagesService.svelte
+++ b/svelte/lib/pagesService/PagesService.svelte
@@ -112,13 +112,13 @@
   );
 </script>
 
+<svelte:body on:mesure-modifiee={rafraichisServiceComplet} />
 <svelte:document
   onclick={interecepteNavigation}
   on:description-service-modifiee={rafraichisResumeService}
   on:contacts-utiles-service-modifiee={rafraichisServiceComplet}
   on:homologation-supprimee={rafraichisServiceComplet}
   on:homologation-modifiee={rafraichisServiceComplet}
-  on:mesure-modifiee={rafraichisServiceComplet}
   on:parcours-homologation-initie={rafraichisServiceComplet}
   on:homologation-finalisee={rafraichisServiceComplet}
 />


### PR DESCRIPTION
...l'évènement "mesure-modifiée" est émis sur le body et non le document. Il n'était donc pas traité et l'indice cyber n'était pas mis à jour dans l'onglet concerné.