### PR TITLE
Affichage d'une illustration en cas d'absence d'admins

### DIFF
--- a/svelte/lib/adminEntites/TiroirGestion/AucunAdmin.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/AucunAdmin.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+</script>
+
+<div class="etat-vide">
+  <img
+    src="/statique/assets/images/illustration_recherche_vide.svg"
+    alt=""
+    width="128"
+    height="128"
+  />
+  <div class="contenu">
+    <h3>Aucun admin ajouté à cette entité</h3>
+    <p>
+      Ajoutez un premier admin pour déléguer la gestion et le suivi de vos
+      entités.
+    </p>
+  </div>
+</div>
+
+<style lang="scss">
+  .etat-vide {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding-bottom: 8px;
+    text-align: center;
+    margin-top: 2rem;
+
+    .contenu {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      h3 {
+        font-size: 1.5rem;
+        line-height: 2rem;
+        font-weight: 700;
+        color: #161616;
+        margin: 0;
+      }
+
+      p {
+        font-size: 1.125rem;
+        line-height: 1.75rem;
+        color: #3a3a3a;
+        margin: 0;
+      }
+    }
+  }
+</style>

--- a/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
@@ -9,11 +9,6 @@
   let { administrateurs }: Props = $props();
 </script>
 
-<hr />
-<h3>Administrateurs de l’entité</h3>
-<span class="sous-titre"
-  >Consultez la liste des utilisateurs disposant des droits admins.</span
->
 <div class="conteneur-cartouches">
   {#each administrateurs as admin, i (i)}
     <CartoucheAdmin
@@ -25,22 +20,6 @@
 </div>
 
 <style>
-  hr {
-    border: none;
-    border-top: 1px solid #dddddd;
-  }
-  h3 {
-    font-size: 1rem;
-    line-height: 1.5rem;
-    font-weight: 700;
-    margin-bottom: 4px;
-  }
-  .sous-titre {
-    font-size: 0.75rem;
-    line-height: 1.125rem;
-    color: #666666;
-  }
-
   .conteneur-cartouches {
     margin-top: 32px;
     display: flex;

--- a/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
@@ -10,6 +10,7 @@
   import { toasterStore } from '../../ui/stores/toaster.store';
   import { api } from '../adminEntites.api';
   import { SvelteSet } from 'svelte/reactivity';
+  import AucunAdmin from './AucunAdmin.svelte';
 
   interface Props {
     entite: EntiteSupervisee;
@@ -49,8 +50,19 @@
 
   <div class="conteneur-admins">
     {#if etatAffichage === 'LISTE'}
-      <ListeAdmins administrateurs={entite.administrateurs} />
-    {:else}
+      <hr />
+      <h3>Administrateurs de l’entité</h3>
+      <span class="sous-titre">
+        Consultez la liste des utilisateurs disposant des droits admins.
+      </span>
+      {#if entite.administrateurs.length === 0}
+        <AucunAdmin />
+      {:else}
+        <ListeAdmins administrateurs={entite.administrateurs} />
+      {/if}
+    {/if}
+
+    {#if etatAffichage === 'INVITATION'}
       <div class="conteneur-cartouches">
         {#each listeAdminsAInviter as emailAdmin, i (i)}
           <CartoucheAdmin prenomNom={emailAdmin} />
@@ -85,6 +97,22 @@
       display: flex;
       flex-direction: column;
       gap: 12px;
+    }
+
+    hr {
+      border: none;
+      border-top: 1px solid #dddddd;
+    }
+    h3 {
+      font-size: 1rem;
+      line-height: 1.5rem;
+      font-weight: 700;
+      margin-bottom: 4px;
+    }
+    .sous-titre {
+      font-size: 0.75rem;
+      line-height: 1.125rem;
+      color: #666666;
     }
   }
 </style>


### PR DESCRIPTION
Cette PR rajoute l'affichage "aucun admin" :

<img width="550" src="https://github.com/user-attachments/assets/748ab03c-2d1e-45b9-94bd-638683edd55c" />
