### PR TITLE
[CORRECTION] Rafraîchis les données de service lors de la modification de la description

### DIFF
--- a/svelte/lib/pagesService/PagesService.svelte
+++ b/svelte/lib/pagesService/PagesService.svelte
@@ -114,7 +114,10 @@
 <svelte:body on:mesure-modifiee={rafraichisServiceComplet} />
 <svelte:document
   onclick={interecepteNavigation}
-  on:description-service-modifiee={rafraichisResumeService}
+  on:description-service-modifiee={() => {
+    rafraichisResumeService();
+    rafraichisServiceComplet();
+  }}
   on:contacts-utiles-service-modifiee={rafraichisServiceComplet}
   on:homologation-supprimee={rafraichisServiceComplet}
   on:homologation-modifiee={rafraichisServiceComplet}


### PR DESCRIPTION
...car on utilise aussi la description du service complet, et qu'elle a besoin d'être mise à jour