### PR TITLE
[SOIN] Extrais une interface concrète pour l'adaptateur mail

### DIFF
--- a/admin/consoleAdministration.js
+++ b/admin/consoleAdministration.js
@@ -18,7 +18,7 @@ import * as FabriqueAutorisation from '../src/modeles/autorisations/fabriqueAuto
 import { EvenementCollaboratifServiceModifie } from '../src/modeles/journalMSS/evenementCollaboratifServiceModifie.js';
 import { fabriqueAdaptateurChiffrement } from '../src/adaptateurs/fabriqueAdaptateurChiffrement.js';
 import * as adaptateurRechercheEntrepriseAPI from '../src/adaptateurs/adaptateurRechercheEntrepriseAPI.js';
-import * as adaptateurMail from '../src/adaptateurs/adaptateurMailSendinblue.js';
+import { adaptateurMailSendinblue as adaptateurMail } from '../src/adaptateurs/adaptateurMailSendinblue.js';
 import CrmBrevo from '../src/crm/crmBrevo.js';
 import { verifieCoherenceDesDroits } from '../src/modeles/autorisations/gestionDroits.js';
 import BusEvenements from '../src/bus/busEvenements.js';

--- a/admin/duplicationEnMasseDeServices/duplicationEnMasseDeServices.js
+++ b/admin/duplicationEnMasseDeServices/duplicationEnMasseDeServices.js
@@ -11,7 +11,7 @@ import * as Referentiel from '../../src/referentiel.js';
 import donneesReferentiel from '../../donneesReferentiel.js';
 import * as AdaptateurPostgres from '../../src/adaptateurs/adaptateurPostgres.js';
 import { fabriqueProcedures } from '../../src/routes/procedures.js';
-import * as adaptateurMail from '../../src/adaptateurs/adaptateurMailSendinblue.js';
+import { adaptateurMailSendinblue as adaptateurMail } from '../../src/adaptateurs/adaptateurMailSendinblue.js';
 import fabriqueAdaptateurTracking from '../../src/adaptateurs/fabriqueAdaptateurTracking.js';
 import { EvenementServiceRattacheAPrestataire } from '../../src/bus/evenementServiceRattacheAPrestataire.js';
 import { cableTousLesAbonnes } from '../../src/bus/cablage.js';

--- a/scripts/taches/tacheEnvoieMailsNotificationExpiration.js
+++ b/scripts/taches/tacheEnvoieMailsNotificationExpiration.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 import * as DepotDonnees from '../../src/depotDonnees.js';
 import * as adaptateurEnvironnement from '../../src/adaptateurs/adaptateurEnvironnement.js';
-import * as adaptateurMail from '../../src/adaptateurs/adaptateurMailSendinblue.js';
+import { adaptateurMailSendinblue as adaptateurMail } from '../../src/adaptateurs/adaptateurMailSendinblue.js';
 import { envoieMailsNotificationExpirationHomologation } from '../../src/taches/envoieMailsNotificationExpirationHomologation.js';
 import { fabriqueAdaptateurHorloge } from '../../src/adaptateurs/adaptateurHorloge.js';
 

--- a/server.ts
+++ b/server.ts
@@ -6,12 +6,10 @@ import * as MSS from './src/mss.js';
 import { fabriqueAnnuaire } from './src/annuaire/serviceAnnuaire.js';
 import * as adaptateurCsv from './src/adaptateurs/adaptateurCsv.js';
 import * as adaptateurEnvironnement from './src/adaptateurs/adaptateurEnvironnement.js';
-import { sendinblue } from './src/adaptateurs/adaptateurEnvironnement.js';
 import { fabriqueAdaptateurGestionErreur } from './src/adaptateurs/fabriqueAdaptateurGestionErreur.js';
 import fabriqueAdaptateurTracking from './src/adaptateurs/fabriqueAdaptateurTracking.js';
 import { fabriqueAdaptateurHorloge } from './src/adaptateurs/adaptateurHorloge.js';
 import { fabriqueAdaptateurJWT } from './src/adaptateurs/adaptateurJWT.js';
-import * as adaptateurMailSendinblue from './src/adaptateurs/adaptateurMailSendinblue.js';
 import * as adaptateurPdf from './src/adaptateurs/adaptateurPdf.js';
 import * as lecteurDeFormData from './src/http/lecteurDeFormData.js';
 import * as adaptateurTeleversementServices from './src/adaptateurs/adaptateurTeleversementServices.xls.js';
@@ -32,10 +30,10 @@ import { fabriqueServiceCgu } from './src/serviceCgu.js';
 import ServiceSupervision from './src/supervision/serviceSupervision.js';
 import { fabriqueServiceGestionnaireSession } from './src/session/serviceGestionnaireSession.js';
 import { fabriqueServiceVerificationCoherenceSels } from './src/sel/serviceVerificationCoherenceSels.js';
-import { fabriqueAdaptateurMailMemoire } from './src/adaptateurs/adaptateurMailMemoire.js';
 import { fabriqueReferentiel } from './src/fabriqueReferentiel.js';
 import { ServiceAdministrationOrganisations } from './src/supervision/serviceAdministrationOrganisations.js';
 import { fabriqueAdaptateurUUID } from './src/adaptateurs/adaptateurUUID.js';
