### PR TITLE
[ADMIN] Vérification de l'existence de l'email de l'admin à nommer

### DIFF
--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import z from 'zod';
 import { RequestRouteConnecte } from './routesConnecte.types.js';
 import { ServiceAdministrationOrganisations } from '../../supervision/serviceAdministrationOrganisations.js';
 import { valideBody } from '../../http/validePayloads.js';
@@ -43,6 +44,24 @@ const routesConnecteApiAdmin = ({
       }))
     );
   });
+
+  routes.post(
+    '/verifieEmail',
+    valideBody(z.strictObject({ email: z.email() })),
+    async (requete, reponse) => {
+      const { idUtilisateurCourant } = requete as RequestRouteConnecte;
+      const superviseur =
+        await depotDonnees.lisSuperviseur(idUtilisateurCourant);
+      if (!superviseur) {
+        reponse.sendStatus(403);
+        return;
+      }
+
+      const cible = await depotDonnees.utilisateurAvecEmail(requete.body.email);
+
+      reponse.json({ existe: !!cible });
+    }
+  );
 
   routes.post(
     '/nomme',

--- a/svelte/lib/adminEntites/TiroirGestion/SaisieEmailAdmin.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/SaisieEmailAdmin.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { api } from '../adminEntites.api';
+
+  interface Props {
+    onemailvalide: (email: string) => void;
+  }
+
+  let { onemailvalide }: Props = $props();
+
+  let nouvelAdmin = $state('');
+  let emailValide = $state(true);
+
+  const metAJourEmail = (email: string) => {
+    nouvelAdmin = email;
+    emailValide = true;
+  };
+
+  const valide = async () => {
+    emailValide = (await api.verifieEmail(nouvelAdmin)).existe;
+    if (!emailValide) return;
+
+    onemailvalide(nouvelAdmin);
+    nouvelAdmin = '';
+  };
+</script>
+
+<dsfr-input
+  value={nouvelAdmin}
+  onvaluechanged={(e: CustomEvent<string>) => metAJourEmail(e.detail)}
+  type="email"
+  label="Ajouter un administrateur"
+  hint="Vous pouvez ajouter un administrateur via son adresse e-mail."
+  status={emailValide ? 'info' : 'error'}
+  infoMessage="L’utilisateur doit toutefois déjà disposer d’un compte sur MonServiceSécurisé ; dans le cas contraire, il ne pourra pas être ajouté en tant qu’administrateur."
+></dsfr-input>
+<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+<dsfr-button label="Nommer admin" size="sm" onclick={async () => await valide()}
+></dsfr-button>

--- a/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
@@ -3,6 +3,7 @@
   import ActionsTiroir from '../../ui/tiroirs/ActionsTiroir.svelte';
   import ListeAdmins from './ListeAdmins.svelte';
   import CartoucheAdmin from './CartoucheAdmin.svelte';
+  import SaisieEmailAdmin from './SaisieEmailAdmin.svelte';
   import type { EntiteSupervisee } from '../adminEntites.types';
   import { untrack } from 'svelte';
   import { tiroirStore } from '../../ui/stores/tiroir.store';
@@ -20,19 +21,16 @@
     'Invitez et gérez les administrateurs de votre entité';
 
   let etatAffichage: 'LISTE' | 'INVITATION' = $state('LISTE');
-  let nouvelAdmin = $state('');
   const listeAdminsAInviter: SvelteSet<string> = new SvelteSet<string>();
 
-  const inviteAdmin = () => {
+  const inviteAdmin = (email: string) => {
     etatAffichage = 'INVITATION';
-    listeAdminsAInviter.add(nouvelAdmin);
-    nouvelAdmin = '';
+    listeAdminsAInviter.add(email);
   };
 
   const retourModeListe = () => {
     etatAffichage = 'LISTE';
     listeAdminsAInviter.clear();
-    nouvelAdmin = '';
   };
 
   const envoieInvitations = async () => {
@@ -47,18 +45,7 @@
 </script>
 
 <ContenuTiroir>
-  <dsfr-input
-    value={nouvelAdmin}
-    onvaluechanged={(e: CustomEvent<string>) => (nouvelAdmin = e.detail)}
-    type="email"
-    label="Ajouter un administrateur"
-    hint="Vous pouvez ajouter un administrateur via son adresse e-mail."
-    status="info"
-    infoMessage="L’utilisateur doit toutefois déjà disposer d’un compte sur MonServiceSécurisé ; dans le cas contraire, il ne pourra pas être ajouté en tant qu’administrateur."
-  ></dsfr-input>
-  <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-  <dsfr-button label="Nommer admin" size="sm" onclick={() => inviteAdmin()}
-  ></dsfr-button>
+  <SaisieEmailAdmin onemailvalide={inviteAdmin} />
 
   <div class="conteneur-admins">
     {#if etatAffichage === 'LISTE'}

--- a/svelte/lib/adminEntites/adminEntites.api.ts
+++ b/svelte/lib/adminEntites/adminEntites.api.ts
@@ -1,10 +1,23 @@
+import type { AxiosError } from 'axios';
 import type { EntiteSupervisee } from './adminEntites.types';
 
 export const api = {
   entitesDansMonPerimetre: async (): Promise<Array<EntiteSupervisee>> =>
     (await axios.get<Array<EntiteSupervisee>>('/api/admin/entites')).data,
+
   envoieInvitations: async (
     emails: Array<string>,
     siret: string
   ): Promise<void> => await axios.post('/api/admin/nomme', { emails, siret }),
+
+  verifieEmail: async (email: string): Promise<{ existe: boolean }> => {
+    try {
+      const { data } = await axios.post('/api/admin/verifieEmail', { email });
+      return data;
+    } catch (e) {
+      if ((e as AxiosError)?.response?.status === 400) return { existe: false };
+
+      throw e;
+    }
+  },
 };

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -2,7 +2,7 @@ import testeurMSS from '../testeurMSS.js';
 import { DonneesEntite } from '../../../src/modeles/entite.ts';
 import { UUID } from '../../../src/typesBasiques.ts';
 import { unUtilisateur } from '../../constructeurs/constructeurUtilisateur.js';
-import { unUUID } from '../../constructeurs/UUID.ts';
+import { unUUID, unUUIDRandom } from '../../constructeurs/UUID.ts';
 import Superviseur from '../../../src/modeles/superviseur.ts';
 
 describe('Le serveur MSS des routes /api/admin/*', () => {
@@ -81,6 +81,48 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
           postes: ['RSSI'],
         },
       ]);
+    });
+  });
+
+  describe('quand requete POST sur `/api/admin/verifieEmail', () => {
+    beforeEach(() => {
+      testeur.depotDonnees().lisSuperviseur = async () =>
+        Superviseur.nouveau(unUUIDRandom());
+    });
+
+    it("renvoie une erreur 403 si l'utilisateur courant n'est pas superviseur", async () => {
+      testeur.depotDonnees().lisSuperviseur = async () => undefined;
+
+      const { status } = await testeur.post('/api/admin/verifieEmail', {
+        email: 'a@a.fr',
+      });
+
+      expect(status).toBe(403);
+    });
+
+    it("jette une erreur 400 si l'email est invalide", async () => {
+      const { status } = await testeur.post('/api/admin/verifieEmail', {
+        email: 'pasUnEmail',
+      });
+      expect(status).toBe(400);
+    });
+
+    it("renvoie l'information de l'existence ou non de l'email", async () => {
+      testeur.depotDonnees().utilisateurAvecEmail = async (email: string) => {
+        if (email === 'existe@societe.fr') return unUtilisateur().donnees;
+
+        return undefined;
+      };
+
+      const oui = await testeur.post('/api/admin/verifieEmail', {
+        email: 'existe@societe.fr',
+      });
+      expect(oui.body).toEqual({ existe: true });
+
+      const non = await testeur.post('/api/admin/verifieEmail', {
+        email: 'fantome@societe.fr',
+      });
+      expect(non.body).toEqual({ existe: false });
     });
   });
 


### PR DESCRIPTION
Cette PR ajoute la vérification de l'email saisi par le superviseur lorsqu'il veut nommer un admin.

Si l'email n'existe pas : 👇 
<img width="500" src="https://github.com/user-attachments/assets/998e9c42-2cf8-4c68-a5e6-745a822b4aa3" />
