### PR TITLE
[ADMIN] Égalise l'écran de gestion des entités pour les admins

### DIFF
--- a/src/adaptateurs/adaptateurPostgresTS.ts
+++ b/src/adaptateurs/adaptateurPostgresTS.ts
@@ -27,6 +27,13 @@ export class AdaptateurPostgresTS implements PersistanceTS {
   }
 
   async sauvegardeAdminOrganisations(donnees: DonneesAdminOrganisations) {
+    if (donnees.entitesAdministrees.length === 0) {
+      await this.knex(TABLES.ADMINS_ORGANISATIONS)
+        .where('id_utilisateur', donnees.idUtilisateur)
+        .delete();
+      return;
+    }
+
     const donneesAInserer = await Promise.all(
       donnees.entitesAdministrees.map(async (d) => ({
         id_utilisateur: donnees.idUtilisateur,
@@ -37,6 +44,7 @@ export class AdaptateurPostgresTS implements PersistanceTS {
     const siretsHashAConserver = donneesAInserer.map((d) => d.siret_hash);
     await this.knex(TABLES.ADMINS_ORGANISATIONS)
       .whereNotIn('siret_hash', siretsHashAConserver)
+      .where('id_utilisateur', donnees.idUtilisateur)
       .delete();
     await this.knex(TABLES.ADMINS_ORGANISATIONS)
       .insert(donneesAInserer)

--- a/src/adaptateurs/adaptateurPostgresTS.ts
+++ b/src/adaptateurs/adaptateurPostgresTS.ts
@@ -85,6 +85,11 @@ export class AdaptateurPostgresTS implements PersistanceTS {
   }
 
   async sauvegardeSuperviseur(donnees: DonneesSuperviseur): Promise<void> {
+    if (donnees.entitesSupervisees.length === 0) {
+      await this.supprimeSuperviseur(donnees.idUtilisateur);
+      return;
+    }
+
     const donneesAInserer = await Promise.all(
       donnees.entitesSupervisees.map(async (d) => ({
         id_superviseur: donnees.idUtilisateur,

--- a/src/modeles/gestionOrganisations/adminOrganisations.ts
+++ b/src/modeles/gestionOrganisations/adminOrganisations.ts
@@ -46,4 +46,8 @@ export class AdminOrganisations {
       (e) => e.siret !== entite.siret
     );
   }
+
+  estAdminDe(siret: string) {
+    return this.entitesAdministrees.some((e) => e.siret === siret);
+  }
 }

--- a/src/modeles/superviseur.ts
+++ b/src/modeles/superviseur.ts
@@ -33,7 +33,7 @@ class Superviseur {
   }
 
   estSuperviseurDe(siret: string) {
-    return this.entitesSupervisees.map((e) => e.siret).includes(siret);
+    return this.entitesSupervisees.some((e) => e.siret === siret);
   }
 
   donnees(): DonneesSuperviseur {

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -422,7 +422,11 @@ const routesConnecteApi = ({
   routes.use(
     '/admin',
     middleware.verificationAcceptationCGU,
-    routesConnecteApiAdmin({ depotDonnees, serviceAdministrationOrganisations })
+    routesConnecteApiAdmin({
+      depotDonnees,
+      middleware,
+      serviceAdministrationOrganisations,
+    })
   );
 
   routes.post(

--- a/src/routes/connecte/routesConnecteApiAdmin.schema.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.schema.ts
@@ -5,3 +5,8 @@ export const schemaPostAdminNomme = z.strictObject({
   emails: z.array(z.email()).min(1).max(50),
   siret: schemaSiret.siret(),
 });
+
+export const schemaDeleteAdmin = z.strictObject({
+  siret: schemaSiret.siret(),
+  idUtilisateur: z.uuid(),
+});

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -10,6 +10,7 @@ import {
 import { DepotDonnees } from '../../depotDonnees.interface.js';
 import { UUID } from '../../typesBasiques.js';
 import { Middleware } from '../../http/middleware.interface.js';
+import { ErreurSuppressionImpossible } from '../../erreurs.js';
 
 type Configuration = {
   depotDonnees: DepotDonnees;
@@ -114,7 +115,7 @@ const routesConnecteApiAdmin = ({
   routes.delete(
     '/',
     valideBody(schemaDeleteAdmin),
-    async (requete, reponse) => {
+    async (requete, reponse, suite) => {
       const { siret, idUtilisateur } = requete.body;
       const { idUtilisateurCourant } = requete as RequestRouteConnecte;
 
@@ -123,11 +124,19 @@ const routesConnecteApiAdmin = ({
         return;
       }
 
-      await serviceAdministrationOrganisations.retireAdmin(
-        siret,
-        idUtilisateur as UUID
-      );
-      reponse.sendStatus(200);
+      try {
+        await serviceAdministrationOrganisations.retireAdmin(
+          siret,
+          idUtilisateur as UUID
+        );
+        reponse.sendStatus(200);
+      } catch (erreur) {
+        if (erreur instanceof ErreurSuppressionImpossible) {
+          reponse.sendStatus(422);
+          return;
+        }
+        suite(erreur);
+      }
     }
   );
 

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -38,8 +38,15 @@ const routesConnecteApiAdmin = ({
 
     const entites =
       await serviceAdministrationOrganisations.entitesDe(idUtilisateurCourant);
+    const entitesAvecInfoUtilisateurCourant = entites.map((e) => ({
+      ...e,
+      administrateurs: e.administrateurs.map((a) => ({
+        ...a,
+        estUtilisateurCourant: a.id === idUtilisateurCourant,
+      })),
+    }));
 
-    reponse.json(entites);
+    reponse.json(entitesAvecInfoUtilisateurCourant);
   });
 
   routes.get('/utilisateurs', async (requete, reponse) => {

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -9,14 +9,17 @@ import {
 } from './routesConnecteApiAdmin.schema.js';
 import { DepotDonnees } from '../../depotDonnees.interface.js';
 import { UUID } from '../../typesBasiques.js';
+import { Middleware } from '../../http/middleware.interface.js';
 
 type Configuration = {
   depotDonnees: DepotDonnees;
+  middleware: Middleware;
   serviceAdministrationOrganisations: ServiceAdministrationOrganisations;
 };
 
 const routesConnecteApiAdmin = ({
   depotDonnees,
+  middleware,
   serviceAdministrationOrganisations,
 }: Configuration) => {
   const routes = express.Router();
@@ -61,6 +64,7 @@ const routesConnecteApiAdmin = ({
 
   routes.post(
     '/verifieEmail',
+    middleware.protegeTrafic(),
     valideBody(z.strictObject({ email: z.email() })),
     async (requete, reponse) => {
       const { idUtilisateurCourant } = requete as RequestRouteConnecte;

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -3,8 +3,12 @@ import z from 'zod';
 import { RequestRouteConnecte } from './routesConnecte.types.js';
 import { ServiceAdministrationOrganisations } from '../../supervision/serviceAdministrationOrganisations.js';
 import { valideBody } from '../../http/validePayloads.js';
-import { schemaPostAdminNomme } from './routesConnecteApiAdmin.schema.js';
+import {
+  schemaDeleteAdmin,
+  schemaPostAdminNomme,
+} from './routesConnecteApiAdmin.schema.js';
 import { DepotDonnees } from '../../depotDonnees.interface.js';
+import { UUID } from '../../typesBasiques.js';
 
 type Configuration = {
   depotDonnees: DepotDonnees;
@@ -16,6 +20,14 @@ const routesConnecteApiAdmin = ({
   serviceAdministrationOrganisations,
 }: Configuration) => {
   const routes = express.Router();
+
+  const estAutoriseSurSiret = async (idUtilisateur: UUID, siret: string) => {
+    const superviseur = await depotDonnees.lisSuperviseur(idUtilisateur);
+    if (superviseur?.estSuperviseurDe(siret)) return true;
+
+    const admin = await depotDonnees.lisAdminOrganisations(idUtilisateur);
+    return admin ? admin.estAdminDe(siret) : false;
+  };
 
   routes.get('/entites', async (requete, reponse) => {
     const { idUtilisateurCourant } = requete as RequestRouteConnecte;
@@ -75,16 +87,7 @@ const routesConnecteApiAdmin = ({
       const { emails, siret } = requete.body;
       const { idUtilisateurCourant } = requete as RequestRouteConnecte;
 
-      const superviseur =
-        await depotDonnees.lisSuperviseur(idUtilisateurCourant);
-      const nonPourSuperviseur =
-        !superviseur || !superviseur.estSuperviseurDe(siret);
-
-      const admin =
-        await depotDonnees.lisAdminOrganisations(idUtilisateurCourant);
-      const nonPourAdmin = !admin || !admin.estAdminDe(siret);
-
-      if (nonPourSuperviseur && nonPourAdmin) {
+      if (!(await estAutoriseSurSiret(idUtilisateurCourant, siret))) {
         reponse.sendStatus(403);
         return;
       }
@@ -100,6 +103,26 @@ const routesConnecteApiAdmin = ({
       };
 
       await Promise.all([...new Set(emails)].map(nommeAdmin));
+      reponse.sendStatus(200);
+    }
+  );
+
+  routes.delete(
+    '/',
+    valideBody(schemaDeleteAdmin),
+    async (requete, reponse) => {
+      const { siret, idUtilisateur } = requete.body;
+      const { idUtilisateurCourant } = requete as RequestRouteConnecte;
+
+      if (!(await estAutoriseSurSiret(idUtilisateurCourant, siret))) {
+        reponse.sendStatus(403);
+        return;
+      }
+
+      await serviceAdministrationOrganisations.retireAdmin(
+        siret,
+        idUtilisateur as UUID
+      );
       reponse.sendStatus(200);
     }
   );

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -54,7 +54,10 @@ const routesConnecteApiAdmin = ({
       const { idUtilisateurCourant } = requete as RequestRouteConnecte;
       const superviseur =
         await depotDonnees.lisSuperviseur(idUtilisateurCourant);
-      if (!superviseur) {
+      const admin =
+        await depotDonnees.lisAdminOrganisations(idUtilisateurCourant);
+
+      if (!superviseur && !admin) {
         reponse.sendStatus(403);
         return;
       }
@@ -74,7 +77,14 @@ const routesConnecteApiAdmin = ({
 
       const superviseur =
         await depotDonnees.lisSuperviseur(idUtilisateurCourant);
-      if (!superviseur || !superviseur.estSuperviseurDe(siret)) {
+      const nonPourSuperviseur =
+        !superviseur || !superviseur.estSuperviseurDe(siret);
+
+      const admin =
+        await depotDonnees.lisAdminOrganisations(idUtilisateurCourant);
+      const nonPourAdmin = !admin || !admin.estAdminDe(siret);
+
+      if (nonPourSuperviseur && nonPourAdmin) {
         reponse.sendStatus(403);
         return;
       }

--- a/src/routes/connecte/routesConnecteApiAdmin.ts
+++ b/src/routes/connecte/routesConnecteApiAdmin.ts
@@ -119,6 +119,11 @@ const routesConnecteApiAdmin = ({
       const { siret, idUtilisateur } = requete.body;
       const { idUtilisateurCourant } = requete as RequestRouteConnecte;
 
+      if (idUtilisateurCourant === idUtilisateur) {
+        reponse.sendStatus(400);
+        return;
+      }
+
       if (!(await estAutoriseSurSiret(idUtilisateurCourant, siret))) {
         reponse.sendStatus(403);
         return;

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -15,7 +15,12 @@ import { UtilisateurAdministre } from '../modeles/gestionOrganisations/utilisate
 import { ErreurSuppressionImpossible } from '../erreurs.js';
 
 export type DonneesEntiteSupervisee = DonneesEntite & {
-  administrateurs: Array<{ id: UUID; prenomNom: string }>;
+  administrateurs: Array<{
+    id: UUID;
+    prenomNom: string;
+    initiales: string;
+    postes: string;
+  }>;
   nombreServices: number;
   nombreUtilisateurs: number;
 };

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -134,9 +134,14 @@ export class ServiceAdministrationOrganisations {
 
   async entitesDe(
     idUtilisateur: UUID
-  ): Promise<Array<DonneesEntite | DonneesEntiteSupervisee>> {
+  ): Promise<Array<DonneesEntiteSupervisee>> {
     const admin = await this.depotDonnees.lisAdminOrganisations(idUtilisateur);
-    if (admin) return admin.donnees().entitesAdministrees;
+    if (admin) {
+      const toutesEntites = admin.donnees().entitesAdministrees;
+      return Promise.all(
+        toutesEntites.map((e) => this.enrichisEntiteSupervisee(e))
+      );
+    }
 
     const superviseur = await this.depotDonnees.lisSuperviseur(idUtilisateur);
     if (superviseur) {
@@ -153,7 +158,7 @@ export class ServiceAdministrationOrganisations {
     uneEntite: DonneesEntite
   ): Promise<DonneesEntiteSupervisee> {
     const admins = await this.depotDonnees.lisAdminsPour(uneEntite.siret);
-    const administrateurs = await Promise.all(
+    const enUtilisateurs = await Promise.all(
       admins.map((a) =>
         this.depotDonnees.utilisateur(a.donnees().idUtilisateur)
       )
@@ -171,7 +176,7 @@ export class ServiceAdministrationOrganisations {
           s.contributeurs.map((c: Contributeur) => c.idUtilisateur)
         )
       ).size,
-      administrateurs: administrateurs.map((u) => ({
+      administrateurs: enUtilisateurs.map((u) => ({
         prenomNom: u!.prenomNom(),
         initiales: u!.initiales(),
         postes: u!.posteDetaille(),

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -14,7 +14,7 @@ import { AdaptateurMail } from '../adaptateurs/adaptateurMail.interface.js';
 import { UtilisateurAdministre } from '../modeles/gestionOrganisations/utilisateurAdministre.js';
 
 export type DonneesEntiteSupervisee = DonneesEntite & {
-  administrateurs: Array<{ prenomNom: string }>;
+  administrateurs: Array<{ id: UUID; prenomNom: string }>;
   nombreServices: number;
   nombreUtilisateurs: number;
 };
@@ -177,6 +177,7 @@ export class ServiceAdministrationOrganisations {
         )
       ).size,
       administrateurs: enUtilisateurs.map((u) => ({
+        id: u!.id,
         prenomNom: u!.prenomNom(),
         initiales: u!.initiales(),
         postes: u!.posteDetaille(),

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -80,10 +80,18 @@ export class ServiceAdministrationOrganisations {
     );
   }
 
-  // eslint-disable-next-line class-methods-use-this
   async retireAdmin(siret: string, idUtilisateur: UUID) {
-    // eslint-disable-next-line no-console
-    console.log('retireAdmin', { siret, idUtilisateur });
+    const admin = await this.depotDonnees.lisAdminOrganisations(idUtilisateur);
+
+    if (!admin) return;
+
+    admin?.cesseDAdministrer(new Entite({ siret }));
+    await this.depotDonnees.sauvegardeAdminOrganisations(admin!);
+
+    const services = await this.depotDonnees.tousLesServicesAvecSiret(siret);
+    await Promise.all(
+      services.map((service) => this.rattacheLesAdministrateursDe(service))
+    );
   }
 
   async nommeAdmin(siret: string, idAdmin: UUID, emailAdmin: string) {

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -80,6 +80,12 @@ export class ServiceAdministrationOrganisations {
     );
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  async retireAdmin(siret: string, idUtilisateur: UUID) {
+    // eslint-disable-next-line no-console
+    console.log('retireAdmin', { siret, idUtilisateur });
+  }
+
   async nommeAdmin(siret: string, idAdmin: UUID, emailAdmin: string) {
     await this.ajouteSiretAAdmin(siret, idAdmin);
 

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -12,6 +12,7 @@ import { AdaptateurRechercheEntreprise } from '../adaptateurs/adaptateurRecherch
 import { Contributeur } from '../modeles/contributeur.js';
 import { AdaptateurMail } from '../adaptateurs/adaptateurMail.interface.js';
 import { UtilisateurAdministre } from '../modeles/gestionOrganisations/utilisateurAdministre.js';
+import { ErreurSuppressionImpossible } from '../erreurs.js';
 
 export type DonneesEntiteSupervisee = DonneesEntite & {
   administrateurs: Array<{ id: UUID; prenomNom: string }>;
@@ -85,10 +86,12 @@ export class ServiceAdministrationOrganisations {
 
     if (!admin) return;
 
+    const services = await this.depotDonnees.tousLesServicesAvecSiret(siret);
+    if (services.some((s) => s.contributeurs.length === 1))
+      throw new ErreurSuppressionImpossible();
+
     admin?.cesseDAdministrer(new Entite({ siret }));
     await this.depotDonnees.sauvegardeAdminOrganisations(admin!);
-
-    const services = await this.depotDonnees.tousLesServicesAvecSiret(siret);
     await Promise.all(
       services.map((service) => this.rattacheLesAdministrateursDe(service))
     );

--- a/svelte/lib/adminEntites/AdminEntites.svelte
+++ b/svelte/lib/adminEntites/AdminEntites.svelte
@@ -2,10 +2,13 @@
   import { onMount } from 'svelte';
   import { api } from './adminEntites.api';
   import type { EntiteSupervisee } from './adminEntites.types';
-  import TiroirGestionAdmins from './TiroirGestion/TiroirGestionAdmins.svelte';
-  import { tiroirStore } from '../ui/stores/tiroir.store';
   import Toaster from '../ui/Toaster.svelte';
   import Tuiles from './Tuiles.svelte';
+  import BadgeAdministrateur from './LignesDuTableau/BadgeAdministrateur.svelte';
+  import NombreServices from './LignesDuTableau/NombreServices.svelte';
+  import NombreUtilisateurs from './LignesDuTableau/NombreUtilisateurs.svelte';
+  import NommerUnAdmin from './LignesDuTableau/NommerUnAdmin.svelte';
+  import GererLesAdmins from './LignesDuTableau/GererLesAdmins.svelte';
 
   let mesEntites: Array<EntiteSupervisee> = $state([]);
 
@@ -42,58 +45,21 @@
       <span><b>{entite.nom}</b></span>
     </div>
     <div slot="cell:admins:{i}" class="conteneur-admins">
-      {#each entite.administrateurs as administrateur, j (j)}
-        <dsfr-badge
-          label={administrateur.prenomNom}
-          type="accent"
-          accent="blue-ecume"
-          size="sm"
-        ></dsfr-badge>
+      {#each entite.administrateurs as { prenomNom }, j (j)}
+        <BadgeAdministrateur {prenomNom} />
       {/each}
     </div>
     <div slot="cell:nombreServices:{i}">
-      <span>
-        {#if entite.nombreServices === 0}
-          Aucun service
-        {:else}
-          {entite.nombreServices} service{entite.nombreServices > 1 ? 's' : ''}
-        {/if}
-      </span>
+      <NombreServices nombreServices={entite.nombreServices} />
     </div>
     <div slot="cell:nombreUtilisateurs:{i}">
-      <span>
-        {#if entite.nombreUtilisateurs === 0}
-          Aucun utilisateur
-        {:else}
-          {entite.nombreUtilisateurs} utilisateur{entite.nombreUtilisateurs > 1
-            ? 's'
-            : ''}
-        {/if}
-      </span>
+      <NombreUtilisateurs nombreUtilisateurs={entite.nombreUtilisateurs} />
     </div>
     <div slot="cell:actions:{i}">
       {#if entite.administrateurs.length === 0}
-        <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-        <dsfr-button
-          kind="primary"
-          label="Nommer un admin"
-          size="sm"
-          hasIcon
-          icon="add-line"
-          onclick={() => {
-            tiroirStore.afficheContenu(TiroirGestionAdmins, { entite });
-          }}
-        ></dsfr-button>
+        <NommerUnAdmin {entite} />
       {:else}
-        <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
-        <dsfr-button
-          kind="secondary"
-          label="Gérer les admins"
-          size="sm"
-          onclick={() => {
-            tiroirStore.afficheContenu(TiroirGestionAdmins, { entite });
-          }}
-        ></dsfr-button>
+        <GererLesAdmins {entite} />
       {/if}
     </div>
   {/each}
@@ -121,9 +87,5 @@
     display: flex;
     gap: 8px;
     flex-wrap: wrap;
-  }
-
-  dsfr-button {
-    white-space: nowrap;
   }
 </style>

--- a/svelte/lib/adminEntites/LignesDuTableau/BadgeAdministrateur.svelte
+++ b/svelte/lib/adminEntites/LignesDuTableau/BadgeAdministrateur.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  interface Props {
+    prenomNom: string;
+  }
+
+  let { prenomNom }: Props = $props();
+</script>
+
+<dsfr-badge label={prenomNom} type="accent" accent="blue-ecume" size="sm"
+></dsfr-badge>

--- a/svelte/lib/adminEntites/LignesDuTableau/GererLesAdmins.svelte
+++ b/svelte/lib/adminEntites/LignesDuTableau/GererLesAdmins.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { EntiteSupervisee } from '../adminEntites.types';
+  import TiroirGestionAdmins from '../TiroirGestion/TiroirGestionAdmins.svelte';
+  import { tiroirStore } from '../../ui/stores/tiroir.store';
+
+  interface Props {
+    entite: EntiteSupervisee;
+  }
+
+  let { entite }: Props = $props();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+<dsfr-button
+  kind="secondary"
+  label="Gérer les admins"
+  size="sm"
+  onclick={() => {
+    tiroirStore.afficheContenu(TiroirGestionAdmins, { entite });
+  }}
+></dsfr-button>
+
+<style>
+  dsfr-button {
+    white-space: nowrap;
+  }
+</style>

--- a/svelte/lib/adminEntites/LignesDuTableau/NombreServices.svelte
+++ b/svelte/lib/adminEntites/LignesDuTableau/NombreServices.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  interface Props {
+    nombreServices: number;
+  }
+
+  let { nombreServices }: Props = $props();
+</script>
+
+<span>
+  {#if nombreServices === 0}
+    Aucun service
+  {:else}
+    {nombreServices} service{nombreServices > 1 ? 's' : ''}
+  {/if}
+</span>

--- a/svelte/lib/adminEntites/LignesDuTableau/NombreUtilisateurs.svelte
+++ b/svelte/lib/adminEntites/LignesDuTableau/NombreUtilisateurs.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  interface Props {
+    nombreUtilisateurs: number;
+  }
+
+  let { nombreUtilisateurs }: Props = $props();
+</script>
+
+<span>
+  {#if nombreUtilisateurs === 0}
+    Aucun utilisateur
+  {:else}
+    {nombreUtilisateurs} utilisateur{nombreUtilisateurs > 1 ? 's' : ''}
+  {/if}
+</span>

--- a/svelte/lib/adminEntites/LignesDuTableau/NommerUnAdmin.svelte
+++ b/svelte/lib/adminEntites/LignesDuTableau/NommerUnAdmin.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { EntiteSupervisee } from '../adminEntites.types';
+  import TiroirGestionAdmins from '../TiroirGestion/TiroirGestionAdmins.svelte';
+  import { tiroirStore } from '../../ui/stores/tiroir.store';
+
+  interface Props {
+    entite: EntiteSupervisee;
+  }
+
+  let { entite }: Props = $props();
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+<dsfr-button
+  kind="primary"
+  label="Nommer un admin"
+  size="sm"
+  hasIcon
+  icon="add-line"
+  onclick={() => {
+    tiroirStore.afficheContenu(TiroirGestionAdmins, { entite });
+  }}
+></dsfr-button>
+
+<style>
+  dsfr-button {
+    white-space: nowrap;
+  }
+</style>

--- a/svelte/lib/adminEntites/TiroirGestion/ActionsSurConfirmationSuppression.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ActionsSurConfirmationSuppression.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import ActionsTiroir from '../../ui/tiroirs/ActionsTiroir.svelte';
+
+  interface Props {
+    onannuler: () => void;
+    onvalider: () => void;
+  }
+
+  let { onannuler, onvalider }: Props = $props();
+</script>
+
+<ActionsTiroir>
+  <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+  <dsfr-button label="Annuler" onclick={onannuler} kind="tertiary-no-outline"
+  ></dsfr-button>
+  <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+  <dsfr-button label="Confirmer" onclick={onvalider} kind="primary"
+  ></dsfr-button>
+</ActionsTiroir>

--- a/svelte/lib/adminEntites/TiroirGestion/ActionsSurInvitation.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ActionsSurInvitation.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import ActionsTiroir from '../../ui/tiroirs/ActionsTiroir.svelte';
+
+  interface Props {
+    onannuler: () => void;
+    onvalider: () => void;
+  }
+
+  let { onannuler, onvalider }: Props = $props();
+</script>
+
+<ActionsTiroir>
+  <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+  <dsfr-button label="Annuler" onclick={onannuler} kind="tertiary-no-outline"
+  ></dsfr-button>
+  <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+  <dsfr-button
+    label="Envoyer une invitation"
+    onclick={onvalider}
+    kind="primary"
+    hasIcon
+    icon="send-plane-line"
+  ></dsfr-button>
+</ActionsTiroir>

--- a/svelte/lib/adminEntites/TiroirGestion/CartoucheAdmin.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/CartoucheAdmin.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
   import BoutonSuppressionContributeur from '../../ui/BoutonSuppressionContributeur.svelte';
+  import Infobulle from '../../ui/Infobulle.svelte';
 
   interface Props {
     prenomNom: string;
     initiales?: string;
     postes?: string;
     onsupprimer?: () => void;
+    estSeulAdmin?: boolean;
   }
 
-  let { prenomNom, initiales, postes, onsupprimer }: Props = $props();
+  let {
+    prenomNom,
+    initiales,
+    postes,
+    onsupprimer,
+    estSeulAdmin = false,
+  }: Props = $props();
 </script>
 
 <div class="cartouche-admin">
@@ -16,12 +24,20 @@
     <div class="initiales"><span>{initiales}</span></div>
   {/if}
   <div class="identite">
-    <span class="nom-prenom">{prenomNom}</span>
+    <span class="nom-prenom"
+      >{prenomNom}
+
+      {#if estSeulAdmin}
+        <Infobulle
+          contenu="Cet admin ne peut être supprimé car il est potentiellement seul contributeur des services de cette entité."
+        />
+      {/if}
+    </span>
     {#if postes}
       <span class="postes">{postes}</span>
     {/if}
   </div>
-  {#if onsupprimer}
+  {#if onsupprimer && !estSeulAdmin}
     <BoutonSuppressionContributeur onclick={onsupprimer} />
   {/if}
 </div>
@@ -45,6 +61,9 @@
         font-size: 1rem;
         line-height: 1.5rem;
         color: #3a3a3a;
+        display: flex;
+        gap: 4px;
+        align-items: center;
       }
 
       .postes {

--- a/svelte/lib/adminEntites/TiroirGestion/CartoucheAdmin.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/CartoucheAdmin.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+  import BoutonSuppressionContributeur from '../../ui/BoutonSuppressionContributeur.svelte';
+
   interface Props {
     prenomNom: string;
     initiales?: string;
     postes?: string;
+    onsupprimer?: () => void;
   }
 
-  let { prenomNom, initiales, postes }: Props = $props();
+  let { prenomNom, initiales, postes, onsupprimer }: Props = $props();
 </script>
 
 <div class="cartouche-admin">
@@ -18,6 +21,9 @@
       <span class="postes">{postes}</span>
     {/if}
   </div>
+  {#if onsupprimer}
+    <BoutonSuppressionContributeur onclick={onsupprimer} />
+  {/if}
 </div>
 
 <style>
@@ -33,6 +39,7 @@
       display: flex;
       flex-direction: column;
       gap: 4px;
+      flex: 1;
 
       .nom-prenom {
         font-size: 1rem;

--- a/svelte/lib/adminEntites/TiroirGestion/ConfirmationSuppression.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ConfirmationSuppression.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import type { AdminSupervise } from '../adminEntites.types';
+
+  interface Props {
+    admin: AdminSupervise;
+  }
+
+  let props: Props = $props();
+</script>
+
+<p class="entete">
+  Souhaitez-vous vraiment retirer les droits d'admin de
+  <strong>{props.admin.prenomNom}</strong> ?
+</p>

--- a/svelte/lib/adminEntites/TiroirGestion/ConfirmationSuppression.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ConfirmationSuppression.svelte
@@ -5,10 +5,10 @@
     admin: AdminSupervise;
   }
 
-  let props: Props = $props();
+  let { admin }: Props = $props();
 </script>
 
 <p class="entete">
   Souhaitez-vous vraiment retirer les droits d'admin de
-  <strong>{props.admin.prenomNom}</strong> ?
+  <strong>{admin.prenomNom}</strong> ?
 </p>

--- a/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
@@ -17,6 +17,7 @@
       initiales={admin.initiales}
       postes={admin.postes}
       onsupprimer={() => onsupprimer(admin)}
+      estSeulAdmin={administrateurs.length === 1}
     />
   {/each}
 </div>

--- a/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
@@ -4,9 +4,10 @@
 
   interface Props {
     administrateurs: Array<AdminSupervise>;
+    onsupprimer: (admin: AdminSupervise) => void;
   }
 
-  let { administrateurs }: Props = $props();
+  let { administrateurs, onsupprimer }: Props = $props();
 </script>
 
 <div class="conteneur-cartouches">
@@ -15,6 +16,7 @@
       prenomNom={admin.prenomNom}
       initiales={admin.initiales}
       postes={admin.postes}
+      onsupprimer={() => onsupprimer(admin)}
     />
   {/each}
 </div>

--- a/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/ListeAdmins.svelte
@@ -16,7 +16,9 @@
       prenomNom={admin.prenomNom}
       initiales={admin.initiales}
       postes={admin.postes}
-      onsupprimer={() => onsupprimer(admin)}
+      onsupprimer={admin.estUtilisateurCourant
+        ? undefined
+        : () => onsupprimer(admin)}
       estSeulAdmin={administrateurs.length === 1}
     />
   {/each}

--- a/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
@@ -4,13 +4,14 @@
   import ListeAdmins from './ListeAdmins.svelte';
   import CartoucheAdmin from './CartoucheAdmin.svelte';
   import SaisieEmailAdmin from './SaisieEmailAdmin.svelte';
-  import type { EntiteSupervisee } from '../adminEntites.types';
+  import type { AdminSupervise, EntiteSupervisee } from '../adminEntites.types';
   import { untrack } from 'svelte';
   import { tiroirStore } from '../../ui/stores/tiroir.store';
   import { toasterStore } from '../../ui/stores/toaster.store';
   import { api } from '../adminEntites.api';
   import { SvelteSet } from 'svelte/reactivity';
   import AucunAdmin from './AucunAdmin.svelte';
+  import ConfirmationSuppression from './ConfirmationSuppression.svelte';
 
   interface Props {
     entite: EntiteSupervisee;
@@ -21,8 +22,11 @@
   export const sousTitre: string =
     'Invitez et gérez les administrateurs de votre entité';
 
-  let etatAffichage: 'LISTE' | 'INVITATION' = $state('LISTE');
+  let etatAffichage: 'LISTE' | 'INVITATION' | 'CONFIRMATION_SUPPRESSION' =
+    $state('LISTE');
+
   const listeAdminsAInviter: SvelteSet<string> = new SvelteSet<string>();
+  let adminPourSuppression: AdminSupervise | undefined = $state();
 
   const inviteAdmin = (email: string) => {
     etatAffichage = 'INVITATION';
@@ -32,6 +36,21 @@
   const retourModeListe = () => {
     etatAffichage = 'LISTE';
     listeAdminsAInviter.clear();
+  };
+
+  const suppression = {
+    demanderConfirmation: (admin: AdminSupervise) => {
+      adminPourSuppression = admin;
+      etatAffichage = 'CONFIRMATION_SUPPRESSION';
+    },
+    annuler: () => {
+      adminPourSuppression = undefined;
+      etatAffichage = 'LISTE';
+    },
+    valider: async () => {
+      await api.supprimerAdmin(adminPourSuppression!);
+      etatAffichage = 'LISTE';
+    },
   };
 
   const envoieInvitations = async () => {
@@ -46,31 +65,40 @@
 </script>
 
 <ContenuTiroir>
-  <SaisieEmailAdmin onemailvalide={inviteAdmin} />
+  {#if etatAffichage === 'LISTE' || etatAffichage === 'INVITATION'}
+    <SaisieEmailAdmin onemailvalide={inviteAdmin} />
 
-  <div class="conteneur-admins">
-    {#if etatAffichage === 'LISTE'}
-      <hr />
-      <h3>Administrateurs de l’entité</h3>
-      <span class="sous-titre">
-        Consultez la liste des utilisateurs disposant des droits admins.
-      </span>
-      {#if entite.administrateurs.length === 0}
-        <AucunAdmin />
-      {:else}
-        <ListeAdmins administrateurs={entite.administrateurs} />
+    <div class="conteneur-admins">
+      {#if etatAffichage === 'LISTE'}
+        <hr />
+        <h3>Administrateurs de l’entité</h3>
+        <span class="sous-titre">
+          Consultez la liste des utilisateurs disposant des droits admins.
+        </span>
+        {#if entite.administrateurs.length === 0}
+          <AucunAdmin />
+        {:else}
+          <ListeAdmins
+            administrateurs={entite.administrateurs}
+            onsupprimer={suppression.demanderConfirmation}
+          />
+        {/if}
       {/if}
-    {/if}
 
-    {#if etatAffichage === 'INVITATION'}
-      <div class="conteneur-cartouches">
-        {#each listeAdminsAInviter as emailAdmin, i (i)}
-          <CartoucheAdmin prenomNom={emailAdmin} />
-        {/each}
-      </div>
-    {/if}
-  </div>
+      {#if etatAffichage === 'INVITATION'}
+        <div class="conteneur-cartouches">
+          {#each listeAdminsAInviter as emailAdmin, i (i)}
+            <CartoucheAdmin prenomNom={emailAdmin} />
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/if}
+  {#if etatAffichage === 'CONFIRMATION_SUPPRESSION'}
+    <ConfirmationSuppression admin={adminPourSuppression!} />
+  {/if}
 </ContenuTiroir>
+
 {#if etatAffichage === 'INVITATION'}
   <ActionsTiroir>
     <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
@@ -86,6 +114,22 @@
       kind="primary"
       hasIcon
       icon="send-plane-line"
+    ></dsfr-button>
+  </ActionsTiroir>
+{/if}
+{#if etatAffichage === 'CONFIRMATION_SUPPRESSION'}
+  <ActionsTiroir>
+    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+    <dsfr-button
+      label="Annuler"
+      onclick={() => suppression.annuler()}
+      kind="tertiary-no-outline"
+    ></dsfr-button>
+    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+    <dsfr-button
+      label="Confirmer"
+      onclick={async () => await suppression.valider()}
+      kind="primary"
     ></dsfr-button>
   </ActionsTiroir>
 {/if}

--- a/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
@@ -28,14 +28,24 @@
   const listeAdminsAInviter: SvelteSet<string> = new SvelteSet<string>();
   let adminPourSuppression: AdminSupervise | undefined = $state();
 
-  const inviteAdmin = (email: string) => {
-    etatAffichage = 'INVITATION';
-    listeAdminsAInviter.add(email);
-  };
-
-  const retourModeListe = () => {
-    etatAffichage = 'LISTE';
-    listeAdminsAInviter.clear();
+  const invitation = {
+    ajouter: (email: string) => {
+      etatAffichage = 'INVITATION';
+      listeAdminsAInviter.add(email);
+    },
+    annuler: () => {
+      etatAffichage = 'LISTE';
+      listeAdminsAInviter.clear();
+    },
+    envoyer: async () => {
+      await api.envoieInvitations([...listeAdminsAInviter], entite.siret);
+      toasterStore.succes(
+        'Invitation envoyée',
+        `${listeAdminsAInviter.size} administrateur(s) nommé(s) sur l'entité ${entite.nom}`
+      );
+      document.dispatchEvent(new CustomEvent('admins-entites-modifiees'));
+      tiroirStore.ferme();
+    },
   };
 
   const suppression = {
@@ -52,21 +62,11 @@
       etatAffichage = 'LISTE';
     },
   };
-
-  const envoieInvitations = async () => {
-    await api.envoieInvitations([...listeAdminsAInviter], entite.siret);
-    toasterStore.succes(
-      'Invitation envoyée',
-      `${listeAdminsAInviter.size} administrateur(s) nommé(s) sur l'entité ${entite.nom}`
-    );
-    document.dispatchEvent(new CustomEvent('admins-entites-modifiees'));
-    tiroirStore.ferme();
-  };
 </script>
 
 <ContenuTiroir>
   {#if etatAffichage === 'LISTE' || etatAffichage === 'INVITATION'}
-    <SaisieEmailAdmin onemailvalide={inviteAdmin} />
+    <SaisieEmailAdmin onemailvalide={invitation.ajouter} />
 
     <div class="conteneur-admins">
       {#if etatAffichage === 'LISTE'}
@@ -104,13 +104,13 @@
     <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
     <dsfr-button
       label="Annuler"
-      onclick={() => retourModeListe()}
+      onclick={() => invitation.annuler()}
       kind="tertiary-no-outline"
     ></dsfr-button>
     <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
     <dsfr-button
       label="Envoyer une invitation"
-      onclick={() => envoieInvitations()}
+      onclick={() => invitation.envoyer()}
       kind="primary"
       hasIcon
       icon="send-plane-line"

--- a/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
@@ -13,6 +13,7 @@
   import { SvelteSet } from 'svelte/reactivity';
   import AucunAdmin from './AucunAdmin.svelte';
   import ConfirmationSuppression from './ConfirmationSuppression.svelte';
+  import type { AxiosError } from 'axios';
 
   interface Props {
     entite: EntiteSupervisee;
@@ -63,8 +64,25 @@
       etatAffichage = 'LISTE';
     },
     valider: async () => {
-      await api.supprimerAdmin(adminPourSuppression!);
-      etatAffichage = 'LISTE';
+      try {
+        await api.supprimeAdmin(adminPourSuppression!, entite.siret);
+        etatAffichage = 'LISTE';
+        toasterStore.succes(
+          'Admin supprimé avec succès',
+          `L'administrateur a bien été supprimé de l'entité ${entite.nom}`
+        );
+        document.dispatchEvent(new CustomEvent('admins-entites-modifiees'));
+        tiroirStore.ferme();
+      } catch (e) {
+        const erreurAxios = e as AxiosError;
+        if (erreurAxios?.response?.status === 422) {
+          toasterStore.erreur(
+            "Impossible de supprimer l'admin",
+            `L'administrateur est seul contributeur d'un service de ${entite.nom} : il ne peut pas être supprimé`
+          );
+          etatAffichage = 'LISTE';
+        }
+      }
     },
   };
 </script>

--- a/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import ContenuTiroir from '../../ui/tiroirs/ContenuTiroir.svelte';
-  import ActionsTiroir from '../../ui/tiroirs/ActionsTiroir.svelte';
   import ListeAdmins from './ListeAdmins.svelte';
   import CartoucheAdmin from './CartoucheAdmin.svelte';
   import SaisieEmailAdmin from './SaisieEmailAdmin.svelte';
+  import ActionsSurInvitation from './ActionsSurInvitation.svelte';
+  import ActionsSurConfirmationSuppression from './ActionsSurConfirmationSuppression.svelte';
   import type { AdminSupervise, EntiteSupervisee } from '../adminEntites.types';
   import { untrack } from 'svelte';
   import { tiroirStore } from '../../ui/stores/tiroir.store';
@@ -107,38 +108,16 @@
 </ContenuTiroir>
 
 {#if etatAffichage === 'INVITATION'}
-  <ActionsTiroir>
-    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-    <dsfr-button
-      label="Annuler"
-      onclick={() => invitation.annuler()}
-      kind="tertiary-no-outline"
-    ></dsfr-button>
-    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-    <dsfr-button
-      label="Envoyer une invitation"
-      onclick={() => invitation.envoyer()}
-      kind="primary"
-      hasIcon
-      icon="send-plane-line"
-    ></dsfr-button>
-  </ActionsTiroir>
+  <ActionsSurInvitation
+    onannuler={invitation.annuler}
+    onvalider={invitation.envoyer}
+  />
 {/if}
 {#if etatAffichage === 'CONFIRMATION_SUPPRESSION'}
-  <ActionsTiroir>
-    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-    <dsfr-button
-      label="Annuler"
-      onclick={() => suppression.annuler()}
-      kind="tertiary-no-outline"
-    ></dsfr-button>
-    <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-    <dsfr-button
-      label="Confirmer"
-      onclick={async () => await suppression.valider()}
-      kind="primary"
-    ></dsfr-button>
-  </ActionsTiroir>
+  <ActionsSurConfirmationSuppression
+    onannuler={suppression.annuler}
+    onvalider={suppression.valider}
+  />
 {/if}
 
 <style>

--- a/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
+++ b/svelte/lib/adminEntites/TiroirGestion/TiroirGestionAdmins.svelte
@@ -33,6 +33,10 @@
       etatAffichage = 'INVITATION';
       listeAdminsAInviter.add(email);
     },
+    retirer: (email: string) => {
+      listeAdminsAInviter.delete(email);
+      if (listeAdminsAInviter.size === 0) etatAffichage = 'LISTE';
+    },
     annuler: () => {
       etatAffichage = 'LISTE';
       listeAdminsAInviter.clear();
@@ -88,7 +92,10 @@
       {#if etatAffichage === 'INVITATION'}
         <div class="conteneur-cartouches">
           {#each listeAdminsAInviter as emailAdmin, i (i)}
-            <CartoucheAdmin prenomNom={emailAdmin} />
+            <CartoucheAdmin
+              prenomNom={emailAdmin}
+              onsupprimer={() => invitation.retirer(emailAdmin)}
+            />
           {/each}
         </div>
       {/if}

--- a/svelte/lib/adminEntites/adminEntites.api.ts
+++ b/svelte/lib/adminEntites/adminEntites.api.ts
@@ -20,7 +20,8 @@ export const api = {
       throw e;
     }
   },
-  supprimerAdmin: async (cible: AdminSupervise) => {
-    console.log(`✅ SUPPRESSION DE`, cible);
-  },
+  supprimeAdmin: async (cible: AdminSupervise, siret: string) =>
+    await axios.delete('/api/admin', {
+      data: { siret, idUtilisateur: cible.id },
+    }),
 };

--- a/svelte/lib/adminEntites/adminEntites.api.ts
+++ b/svelte/lib/adminEntites/adminEntites.api.ts
@@ -1,5 +1,5 @@
 import type { AxiosError } from 'axios';
-import type { EntiteSupervisee } from './adminEntites.types';
+import type { AdminSupervise, EntiteSupervisee } from './adminEntites.types';
 
 export const api = {
   entitesDansMonPerimetre: async (): Promise<Array<EntiteSupervisee>> =>
@@ -19,5 +19,8 @@ export const api = {
 
       throw e;
     }
+  },
+  supprimerAdmin: async (cible: AdminSupervise) => {
+    console.log(`✅ SUPPRESSION DE`, cible);
   },
 };

--- a/svelte/lib/adminEntites/adminEntites.types.ts
+++ b/svelte/lib/adminEntites/adminEntites.types.ts
@@ -1,6 +1,7 @@
 import type { Entite } from '../ui/types';
 
 export type AdminSupervise = {
+  id: string;
   prenomNom: string;
   initiales: string;
   postes: string;

--- a/svelte/lib/adminEntites/adminEntites.types.ts
+++ b/svelte/lib/adminEntites/adminEntites.types.ts
@@ -5,6 +5,7 @@ export type AdminSupervise = {
   prenomNom: string;
   initiales: string;
   postes: string;
+  estUtilisateurCourant: boolean;
 };
 
 export type EntiteSupervisee = Entite & {

--- a/svelte/lib/ui/BoutonSuppressionContributeur.svelte
+++ b/svelte/lib/ui/BoutonSuppressionContributeur.svelte
@@ -9,7 +9,7 @@
   <img
     class="bouton-suppression-contributeur"
     src="/statique/assets/images/icone_supprimer_gris.svg"
-    alt="bouton de suppression d'un contributeur"
+    alt=""
   />
 </button>
 

--- a/svelte/lib/ui/BoutonSuppressionContributeur.svelte
+++ b/svelte/lib/ui/BoutonSuppressionContributeur.svelte
@@ -5,7 +5,7 @@
   let { onclick }: Props = $props();
 </script>
 
-<button type="button" {onclick}>
+<button type="button" {onclick} aria-label="Supprimer le contributeur">
   <img
     class="bouton-suppression-contributeur"
     src="/statique/assets/images/icone_supprimer_gris.svg"

--- a/test/adaptateurs/adaptateurPostgresTS.spec.ts
+++ b/test/adaptateurs/adaptateurPostgresTS.spec.ts
@@ -258,6 +258,23 @@ describe("L'adaptateur persistance Postgres", () => {
         entitesSupervisees: [entiteB, entiteC],
       });
     });
+    it("supprime le superviseur s'il n'a plus d'entité supervisée", async () => {
+      const idSuperviseur = unUUIDRandom();
+      const entiteA = { siret: 'siretA', nom: 'nomA', departement: '75' };
+      await trx.table('superviseurs').insert({
+        id_superviseur: idSuperviseur,
+        siret_hash: chiffrement.hacheSha256('siretA'),
+        donnees: await chiffrement.chiffre(entiteA),
+      });
+
+      await persistance.sauvegardeSuperviseur({
+        idUtilisateur: idSuperviseur,
+        entitesSupervisees: [],
+      });
+
+      const superviseur = await persistance.lisSuperviseur(idSuperviseur);
+      expect(superviseur).toBeUndefined();
+    });
   });
 
   describe("sur demande de mise à jour d'un admin d'organisations", () => {

--- a/test/adaptateurs/adaptateurPostgresTS.spec.ts
+++ b/test/adaptateurs/adaptateurPostgresTS.spec.ts
@@ -316,5 +316,41 @@ describe("L'adaptateur persistance Postgres", () => {
         entitesAdministrees: [donneesEntiteB, donneesEntiteC],
       });
     });
+
+    it("supprime l'admin s'il n'a plus d'entités administrées", async () => {
+      const idAdmin = unUUIDRandom();
+      const donneesEntite = { siret: 'siret' };
+      await persistance.sauvegardeAdminOrganisations({
+        idUtilisateur: idAdmin,
+        entitesAdministrees: [donneesEntite],
+      });
+
+      await persistance.sauvegardeAdminOrganisations({
+        idUtilisateur: idAdmin,
+        entitesAdministrees: [],
+      });
+
+      const adminSauvegarde = await persistance.lisAdminOrganisations(idAdmin);
+      expect(adminSauvegarde).toBeUndefined();
+    });
+
+    it('ne supprime pas les autres admins', async () => {
+      const idAdmin1 = unUUIDRandom();
+      const idAdmin2 = unUUIDRandom();
+      const donneesEntite1 = { siret: 'siret-1' };
+      const donneesEntite2 = { siret: 'siret-2' };
+      await persistance.sauvegardeAdminOrganisations({
+        idUtilisateur: idAdmin1,
+        entitesAdministrees: [donneesEntite1],
+      });
+
+      await persistance.sauvegardeAdminOrganisations({
+        idUtilisateur: idAdmin2,
+        entitesAdministrees: [donneesEntite2],
+      });
+
+      const adminSauvegarde = await persistance.lisAdminOrganisations(idAdmin1);
+      expect(adminSauvegarde).toBeDefined();
+    });
   });
 });

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -137,6 +137,7 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
   describe('quand requête POST sur `/api/admin/nomme`', () => {
     const siret = '13000766900018';
     const idSuperviseur = unUUID('S');
+    const idAdmin = unUUID('A');
 
     beforeEach(() => {
       testeur.depotDonnees().lisSuperviseur = async () =>
@@ -221,7 +222,7 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
       ).toHaveBeenCalledTimes(1);
     });
 
-    describe('applique les contrôles de permissions suivants', () => {
+    describe('applique les contrôles de permissions', () => {
       beforeEach(() => {
         testeur.depotDonnees().lisSuperviseur = async () => undefined;
         testeur.depotDonnees().lisAdminOrganisations = async () => undefined;
@@ -229,14 +230,14 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
 
       it("jette une erreur si l'utilisateur n'est ni superviseur, ni admin", async () => {
         const { status } = await testeur.post('/api/admin/nomme', {
-          emails: ['inconnu@mail.fr'],
+          emails: ['utilisateur_lambda@mail.fr'],
           siret,
         });
 
         expect(status).toBe(403);
       });
 
-      it("jette une erreur si un superviseur veut nommer sur un SIRET qui n'est pas dans on périmètre", async () => {
+      it("jette une erreur si un superviseur veut nommer sur un SIRET qui n'est pas dans son périmètre", async () => {
         testeur.depotDonnees().lisSuperviseur = async () =>
           Superviseur.hydrate({
             idUtilisateur: idSuperviseur,
@@ -245,23 +246,23 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
 
         const unAutreSiret = '13000766900999';
         const { status } = await testeur.post('/api/admin/nomme', {
-          emails: ['inconnu@mail.fr'],
+          emails: ['futur_admin@mail.fr'],
           siret: unAutreSiret,
         });
 
         expect(status).toBe(403);
       });
 
-      it("jette une erreur si un admin veut nommer sur un SIRET qui n'est pas dans on périmètre", async () => {
+      it("jette une erreur si un admin veut nommer sur un SIRET qui n'est pas dans son périmètre", async () => {
         testeur.depotDonnees().lisAdminOrganisations = async () =>
           AdminOrganisations.hydrate({
-            idUtilisateur: idSuperviseur,
+            idUtilisateur: idAdmin,
             entitesAdministrees: [{ siret }],
           });
 
         const unAutreSiret = '13000766900999';
         const { status } = await testeur.post('/api/admin/nomme', {
-          emails: ['inconnu@mail.fr'],
+          emails: ['futur_admin@mail.fr'],
           siret: unAutreSiret,
         });
 

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -6,6 +6,7 @@ import { unUUID, unUUIDRandom } from '../../constructeurs/UUID.ts';
 import Superviseur from '../../../src/modeles/superviseur.ts';
 import { AdminOrganisations } from '../../../src/modeles/gestionOrganisations/adminOrganisations.ts';
 import { UtilisateurAdministre } from '../../../src/modeles/gestionOrganisations/utilisateurAdministre.ts';
+import { ErreurSuppressionImpossible } from '../../../src/erreurs.ts';
 
 describe('Le serveur MSS des routes /api/admin/*', () => {
   const testeur = testeurMSS();
@@ -202,7 +203,6 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
     });
 
     it('dédoublonne les emails', async () => {
-      const idAdmin = unUUID('A');
       const email = 'jean.dujardin@beta.gouv.fr';
       testeur.middleware().reinitialise({ idUtilisateur: idSuperviseur });
       testeur.depotDonnees().utilisateurAvecEmail = async (e: string) =>
@@ -308,6 +308,20 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
       });
 
       expect(status).toBe(400);
+    });
+
+    it('jette une erreur 422 si la suppression est impossible', async () => {
+      testeur.middleware().reinitialise({ idUtilisateur: idSuperviseur });
+      testeur.serviceAdministrationOrganisations().retireAdmin = async () => {
+        throw new ErreurSuppressionImpossible();
+      };
+
+      const { status } = await testeur.delete('/api/admin', {
+        siret,
+        idUtilisateur: idAdminASupprimer,
+      });
+
+      expect(status).toBe(422);
     });
 
     describe('applique les contrôles de permissions suivants', () => {

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -91,6 +91,13 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
         Superviseur.nouveau(unUUIDRandom());
     });
 
+    it('applique une protection de trafic', async () => {
+      await testeur.middleware().verifieProtectionTrafic(testeur.app(), {
+        method: 'post',
+        url: '/api/admin/verifieEmail',
+      });
+    });
+
     it("renvoie une erreur 403 si l'utilisateur courant n'est pas superviseur", async () => {
       testeur.depotDonnees().lisSuperviseur = async () => undefined;
 

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -310,6 +310,17 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
       expect(status).toBe(400);
     });
 
+    it("jette une erreur 400 si l'utilisateur courant essaie de se supprimer", async () => {
+      testeur.middleware().reinitialise({ idUtilisateur: idAdminASupprimer });
+
+      const { status } = await testeur.delete('/api/admin', {
+        siret,
+        idUtilisateur: idAdminASupprimer,
+      });
+
+      expect(status).toBe(400);
+    });
+
     it('jette une erreur 422 si la suppression est impossible', async () => {
       testeur.middleware().reinitialise({ idUtilisateur: idSuperviseur });
       testeur.serviceAdministrationOrganisations().retireAdmin = async () => {

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -262,4 +262,92 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
       });
     });
   });
+
+  describe('quand requête DELETE sur `/api/admin/:idUtilisateur`', () => {
+    const siret = '13000766900018';
+    const idSuperviseur = unUUID('S');
+    const idAdminASupprimer = unUUIDRandom();
+
+    beforeEach(() => {
+      testeur.depotDonnees().lisSuperviseur = async () =>
+        Superviseur.hydrate({
+          idUtilisateur: idSuperviseur,
+          entitesSupervisees: [{ siret }],
+        });
+    });
+
+    it("délègue au service d'administration le retrait de l'admin sur le siret", async () => {
+      testeur.middleware().reinitialise({ idUtilisateur: idSuperviseur });
+      testeur.serviceAdministrationOrganisations().retireAdmin = vi.fn();
+
+      const { status } = await testeur.delete('/api/admin', {
+        siret,
+        idUtilisateur: idAdminASupprimer,
+      });
+
+      expect(status).toBe(200);
+      expect(
+        testeur.serviceAdministrationOrganisations().retireAdmin
+      ).toHaveBeenCalledWith(siret, idAdminASupprimer);
+    });
+
+    it("jette une erreur 400 si l'id de l'utilisateur n'est pas un UUID valide", async () => {
+      testeur.middleware().reinitialise({ idUtilisateur: idSuperviseur });
+
+      const { status } = await testeur.delete('/api/admin', {
+        siret,
+        idUtilisateur: 'pas-un-uuid',
+      });
+
+      expect(status).toBe(400);
+    });
+
+    describe('applique les contrôles de permissions suivants', () => {
+      beforeEach(() => {
+        testeur.depotDonnees().lisSuperviseur = async () => undefined;
+        testeur.depotDonnees().lisAdminOrganisations = async () => undefined;
+      });
+
+      it("jette une erreur si l'utilisateur n'est ni superviseur, ni admin", async () => {
+        const { status } = await testeur.delete('/api/admin', {
+          siret,
+          idUtilisateur: idAdminASupprimer,
+        });
+
+        expect(status).toBe(403);
+      });
+
+      it("jette une erreur si un superviseur veut retirer un admin sur un SIRET qui n'est pas dans son périmètre", async () => {
+        testeur.depotDonnees().lisSuperviseur = async () =>
+          Superviseur.hydrate({
+            idUtilisateur: idSuperviseur,
+            entitesSupervisees: [{ siret }],
+          });
+
+        const unAutreSiret = '13000766900999';
+        const { status } = await testeur.delete('/api/admin', {
+          siret: unAutreSiret,
+          idUtilisateur: idAdminASupprimer,
+        });
+
+        expect(status).toBe(403);
+      });
+
+      it("jette une erreur si un admin veut retirer un admin sur un SIRET qui n'est pas dans son périmètre", async () => {
+        testeur.depotDonnees().lisAdminOrganisations = async () =>
+          AdminOrganisations.hydrate({
+            idUtilisateur: idSuperviseur,
+            entitesAdministrees: [{ siret }],
+          });
+
+        const unAutreSiret = '13000766900999';
+        const { status } = await testeur.delete('/api/admin', {
+          siret: unAutreSiret,
+          idUtilisateur: idAdminASupprimer,
+        });
+
+        expect(status).toBe(403);
+      });
+    });
+  });
 });

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -4,6 +4,7 @@ import { UUID } from '../../../src/typesBasiques.ts';
 import { unUtilisateur } from '../../constructeurs/constructeurUtilisateur.js';
 import { unUUID, unUUIDRandom } from '../../constructeurs/UUID.ts';
 import Superviseur from '../../../src/modeles/superviseur.ts';
+import { AdminOrganisations } from '../../../src/modeles/gestionOrganisations/adminOrganisations.ts';
 import { UtilisateurAdministre } from '../../../src/modeles/gestionOrganisations/utilisateurAdministre.ts';
 
 describe('Le serveur MSS des routes /api/admin/*', () => {
@@ -131,7 +132,7 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
     const idSuperviseur = unUUID('S');
 
     beforeEach(() => {
-      testeur.depotDonnees().lisSuperviseur = () =>
+      testeur.depotDonnees().lisSuperviseur = async () =>
         Superviseur.hydrate({
           idUtilisateur: idSuperviseur,
           entitesSupervisees: [{ siret }],
@@ -145,26 +146,6 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
       });
 
       expect(status).toBe(400);
-    });
-
-    it("jette une erreur si l'utilisateur n'est pas superviseur", async () => {
-      testeur.depotDonnees().lisSuperviseur = () => undefined;
-
-      const { status } = await testeur.post('/api/admin/nomme', {
-        emails: ['inconnu@mail.fr'],
-        siret,
-      });
-
-      expect(status).toBe(403);
-    });
-
-    it("jette une erreur si le siret n'est pas supervisé par le superviseur", async () => {
-      const { status } = await testeur.post('/api/admin/nomme', {
-        emails: ['inconnu@mail.fr'],
-        siret: '13000766999999',
-      });
-
-      expect(status).toBe(403);
     });
 
     it('ne fait rien pour un utilisateur non existant', async () => {
@@ -231,6 +212,54 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
       expect(
         testeur.serviceAdministrationOrganisations().nommeAdmin
       ).toHaveBeenCalledTimes(1);
+    });
+
+    describe('applique les contrôles de permissions suivants', () => {
+      beforeEach(() => {
+        testeur.depotDonnees().lisSuperviseur = async () => undefined;
+        testeur.depotDonnees().lisAdminOrganisations = async () => undefined;
+      });
+
+      it("jette une erreur si l'utilisateur n'est ni superviseur, ni admin", async () => {
+        const { status } = await testeur.post('/api/admin/nomme', {
+          emails: ['inconnu@mail.fr'],
+          siret,
+        });
+
+        expect(status).toBe(403);
+      });
+
+      it("jette une erreur si un superviseur veut nommer sur un SIRET qui n'est pas dans on périmètre", async () => {
+        testeur.depotDonnees().lisSuperviseur = async () =>
+          Superviseur.hydrate({
+            idUtilisateur: idSuperviseur,
+            entitesSupervisees: [{ siret }],
+          });
+
+        const unAutreSiret = '13000766900999';
+        const { status } = await testeur.post('/api/admin/nomme', {
+          emails: ['inconnu@mail.fr'],
+          siret: unAutreSiret,
+        });
+
+        expect(status).toBe(403);
+      });
+
+      it("jette une erreur si un admin veut nommer sur un SIRET qui n'est pas dans on périmètre", async () => {
+        testeur.depotDonnees().lisAdminOrganisations = async () =>
+          AdminOrganisations.hydrate({
+            idUtilisateur: idSuperviseur,
+            entitesAdministrees: [{ siret }],
+          });
+
+        const unAutreSiret = '13000766900999';
+        const { status } = await testeur.post('/api/admin/nomme', {
+          emails: ['inconnu@mail.fr'],
+          siret: unAutreSiret,
+        });
+
+        expect(status).toBe(403);
+      });
     });
   });
 });

--- a/test/routes/connecte/routesConnecteApiAdmin.spec.ts
+++ b/test/routes/connecte/routesConnecteApiAdmin.spec.ts
@@ -1,5 +1,4 @@
 import testeurMSS from '../testeurMSS.js';
-import { DonneesEntite } from '../../../src/modeles/entite.ts';
 import { UUID } from '../../../src/typesBasiques.ts';
 import { unUtilisateur } from '../../constructeurs/constructeurUtilisateur.js';
 import { unUUID, unUUIDRandom } from '../../constructeurs/UUID.ts';
@@ -33,14 +32,31 @@ describe('Le serveur MSS des routes /api/admin/*', () => {
         idUtilisateur: UUID
       ) => {
         idAdmin = idUtilisateur;
-        return [{ siret: '123', nom: 'Une entite', departement: '33' }];
+        return [
+          {
+            siret: '123',
+            nom: 'Une entite',
+            nombreServices: 2,
+            nombreUtilisateurs: 4,
+            administrateurs: [{ id: 'U1' }, { id: 'U2' }],
+          },
+        ];
       };
 
       const reponse = await testeur.get('/api/admin/entites');
 
       expect(idAdmin).toBe('U1');
-      expect(reponse.body).toEqual<DonneesEntite[]>([
-        { siret: '123', nom: 'Une entite', departement: '33' },
+      expect(reponse.body).toEqual([
+        {
+          siret: '123',
+          nom: 'Une entite',
+          nombreServices: 2,
+          nombreUtilisateurs: 4,
+          administrateurs: [
+            { id: 'U1', estUtilisateurCourant: true },
+            { id: 'U2', estUtilisateurCourant: false },
+          ],
+        },
       ]);
     });
   });

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -263,7 +263,12 @@ describe("Le service de gestion des admins d'organisation", () => {
       expect(entitesDe[0].nombreServices).toBe(1);
       expect(entitesDe[0].nombreUtilisateurs).toBe(1);
       expect(entitesDe[0].administrateurs).toEqual([
-        { prenomNom: 'Jean Dujardin', initiales: 'JD', postes: 'RSSI' },
+        {
+          id: unUUID('A'),
+          prenomNom: 'Jean Dujardin',
+          initiales: 'JD',
+          postes: 'RSSI',
+        },
       ]);
     });
 
@@ -278,7 +283,12 @@ describe("Le service de gestion des admins d'organisation", () => {
       expect(entitesDe[0].nombreServices).toBe(1);
       expect(entitesDe[0].nombreUtilisateurs).toBe(1);
       expect(entitesDe[0].administrateurs).toEqual([
-        { prenomNom: 'Jean Dujardin', initiales: 'JD', postes: 'RSSI' },
+        {
+          id: unUUID('A'),
+          prenomNom: 'Jean Dujardin',
+          initiales: 'JD',
+          postes: 'RSSI',
+        },
       ]);
     });
 

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -5,10 +5,7 @@ import {
 import { unePersistanceMemoire } from '../constructeurs/constructeurAdaptateurPersistanceMemoire.js';
 import { unUUID, unUUIDRandom } from '../constructeurs/UUID.ts';
 import { unServiceV2 } from '../constructeurs/constructeurService.js';
-import {
-  DonneesEntiteSupervisee,
-  ServiceAdministrationOrganisations,
-} from '../../src/supervision/serviceAdministrationOrganisations.js';
+import { ServiceAdministrationOrganisations } from '../../src/supervision/serviceAdministrationOrganisations.js';
 import { fabriqueAdaptateurUUID } from '../../src/adaptateurs/adaptateurUUID.ts';
 import { fabriqueBusPourLesTests } from '../bus/aides/busPourLesTests.js';
 import { uneAutorisation } from '../constructeurs/constructeurAutorisation.js';
@@ -213,96 +210,96 @@ describe("Le service de gestion des admins d'organisation", () => {
     });
   });
 
-  describe("sur demande des entités dans le périmètre d'un utilisateur", () => {
-    it("renvoie les entités d'un admin", async () => {
-      adaptateurPersistanceTS = unePersistanceMemoireTS()
-        .ajouteAdminSurPerimetre(unUUID('A'), [{ siret: 'SIRET-123' }])
-        .construis();
-      const service = leService({
-        depotDonnees: unDepotComplet({ adaptateurPersistanceTS }),
+  describe("sur demande des entités dans le périmètre d'un utilisateur, qu'il soit admin ou superviseur", () => {
+    let serviceAdministrationOrganisations: ServiceAdministrationOrganisations;
+
+    beforeEach(async () => {
+      const mairieDeX = { siret: 'SIRET-123', nom: 'Mon entité' };
+      const superviseur = Superviseur.hydrate({
+        idUtilisateur: unUUID('S'),
+        entitesSupervisees: [mairieDeX],
       });
+      const adminSurSiret123 = AdminOrganisations.hydrate({
+        idUtilisateur: unUUID('A'),
+        entitesAdministrees: [mairieDeX],
+      });
+      await adaptateurPersistanceTS.sauvegardeSuperviseur(
+        superviseur.donnees()
+      );
+      await adaptateurPersistanceTS.sauvegardeAdminOrganisations(
+        adminSurSiret123.donnees()
+      );
+      await adaptateurPersistance.ajouteUtilisateur(
+        unUUID('A'),
+        unUtilisateur().quiSAppelle('Jean Dujardin').avecPostes(['RSSI'])
+          .donnees
+      );
+      await adaptateurPersistance.sauvegardeService(
+        unUUID('S'),
+        unServiceV2().donnees,
+        '',
+        'SIRET-123-haché256'
+      );
+      await adaptateurPersistance.ajouteAutorisation(
+        unUUIDRandom(),
+        uneAutorisation().deProprietaire(unUUID('P'), unUUID('S')).donnees
+      );
+      await adaptateurPersistance.ajouteUtilisateur(
+        unUUID('P'),
+        unUtilisateur().donnees
+      );
+
+      serviceAdministrationOrganisations = leService();
+    });
+
+    it("sait renvoyer les entités du point-de-vue d'un admin : l'admin est alors lui-même présent dans les admins renvoyés", async () => {
+      const service = leService();
 
       const entitesDe = await service.entitesDe(unUUID('A'));
 
       expect(entitesDe).toHaveLength(1);
       expect(entitesDe[0].siret).toBe('SIRET-123');
+      expect(entitesDe[0].nom).toBe('Mon entité');
+      expect(entitesDe[0].nombreServices).toBe(1);
+      expect(entitesDe[0].nombreUtilisateurs).toBe(1);
+      expect(entitesDe[0].administrateurs).toEqual([
+        { prenomNom: 'Jean Dujardin', initiales: 'JD', postes: 'RSSI' },
+      ]);
     });
 
-    describe('concernant les entités supervisées', () => {
-      let serviceAdministrationOrganisations: ServiceAdministrationOrganisations;
+    it("sait renvoyer les entités du point-de-vue d'un superviseur (s'il n'est pas admin) : même structure que ci-dessus", async () => {
+      const entitesDe = await serviceAdministrationOrganisations.entitesDe(
+        unUUID('S')
+      );
 
-      beforeEach(async () => {
-        const superviseur = Superviseur.hydrate({
-          idUtilisateur: unUUID('S'),
-          entitesSupervisees: [{ siret: 'SIRET-123', nom: 'Mon entité' }],
-        });
-        await adaptateurPersistanceTS.sauvegardeSuperviseur(
-          superviseur.donnees()
-        );
-        const adminSurSiret123 = AdminOrganisations.hydrate({
-          idUtilisateur: unUUID('A'),
-          entitesAdministrees: [{ siret: 'SIRET-123' }],
-        });
-        await adaptateurPersistanceTS.sauvegardeAdminOrganisations(
-          adminSurSiret123.donnees()
-        );
-        await adaptateurPersistance.ajouteUtilisateur(
-          unUUID('A'),
-          unUtilisateur().quiSAppelle('Jean Dujardin').avecPostes(['RSSI'])
-            .donnees
-        );
-        await adaptateurPersistance.sauvegardeService(
-          unUUID('S'),
-          unServiceV2().donnees,
-          '',
-          'SIRET-123-haché256'
-        );
-        await adaptateurPersistance.ajouteAutorisation(
-          unUUIDRandom(),
-          uneAutorisation().deProprietaire(unUUID('P'), unUUID('S')).donnees
-        );
-        await adaptateurPersistance.ajouteUtilisateur(
-          unUUID('P'),
-          unUtilisateur().donnees
-        );
+      expect(entitesDe).toHaveLength(1);
+      expect(entitesDe[0].siret).toBe('SIRET-123');
+      expect(entitesDe[0].nom).toBe('Mon entité');
+      expect(entitesDe[0].nombreServices).toBe(1);
+      expect(entitesDe[0].nombreUtilisateurs).toBe(1);
+      expect(entitesDe[0].administrateurs).toEqual([
+        { prenomNom: 'Jean Dujardin', initiales: 'JD', postes: 'RSSI' },
+      ]);
+    });
 
-        serviceAdministrationOrganisations = leService();
-      });
+    it("ne compte qu'une fois chaque utilisateur", async () => {
+      await adaptateurPersistance.sauvegardeService(
+        unUUID('S2'),
+        unServiceV2().donnees,
+        '',
+        'SIRET-123-haché256'
+      );
+      await adaptateurPersistance.ajouteAutorisation(
+        unUUIDRandom(),
+        uneAutorisation().deProprietaire(unUUID('P'), unUUID('S2')).donnees
+      );
 
-      it("renvoie les entités supervisées d'un superviseur s'il n'est pas admin", async () => {
-        const entitesDe = (await serviceAdministrationOrganisations.entitesDe(
-          unUUID('S')
-        )) as unknown as Array<DonneesEntiteSupervisee>;
+      const entitesDe = await serviceAdministrationOrganisations.entitesDe(
+        unUUID('S')
+      );
 
-        expect(entitesDe).toHaveLength(1);
-        expect(entitesDe[0].siret).toBe('SIRET-123');
-        expect(entitesDe[0].nom).toBe('Mon entité');
-        expect(entitesDe[0].nombreServices).toBe(1);
-        expect(entitesDe[0].nombreUtilisateurs).toBe(1);
-        expect(entitesDe[0].administrateurs).toEqual([
-          { prenomNom: 'Jean Dujardin', initiales: 'JD', postes: 'RSSI' },
-        ]);
-      });
-
-      it("ne compte qu'une fois chaque utilisateur", async () => {
-        await adaptateurPersistance.sauvegardeService(
-          unUUID('S2'),
-          unServiceV2().donnees,
-          '',
-          'SIRET-123-haché256'
-        );
-        await adaptateurPersistance.ajouteAutorisation(
-          unUUIDRandom(),
-          uneAutorisation().deProprietaire(unUUID('P'), unUUID('S2')).donnees
-        );
-
-        const entitesDe = (await serviceAdministrationOrganisations.entitesDe(
-          unUUID('S')
-        )) as unknown as Array<DonneesEntiteSupervisee>;
-
-        expect(entitesDe[0].nombreServices).toBe(2);
-        expect(entitesDe[0].nombreUtilisateurs).toBe(1);
-      });
+      expect(entitesDe[0].nombreServices).toBe(2);
+      expect(entitesDe[0].nombreUtilisateurs).toBe(1);
     });
 
     it("renvoie un tableau vide s'il n'est ni admin ni superviseur", async () => {

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -22,6 +22,7 @@ import { creeReferentielV2 } from '../../src/referentielV2.ts';
 import { PersistanceTS } from '../../src/adaptateurs/persistanceTS.interface.ts';
 import Superviseur from '../../src/modeles/superviseur.ts';
 import { AdminOrganisations } from '../../src/modeles/gestionOrganisations/adminOrganisations.ts';
+import { ErreurSuppressionImpossible } from '../../src/erreurs.ts';
 
 type Surcharge = Partial<
   ConstructorParameters<typeof ServiceAdministrationOrganisations>[0]
@@ -367,11 +368,13 @@ describe("Le service de gestion des admins d'organisation", () => {
     let service: ServiceAdministrationOrganisations;
     const siret = 'SIRET-1';
     const autreSiret = '12345';
+    const siretEnErreur = 'SIRET-ERREUR';
     const idService2 = unUUID('S2');
+    const idService3 = unUUID('S3');
 
     beforeEach(() => {
       adaptateurPersistance = unePersistanceMemoire()
-        .ajouteAdminSurPerimetre(idAdmin, [siret])
+        .ajouteAdminSurPerimetre(idAdmin, [siret, siretEnErreur])
         .ajouteUnUtilisateur(unUtilisateur().avecId(idAdmin).donnees)
         .ajouteUnService(
           unServiceV2().avecId(idService).avecOrganisationResponsable({ siret })
@@ -382,6 +385,11 @@ describe("Le service de gestion des admins d'organisation", () => {
             .avecId(idService2)
             .avecOrganisationResponsable({ siret: autreSiret }).donnees
         )
+        .ajouteUnService(
+          unServiceV2()
+            .avecId(idService3)
+            .avecOrganisationResponsable({ siret: siretEnErreur }).donnees
+        )
         .ajouteUneAutorisation(
           uneAutorisation().dAdmin(idAdmin, idService).donnees
         )
@@ -390,6 +398,9 @@ describe("Le service de gestion des admins d'organisation", () => {
         )
         .ajouteUneAutorisation(
           uneAutorisation().deProprietaire(idAdmin, idService2).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().dAdmin(idAdmin, idService3).donnees
         )
         .construis() as unknown as AdaptateurPersistance;
       adaptateurPersistanceTS = unePersistanceMemoireTS()
@@ -403,10 +414,6 @@ describe("Le service de gestion des admins d'organisation", () => {
 
       service = leServiceDAdministrationDesOrgas();
     });
-
-    it.todo(
-      "ne supprime pas l'autorisation si l'admin est seul contributeur d'un service"
-    );
 
     it("ne jette pas d'erreur si l'utilisateur n'est pas admin", async () => {
       await expect(
@@ -425,8 +432,14 @@ describe("Le service de gestion des admins d'organisation", () => {
       await service.retireAdmin(siret, idAdmin);
 
       const autorisations = await depotComplet.autorisations(idAdmin);
-      expect(autorisations).toHaveLength(1);
+      expect(autorisations).toHaveLength(2);
       expect(autorisations[0].idService).toBe(idService2);
+    });
+
+    it("jette une erreur si l'admin est seul contributeurs d'un des services administrés", async () => {
+      await expect(service.retireAdmin(siretEnErreur, idAdmin)).rejects.toThrow(
+        new ErreurSuppressionImpossible()
+      );
     });
   });
 });

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -60,7 +60,7 @@ describe("Le service de gestion des admins d'organisation", () => {
     });
   };
 
-  const leService = (surcharge: Surcharge = {}) =>
+  const leServiceDAdministrationDesOrgas = (surcharge: Surcharge = {}) =>
     new ServiceAdministrationOrganisations({
       adaptateurUUID: fabriqueAdaptateurUUID(),
       depotDonnees: depotComplet,
@@ -75,7 +75,7 @@ describe("Le service de gestion des admins d'organisation", () => {
 
   describe("sur demande de rattachement d'un service à ses admins", () => {
     it('crée les autorisations admins correspondantes', async () => {
-      const administrationOrganisations = leService();
+      const administrationOrganisations = leServiceDAdministrationDesOrgas();
 
       await administrationOrganisations.rattacheLesAdministrateursDe(unService);
 
@@ -89,7 +89,7 @@ describe("Le service de gestion des admins d'organisation", () => {
       await depotComplet.sauvegardeAutorisation(
         uneAutorisation().deProprietaire(idAdmin, idService).construis()
       );
-      const administrationOrganisations = leService();
+      const administrationOrganisations = leServiceDAdministrationDesOrgas();
 
       await administrationOrganisations.rattacheLesAdministrateursDe(unService);
 
@@ -102,7 +102,7 @@ describe("Le service de gestion des admins d'organisation", () => {
     it('délègue au dépôt la suppression des autorisations admins pré-existantes', async () => {
       const mockSupprimeAutorisations = vi.fn();
       depotComplet.supprimeAutorisationsAdminPour = mockSupprimeAutorisations;
-      const administrationOrganisations = leService();
+      const administrationOrganisations = leServiceDAdministrationDesOrgas();
 
       await administrationOrganisations.rattacheLesAdministrateursDe(unService);
 
@@ -143,7 +143,7 @@ describe("Le service de gestion des admins d'organisation", () => {
         adaptateurChiffrement: fauxAdaptateurChiffrement(),
       });
 
-      administrationOrganisations = leService();
+      administrationOrganisations = leServiceDAdministrationDesOrgas();
     });
 
     it('crée le nouvel admin', async () => {
@@ -200,7 +200,7 @@ describe("Le service de gestion des admins d'organisation", () => {
       adaptateurMail.envoieMessageNominationAdmin =
         envoieMessageNominationAdmin;
 
-      const service = leService({ adaptateurMail });
+      const service = leServiceDAdministrationDesOrgas({ adaptateurMail });
 
       await service.nommeAdmin('1234', unUUID('A'), 'nouvel-admin@mail.fr');
 
@@ -249,11 +249,11 @@ describe("Le service de gestion des admins d'organisation", () => {
         unUtilisateur().donnees
       );
 
-      serviceAdministrationOrganisations = leService();
+      serviceAdministrationOrganisations = leServiceDAdministrationDesOrgas();
     });
 
     it("sait renvoyer les entités du point-de-vue d'un admin : l'admin est alors lui-même présent dans les admins renvoyés", async () => {
-      const service = leService();
+      const service = leServiceDAdministrationDesOrgas();
 
       const entitesDe = await service.entitesDe(unUUID('A'));
 
@@ -313,7 +313,7 @@ describe("Le service de gestion des admins d'organisation", () => {
     });
 
     it("renvoie un tableau vide s'il n'est ni admin ni superviseur", async () => {
-      const service = leService();
+      const service = leServiceDAdministrationDesOrgas();
 
       const entitesDe = await service.entitesDe(unUUID('U'));
 
@@ -351,7 +351,7 @@ describe("Le service de gestion des admins d'organisation", () => {
 
       depotComplet = unDepotComplet({ adaptateurPersistance });
 
-      service = leService();
+      service = leServiceDAdministrationDesOrgas();
     });
 
     it("retourne les contributeurs des services d'un admin", async () => {
@@ -360,6 +360,73 @@ describe("Le service de gestion des admins d'organisation", () => {
       expect(utilisateurs).toHaveLength(2);
       expect(utilisateurs[0].id).toBe(idU1);
       expect(utilisateurs[1].id).toBe(idU2);
+    });
+  });
+
+  describe("sur demande de retrait d'une entité administrée", () => {
+    let service: ServiceAdministrationOrganisations;
+    const siret = 'SIRET-1';
+    const autreSiret = '12345';
+    const idService2 = unUUID('S2');
+
+    beforeEach(() => {
+      adaptateurPersistance = unePersistanceMemoire()
+        .ajouteAdminSurPerimetre(idAdmin, [siret])
+        .ajouteUnUtilisateur(unUtilisateur().avecId(idAdmin).donnees)
+        .ajouteUnService(
+          unServiceV2().avecId(idService).avecOrganisationResponsable({ siret })
+            .donnees
+        )
+        .ajouteUnService(
+          unServiceV2()
+            .avecId(idService2)
+            .avecOrganisationResponsable({ siret: autreSiret }).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().dAdmin(idAdmin, idService).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire(unUUIDRandom(), idService).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire(idAdmin, idService2).donnees
+        )
+        .construis() as unknown as AdaptateurPersistance;
+      adaptateurPersistanceTS = unePersistanceMemoireTS()
+        .ajouteAdminSurPerimetre(idAdmin, [{ siret }])
+        .construis();
+
+      depotComplet = unDepotComplet({
+        adaptateurPersistance,
+        adaptateurPersistanceTS,
+      });
+
+      service = leServiceDAdministrationDesOrgas();
+    });
+
+    it.todo(
+      "ne supprime pas l'autorisation si l'admin est seul contributeur d'un service"
+    );
+
+    it("ne jette pas d'erreur si l'utilisateur n'est pas admin", async () => {
+      await expect(
+        service.retireAdmin(siret, unUUIDRandom())
+      ).resolves.not.toThrow();
+    });
+
+    it("retire l'entité du périmètre de l'admin", async () => {
+      await service.retireAdmin(siret, idAdmin);
+
+      const adminAJour = await depotComplet.lisAdminOrganisations(idAdmin);
+      expect(adminAJour?.estAdminDe(siret)).toBe(false);
+    });
+
+    it('supprime les autorisations admin sur les services de ce siret', async () => {
+      await service.retireAdmin(siret, idAdmin);
+
+      const autorisations = await depotComplet.autorisations(idAdmin);
+      expect(autorisations).toHaveLength(1);
+      expect(autorisations[0].idService).toBe(idService2);
     });
   });
 });


### PR DESCRIPTION
Cette PR permet aux admins de voir leurs entités, de la même façon qu'un superviseur pourrait les voir.

Exemple 👇 :
 - _John Doe_ en (1) est un admin, du point-de-vue du superviseur
 - quand on se connecte en tant que _John Doe_, en(2), alors on voit l'entité `MALEA` 

<img width="600" src="https://github.com/user-attachments/assets/35ddb987-449f-4fae-af4d-4debb99f894e" />
