### PR TITLE
[CORRECTION] Corrige l'affichage du tiroir de gestion contributeurs

### DIFF
--- a/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
+++ b/svelte/lib/gestionContributeurs/GestionContributeurs.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
+  import { derived } from 'svelte/store';
   import { store } from './gestionContributeurs.store';
   import InvitationContributeur from './invitation/InvitationContributeur.svelte';
   import LigneContributeur from './kit/LigneContributeur.svelte';
   import SuppressionContributeur from './suppression/SuppressionContributeur.svelte';
   import PersonnalisationContributeur from './personnalisation/PersonnalisationContributeur.svelte';
-  import { autorisationsVisiteGuidee } from './modeVisiteGuidee/donneesVisiteGuidee';
-  import { storeAutorisations } from './stores/autorisations.store';
-  import { derived } from 'svelte/store';
 
   interface Props {
     modeVisiteGuidee: boolean;
@@ -16,18 +14,6 @@
 
   let surServiceUnique = derived(store, ($s) => $s.services.length === 1);
   let serviceUnique = derived(store, ($s) => $s.services[0]);
-
-  $effect(() => {
-    if (modeVisiteGuidee) storeAutorisations.charge(autorisationsVisiteGuidee);
-    else if ($surServiceUnique) {
-      (async () => {
-        const reponse = await axios.get(
-          `/api/service/${$serviceUnique.id}/autorisations`
-        );
-        storeAutorisations.charge(reponse.data);
-      })();
-    }
-  });
 </script>
 
 {#if $store.etapeCourante === 'SuppressionContributeur'}

--- a/svelte/lib/ui/tiroirs/TiroirGestionContributeurs.svelte
+++ b/svelte/lib/ui/tiroirs/TiroirGestionContributeurs.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+  import { onMount, untrack } from 'svelte';
   import ContenuTiroir from './ContenuTiroir.svelte';
   import GestionContributeurs from '../../gestionContributeurs/GestionContributeurs.svelte';
   import { store } from '../../gestionContributeurs/gestionContributeurs.store';
-  import { untrack } from 'svelte';
-  import { donneesServiceVisiteGuidee } from '../../gestionContributeurs/modeVisiteGuidee/donneesVisiteGuidee';
+  import {
+    autorisationsVisiteGuidee,
+    donneesServiceVisiteGuidee,
+  } from '../../gestionContributeurs/modeVisiteGuidee/donneesVisiteGuidee';
   import type { DonneesServicePourTiroirContributeurs } from '../../gestionContributeurs/gestionContributeurs.d';
+  import { storeAutorisations } from '../../gestionContributeurs/stores/autorisations.store';
 
   interface Props {
     services: DonneesServicePourTiroirContributeurs[];
@@ -12,6 +16,7 @@
   }
 
   let { services, modeVisiteGuidee = false }: Props = $props();
+
   export const titre: string = 'Gérer les contributeurs';
   export const sousTitre: string = untrack(() =>
     services.length > 1
@@ -19,17 +24,32 @@
       : 'Gérer la liste des personnes invitées à contribuer au service.'
   );
 
-  $effect(() => {
-    if (modeVisiteGuidee) {
-      store.reinitialise([donneesServiceVisiteGuidee]);
-    } else {
-      store.reinitialise(services);
+  let chargementTermine = $state(false);
+
+  onMount(async () => {
+    store.reinitialise(
+      modeVisiteGuidee ? [donneesServiceVisiteGuidee] : services
+    );
+
+    if (modeVisiteGuidee) storeAutorisations.charge(autorisationsVisiteGuidee);
+    else {
+      const surServiceUnique = services.length === 1;
+      if (surServiceUnique) {
+        const reponse = await axios.get(
+          `/api/service/${services.at(0)!.id}/autorisations`
+        );
+        storeAutorisations.charge(reponse.data);
+      }
     }
+
+    chargementTermine = true;
   });
 </script>
 
 <ContenuTiroir>
   <div id="contenu-contributeurs">
-    <GestionContributeurs {modeVisiteGuidee} />
+    {#if chargementTermine}
+      <GestionContributeurs {modeVisiteGuidee} />
+    {/if}
   </div>
 </ContenuTiroir>


### PR DESCRIPTION
Bug :
 - je clique sur la pastille contributeurs du Service A
 - je vois les contributeurs du service A, avec leurs couleurs
 - le fait de voir les couleurs montre que les autorisations sont bien matchées avec les contributeurs du service
 - je clique sur la pastille du Service B
 - je vois les contributeurs, mais sans couleurs
 - je reclique sur la pastille du Service B
 - cette fois les couleurs apparaissent

On a une hiérarchie :
TiroirGestionContributeurs > GestionContributeurs > LigneContributeur

Avant ce commit, GestionContributeurs chargeait les autorisations, mais on avait un bug de "premier rendu" de LigneContributeur où la ligne se rendait avant d'avoir les autorisations finies de chargées : donc pas de couleur affichée.

Pour simplifier, on remonte le chargement dans TiroirGestionContributeurs et on conditionne l'affichage des enfants sur la complétion du chargement.

On a donc un chargement à un seul endroit + pas d'enfant qui déclenchent des chargements dont les conséquences en termes de re-rendu sont floues.