### PR TITLE
[SOIN] Regroupe les déploiements sous un même nom

### DIFF
--- a/.github/workflows/deploiement-clever-cloud.yml
+++ b/.github/workflows/deploiement-clever-cloud.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   deploiement:
-    name: Déploiement en ${{ inputs.environment }}
+    name: Déploiement
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploiement-dev.yml
+++ b/.github/workflows/deploiement-dev.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploiement-dev:
-    name: Déploiement en DEV
+    name: Déploiement
     uses: ./.github/workflows/deploiement-clever-cloud.yml
     with:
       environment: DEV

--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploiement-demo:
-    name: Déploiement en DÉMO
+    name: Déploiement
     uses: ./.github/workflows/deploiement-clever-cloud.yml
     with:
       environment: DEMO
@@ -21,7 +21,7 @@ jobs:
 
   deploiement-prod:
     needs: [deploiement-demo]
-    name: Déploiement en PROD
+    name: Déploiement
     uses: ./.github/workflows/deploiement-clever-cloud.yml
     with:
       environment: PROD


### PR DESCRIPTION
… pour éviter, dans l'écran des github actions, d'avoir deux fois "menu + sous-menu" sur la gauche. On veut un seul menu "Déploiement" avec deux sous-menus : un pour la DEMO, un autre pour la PROD.

Pour éviter cette duplication 👇 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/a934d26f-b0ce-416e-bb1f-f6068df70745" />


Je trouve la façon de MSC plus claire 👇 
<img width="328" height="298" alt="image" src="https://github.com/user-attachments/assets/65dddb6f-c1e7-4766-8608-c8a1086e6d31" />
