### PR TITLE
[SOIN] Supprime les warnings de "Unused CSS selector"

### DIFF
--- a/svelte/lib/adminUtilisateurs/TiroirGestionUtilisateurAdministre/TableauEntitesSelectionnables.svelte
+++ b/svelte/lib/adminUtilisateurs/TiroirGestionUtilisateurAdministre/TableauEntitesSelectionnables.svelte
@@ -248,12 +248,6 @@
       .conteneur-ligne-service {
         display: flex;
         gap: 16px;
-
-        &.estAdmin {
-          span {
-            color: #666666;
-          }
-        }
       }
 
       dsfr-checkbox {

--- a/svelte/lib/adminUtilisateurs/TiroirNommerAdmin/TiroirNommerAdmin.svelte
+++ b/svelte/lib/adminUtilisateurs/TiroirNommerAdmin/TiroirNommerAdmin.svelte
@@ -337,9 +337,6 @@
 </ActionsTiroir>
 
 <style lang="scss">
-  h1 {
-    text-align: center;
-  }
   .barre-actions {
     padding-bottom: 24px;
     display: flex;

--- a/svelte/lib/risquesV2/TableauAnciensRisques.svelte
+++ b/svelte/lib/risquesV2/TableauAnciensRisques.svelte
@@ -112,39 +112,11 @@
     width: 168px;
   }
 
-  .colonne:not(.inactif) .lien-intitule-risque {
-    cursor: pointer;
-
-    &:hover span {
-      color: var(--bleu-mise-en-avant);
-    }
-  }
-
-  .colonne-intitule {
-    .lien-intitule-risque {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      border: none;
-      outline: none;
-      background: none;
-      text-align: left;
-
-      span {
-        font-weight: 500;
-      }
-    }
-  }
-
   .colonne-actions {
     min-width: 132px;
     display: flex;
     flex-direction: row;
     gap: 8px;
     align-items: center;
-  }
-
-  dsfr-button {
-    white-space: nowrap;
   }
 </style>

--- a/svelte/lib/risquesV2/TableauRisquesV2.svelte
+++ b/svelte/lib/risquesV2/TableauRisquesV2.svelte
@@ -184,32 +184,10 @@
     }
   }
 
-  .colonne:not(.inactif) .lien-intitule-risque {
-    cursor: pointer;
-
-    &:hover span {
-      color: var(--bleu-mise-en-avant);
-    }
-  }
-
   .colonne-intitule {
     display: flex;
     flex-direction: column;
     gap: 4px;
-
-    .lien-intitule-risque {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      border: none;
-      outline: none;
-      background: none;
-      text-align: left;
-
-      span {
-        font-weight: 500;
-      }
-    }
   }
 
   .colonne-actions {

--- a/svelte/lib/risquesV2/tiroir/BadgesTiroirRisqueSpecifiqueV2.svelte
+++ b/svelte/lib/risquesV2/tiroir/BadgesTiroirRisqueSpecifiqueV2.svelte
@@ -24,10 +24,5 @@
     align-items: center;
     gap: 8px;
     margin-top: 16px;
-
-    dsfr-badge {
-      height: fit-content;
-      white-space: nowrap;
-    }
   }
 </style>

--- a/svelte/lib/risquesV2/tiroir/TiroirRisqueGeneralV2.svelte
+++ b/svelte/lib/risquesV2/tiroir/TiroirRisqueGeneralV2.svelte
@@ -262,11 +262,6 @@
     margin-top: -30px;
     border-top: none;
 
-    label {
-      margin-bottom: 8px;
-      display: block;
-    }
-
     & > div {
       display: flex;
       flex-direction: column;

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/svelte/vite.config.mts
+++ b/svelte/vite.config.mts
@@ -1,7 +1,6 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { defineConfig, createLogger } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { resolve } from 'node:path';
 import { glob } from 'glob';
 
@@ -27,7 +26,7 @@ loggerPersonnalise.info = (msg, options) => {
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    svelte({ preprocess: vitePreprocess() }),
+    svelte(),
     sentryVitePlugin({
       disable:
         !process.env.SENTRY_AUTH_TOKEN || process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
... en déplaçant la configuration svelte dans son fichier dédié, afin de profiter du même contexte lorsque l'on "build", et lorsque l'on "svelte-check". 
"svelte-check" va donc dorénavant traiter les warnings "unused CSS selector" comme des erreurs.