### PR TITLE
[CORRECTION] Répare l'étape "piloter" de la visite guidée

### DIFF
--- a/svelte/lib/tableauDeBord/BandeauFiltres.svelte
+++ b/svelte/lib/tableauDeBord/BandeauFiltres.svelte
@@ -94,6 +94,7 @@
     {#if $services.length > 0 || $brouillonsService.length > 0}
       <BoutonAvecListeDeroulante
         titre="Ajouter un / des services"
+        classesCss={['nouveau-service']}
         aligneADroite
         options={[
           {

--- a/svelte/lib/tableauDeBord/TableauDesServices.svelte
+++ b/svelte/lib/tableauDeBord/TableauDesServices.svelte
@@ -122,6 +122,7 @@
         slot="cell:nom:{index}"
         class="cellule-noms"
         href="/service/{idService}"
+        data-visite-guidee-id-service={idService}
       >
         <span class="denomination-service">
           {#if service.estAdmin}

--- a/svelte/lib/ui/BoutonAvecListeDeroulante.svelte
+++ b/svelte/lib/ui/BoutonAvecListeDeroulante.svelte
@@ -13,6 +13,7 @@
     options: OptionBoutonListeDeroulante[];
     disabled?: boolean;
     aligneADroite?: boolean;
+    classesCss?: string[];
   }
 
   let {
@@ -20,6 +21,7 @@
     options,
     disabled = false,
     aligneADroite = false,
+    classesCss = [],
   }: Props = $props();
 
   let optionsPourDropdown = $derived(
@@ -40,6 +42,7 @@
 <dsfr-dropdown
   id="bouton-liste-deroulante"
   collapse-id="bouton-liste-deroulante-collapse"
+  class={classesCss.join(' ')}
   button-title={titre}
   button-kind="primary"
   button-size="md"

--- a/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
+++ b/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
@@ -20,10 +20,9 @@
       {
         cible: cibleNomService,
         positionnementModale: 'BasDroite',
+        margeElementMisEnAvant: 3,
         callbackInitialeCible: async () => {
-          document
-            .getElementsByClassName('lien-service')[0]
-            .removeAttribute('href');
+          elementDeClasse('cellule-noms').removeAttribute('href');
           const bouton =
             document.querySelector<HTMLButtonElement>('.selection-service');
           if (bouton) bouton.disabled = true;
@@ -51,7 +50,10 @@
 
   const rechargeEtape = () => {
     cibleNomService = elementDeClasse('cellule-noms');
-    cibleLignePremierService = elementDeClasse('ligne-service');
+    cibleLignePremierService =
+      document
+        .querySelector('dsfr-table')
+        ?.shadowRoot?.querySelector('tbody tr') ?? undefined;
     cibleCentreNotifications = elementDeClasse('centre-notifications');
     cibleNouveauService = elementDeClasse('nouveau-service');
   };
@@ -61,9 +63,8 @@
   );
 
   const derniereSousEtape = (): SousEtape | null => {
-    if (!cibleNouveauService || !cibleLignePremierService) {
-      return null;
-    }
+    if (!cibleNouveauService || !cibleLignePremierService) return null;
+
     if ($utilisateurCourant.profilComplet) {
       return {
         cible: cibleNouveauService,
@@ -71,10 +72,8 @@
         margesElementMisEnAvant: '3 3 3 3',
         callbackInitialeCible: async (cible) => {
           if (!cible) return;
-          const cibleBouton = cible.getElementsByClassName(
-            'bouton'
-          )[0] as HTMLButtonElement;
-          cibleBouton.inert = true;
+          const cibleBouton = cible.shadowRoot?.querySelector('button');
+          if (cibleBouton) cibleBouton.inert = true;
         },
         titre: 'Créez votre premier service !',
         description:
@@ -82,6 +81,7 @@
         texteBoutonDerniereEtape: "C'est parti !",
       };
     }
+
     return {
       cible: cibleLignePremierService,
       positionnementModale: 'HautMilieu',

--- a/svelte/lib/visiteGuidee/visiteGuidee.store.ts
+++ b/svelte/lib/visiteGuidee/visiteGuidee.store.ts
@@ -21,13 +21,16 @@ const { subscribe: subscribeUtilisateur, set: setUtilisateur } =
   writable<Utilisateur>();
 
 const redirigeApresFinalisationVisite = () => {
-  const ligneService = document.getElementsByClassName(
-    'ligne-service'
-  )[0] as HTMLElement;
-  const { idService } = ligneService.dataset;
-  window.location.href = get(utilisateurCourant).profilComplet
-    ? '/tableauDeBord'
-    : `/service/${idService}`;
+  if (get(utilisateurCourant).profilComplet) {
+    window.location.href = '/tableauDeBord';
+    return;
+  }
+
+  const ligneService = document.querySelector(
+    '[data-visite-guidee-id-service]'
+  ) as HTMLElement;
+  const idService = ligneService.dataset.visiteGuideeIdService;
+  window.location.href = `/service/${idService}`;
 };
 
 export const visiteGuidee = {


### PR DESCRIPTION
Avant ce commit, arrivée sur l'étape "piloter" on avait un écran gris (le background de la modale)… sans la modale.
À cause de sélecteurs CSS qui ne fonctionnent plus.

Dans EtapePiloter.svelte on remet d'équerre les sélecteurs CSS qui étaient cassé. Beaucoup ont disparu avec le refactoring du tableau de bord en version DSFR.

Remettre la classe "nouveau-service" sur le bouton d'ajout de service. Elle avait disparu en 67afc138a.

Dans le tableau des services, on a besoin d'un data attribute pour que le store de la visite guidée puisse rediriger vers le service dans le cas où l'utilisateur qui suit la visite guidée est sur MSS grâce à une invitation sur ce service.
Il avait été supprimé par 7c1df116e.
On en profite pour commencer une amélioration : explicite `data-visite-guidee` pour qu'à l'avenir, on ne vienne pas supprimer cet attribut sans penser à la visite guidée.

---

### AVANT 

<img width="600" src="https://github.com/user-attachments/assets/3254a672-3d94-4fd8-94b3-76eee3dedea0" />

### APRÈS

<img width="600" src="https://github.com/user-attachments/assets/a677841a-8af6-41c4-bf1e-9de69d9aceee" />
