### PR TITLE
[CORRECTION] Évite d'imbriquer deux `button`

### DIFF
--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -50,9 +50,9 @@
 <MenuFlottant parDessusDeclencheur={true}>
   {#snippet declencheur()}
     <div>
-      <button class="bouton bouton-secondaire bouton-filtre">
+      <span class="bouton bouton-secondaire bouton-filtre">
         <IconeFiltre filtresActifs={$nombreResultats.aDesFiltresAppliques} />
-      </button>
+      </span>
     </div>
   {/snippet}
 


### PR DESCRIPTION
… pour corriger une erreur d'accessibilité niveau "Sérieux"

> 🟠 `nested-interactive` — Interactive controls must not be nested

On touche à ce composant 👇  

<img width="500" src="https://github.com/user-attachments/assets/8980963e-3f8e-436e-a2e7-d117381bda1b" />