+import { fabriqueAdaptateurMail } from './src/adaptateurs/fabriqueAdaptateurMail.js';
 
 const adaptateurHorloge = fabriqueAdaptateurHorloge();
 const adaptateurProfilAnssi = fabriqueAdaptateurProfilAnssi();
@@ -46,9 +44,7 @@ const adaptateurJournal = fabriqueAdaptateurJournalMSS();
 const adaptateurChiffrement = fabriqueAdaptateurChiffrement();
 const adaptateurOidc = fabriqueAdaptateurOidc();
 const adaptateurSupervision = fabriqueAdaptateurSupervision();
-const adaptateurMail = sendinblue().clefAPIEmail()
-  ? adaptateurMailSendinblue
-  : fabriqueAdaptateurMailMemoire();
+const adaptateurMail = fabriqueAdaptateurMail();
 
 const busEvenements = new BusEvenements({ adaptateurGestionErreur });
 const port = process.env.PORT || 3000;

--- a/src/adaptateurs/adaptateurMail.interface.ts
+++ b/src/adaptateurs/adaptateurMail.interface.ts
@@ -1,3 +1,83 @@
-import * as adaptateurMail from './adaptateurMailSendinblue.js';
+import { UUID } from '../typesBasiques.js';
 
-export type AdaptateurMail = typeof adaptateurMail;
+type IdEntreprise = string;
+
+export interface AdaptateurMail {
+  creeContact(
+    destinataire: string,
+    prenom: string,
+    nom: string,
+    telephone: string,
+    bloqueNewsletter: boolean,
+    bloqueMarketing: boolean
+  ): Promise<void>;
+
+  creeEntreprise(
+    siret: string,
+    nom: string,
+    natureJuridique: string
+  ): Promise<IdEntreprise>;
+
+  desinscrisEmailsTransactionnels(destinataire: string): Promise<void>;
+
+  desinscrisInfolettre(destinataire: string): Promise<void>;
+
+  envoieMessageFelicitationHomologation(
+    destinataire: string,
+    idService: UUID
+  ): Promise<void>;
+
+  envoieMessageInvitationContribution(
+    destinataire: string,
+    prenomNomEmetteur: string,
+    nbServices: string
+  ): Promise<void>;
+
+  envoieMessageInvitationInscription(
+    destinataire: string,
+    prenomNomEmetteur: string,
+    nbServices: number
+  ): Promise<void>;
+
+  envoieNotificationExpirationHomologation(
+    destinataire: string,
+    idService: UUID,
+    delaiAvantExpirationMois: number
+  ): Promise<void>;
+
+  envoieMessageNominationAdmin(destinataire: string): Promise<void>;
+
+  inscrisEmailsTransactionnels(destinataire: string): Promise<void>;
+
+  inscrisInfolettre(destinataire: string): Promise<void>;
+
+  metAJourContact(
+    destinataire: string,
+    prenom: string,
+    nom: string,
+    telephone: string
+  ): Promise<void>;
+
+  metAJourDonneesContact(
+    destinataire: string,
+    donnees: Record<string, unknown>
+  ): Promise<void>;
+
+  recupereEntreprise(siret: string): Promise<IdEntreprise>;
+
+  recupereEntrepriseDuContact(idContact: string): Promise<IdEntreprise>;
+
+  recupereIdentifiantContact(email: string): Promise<string>;
+
+  relieContactAEntreprise(
+    idContact: string,
+    idEntreprise: IdEntreprise
+  ): Promise<void>;
+
+  supprimeContact(email: string): Promise<void>;
+
+  supprimeLienEntreContactEtEntreprise(
+    idContact: string,
+    idEntreprise: IdEntreprise
+  ): Promise<void>;
+}

--- a/src/adaptateurs/adaptateurMailMemoire.ts
+++ b/src/adaptateurs/adaptateurMailMemoire.ts
@@ -1,10 +1,11 @@
+/* eslint-disable no-console */
 import { emailMemoire } from './adaptateurEnvironnement.js';
