### PR TITLE
Déplace la logique de timeout directement dans les toasts

### DIFF
--- a/svelte/lib/ui/Toast.svelte
+++ b/svelte/lib/ui/Toast.svelte
@@ -11,6 +11,7 @@
     avecAnimation?: boolean;
     avecFermeture?: boolean;
     avecInterpolationHTMLDangereuse?: boolean;
+    timeout?: number;
     onClose?: () => void;
   }
 
@@ -23,8 +24,22 @@
     avecAnimation = true,
     avecFermeture = false,
     avecInterpolationHTMLDangereuse = false,
+    timeout = undefined,
     onClose,
   }: Props = $props();
+
+  let minuteur: ReturnType<typeof setTimeout>;
+
+  const armeFermeture = () => {
+    if (!timeout) return;
+    minuteur = setTimeout(() => onClose?.(), timeout);
+  };
+  const stoppeFermeture = () => clearTimeout(minuteur);
+
+  $effect(() => {
+    armeFermeture();
+    return stoppeFermeture;
+  });
 
   const icones = {
     info: 'icone_info',
@@ -45,6 +60,8 @@
 <article
   class={niveau}
   class:avecOmbre
+  onmouseenter={stoppeFermeture}
+  onmouseleave={armeFermeture}
   transition:transitionConditionnelle|global={{
     fonction: glisse,
     depuis: 'right',

--- a/svelte/lib/ui/Toaster.svelte
+++ b/svelte/lib/ui/Toaster.svelte
@@ -5,11 +5,12 @@
 
 {#if $toasterStore.queue.length}
   <aside id="conteneur-toasts">
-    {#each $toasterStore.queue as { niveau, contenu, titre, id, avecInterpolationHTMLDangereuse = false, boutonAction } (id)}
+    {#each $toasterStore.queue as { niveau, contenu, titre, id, timeout, avecInterpolationHTMLDangereuse = false, boutonAction } (id)}
       <Toast
         {niveau}
         {titre}
         {contenu}
+        {timeout}
         {avecInterpolationHTMLDangereuse}
         avecBoutonAction={boutonAction}
         avecFermeture

--- a/svelte/lib/ui/stores/toaster.store.ts
+++ b/svelte/lib/ui/stores/toaster.store.ts
@@ -124,12 +124,6 @@ function afficheToast(
     avecInterpolationHTMLDangereuse,
     boutonAction
   );
-  setTimeout(() => {
-    update((etatActuel) => {
-      etatActuel.queue.shift();
-      return etatActuel;
-    });
-  }, message.timeout);
   update((etatActuel) => {
     etatActuel.queue = [...etatActuel.queue, message];
     return etatActuel;


### PR DESCRIPTION
... permettant ainsi de "repousser" la fermeture d'un toast si la souris de l'utilisateur est "au-dessus".