### PR TITLE
Spécifie les secrets dont on a besoin

### DIFF
--- a/.github/workflows/deploiement-clever-cloud.yml
+++ b/.github/workflows/deploiement-clever-cloud.yml
@@ -7,6 +7,15 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      CLEVER_SECRET:
+        required: true
+      CLEVER_TOKEN:
+        required: true
+      ID_APP:
+        required: true
+      ID_ORGANISATION:
+        required: true
 
 jobs:
   deploiement:


### PR DESCRIPTION
D'après https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow le "reusable workflow" peut spécifier les secrets qu'il utilise (un peu comme une déclaration de paramètres dans une signature de fonction).

Il semblerait qu'`inherit` faisait cela de façon transparente ; Et qu'on doive maintenant expliciter les secrets dont on a besoin avant de pouvoir les consommer.