### PR TITLE
[CORRECTION] Ne crash pas lors de l'export des mesures en CSV pour les services V1

### DIFF
--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -112,7 +112,7 @@ const genereCsvMesures = async (
     separesParVirgule(
       referentiel
         .referentielsExternesDeMesure(idMesure)
-        [referentielExterne].map((d) => d.id)
+        ?.[referentielExterne]?.map((d) => d.id) ?? []
     );
 
   const donneesCsv = Object.entries(mesuresGenerales)


### PR DESCRIPTION
... car le référentiel V1 ne connait pas de référentiels externes de mesure