### PR TITLE
[CORRECTION] Compacte l'affichage des risques v2 dans les cellules de matrices du PDF

### DIFF
--- a/src/pdf/modeles/ressources/styles.css
+++ b/src/pdf/modeles/ressources/styles.css
@@ -1356,7 +1356,7 @@ table.matrice-risques-v2 .contenu-cellule {
   color: #fff;
   font-size: 0.7rem;
   font-weight: bold;
-  line-height: 1.5rem;
+  line-height: 0.75rem;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION

| Avant | Après |
|--------|--------|
| <img width="981" height="782" alt="Screenshot from 2026-06-30 12-13-12" src="https://github.com/user-attachments/assets/71b0be51-2839-4f1c-af59-ddd18ca74d93" /> | <img width="981" height="782" alt="Screenshot from 2026-06-30 12-14-22" src="https://github.com/user-attachments/assets/b5ac1cbb-4921-4053-ab6e-1a5a36d0a253" /> | 