### PR TITLE
[CORRECTION] Utilise un `silent retry` lors des erreurs CSRF

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -87,7 +87,7 @@ module.exports = defineConfig([
       'no-underscore-dangle': [
         'error',
         {
-          allow: ['_paq', '_mtm'],
+          allow: ['_paq', '_mtm', '_csrf'],
         },
       ],
 

--- a/public/scripts/csrf.mjs
+++ b/public/scripts/csrf.mjs
@@ -1,20 +1,50 @@
 import lisDonneesPartagees from '../modules/donneesPartagees.mjs';
 import { afficheModaleDeconnexion } from '../modules/deconnexion.js';
 
+const HEADER_TOKEN_CSRF = 'X-CSRF-Token';
+
 $(() => {
-  const { token } = lisDonneesPartagees('infos-csrf');
-  axios.defaults.headers.common['X-CSRF-Token'] = token;
+  const { token, hashIdUtilisateur } = lisDonneesPartagees('infos-csrf');
+  axios.defaults.headers.common[HEADER_TOKEN_CSRF] = token;
+
+  const afficheModaleEtJetteErreur = (error) => {
+    afficheModaleDeconnexion();
+    return Promise.reject(error);
+  };
 
   axios.interceptors.response.use(
     (response) => response,
-    (error) => {
-      if (
+    async (error) => {
+      const estMismatchCsrf =
         typeof error?.response?.data === 'string' &&
-        error?.response?.data?.includes('CSRF token mismatch')
-      ) {
-        afficheModaleDeconnexion();
+        error.response.data.includes('CSRF token mismatch');
+      if (!estMismatchCsrf) return Promise.reject(error);
+
+      const { config } = error;
+      if (!config || config.dejaRejoueeApresMismatchCsrf) {
+        return afficheModaleEtJetteErreur(error);
       }
-      return Promise.reject(error);
+
+      try {
+        const { data } = await axios.get('/api/csrf');
+
+        const memeUtilisateur = data.hashIdUtilisateur === hashIdUtilisateur;
+        if (!hashIdUtilisateur || !memeUtilisateur) {
+          return afficheModaleEtJetteErreur(error);
+        }
+
+        axios.defaults.headers.common[HEADER_TOKEN_CSRF] = data.token;
+        config.dejaRejoueeApresMismatchCsrf = true;
+        // La version d'axios 1.0.0 perd les en-têtes quand on rejoue une requête : on repart d'un objet brut.
+        const headers =
+          typeof config.headers?.toJSON === 'function'
+            ? config.headers.toJSON()
+            : { ...config.headers };
+        headers[HEADER_TOKEN_CSRF] = data.token;
+        return axios({ ...config, headers });
+      } catch (e) {
+        return afficheModaleEtJetteErreur(e);
+      }
     }
   );
 });

--- a/src/adaptateurs/adaptateurGestionErreurSentry.ts
+++ b/src/adaptateurs/adaptateurGestionErreurSentry.ts
@@ -74,12 +74,6 @@ const controleurErreurs = (
     reponse.end();
     return;
   }
-  const estErreurCSRF = erreur.message === 'CSRF token mismatch';
-  if (estErreurCSRF) {
-    logueErreur(new Error('Une erreur CSRF mismatch a été détectée'), {
-      'Token CSRF du client': requete.headers['x-csrf-token'],
-    });
-  }
 
   Sentry.Handlers.errorHandler()(erreur, requete, reponse, suite);
 };

--- a/src/http/middleware.ts
+++ b/src/http/middleware.ts
@@ -163,6 +163,9 @@ const middleware = (configuration: ConfigurationMiddleware) => {
 
     requete.idUtilisateurCourant = utilisateurCourant.id;
     requete.sourceAuthentification = utilisateurCourant.source;
+    reponse.locals.hashIdUtilisateurCourant = adaptateurChiffrement.hacheSha256(
+      utilisateurCourant.id
+    );
     reponse.locals.utilisateurConnecte = {
       prenomNom: utilisateurCourant.prenomNom,
       email: utilisateurCourant.email,

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -74,6 +74,13 @@ const routesConnecteApi = ({
 }) => {
   const routes = express.Router();
 
+  routes.get('/csrf', (_requete, reponse) => {
+    reponse.json({
+      token: reponse.locals._csrf,
+      hashIdUtilisateur: reponse.locals.hashIdUtilisateurCourant,
+    });
+  });
+
   routes.get(
     '/services',
     middleware.verificationAcceptationCGU,

--- a/src/vues/csrf.pug
+++ b/src/vues/csrf.pug
@@ -1,6 +1,6 @@
 include ./fragments/donneesPartagees
 
-+donneesPartagees('infos-csrf',{ token: _csrf })
++donneesPartagees('infos-csrf',{ token: _csrf, hashIdUtilisateur: hashIdUtilisateurCourant || null })
 
 block append scripts
   script(type = 'module', src = '/statique/scripts/csrf.mjs')

--- a/test/http/middleware.spec.js
+++ b/test/http/middleware.spec.js
@@ -279,6 +279,17 @@ describe('Le middleware MSS', () => {
       });
     });
 
+    it("ajoute le hash de l'identifiant de l'utilisateur connecté à `reponse.locals`", async () => {
+      const adaptateurChiffrement = {
+        hacheSha256: (chaine) => `HASH-${chaine}`,
+      };
+      const middleware = leMiddleware({ adaptateurChiffrement });
+
+      await middleware.verificationJWT(requete, reponse, () => {});
+
+      expect(reponse.locals.hashIdUtilisateurCourant).to.be('HASH-123');
+    });
+
     describe('quand le JWT est expiré', () => {
       const adaptateurJWT = {
         decode: () => {

--- a/test/mocks/middleware.js
+++ b/test/mocks/middleware.js
@@ -204,10 +204,12 @@ const middlewareFantaisie = {
     suite();
   },
 
-  verificationJWT: (requete, _reponse, suite) => {
+  verificationJWT: (requete, reponse, suite) => {
     requete.sourceAuthentification = sourceAuthentification;
     requete.idUtilisateurCourant = idUtilisateurCourant;
     requete.cguAcceptees = cguAcceptees;
+    reponse.locals.hashIdUtilisateurCourant =
+      idUtilisateurCourant && `hash-de-${idUtilisateurCourant}`;
     verificationJWTMenee = true;
     suite();
   },

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -43,6 +43,20 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       .verifieRequeteExigeJWT(testeur.app(), '/api/services');
   });
 
+  describe('quand requête GET sur `/api/csrf`', () => {
+    it("retourne le token CSRF courant et le hash de l'identifiant de l'utilisateur, sans exposer l'identifiant en clair", async () => {
+      testeur.middleware().reinitialise({ idUtilisateur: 'U1' });
+
+      const reponse = await testeur.get('/api/csrf');
+
+      expect(reponse.status).to.be(200);
+      expect(reponse.body).to.eql({
+        token: 'token-csrf-de-test',
+        hashIdUtilisateur: 'hash-de-U1',
+      });
+    });
+  });
+
   describe('quand requête GET sur `/api/services`', () => {
     beforeEach(() => {
       testeur.middleware().reinitialise({ idUtilisateur: '123' });

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -132,7 +132,10 @@ const testeurMss = () => {
       oidc: () => ({ fournisseursAvecMFA: () => [] }),
     };
     adaptateurProtection = {
-      protectionCsrf: () => (_requete, _reponse, suite) => suite(),
+      protectionCsrf: () => (_requete, reponse, suite) => {
+        reponse.locals._csrf = 'token-csrf-de-test';
+        suite();
+      },
       protectionLimiteTrafic: () => (_requete, _reponse, suite) => suite(),
       protectionLimiteTraficEndpointSensible:
         () => (_requete, _reponse, suite) =>


### PR DESCRIPTION
...  afin d'éviter une interruption UX pour nos utilisateurs.