### PR TITLE
[CORRECTION] Empêche les toasts de rester visible quand il y en a plusieurs

### DIFF
--- a/svelte/lib/ui/Toast.svelte
+++ b/svelte/lib/ui/Toast.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { glisse } from './animations/transitions';
   import type { BoutonAction } from './stores/toaster.store';
+  import { onMount } from 'svelte';
 
   interface Props {
     niveau: 'info' | 'succes' | 'erreur' | 'alerte';
@@ -36,7 +37,7 @@
   };
   const stoppeFermeture = () => clearTimeout(minuteur);
 
-  $effect(() => {
+  onMount(() => {
     armeFermeture();
     return stoppeFermeture;
   });


### PR DESCRIPTION
... en remplaçant `$effect` par `onMount`. Sinon, chaque nouveau toast repousse le setTimeout de 5 secondes pour les autres.