### PR TITLE
[ORGAS] Corrige la sauvegarde du nouveau périmètre d'un admin

### DIFF
--- a/src/modeles/gestionOrganisations/adminOrganisations.ts
+++ b/src/modeles/gestionOrganisations/adminOrganisations.ts
@@ -50,4 +50,10 @@ export class AdminOrganisations {
   estAdminDe(siret: string) {
     return this.entitesAdministrees.some((e) => e.siret === siret);
   }
+
+  estAdminDuPerimetre(sirets: string[]) {
+    return new Set(sirets).isSubsetOf(
+      new Set(this.entitesAdministrees.map((e) => e.siret))
+    );
+  }
 }

--- a/src/modeles/superviseur.ts
+++ b/src/modeles/superviseur.ts
@@ -36,6 +36,12 @@ class Superviseur {
     return this.entitesSupervisees.some((e) => e.siret === siret);
   }
 
+  estSuperviseurDuPerimetre(sirets: string[]) {
+    return new Set(sirets).isSubsetOf(
+      new Set(this.entitesSupervisees.map((e) => e.siret))
+    );
+  }
+
   donnees(): DonneesSuperviseur {
     return {
       idUtilisateur: this.idUtilisateur,

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -222,12 +222,9 @@ export class ServiceAdministrationOrganisations {
       admin = AdminOrganisations.nouveau(idAdmin);
     }
 
-    const donneesEntite = await Entite.completeDonnees(
-      { siret },
-      this.adaptateurRechercheEntite
-    );
+    const entite = await this.completeEntite(siret);
 
-    admin.administre(new Entite(donneesEntite));
+    admin.administre(entite);
 
     await this.depotDonnees.sauvegardeAdminOrganisations(admin);
   }
@@ -492,9 +489,19 @@ export class ServiceAdministrationOrganisations {
     }
   }
 