+import { AdaptateurMail } from './adaptateurMail.interface.js';
 
 const fabriqueAdaptateurMailMemoire = () => {
   const doitLoguer = emailMemoire().logEmailDansConsole();
 
   const envoyer = (texte: string, ...args: unknown[]) => {
-    // eslint-disable-next-line no-console
     if (doitLoguer) console.log(texte, args);
   };
 
@@ -63,25 +64,24 @@ const fabriqueAdaptateurMailMemoire = () => {
 
   const recupereIdentifiantContact = async (email: string) => {
     if (doitLoguer)
-      // eslint-disable-next-line no-console
       console.log(
         `Récupération de l'identifiant Brevo pour l'utilisateur ${email}`
       );
-    return 42;
+    return '42';
   };
 
   const recupereEntreprise = async (siret: string) => {
     if (doitLoguer)
-      // eslint-disable-next-line no-console
       console.log(`Récupération de l'entreprise Brevo pour le SIRET ${siret}`);
+    return 'ID-ENTREPRISE-FACTICE';
   };
 
   const recupereEntrepriseDuContact = async (idContact: string) => {
     if (doitLoguer)
-      // eslint-disable-next-line no-console
       console.log(
         `Récupération de l'entreprise Brevo pour le contact ${idContact}`
       );
+    return 'ID-ENTREPRISE-FACTICE';
   };
 
   const relieContactAEntreprise = async (
@@ -89,7 +89,6 @@ const fabriqueAdaptateurMailMemoire = () => {
     idEntreprise: string
   ) => {
     if (doitLoguer)
-      // eslint-disable-next-line no-console
       console.log(
         `Relie l'utilisateur ${idContact} à l'entreprise Brevo ${idEntreprise}`
       );
@@ -100,7 +99,6 @@ const fabriqueAdaptateurMailMemoire = () => {
     idEntreprise: string
   ) => {
     if (doitLoguer)
-      // eslint-disable-next-line no-console
       console.log(
         `Supprime le lien entre l'utilisateur ${idContact} à l'entreprise Brevo ${idEntreprise}`
       );
@@ -108,18 +106,16 @@ const fabriqueAdaptateurMailMemoire = () => {
 
   const creeEntreprise = async (...args: unknown[]) => {
     if (doitLoguer)
-      // eslint-disable-next-line no-console
       console.log(
         `Création d'une entreprise Brevo avec les paramètres: ${JSON.stringify(
           args
         )}`
       );
+    return 'ID-ENTREPRISE-FACTICE';
   };
 
   const supprimeContact = async (email: string) => {
-    if (doitLoguer)
-      // eslint-disable-next-line no-console
-      console.log(`Suppression du contact ${email}`);
+    if (doitLoguer) console.log(`Suppression du contact ${email}`);
   };
 
   return {
@@ -142,7 +138,7 @@ const fabriqueAdaptateurMailMemoire = () => {
     relieContactAEntreprise,
     supprimeContact,
     supprimeLienEntreContactEtEntreprise,
-  };
+  } satisfies AdaptateurMail;
 };
 
 export { fabriqueAdaptateurMailMemoire };

--- a/src/adaptateurs/adaptateurMailSendinblue.ts
+++ b/src/adaptateurs/adaptateurMailSendinblue.ts
@@ -3,6 +3,7 @@ import { fabriqueAdaptateurGestionErreur } from './fabriqueAdaptateurGestionErre
 import { enCadence } from '../utilitaires/pThrottle.js';
 import { UUID } from '../typesBasiques.js';
 import { ErreurApiBrevo } from '../erreurs.js';
+import { AdaptateurMail } from './adaptateurMail.interface.js';
 
 const enteteJSON = {
   headers: {
@@ -435,10 +436,10 @@ const envoieNotificationExpirationHomologationCadencee = async (
   );
 };
 
-export {
+export const adaptateurMailSendinblue = {
   creeContact,
   metAJourContact,
-  metAJourDonneesContactCadencee as metAJourDonneesContact,
+  metAJourDonneesContact: metAJourDonneesContactCadencee,
   creeEntreprise,
   desinscrisEmailsTransactionnels,
   desinscrisInfolettre,
@@ -448,11 +449,12 @@ export {
   envoieMessageInvitationContribution,
   envoieMessageInvitationInscription,
   envoieMessageNominationAdmin,
-  envoieNotificationExpirationHomologationCadencee as envoieNotificationExpirationHomologation,
+  envoieNotificationExpirationHomologation:
+    envoieNotificationExpirationHomologationCadencee,
   recupereEntreprise,
   recupereEntrepriseDuContact,
   recupereIdentifiantContact,
   relieContactAEntreprise,
   supprimeContact,
   supprimeLienEntreContactEtEntreprise,
-};
+} satisfies AdaptateurMail;

--- a/src/adaptateurs/fabriqueAdaptateurMail.ts
+++ b/src/adaptateurs/fabriqueAdaptateurMail.ts
@@ -1,0 +1,9 @@
+import { sendinblue } from './adaptateurEnvironnement.js';
+import { adaptateurMailSendinblue } from './adaptateurMailSendinblue.js';
+import { fabriqueAdaptateurMailMemoire } from './adaptateurMailMemoire.js';
+import { AdaptateurMail } from './adaptateurMail.interface.js';
+
+export const fabriqueAdaptateurMail = (): AdaptateurMail =>
+  sendinblue().clefAPIEmail()
+    ? adaptateurMailSendinblue
+    : fabriqueAdaptateurMailMemoire();


### PR DESCRIPTION
Pour simplifier le raisonnement : on préfère des interfaces explicites. Le `satisfies AdaptateurMail` est ce qui nous assure que l'implémentation Brevo respecte le contrat.

Note : dans le typage, le "id contact" renvoyé par `recupereIdentifiantContact()` est ici un string. Dans les faits, Brevo renvoie un number. Mais les autres méthodes de l'adaptateur qui parlent d'ID contact utilisent un string… donc on préfère retourner un string même dans l'adaptateur mémoire.