### PR TITLE
Ajoute les nouveaux ACR garantissant l'usage d'un MFA de Proconnect

### DIFF
--- a/src/oidc/serviceForceMFA.ts
+++ b/src/oidc/serviceForceMFA.ts
@@ -3,6 +3,8 @@ export const ACR_GARANTISSANT_MFA = [
   'eidas3',
   'https://proconnect.gouv.fr/assurance/self-asserted-2fa',
   'https://proconnect.gouv.fr/assurance/consistency-checked-2fa',
+  'eidas0-mfa',
+  'eidas1-mfa',
 ] as const;
 
 export type ACR = (typeof ACR_GARANTISSANT_MFA)[number];
@@ -40,7 +42,8 @@ export class ServiceForceMFA {
     if (!this.config.fournisseursAvecMFA.includes(idFournisseurIdentite))
       return { action: 'LAISSE_PASSER', raison: 'MFA_NON_PRIS_EN_CHARGE' };
 
-    if (acr) return { action: 'LAISSE_PASSER', raison: 'MFA_DEJA_VALIDE' };
+    if (acr && ACR_GARANTISSANT_MFA.includes(acr))
+      return { action: 'LAISSE_PASSER', raison: 'MFA_DEJA_VALIDE' };
 
     const { url, nonce, state } =
       await this.config.generationUrlProConnectMFA(email);

--- a/test/oidc/serviceForceMFA.spec.ts
+++ b/test/oidc/serviceForceMFA.spec.ts
@@ -1,4 +1,4 @@
-import { ServiceForceMFA } from '../../src/oidc/serviceForceMFA.ts';
+import { ACR, ServiceForceMFA } from '../../src/oidc/serviceForceMFA.ts';
 
 describe('Le service qui force le MFA', () => {
   it("laisse passer, si le fournisseur d'identité ne supporte même pas le MFA", async () => {
@@ -17,22 +17,32 @@ describe('Le service qui force le MFA', () => {
     expect(resultat.raison).toBe('MFA_NON_PRIS_EN_CHARGE');
   });
 
-  it("laisse passer, si ProConnect assure la présence d'un MFA via le claim `acr`", async () => {
-    const s = new ServiceForceMFA({
-      fournisseursAvecMFA: ['F-1'],
-      generationUrlProConnectMFA: vi.fn(),
-    });
+  it.each([
+    'eidas2',
+    'eidas3',
+    'https://proconnect.gouv.fr/assurance/self-asserted-2fa',
+    'https://proconnect.gouv.fr/assurance/consistency-checked-2fa',
+    'eidas0-mfa',
+    'eidas1-mfa',
+  ] as Array<ACR>)(
+    "laisse passer, si ProConnect assure la présence d'un MFA via le claim `acr: %s`",
+    async (acr) => {
+      const s = new ServiceForceMFA({
+        fournisseursAvecMFA: ['F-1'],
+        generationUrlProConnectMFA: vi.fn(),
+      });
 
-    const resultat = await s.execute({
-      idFournisseurIdentite: 'F-1',
-      acr: 'eidas2',
-      email: 'j@mail.fr',
-    });
+      const resultat = await s.execute({
+        idFournisseurIdentite: 'F-1',
+        acr,
+        email: 'j@mail.fr',
+      });
 
-    expect(resultat.action).toBe('LAISSE_PASSER');
-    assert(resultat.action === 'LAISSE_PASSER');
-    expect(resultat.raison).toBe('MFA_DEJA_VALIDE');
-  });
+      expect(resultat.action).toBe('LAISSE_PASSER');
+      assert(resultat.action === 'LAISSE_PASSER');
+      expect(resultat.raison).toBe('MFA_DEJA_VALIDE');
+    }
+  );
 
   it("ordonne de rediriger si le fournisseur d'identité supporte le MFA mais on n'a pas encore d'ACR", async () => {
     const generationUrlProConnectMFA = async (email: string) => ({


### PR DESCRIPTION
... suite à l'évolution de la gestion des MFA côté ProConnect.

> [!NOTE]
>  On supprimera ceux devenus obsoletes dans une prochaine PR, après le 18 juin.
