### PR TITLE
[CORRECTION] Supprime l'attribut `setGenerationTimeMs`

### DIFF
--- a/svelte/lib/pagesService/store/routeur.store.ts
+++ b/svelte/lib/pagesService/store/routeur.store.ts
@@ -52,7 +52,6 @@ const trackMatomo = (url: string, titrePage: string) => {
 
   _paq.push(['setReferrerUrl', urlCompleteSansId(get(routeurStore).location)]);
   _paq.push(['setCustomUrl', urlCompleteSansId(url)]);
-  _paq.push(['setGenerationTimeMs', 0]);
   _paq.push(['setDocumentTitle', titrePage]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);

--- a/svelte/test/pagesService/store/routeur.store.spec.ts
+++ b/svelte/test/pagesService/store/routeur.store.spec.ts
@@ -113,7 +113,6 @@ describe('Le routeur des pages service', () => {
         'setDocumentTitle',
         'Risques | MonServiceSécurisé',
       ]);
-      expect(window._paq).toContainEqual(['setGenerationTimeMs', 0]);
       expect(window._paq).toContainEqual(['trackPageView']);
       expect(window._paq).toContainEqual(['enableLinkTracking']);
     });


### PR DESCRIPTION
... qui est maintenant obsolète.