### PR TITLE
[CORRECTION] Ajoute un `return` dans le middleware

### DIFF
--- a/src/http/middleware.ts
+++ b/src/http/middleware.ts
@@ -199,7 +199,10 @@ const middleware = (configuration: ConfigurationMiddleware) => {
       const resultat = z
         .looseObject({ id: z.uuid() })
         .safeParse(requete.params);
-      if (!resultat.success) reponse.sendStatus(400);
+      if (!resultat.success) {
+        reponse.sendStatus(400);
+        return;
+      }
 
       const idService = requete.params.id;
 

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -462,6 +462,7 @@ describe('Le middleware MSS', () => {
 
     it("jette une erreur technique si l'objet de droits est incohérent", async () => {
       const middleware = leMiddleware();
+      requete.params = { id: unUUIDRandom() };
 
       try {
         await middleware.trouveService({ mauvaiseCle: 'mauvaiseValeur' })(
@@ -511,6 +512,7 @@ describe('Le middleware MSS', () => {
       depotDonnees.service = async () => service;
       depotDonnees.accesAutorise = async () => true;
       const middleware = leMiddleware({ adaptateurJWT });
+      requete.params = { id: unUUIDRandom() };
 
       let appele = false;
       await middleware.trouveService({})(requete, reponse, () => {


### PR DESCRIPTION
... suite à un rapport généré par Beta.

> [!IMPORTANT]
> On se rend compte que certain test n'avait pas le bon `setup`, il faut un vrai `uuid` pour passer la vérification `zod` 