### PR TITLE
Valide la sécurité de l'environnement d'Intégration Continue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/deploiement-clever-cloud.yml
+++ b/.github/workflows/deploiement-clever-cloud.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Cloner l'intégralité du dépôt, pour ne pas avoir de « shallow repo » rejeté par Clever
+          persist-credentials: false
 
       - name: Installer la CLI Clever Cloud
         shell: bash

--- a/.github/workflows/deploiement-dev.yml
+++ b/.github/workflows/deploiement-dev.yml
@@ -10,4 +10,8 @@ jobs:
     uses: ./.github/workflows/deploiement-clever-cloud.yml
     with:
       environment: DEV
-    secrets: inherit
+    secrets:
+      CLEVER_CLOUD_SECRET: ${{ secrets.CLEVER_CLOUD_SECRET }}
+      CLEVER_CLOUD_TOKEN: ${{ secrets.CLEVER_CLOUD_TOKEN }}
+      CLEVER_CLOUD_ID_APP: ${{ secrets.CLEVER_CLOUD_ID_APP }}
+      CLEVER_CLOUD_ID_ORGANISATION: ${{ secrets.CLEVER_CLOUD_ID_ORGANISATION }}

--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -13,7 +13,11 @@ jobs:
     uses: ./.github/workflows/deploiement-clever-cloud.yml
     with:
       environment: DEMO
-    secrets: inherit
+    secrets:
+      CLEVER_CLOUD_SECRET: ${{ secrets.CLEVER_CLOUD_SECRET }}
+      CLEVER_CLOUD_TOKEN: ${{ secrets.CLEVER_CLOUD_TOKEN }}
+      CLEVER_CLOUD_ID_APP: ${{ secrets.CLEVER_CLOUD_ID_APP }}
+      CLEVER_CLOUD_ID_ORGANISATION: ${{ secrets.CLEVER_CLOUD_ID_ORGANISATION }}
 
   deploiement-prod:
     needs: [deploiement-demo]
@@ -21,4 +25,8 @@ jobs:
     uses: ./.github/workflows/deploiement-clever-cloud.yml
     with:
       environment: PROD
-    secrets: inherit
+    secrets:
+      CLEVER_CLOUD_SECRET: ${{ secrets.CLEVER_CLOUD_SECRET }}
+      CLEVER_CLOUD_TOKEN: ${{ secrets.CLEVER_CLOUD_TOKEN }}
+      CLEVER_CLOUD_ID_APP: ${{ secrets.CLEVER_CLOUD_ID_APP }}
+      CLEVER_CLOUD_ID_ORGANISATION: ${{ secrets.CLEVER_CLOUD_ID_ORGANISATION }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Cloner le dépôt Git
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Déterminer la version de Node.js à utiliser
         run: |

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Lance la github action Renovate
         uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
         with:

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Checkov GitHub Action
         uses: bridgecrewio/checkov-action@fa9edf8f0a491c59a924ea6accd5bdcf07752cff # v12.3107.0

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -2,7 +2,7 @@
 # https://www.checkov.io/1.Welcome/What%20is%20Checkov.html
 # https://github.com/bridgecrewio/checkov-action
 ---
-name: checkov
+name: Sécurité de la CI
 permissions: {}
 on:
   push:
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan:
+  checkov:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -1,6 +1,7 @@
 # Vérification des recommandations CIS et autres sur les configurations GitHub
 # https://www.checkov.io/1.Welcome/What%20is%20Checkov.html
 # https://github.com/bridgecrewio/checkov-action
+# https://docs.zizmor.sh/
 ---
 name: Sécurité de la CI
 permissions: {}
@@ -38,3 +39,19 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: results.sarif
+
+  zizmor:
+    name: zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: zizmor GitHub Action
+        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        with:
+          advanced-security: true

--- a/.github/workflows/tests-accessibilite.yml
+++ b/.github/workflows/tests-accessibilite.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Cloner le dépôt Git
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Déterminer la version de Node.js à utiliser
         run: |


### PR DESCRIPTION
On ajoute `zizmor`, qui a des tests complémentaires à `checkov`, notamment sur la gestion des dépendances.

On en profite pour apporter les corrections proposées par l'outil, histoire de commencer avec une CI verte.