### PR TITLE
[CORRECTION] Rétablis l'affichage de l'entête du tiroir

### DIFF
--- a/svelte/lib/tiroir/Tiroir.svelte
+++ b/svelte/lib/tiroir/Tiroir.svelte
@@ -26,18 +26,20 @@
           label="Fermer"
         >
         </dsfr-button>
-        <div class="titre-tiroir">
-          <h2>{configuration?.titre}</h2>
-          {#if configuration?.sousTitre}
-            <p>
-              {configuration.sousTitre}
-            </p>
+        <div class="contenu-entete">
+          <div class="titre-tiroir">
+            <h2>{configuration?.titre}</h2>
+            {#if configuration?.sousTitre}
+              <p>
+                {configuration.sousTitre}
+              </p>
+            {/if}
+          </div>
+          {#if configuration?.composantEntete}
+            {@const ComposantEntete = configuration.composantEntete}
+            <ComposantEntete {...configuration.propsComposantEntete} />
           {/if}
         </div>
-        {#if configuration?.composantEntete}
-          {@const ComposantEntete = configuration.composantEntete}
-          <ComposantEntete {...configuration.propsComposantEntete} />
-        {/if}
       </div>
       {@const Composant = $tiroirStore.contenu.composant}
       <Composant bind:this={composant} {...$tiroirStore.contenu.props} />


### PR DESCRIPTION
...qui avait été décalé suite à la refonte avec un bouton en flex et non en position absolute. Les composantEntete ne sont utilisés que sur les tiroirs de risques v2, c'est donc passé inaperçu