### PR TITLE
Gestion global du pointer-events pendant la visite guidée

### DIFF
--- a/svelte/lib/visiteGuidee/VisiteGuidee.svelte
+++ b/svelte/lib/visiteGuidee/VisiteGuidee.svelte
@@ -6,3 +6,19 @@
 </script>
 
 <SvelteComponent />
+
+<style>
+  :global(body[data-visite-guidee-en-cours]) {
+    pointer-events: none;
+  }
+
+  :global(body[data-visite-guidee-en-cours] #visite-guidee-rideau) {
+    pointer-events: auto;
+  }
+  :global(body[data-visite-guidee-en-cours] #visite-guidee) {
+    pointer-events: auto;
+  }
+  :global(body[data-visite-guidee-en-cours] #visite-guidee-menu-navigation) {
+    pointer-events: auto;
+  }
+</style>

--- a/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrireV2.svelte
+++ b/svelte/lib/visiteGuidee/etapes/decrire/EtapeDecrireV2.svelte
@@ -87,7 +87,6 @@
           behavior: 'instant',
           block: 'end',
         });
-        if (cibleBesoinsSecurite) cibleBesoinsSecurite.inert = true;
         return cibleBesoinsSecurite;
       },
       positionnementModale: 'HautMilieu',

--- a/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
+++ b/svelte/lib/visiteGuidee/etapes/homologuer/EtapeHomologuer.svelte
@@ -18,11 +18,6 @@
     sousEtapes = [
       {
         cible: cibleNouvelleHomologation,
-        callbackInitialeCible: async (cible) => {
-          if (cible) {
-            cible.inert = true;
-          }
-        },
         positionnementModale: 'BasGauche',
         titre: 'Homologuez votre service',
         description:
@@ -33,17 +28,13 @@
       },
       {
         cible: cibleTelechargement,
-        callbackInitialeCible: async (cible) => {
+        callbackInitialeCible: async () => {
           tiroirStore.afficheContenu(TiroirTelechargementDocumentsService, {
             modeVisiteGuidee: true,
             service: donneesVisiteGuidee.services[0],
           });
           const tiroir = document.querySelector<HTMLDivElement>('#tiroir');
           if (tiroir) tiroir.style.zIndex = '10001';
-          const boutonFermeture =
-            document.querySelector<HTMLButtonElement>('.fermeture-tiroir');
-          if (boutonFermeture) boutonFermeture.disabled = true;
-          if (cible) cible.inert = true;
         },
         callbackFinaleCible: async () => {
           tiroirStore.ferme();

--- a/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
+++ b/svelte/lib/visiteGuidee/etapes/piloter/EtapePiloter.svelte
@@ -21,12 +21,6 @@
         cible: cibleNomService,
         positionnementModale: 'BasDroite',
         margeElementMisEnAvant: 3,
-        callbackInitialeCible: async () => {
-          elementDeClasse('cellule-noms').removeAttribute('href');
-          const bouton =
-            document.querySelector<HTMLButtonElement>('.selection-service');
-          if (bouton) bouton.disabled = true;
-        },
         titre: 'Pilotez vos services grâce au tableau de bord',
         description:
           "Suivez l'état de vos homologations, la progression de vos mesures de sécurité et bénéficiez de recommandations personnalisées pour optimiser la protection de vos services.",
@@ -36,9 +30,6 @@
         cible: cibleCentreNotifications,
         positionnementModale: 'BasMilieu',
         margeElementMisEnAvant: 3,
-        callbackInitialeCible: async (cible) => {
-          (cible as HTMLButtonElement).disabled = true;
-        },
         titre: 'Découvrez le centre de notifications',
         description:
           'Ne ratez aucune information ou nouveauté importante de MonServiceSécurisé !',
@@ -70,11 +61,6 @@
         cible: cibleNouveauService,
         positionnementModale: 'HautGauche',
         margesElementMisEnAvant: '3 3 3 3',
-        callbackInitialeCible: async (cible) => {
-          if (!cible) return;
-          const cibleBouton = cible.shadowRoot?.querySelector('button');
-          if (cibleBouton) cibleBouton.inert = true;
-        },
         titre: 'Créez votre premier service !',
         description:
           'N’attendez plus et commencez à sécuriser en créant votre premier service numérique !',
@@ -85,10 +71,6 @@
     return {
       cible: cibleLignePremierService,
       positionnementModale: 'HautMilieu',
-      callbackInitialeCible: async (cible) => {
-        if (!cible) return;
-        cible.inert = true;
-      },
       titre: 'Collaborez avec votre équipe !',
       description:
         'N’attendez plus et contribuez au service numérique sur lequel vous avez été invité !',

--- a/svelte/lib/visiteGuidee/etapes/securiser/EtapeSecuriser.svelte
+++ b/svelte/lib/visiteGuidee/etapes/securiser/EtapeSecuriser.svelte
@@ -30,12 +30,6 @@
     sousEtapes = [
       {
         cible: ciblePremiereMesure,
-        callbackInitialeCible: async (cible) => {
-          if (!cible) return;
-
-          const ligneMesure = cible.parentElement;
-          if (ligneMesure) ligneMesure.inert = true;
-        },
         positionnementModale: 'BasDroite',
         titre: 'Sécurisez, grâce à des mesures adaptées',
         description:
@@ -44,15 +38,6 @@
       },
       {
         cible: cibleOnglets,
-        callbackInitialeCible: async (cible) => {
-          if (!cible) return;
-
-          const onglets =
-            cible.querySelectorAll<HTMLDivElement>('button.onglet');
-          for (let i = 0; i < onglets.length; i++) {
-            onglets[i].inert = true;
-          }
-        },
         positionnementModale: 'MilieuDroite',
         titre: 'Définissez un statut pour chaque mesure !',
         description:
@@ -85,19 +70,7 @@
           document
             .getElementsByClassName('titre-mesure')[0]
             .dispatchEvent(new MouseEvent('click', { bubbles: true }));
-          const bouton = document.querySelector<HTMLButtonElement>(
-            '#conteneur-mesure .conteneur-actions button'
-          );
-          if (bouton) bouton.disabled = true;
-          const boutonFermeture =
-            document.querySelector<HTMLButtonElement>('.fermeture-tiroir');
-          if (boutonFermeture) boutonFermeture.disabled = true;
-          const onglets = document.querySelectorAll<HTMLDivElement>(
-            '#conteneur-mesure .conteneur-onglet .onglet'
-          );
-          for (let i = 0; i < onglets.length; i++) {
-            onglets[i].inert = true;
-          }
+
           setTimeout(() => {
             const ongletPlanAction = document.querySelector(
               '#conteneur-mesure .conteneur-onglet .onglet:nth-of-type(2)'
@@ -125,19 +98,7 @@
           document
             .getElementsByClassName('titre-mesure')[0]
             .dispatchEvent(new MouseEvent('click', { bubbles: true }));
-          const bouton = document.querySelector<HTMLButtonElement>(
-            '#conteneur-mesure .conteneur-actions button'
-          );
-          if (bouton) bouton.disabled = true;
-          const boutonFermeture =
-            document.querySelector<HTMLButtonElement>('.fermeture-tiroir');
-          if (boutonFermeture) boutonFermeture.disabled = true;
-          const onglets = document.querySelectorAll<HTMLDivElement>(
-            '#conteneur-mesure .conteneur-onglet .onglet'
-          );
-          for (let i = 0; i < onglets.length; i++) {
-            onglets[i].inert = true;
-          }
+
           setTimeout(() => {
             const ongletActivites = document.querySelector(
               '#conteneur-mesure .conteneur-onglet .onglet:nth-of-type(3)'

--- a/svelte/lib/visiteGuidee/visiteGuidee.store.ts
+++ b/svelte/lib/visiteGuidee/visiteGuidee.store.ts
@@ -35,6 +35,10 @@ const redirigeApresFinalisationVisite = () => {
 
 export const visiteGuidee = {
   initialise: (etatVisiteGuidee: EtatVisiteGuidee) => {
+    document
+      .querySelector('body')
+      ?.setAttribute('data-visite-guidee-en-cours', 'true');
+
     set(etatVisiteGuidee.etapeCourante ? etatVisiteGuidee : etatParDefaut);
   },
   subscribe,


### PR DESCRIPTION
On veut éviter de devoir tenter des `disabled` et/ou `inert` dans chaque étape de la visite guidée.
Ça marche mal, c'est dur à maintenir car les sélecteurs CSS changent et cassent le comportement, et de toute façon ça ne bloque pas la navigation au clavier sur tout le reste de l'app.
Donc, pour simplifier, on passe par du CSS qui va tout désactiver.
