### PR TITLE
Empêche le front de soumettre des textes trop longs

### DIFF
--- a/svelte/lib/risquesV2/tiroir/TiroirRisqueGeneralV2.svelte
+++ b/svelte/lib/risquesV2/tiroir/TiroirRisqueGeneralV2.svelte
@@ -148,6 +148,7 @@
             disabled={estLectureSeule}
             hint="Apportez des précisions sur le risque"
             onvaluechanged={metsAJourCommentaire}
+            maxlength="1000"
           ></dsfr-input>
         </div>
       </div>

--- a/svelte/lib/risquesV2/tiroir/TiroirRisqueGeneralV2.svelte
+++ b/svelte/lib/risquesV2/tiroir/TiroirRisqueGeneralV2.svelte
@@ -140,8 +140,7 @@
           </div>
         </div>
         <div>
-          <dsfr-input
-            type="text"
+          <dsfr-textarea
             id="commentaire"
             label="Commentaire"
             value={commentaire}
@@ -149,7 +148,8 @@
             hint="Apportez des précisions sur le risque"
             onvaluechanged={metsAJourCommentaire}
             maxlength="1000"
-          ></dsfr-input>
+            rows="8"
+          ></dsfr-textarea>
         </div>
       </div>
     {:else if ongletActif === 'mesuresAssociees'}

--- a/svelte/lib/risquesV2/tiroir/TiroirRisqueSpecifiqueV2.svelte
+++ b/svelte/lib/risquesV2/tiroir/TiroirRisqueSpecifiqueV2.svelte
@@ -208,6 +208,7 @@
               onvaluechanged={metsAJourIntitule}
               required
               disabled={estLectureSeule}
+              maxlength="1000"
             ></dsfr-input>
           </p>
           <p>
@@ -218,6 +219,7 @@
               value={donneesRisque.description}
               onvaluechanged={metsAJourDescription}
               disabled={estLectureSeule}
+              maxlength="2000"
             ></dsfr-textarea>
           </p>
           <p>

--- a/svelte/lib/risquesV2/tiroir/TiroirRisqueSpecifiqueV2.svelte
+++ b/svelte/lib/risquesV2/tiroir/TiroirRisqueSpecifiqueV2.svelte
@@ -312,6 +312,7 @@
               hint="Apportez des précisions sur le risque"
               onvaluechanged={metsAJourCommentaire}
               disabled={estLectureSeule}
+              maxlength="1000"
             ></dsfr-input>
           </div>
         </div>

--- a/svelte/lib/risquesV2/tiroir/TiroirRisqueSpecifiqueV2.svelte
+++ b/svelte/lib/risquesV2/tiroir/TiroirRisqueSpecifiqueV2.svelte
@@ -307,15 +307,15 @@
             </div>
           </div>
           <div>
-            <dsfr-input
+            <dsfr-textarea
               label="Commentaire"
-              type="text"
               value={donneesRisque.commentaire}
               hint="Apportez des précisions sur le risque"
               onvaluechanged={metsAJourCommentaire}
               disabled={estLectureSeule}
               maxlength="1000"
-            ></dsfr-input>
+              rows="8"
+            ></dsfr-textarea>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Pour éviter d'avoir des utilisateurs qui saisissent des textes trop longs pour le backend sans s'en rendre compte.