-  async assignePerimetre(idActeur: UUID, idAdmin: UUID, sirets: string[]) {
-    const acteur = await this.depotDonnees.lisAdminOrganisations(idActeur);
+  private async completeEntite(siret: string) {
+    const donneesEntite = await Entite.completeDonnees(
+      { siret },
+      this.adaptateurRechercheEntite
+    );
 
+    return new Entite(donneesEntite);
+  }
+
+  async assignePerimetre(idActeur: UUID, idAdmin: UUID, sirets: string[]) {
+    if (idActeur === idAdmin) throw new EchecAutorisation();
+
+    const acteur = await this.depotDonnees.lisAdminOrganisations(idActeur);
     if (
       !acteur ||
       !new Set(sirets).isSubsetOf(
@@ -504,23 +511,81 @@ export class ServiceAdministrationOrganisations {
       throw new ErreurEntiteNonAdministre();
     }
 
-    const admin = await this.depotDonnees.lisAdminOrganisations(idAdmin);
+    let admin = await this.depotDonnees.lisAdminOrganisations(idAdmin);
+    if (!admin) {
+      admin = AdminOrganisations.nouveau(idAdmin);
+    }
 
     const siretsAAjouter = sirets.filter(
       (siret) => !admin || !admin.estAdminDe(siret)
     );
-    await Promise.all(
-      siretsAAjouter.map((siret) => this.nommeAdmin(idActeur, siret, idAdmin))
-    );
-
-    if (!admin) return;
-
     const siretsARetirer = admin!
       .donnees()
       .entitesAdministrees.filter((e) => !sirets.includes(e.siret))
       .map((e) => e.siret);
-    await Promise.all(
-      siretsARetirer.map((siret) => this.retireAdmin(idActeur, siret, idAdmin))
+
+    const tableauDeTableauDeServicesARetirer = await Promise.all(
+      siretsARetirer.map(this.depotDonnees.tousLesServicesAvecSiret)
     );
+    const servicesARetirer = tableauDeTableauDeServicesARetirer.flatMap(
+      (v) => v
+    );
+    ServiceAdministrationOrganisations.verifieNEstPasSeulProprietaireDesServices(
+      servicesARetirer,
+      idAdmin
+    );
+
+    const entitesAAjouter = await Promise.all(
+      siretsAAjouter.map((siret) => this.completeEntite(siret))
+    );
+    const entitesARetirer = await Promise.all(
+      siretsARetirer.map((siret) => this.completeEntite(siret))
+    );
+    entitesAAjouter.forEach((e) => {
+      admin?.administre(e);
+    });
+    entitesARetirer.forEach((e) => {
+      admin?.cesseDAdministrer(e);
+    });
+    await this.depotDonnees.sauvegardeAdminOrganisations(admin);
+
+    const tableauDeTableauDeServices = await Promise.all(
+      sirets.map(this.depotDonnees.tousLesServicesAvecSiret)
+    );
+    const services = tableauDeTableauDeServices.flatMap((v) => v);
+    await Promise.all(
+      services.map((service) => this.rattacheLesAdministrateursDe(service))
+    );
+
+    await Promise.all(
+      siretsARetirer.map((siret) =>
+        this.busEvenements.publie(
+          new EvenementAdminRetireDeOrganisation({
+            idActeur,
+            idCible: idAdmin,
+            siret,
+          })
+        )
+      )
+    );
+
+    await Promise.all(
+      siretsAAjouter.map((siret) =>
+        this.busEvenements.publie(
+          new EvenementAdminNommeSurOrganisation({
+            idActeur,
+            idCible: idAdmin,
+            siret,
+          })
+        )
+      )
+    );
+
+    if (sirets.length > 0) {
+      const nouvelAdmin = await this.depotDonnees.utilisateur(idAdmin);
+      await this.adaptateurMail.envoieMessageNominationAdmin(
+        nouvelAdmin!.email
+      );
+    }
   }
 }

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -137,34 +137,16 @@ export class ServiceAdministrationOrganisations {
   }
 
   async retireAdmin(idActeur: UUID, siret: string, idUtilisateur: UUID) {
-    await this.verifieEntitesAdministrees(idActeur, [siret]);
-
-    if (idActeur === idUtilisateur) {
-      throw new EchecAutorisation();
-    }
-
     const admin = await this.depotDonnees.lisAdminOrganisations(idUtilisateur);
     if (!admin) return;
 
-    const services = await this.depotDonnees.tousLesServicesAvecSiret(siret);
-    ServiceAdministrationOrganisations.verifieNEstPasSeulProprietaireDesServices(
-      services,
-      idUtilisateur
-    );
-
-    admin.cesseDAdministrer(new Entite({ siret }));
-    await this.depotDonnees.sauvegardeAdminOrganisations(admin!);
-
-    await Promise.all(
-      services.map((service) => this.rattacheLesAdministrateursDe(service))
-    );
-
-    await this.busEvenements.publie(
-      new EvenementAdminRetireDeOrganisation({
-        idActeur,
-        idCible: idUtilisateur,
-        siret,
-      })
+    await this.assignePerimetre(
+      idActeur,
+      idUtilisateur,
+      admin
+        .donnees()
+        .entitesAdministrees.map((e) => e.siret)
+        .filter((s) => s !== siret)
     );
   }
 
@@ -446,8 +428,6 @@ export class ServiceAdministrationOrganisations {
   async assignePerimetre(idActeur: UUID, idAdmin: UUID, sirets: string[]) {
     if (idActeur === idAdmin) throw new EchecAutorisation();
 
-    await this.verifieEntitesAdministrees(idActeur, sirets);
-
     let admin = await this.depotDonnees.lisAdminOrganisations(idAdmin);
     if (!admin) {
       admin = AdminOrganisations.nouveau(idAdmin);
@@ -460,6 +440,9 @@ export class ServiceAdministrationOrganisations {
       .donnees()
       .entitesAdministrees.filter((e) => !sirets.includes(e.siret))
       .map((e) => e.siret);
+
+    const siretsModifies = [...siretsARetirer, ...siretsAAjouter];
+    await this.verifieEntitesAdministrees(idActeur, siretsModifies);
 
     const tableauDeTableauDeServicesARetirer = await Promise.all(
       siretsARetirer.map(this.depotDonnees.tousLesServicesAvecSiret)
@@ -486,12 +469,16 @@ export class ServiceAdministrationOrganisations {
     });
     await this.depotDonnees.sauvegardeAdminOrganisations(admin);
 
-    const tableauDeTableauDeServices = await Promise.all(
-      sirets.map(this.depotDonnees.tousLesServicesAvecSiret)
+    const tableauDeTableauDeServicesARafraichir = await Promise.all(
+      siretsModifies.map(this.depotDonnees.tousLesServicesAvecSiret)
     );
-    const services = tableauDeTableauDeServices.flatMap((v) => v);
+    const servicesARafraichir = tableauDeTableauDeServicesARafraichir.flatMap(
+      (v) => v
+    );
     await Promise.all(
-      services.map((service) => this.rattacheLesAdministrateursDe(service))
+      servicesARafraichir.map((service) =>
+        this.rattacheLesAdministrateursDe(service)
+      )
     );
 
     await Promise.all(
@@ -518,7 +505,7 @@ export class ServiceAdministrationOrganisations {
       )
     );
 
-    if (sirets.length > 0) {
+    if (siretsAAjouter.length > 0) {
       const nouvelAdmin = await this.depotDonnees.utilisateur(idAdmin);
       await this.adaptateurMail.envoieMessageNominationAdmin(
         nouvelAdmin!.email

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -137,7 +137,7 @@ export class ServiceAdministrationOrganisations {
   }
 
   async retireAdmin(idActeur: UUID, siret: string, idUtilisateur: UUID) {
-    await this.verifieEntiteAdministree(idActeur, siret);
+    await this.verifieEntitesAdministrees(idActeur, [siret]);
 
     if (idActeur === idUtilisateur) {
       throw new EchecAutorisation();
@@ -187,68 +187,13 @@ export class ServiceAdministrationOrganisations {
   }
 
   async nommeAdmin(idActeur: UUID, siret: string, idAdmin: UUID) {
-    await this.verifieEntiteAdministree(idActeur, siret);
-
-    if (idActeur === idAdmin) {
-      throw new EchecAutorisation();
-    }
-
-    await this.ajouteSiretAAdmin(siret, idAdmin);
-
-    const services = await this.depotDonnees.tousLesServicesAvecSiret(siret);
-    const nouvellesAutorisations = this.fabriqueAutorisationsAdminPourServices(
-      services,
-      idAdmin
-    );
-    await this.sauvegardeAutorisations(
-      await Promise.all(nouvellesAutorisations)
-    );
-
-    const nouvelAdmin = await this.depotDonnees.utilisateur(idAdmin);
-    await this.adaptateurMail.envoieMessageNominationAdmin(nouvelAdmin!.email);
-
-    await this.busEvenements.publie(
-      new EvenementAdminNommeSurOrganisation({
-        idActeur,
-        idCible: idAdmin,
-        siret,
-      })
-    );
-  }
-
-  private async ajouteSiretAAdmin(siret: string, idAdmin: UUID) {
     let admin = await this.depotDonnees.lisAdminOrganisations(idAdmin);
-    if (!admin) {
-      admin = AdminOrganisations.nouveau(idAdmin);
-    }
+    if (!admin) admin = AdminOrganisations.nouveau(idAdmin);
 
-    const entite = await this.completeEntite(siret);
-
-    admin.administre(entite);
-
-    await this.depotDonnees.sauvegardeAdminOrganisations(admin);
-  }
-
-  private fabriqueAutorisationsAdminPourServices(
-    services: Service[],
-    idAdmin: UUID
-  ) {
-    return services.map(async (s) => {
-      const autorisationsExistantes =
-        await this.depotDonnees.autorisationsDuService(s.id);
-
-      const autorisationExistantePourAdmin = autorisationsExistantes.find(
-        (a: Autorisation) => a.designeUtilisateur(idAdmin)
-      );
-
-      return Autorisation.NouvelleAutorisationAdmin({
-        id: autorisationExistantePourAdmin
-          ? autorisationExistantePourAdmin.id
-          : this.adaptateurUUID.genereUUID(),
-        idService: s.id,
-        idUtilisateur: idAdmin,
-      });
-    });
+    await this.assignePerimetre(idActeur, idAdmin, [
+      ...admin.donnees().entitesAdministrees.map((e) => e.siret),
+      siret,
+    ]);
   }
 
   async entitesDe(
@@ -460,18 +405,18 @@ export class ServiceAdministrationOrganisations {
     }
   }
 
-  private async verifieEntiteAdministree(idActeur: UUID, siret: string) {
+  private async verifieEntitesAdministrees(idActeur: UUID, sirets: string[]) {
     const acteurAdmin = await this.depotDonnees.lisAdminOrganisations(idActeur);
     const acteurSuperviseur = await this.depotDonnees.lisSuperviseur(idActeur);
-    if (!acteurAdmin && !acteurSuperviseur) {
-      throw new ErreurEntiteNonAdministre();
-    }
 
-    if (acteurSuperviseur && !acteurSuperviseur.estSuperviseurDe(siret)) {
-      throw new ErreurEntiteNonAdministre();
-    }
-
-    if (acteurAdmin && !acteurAdmin.estAdminDe(siret)) {
+    if (
+      (!acteurAdmin && !acteurSuperviseur) ||
+      !(
+        (acteurAdmin && acteurAdmin.estAdminDuPerimetre(sirets)) ||
+        (acteurSuperviseur &&
+          acteurSuperviseur.estSuperviseurDuPerimetre(sirets))
+      )
+    ) {
       throw new ErreurEntiteNonAdministre();
     }
   }
@@ -501,15 +446,7 @@ export class ServiceAdministrationOrganisations {
   async assignePerimetre(idActeur: UUID, idAdmin: UUID, sirets: string[]) {
     if (idActeur === idAdmin) throw new EchecAutorisation();
 
-    const acteur = await this.depotDonnees.lisAdminOrganisations(idActeur);
-    if (
-      !acteur ||
-      !new Set(sirets).isSubsetOf(
-        new Set(acteur.donnees().entitesAdministrees.map((e) => e.siret))
-      )
-    ) {
-      throw new ErreurEntiteNonAdministre();
-    }
+    await this.verifieEntitesAdministrees(idActeur, sirets);
 
     let admin = await this.depotDonnees.lisAdminOrganisations(idAdmin);
     if (!admin) {

--- a/test/constructeurs/constructeurAutorisation.js
+++ b/test/constructeurs/constructeurAutorisation.js
@@ -1,11 +1,12 @@
 import { tousDroitsEnEcriture } from '../../src/modeles/autorisations/gestionDroits.js';
 import { Autorisation } from '../../src/modeles/autorisations/autorisation.js';
+import { unUUIDRandom } from './UUID.js';
 
 class ConstructeurAutorisation {
   constructor() {
     this.donnees = {
       estProprietaire: false,
-      id: '',
+      id: unUUIDRandom(),
       idUtilisateur: '',
       idService: '',
       droits: {},

--- a/test/modeles/gestionOrganisations/adminOrganisations.spec.ts
+++ b/test/modeles/gestionOrganisations/adminOrganisations.spec.ts
@@ -83,4 +83,19 @@ describe("Un admin d'organisations", () => {
       expect(admin.donnees().entitesAdministrees).toHaveLength(1);
     });
   });
+
+  it("sait s'il est admin de tout un périmètre", () => {
+    const admin = AdminOrganisations.hydrate({
+      idUtilisateur: unUUID('U'),
+      entitesAdministrees: [
+        { siret: 'SIRET-123', nom: 'Un nom', departement: '75' },
+        { siret: 'SIRET-456', nom: 'Un nom', departement: '75' },
+      ],
+    });
+
+    expect(admin.estAdminDuPerimetre(['SIRET-123'])).toBeTruthy();
+    expect(admin.estAdminDuPerimetre(['SIRET-123', 'SIRET-456'])).toBeTruthy();
+    expect(admin.estAdminDuPerimetre(['SIRET-123', 'SIRET-124'])).toBeFalsy();
+    expect(admin.estAdminDuPerimetre(['SIRET-124'])).toBeFalsy();
+  });
 });

--- a/test/modeles/superviseur.spec.ts
+++ b/test/modeles/superviseur.spec.ts
@@ -42,4 +42,23 @@ describe('Un superviseur', () => {
       expect(superviseur.donnees().entitesSupervisees).toHaveLength(1);
     });
   });
+
+  it("sait s'il est superviseur de tout un périmètre", () => {
+    const admin = Superviseur.hydrate({
+      idUtilisateur: unUUID('U'),
+      entitesSupervisees: [
+        { siret: 'SIRET-123', nom: 'Un nom', departement: '75' },
+        { siret: 'SIRET-456', nom: 'Un nom', departement: '75' },
+      ],
+    });
+
+    expect(admin.estSuperviseurDuPerimetre(['SIRET-123'])).toBeTruthy();
+    expect(
+      admin.estSuperviseurDuPerimetre(['SIRET-123', 'SIRET-456'])
+    ).toBeTruthy();
+    expect(
+      admin.estSuperviseurDuPerimetre(['SIRET-123', 'SIRET-124'])
+    ).toBeFalsy();
+    expect(admin.estSuperviseurDuPerimetre(['SIRET-124'])).toBeFalsy();
+  });
 });

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -41,9 +41,12 @@ type Surcharge = Partial<
 
 describe("Le service de gestion des admins d'organisation", () => {
   const idService = unUUID('s');
+  const idService2 = unUUID('s2');
+  const idService3 = unUUID('s3');
   const idAdmin = unUUID('u1');
   const idAncienAdmin = unUUIDRandom();
   const entite = { siret: '1234', nom: 'Un nom', departement: '75' };
+  const entite2 = { siret: '4567', nom: 'Un nom 2', departement: '75' };
   const unService = unServiceV2()
     .avecId(idService)
     .avecOrganisationResponsable(entite)
@@ -483,8 +486,6 @@ describe("Le service de gestion des admins d'organisation", () => {
     const siret = 'SIRET-1';
     const autreSiret = '12345';
     const siretSeulAdmin = 'SIRET-SEUL-ADMIN';
-    const idService2 = unUUID('S2');
-    const idService3 = unUUID('S3');
     const idContributeurS3 = unUUID('U3');
     const idSuperviseur = unUUID('SU1');
 
@@ -847,16 +848,49 @@ describe("Le service de gestion des admins d'organisation", () => {
     beforeEach(() => {
       adaptateurPersistance = unePersistanceMemoire()
         .ajouteUnUtilisateur(unUtilisateur().avecId(idAdmin).donnees)
-        .ajouteUnUtilisateur(unUtilisateur().avecId(idNouvelAdmin).donnees)
-        .ajouteUnService(unServiceV2().avecId(idService).donnees)
+        .ajouteUnUtilisateur(
+          unUtilisateur()
+            .avecId(idNouvelAdmin)
+            .avecEmail('nouvel-admin@mail.fr').donnees
+        )
+        .ajouteUnService(
+          unServiceV2().avecId(idService).avecOrganisationResponsable(entite)
+            .donnees
+        )
+        .ajouteUnService(
+          unServiceV2().avecId(idService2).avecOrganisationResponsable(entite2)
+            .donnees
+        )
+        .ajouteUnService(
+          unServiceV2().avecId(idService3).avecOrganisationResponsable(entite2)
+            .donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().dAdmin(idNouvelAdmin, idService).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire(idNouvelAdmin, idService3).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().dAdmin(idActeur, idService).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().dAdmin(idActeur, idService2).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().dAdmin(idActeur, idService3).donnees
+        )
         .construis() as unknown as AdaptateurPersistance;
 
       adaptateurPersistanceTS = unePersistanceMemoireTS()
         .ajouteAdminSurPerimetre(idActeur, [
           { siret: 'SIRET-1' },
           { siret: 'SIRET-2' },
+          entite,
+          entite2,
         ])
         .ajouteAdminSurPerimetre(idAdmin, [{ siret: 'SIRET-2' }])
+        .ajouteAdminSurPerimetre(idNouvelAdmin, [entite])
         .construis();
 
       depotComplet = unDepotComplet({
@@ -865,6 +899,12 @@ describe("Le service de gestion des admins d'organisation", () => {
       });
 
       service = leServiceDAdministrationDesOrgas();
+    });
+
+    it("jette une erreur s'il essaie de se nommer admin lui-même", async () => {
+      await expect(() =>
+        service.assignePerimetre(idActeur, idActeur, ['SIRET-1'])
+      ).rejects.toThrow(EchecAutorisation);
     });
 
     it("jette une erreur si l'admin acteur n'administre pas le périmètre complet demandé", async () => {
@@ -906,6 +946,95 @@ describe("Le service de gestion des admins d'organisation", () => {
 
       const admin = await depotComplet.lisAdminOrganisations(idAdmin);
       expect(admin!.estAdminDe('SIRET-2')).toBeTruthy();
+    });
+
+    it('supprime les autorisations admin sur les services des sirets retirés', async () => {
+      await service.assignePerimetre(idActeur, idNouvelAdmin, [entite2.siret]);
+
+      const autorisations = await depotComplet.autorisations(idAdmin);
+      expect(autorisations).toHaveLength(0);
+    });
+
+    it("publie un évènement d'admin retiré sur le bus", async () => {
+      await service.assignePerimetre(idActeur, idNouvelAdmin, [entite2.siret]);
+
+      expect(
+        busEvenements.aRecuUnEvenement(EvenementAdminRetireDeOrganisation)
+      ).toBe(true);
+      const evenement: EvenementAdminRetireDeOrganisation =
+        busEvenements.recupereEvenement(EvenementAdminRetireDeOrganisation);
+      expect(evenement.idActeur).toBe(idActeur);
+      expect(evenement.idCible).toBe(idNouvelAdmin);
+      expect(evenement.siret).toBe(entite.siret);
+    });
+
+    it('ajoute les autorisations correspondantes', async () => {
+      await service.assignePerimetre(idActeur, idNouvelAdmin, [
+        entite.siret,
+        entite2.siret,
+      ]);
+
+      const autorisationsAdmin: Autorisation[] =
+        await depotComplet.autorisations(idNouvelAdmin);
+
+      expect(autorisationsAdmin).toHaveLength(3);
+      expect(
+        autorisationsAdmin.find((a) => a.idService === idService)
+      ).toBeDefined();
+      expect(
+        autorisationsAdmin.find((a) => a.idService === idService2)
+      ).toBeDefined();
+      expect(
+        autorisationsAdmin.find((a) => a.idService === idService3)
+      ).toBeDefined();
+    });
+
+    it("élève les droits au rôle d'admin si l'admin est un contributeur existant", async () => {
+      await service.assignePerimetre(idActeur, idNouvelAdmin, [
+        entite.siret,
+        entite2.siret,
+      ]);
+
+      const autorisationsAdmin: Autorisation[] =
+        await depotComplet.autorisations(idNouvelAdmin);
+      expect(
+        autorisationsAdmin
+          .find((a) => a.idService === idService3)
+          ?.resumeNiveauDroit()
+      ).toBe('ADMIN');
+    });
+
+    it("notifie par email l'admin nommé", async () => {
+      const adaptateurMail = fabriqueAdaptateurMailMemoire();
+      const envoieMessageNominationAdmin = vi.fn();
+      adaptateurMail.envoieMessageNominationAdmin =
+        envoieMessageNominationAdmin;
+      const leService = leServiceDAdministrationDesOrgas({ adaptateurMail });
+
+      await leService.assignePerimetre(idActeur, idNouvelAdmin, [
+        entite.siret,
+        entite2.siret,
+      ]);
+
+      expect(envoieMessageNominationAdmin).toHaveBeenCalledWith(
+        'nouvel-admin@mail.fr'
+      );
+    });
+
+    it("publie un évènement d'admin nommé sur le bus", async () => {
+      await service.assignePerimetre(idActeur, idNouvelAdmin, [
+        entite.siret,
+        entite2.siret,
+      ]);
+
+      expect(
+        busEvenements.aRecuUnEvenement(EvenementAdminNommeSurOrganisation)
+      ).toBe(true);
+      const evenement: EvenementAdminNommeSurOrganisation =
+        busEvenements.recupereEvenement(EvenementAdminNommeSurOrganisation);
+      expect(evenement.idActeur).toBe(idActeur);
+      expect(evenement.idCible).toBe(idNouvelAdmin);
+      expect(evenement.siret).toBe(entite2.siret);
     });
   });
 });

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -486,8 +486,10 @@ describe("Le service de gestion des admins d'organisation", () => {
     const siret = 'SIRET-1';
     const autreSiret = '12345';
     const siretSeulAdmin = 'SIRET-SEUL-ADMIN';
+    const siretPasSupervise = 'UN-SIRET-PAS-SUPERVISÉ';
     const idContributeurS3 = unUUID('U3');
     const idSuperviseur = unUUID('SU1');
+    const idAdminPasSupervise = unUUIDRandom();
 
     beforeEach(() => {
       adaptateurPersistance = unePersistanceMemoire()
@@ -525,7 +527,13 @@ describe("Le service de gestion des admins d'organisation", () => {
         )
         .construis() as unknown as AdaptateurPersistance;
       adaptateurPersistanceTS = unePersistanceMemoireTS()
-        .ajouteAdminSurPerimetre(idAdmin, [{ siret }])
+        .ajouteAdminSurPerimetre(idAdminPasSupervise, [
+          { siret: siretPasSupervise },
+        ])
+        .ajouteAdminSurPerimetre(idAdmin, [
+          { siret },
+          { siret: siretSeulAdmin },
+        ])
         .ajouteSuperviseurSurPerimetre(idSuperviseur, [
           { siret },
           { siret: siretSeulAdmin },
@@ -543,7 +551,7 @@ describe("Le service de gestion des admins d'organisation", () => {
     it("jette une erreur si l'acteur n'est ni superviseur ni admin", async () => {
       const idActeur = unUUIDRandom();
       await expect(
-        service.retireAdmin(idActeur, siret, unUUIDRandom())
+        service.retireAdmin(idActeur, siret, idAdmin)
       ).rejects.toThrow(ErreurEntiteNonAdministre);
     });
 
@@ -551,15 +559,15 @@ describe("Le service de gestion des admins d'organisation", () => {
       await expect(
         service.retireAdmin(
           idSuperviseur,
-          'UN-SIRET-PAS-SUPERVISÉ',
-          unUUIDRandom()
+          siretPasSupervise,
+          idAdminPasSupervise
         )
       ).rejects.toThrow(ErreurEntiteNonAdministre);
     });
 
     it("jette une erreur si l'acteur n'est pas admin de l'entité demandée", async () => {
       await expect(
-        service.retireAdmin(idAdmin, 'UN-SIRET-PAS-SUPERVISÉ', unUUIDRandom())
+        service.retireAdmin(idAdmin, siretPasSupervise, idAdminPasSupervise)
       ).rejects.toThrow(ErreurEntiteNonAdministre);
     });
 


### PR DESCRIPTION
...qui avait beaucoup d'oublis, et qui ne fonctionnait pas en l'état à cause de lectures/écritures concurrentes.

Par refacto, la méthode devient utilisable par un acteur superviseur également.