### PR TITLE
Affichage des référentiels externes dans la liste des mesures centralisées

### DIFF
--- a/src/adaptateurs/adaptateurCsv.js
+++ b/src/adaptateurs/adaptateurCsv.js
@@ -87,20 +87,21 @@ const genereCsvMesures = async (
     colonnes.push({ id: 'priorite', title: 'Priorité' });
     colonnes.push({ id: 'echeance', title: 'Échéance' });
     colonnes.push({ id: 'responsables', title: 'Responsables' });
-    if (avecReferentielsExternes) {
-      colonnes.push({
-        id: 'mesuresAssocieesReCyf',
-        title: 'Exigences NIS2-ReCyf associées',
-      });
-      colonnes.push({
-        id: 'mesuresAssocieesISO',
-        title: 'Exigences ISO 2700X associées',
-      });
-      colonnes.push({
-        id: 'mesuresAssocieesAE',
-        title: 'Exigences Annexe au Règlement d’exécution 2024/2690 associées',
-      });
-    }
+  }
+
+  if (avecReferentielsExternes) {
+    colonnes.push({
+      id: 'mesuresAssocieesReCyf',
+      title: 'Exigences NIS2-ReCyf associées',
+    });
+    colonnes.push({
+      id: 'mesuresAssocieesISO',
+      title: 'Exigences ISO 2700X associées',
+    });
+    colonnes.push({
+      id: 'mesuresAssocieesAE',
+      title: 'Exigences Annexe au Règlement d’exécution 2024/2690 associées',
+    });
   }
 
   const formatteResponsables = (responsables) =>

--- a/src/referentielV2.ts
+++ b/src/referentielV2.ts
@@ -77,7 +77,9 @@ export type DonneesReferentielV2 = typeof questionsV2 & {
 };
 
 type MethodesSpecifiquesReferentielV2 = {
-  ajouteThematiqueEtPorteurs: (mesures: typeof mesuresV2) => typeof mesuresV2;
+  enrichisPourListeCentraliseeDeMesures: (
+    mesures: typeof mesuresV2
+  ) => typeof mesuresV2;
   descriptionAudienceCible: (audienceCible: AudienceCible) => string;
   descriptionDelaiAvantImpactCritique: (
     dureeDysfonctionnementAcceptable: DureeDysfonctionnementAcceptable
@@ -245,12 +247,18 @@ export const creeReferentielV2 = (
     };
   };
 
-  const ajouteThematiqueEtPorteurs = (desMesures: typeof mesuresV2) =>
+  const enrichisPourListeCentraliseeDeMesures = (
+    desMesures: typeof mesuresV2
+  ) =>
     Object.fromEntries(
       Object.entries(desMesures).map(([id, m]) => {
         const thematique = thematiqueDeMesure(id);
         const porteursSinguliers = porteursSinguliersDeMesure(id);
-        return [id, { ...m, thematique, porteursSinguliers }];
+        const referentielsExternes = referentielsExternesDeMesure(id);
+        return [
+          id,
+          { ...m, thematique, porteursSinguliers, referentielsExternes },
+        ];
       })
     );
 
@@ -260,7 +268,7 @@ export const creeReferentielV2 = (
 
   return {
     ...creeReferentiel(),
-    ajouteThematiqueEtPorteurs,
+    enrichisPourListeCentraliseeDeMesures,
     descriptionAudienceCible,
     descriptionDelaiAvantImpactCritique,
     descriptionsDonneesCaracterePersonnel,

--- a/src/routes/connecte/routesConnecteApi.js
+++ b/src/routes/connecte/routesConnecteApi.js
@@ -600,7 +600,7 @@ const routesConnecteApi = ({
           ...mesuresInteressantes,
           ...ajouteVersion(
             VersionService.v2,
-            referentielV2.ajouteThematiqueEtPorteurs(mesuresV2)
+            referentielV2.enrichisPourListeCentraliseeDeMesures(mesuresV2)
           ),
         };
       }

--- a/src/routes/connecte/routesConnectePage.js
+++ b/src/routes/connecte/routesConnectePage.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { z } from 'zod';
 import Utilisateur from '../../modeles/utilisateur.js';
 import Service from '../../modeles/service.js';
 import routesConnectePageService from './routesConnectePageService.js';
@@ -6,6 +7,7 @@ import { questionsV2 } from '../../../donneesReferentielMesuresV2.js';
 import { VersionService } from '../../modeles/versionService.js';
 import { adaptateurJWT } from '../../adaptateurs/adaptateurJWT.js';
 import { routesConnectePageAdmin } from './routesConnectePageAdmin.js';
+import { valideQuery } from '../../http/validePayloads.js';
 
 const routesConnectePage = ({
   middleware,
@@ -170,9 +172,15 @@ const routesConnectePage = ({
   routes.get(
     '/mesures/export.csv',
     middleware.verificationAcceptationCGU,
+    valideQuery(
+      z.strictObject({
+        version: z.enum(VersionService).optional(),
+        avecReferentielsExternes: z.stringbool().optional().default(false),
+      })
+    ),
     async (requete, reponse) => {
       try {
-        const { version } = requete.query;
+        const { version, avecReferentielsExternes } = requete.query;
         const modelesMesureSpecifique =
           await depotDonnees.lisModelesMesureSpecifiquePourUtilisateur(
             requete.idUtilisateurCourant
@@ -188,7 +196,8 @@ const routesConnectePage = ({
           [],
           false,
           referentielAUtiliser,
-          false
+          false,
+          avecReferentielsExternes
         );
         reponse
           .contentType('text/csv;charset=utf-8')

--- a/svelte/lib/listeMesures/ActionsComplementaires.svelte
+++ b/svelte/lib/listeMesures/ActionsComplementaires.svelte
@@ -39,7 +39,7 @@
   <div class="ligne-2">
     <Lien
       type="bouton-tertiaire"
-      href="/mesures/export.csv?version={$storeVersionsDeService.versionSelectionnee}"
+      href="/mesures/export.csv?version={$storeVersionsDeService.versionSelectionnee}&avecReferentielsExternes={afficherReferentielsExternes}"
       titre="Télécharger la liste de mesures"
       target="_blank"
       icone="telecharger"

--- a/svelte/lib/listeMesures/ActionsComplementaires.svelte
+++ b/svelte/lib/listeMesures/ActionsComplementaires.svelte
@@ -11,12 +11,15 @@
     capaciteAjoutDeMesure: CapaciteAjoutDeMesure;
     onajouterunemesureclick: () => void;
     onteleverserdesmesuresclick: () => void;
+    afficherReferentielsExternes: boolean;
   }
 
   let {
     capaciteAjoutDeMesure,
     onajouterunemesureclick,
     onteleverserdesmesuresclick,
+    // eslint-disable-next-line no-useless-assignment
+    afficherReferentielsExternes = $bindable(),
   }: Props = $props();
 
   let peutAjouterModelesMesureSpecifique = derived(
@@ -29,6 +32,9 @@
   <dsfr-toggle
     label="Afficher les référentiels d'exigences associés"
     id="affiche-referentiels-externes"
+    onvaluechanged={async (e: CustomEvent<boolean>) => {
+      afficherReferentielsExternes = e.detail;
+    }}
   ></dsfr-toggle>
   <div class="ligne-2">
     <Lien

--- a/svelte/lib/listeMesures/ActionsComplementaires.svelte
+++ b/svelte/lib/listeMesures/ActionsComplementaires.svelte
@@ -25,42 +25,68 @@
   );
 </script>
 
-<div class="conteneur-actions-complementaires">
-  <Lien
-    type="bouton-tertiaire"
-    href="/mesures/export.csv?version={$storeVersionsDeService.versionSelectionnee}"
-    titre="Télécharger la liste de mesures"
-    target="_blank"
-    icone="telecharger"
-  />
-  <div class="action-ajout-modeles-mesure-specifique">
-    <BoutonAvecListeDeroulante
-      titre="Ajouter une / des mesures"
-      aligneADroite
-      options={[
-        {
-          label: 'Ajouter une mesure',
-          icone: 'add-line',
-          action: onajouterunemesureclick,
-        },
-        {
-          label: 'Téléverser des mesures',
-          icone: 'upload-2-line',
-          action: onteleverserdesmesuresclick,
-        },
-      ]}
-      disabled={!$peutAjouterModelesMesureSpecifique}
+<div class="conteneur-actions">
+  <dsfr-toggle
+    label="Afficher les référentiels d'exigences associés"
+    id="affiche-referentiels-externes"
+  ></dsfr-toggle>
+  <div class="ligne-2">
+    <Lien
+      type="bouton-tertiaire"
+      href="/mesures/export.csv?version={$storeVersionsDeService.versionSelectionnee}"
+      titre="Télécharger la liste de mesures"
+      target="_blank"
+      icone="telecharger"
     />
-    {#if !$peutAjouterModelesMesureSpecifique}
-      <Infobulle
-        contenu="Vous avez atteint la limite maximale de ${capaciteAjoutDeMesure.nombreMaximum} mesures. Pour ajouter des mesures, veuillez d'abord en supprimer."
+    <div class="action-ajout-modeles-mesure-specifique">
+      <BoutonAvecListeDeroulante
+        titre="Ajouter une / des mesures"
+        aligneADroite
+        options={[
+          {
+            label: 'Ajouter une mesure',
+            icone: 'add-line',
+            action: onajouterunemesureclick,
+          },
+          {
+            label: 'Téléverser des mesures',
+            icone: 'upload-2-line',
+            action: onteleverserdesmesuresclick,
+          },
+        ]}
+        disabled={!$peutAjouterModelesMesureSpecifique}
       />
-    {/if}
+      {#if !$peutAjouterModelesMesureSpecifique}
+        <Infobulle
+          contenu="Vous avez atteint la limite maximale de ${capaciteAjoutDeMesure.nombreMaximum} mesures. Pour ajouter des mesures, veuillez d'abord en supprimer."
+        />
+      {/if}
+    </div>
   </div>
 </div>
 
 <style lang="scss">
-  .conteneur-actions-complementaires {
+  /* <Tableau> est utilisé à au moins 8 endroits… pour ne pas casser l'existant,
+   on vient modifier en flex-start seulement ici, via un global.
+   */
+  :global(.conteneur-tableau .filtres) {
+    align-items: flex-start;
+  }
+
+  .conteneur-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    padding-top: 8px;
+
+    dsfr-toggle {
+      width: fit-content;
+      white-space: nowrap;
+      margin-left: auto;
+    }
+  }
+
+  .ligne-2 {
     margin-left: auto;
     display: flex;
     gap: 12px;

--- a/svelte/lib/listeMesures/ActionsComplementaires.svelte
+++ b/svelte/lib/listeMesures/ActionsComplementaires.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { derived } from 'svelte/store';
+  import Lien from '../ui/Lien.svelte';
+  import BoutonAvecListeDeroulante from '../ui/BoutonAvecListeDeroulante.svelte';
+  import Infobulle from '../ui/Infobulle.svelte';
+  import { storeVersionsDeService } from './mesureGenerale/modelesMesureGenerale.store';
+  import { modelesMesureSpecifique } from '../ui/stores/modelesMesureSpecifique.store';
+  import type { CapaciteAjoutDeMesure } from './listeMesures.d';
+
+  interface Props {
+    capaciteAjoutDeMesure: CapaciteAjoutDeMesure;
+    onajouterunemesureclick: () => void;
+    onteleverserdesmesuresclick: () => void;
+  }
+
+  let {
+    capaciteAjoutDeMesure,
+    onajouterunemesureclick,
+    onteleverserdesmesuresclick,
+  }: Props = $props();
+
+  let peutAjouterModelesMesureSpecifique = derived(
+    modelesMesureSpecifique,
+    ($s) => $s.length < capaciteAjoutDeMesure.nombreMaximum
+  );
+</script>
+
+<div class="conteneur-actions-complementaires">
+  <Lien
+    type="bouton-tertiaire"
+    href="/mesures/export.csv?version={$storeVersionsDeService.versionSelectionnee}"
+    titre="Télécharger la liste de mesures"
+    target="_blank"
+    icone="telecharger"
+  />
+  <div class="action-ajout-modeles-mesure-specifique">
+    <BoutonAvecListeDeroulante
+      titre="Ajouter une / des mesures"
+      aligneADroite
+      options={[
+        {
+          label: 'Ajouter une mesure',
+          icone: 'add-line',
+          action: onajouterunemesureclick,
+        },
+        {
+          label: 'Téléverser des mesures',
+          icone: 'upload-2-line',
+          action: onteleverserdesmesuresclick,
+        },
+      ]}
+      disabled={!$peutAjouterModelesMesureSpecifique}
+    />
+    {#if !$peutAjouterModelesMesureSpecifique}
+      <Infobulle
+        contenu="Vous avez atteint la limite maximale de ${capaciteAjoutDeMesure.nombreMaximum} mesures. Pour ajouter des mesures, veuillez d'abord en supprimer."
+      />
+    {/if}
+  </div>
+</div>
+
+<style lang="scss">
+  .conteneur-actions-complementaires {
+    margin-left: auto;
+    display: flex;
+    gap: 12px;
+
+    .action-ajout-modeles-mesure-specifique {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+  }
+</style>

--- a/svelte/lib/listeMesures/ListeMesures.svelte
+++ b/svelte/lib/listeMesures/ListeMesures.svelte
@@ -96,6 +96,8 @@
     idCategorie: 'thematique',
   }));
 
+  let afficherReferentielsExternes = $state(false);
+
   const groupeReferentiel = { id: 'referentiel', libelle: 'Référentiel' };
   const groupeCategorie = { id: 'categorie', libelle: 'Catégories' };
   const groupeThematique = { id: 'thematique', libelle: 'Thématiques' };
@@ -323,6 +325,7 @@
       onajouterunemesureclick={afficheTiroirAjout}
       onteleverserdesmesuresclick={afficheTiroirTeleversement}
       {capaciteAjoutDeMesure}
+      bind:afficherReferentielsExternes
     />
   {/snippet}
 
@@ -366,7 +369,7 @@
         onclick={() => cliquable && ouvreTiroirEdition(donnee)}
       >
         <span>{donnee.description}</span>
-        {#if donnee.referentielsExternes}
+        {#if afficherReferentielsExternes && donnee.referentielsExternes}
           <EncartReferentielsExternes donnees={donnee.referentielsExternes} />
         {/if}
         <div class="conteneur-cartouches">

--- a/svelte/lib/listeMesures/ListeMesures.svelte
+++ b/svelte/lib/listeMesures/ListeMesures.svelte
@@ -45,6 +45,7 @@
   import { derived } from 'svelte/store';
   import { singulierPluriel } from '../outils/string';
   import ActionsComplementaires from './ActionsComplementaires.svelte';
+  import EncartReferentielsExternes from '../referentielsExternesDeMesures/EncartReferentielsExternes.svelte';
 
   interface Props {
     statuts: ReferentielStatut;
@@ -365,6 +366,9 @@
         onclick={() => cliquable && ouvreTiroirEdition(donnee)}
       >
         <span>{donnee.description}</span>
+        {#if donnee.referentielsExternes}
+          <EncartReferentielsExternes donnees={donnee.referentielsExternes} />
+        {/if}
         <div class="conteneur-cartouches">
           <CartoucheReferentiel referentiel={donnee.referentiel} />
           <CartoucheCategorieMesure categorie={donnee.categorie} />

--- a/svelte/lib/listeMesures/ListeMesures.svelte
+++ b/svelte/lib/listeMesures/ListeMesures.svelte
@@ -46,6 +46,10 @@
   import { singulierPluriel } from '../outils/string';
   import ActionsComplementaires from './ActionsComplementaires.svelte';
   import EncartReferentielsExternes from '../referentielsExternesDeMesures/EncartReferentielsExternes.svelte';
+  import {
+    LIBELLES_REFERENTIELS_EXTERNES,
+    type ReferentielExterne,
+  } from '../referentielsExternesDeMesures/referentielsExternes';
 
   interface Props {
     statuts: ReferentielStatut;
@@ -96,17 +100,30 @@
     idCategorie: 'thematique',
   }));
 
+  const itemsFiltrageReferentielsExternes = Object.entries(
+    LIBELLES_REFERENTIELS_EXTERNES
+  ).map(([cle, valeur]) => ({
+    libelle: valeur,
+    valeur: cle,
+    idCategorie: 'referentielsExternes',
+  }));
+
   let afficherReferentielsExternes = $state(false);
 
   const groupeReferentiel = { id: 'referentiel', libelle: 'Référentiel' };
   const groupeCategorie = { id: 'categorie', libelle: 'Catégories' };
   const groupeThematique = { id: 'thematique', libelle: 'Thématiques' };
+  const groupeReferentielsExternes = {
+    id: 'referentielsExternes',
+    libelle: "Référentiels d'exigences associés",
+  };
 
   type ConfigurationTableau = {
     donnees: ModeleDeMesure[];
     configurationRecherche: { champsRecherche: string[] };
     configurationFiltrage: ConfigurationFiltrage;
   };
+
   const listeModeleMesuresGenerales = derived(
     [modelesMesureGenerale, mesuresAvecServicesAssociesStore],
     ([$mMG, $mASAS]) =>
@@ -120,10 +137,15 @@
   const categoriesFiltragePourMesuresGenerales = derived(
     storeVersionsDeService,
     ($s) => {
-      const categoriesFiltrage = [groupeReferentiel, groupeCategorie];
-      if ($s.versionSelectionnee === 'v2') {
+      const categoriesFiltrage = [
+        groupeReferentiel,
+        groupeCategorie,
+        groupeReferentielsExternes,
+      ];
+
+      if ($s.versionSelectionnee === 'v2')
         categoriesFiltrage.push(groupeThematique);
-      }
+
       return categoriesFiltrage;
     }
   );
@@ -131,10 +153,15 @@
   const itemsFiltragePourMesuresGenerales = derived(
     storeVersionsDeService,
     ($s) => {
-      const items = [...itemsFiltrageReferentiel, ...itemsFiltrageCategories];
-      if ($s.versionSelectionnee === 'v2') {
+      const items = [
+        ...itemsFiltrageReferentiel,
+        ...itemsFiltrageCategories,
+        ...itemsFiltrageReferentielsExternes,
+      ];
+
+      if ($s.versionSelectionnee === 'v2')
         items.push(...itemsFiltrageThematiques);
-      }
+
       return items;
     }
   );
@@ -146,12 +173,34 @@
       type: 'specifique' as ModeleDeMesure['type'],
     }))
   );
+
+  const filtreSurReferentielExterne = (
+    donnee: object,
+    referentielsSelectionnes: string[]
+  ) => {
+    // Le 'donnee' est envoyé par <Tableau.svelte>, via un mécanisme de prédicat.
+    // De notre côté, on sait que c'est un record { ReCyf: […], ISO2700x: […] … }
+    const d = donnee as Record<ReferentielExterne, []>;
+    const mesuresRecyf = d?.ReCyf ?? [];
+    const mesuresISO = d?.ISO2700X ?? [];
+    const mesuresAE = d?.AE2690 ?? [];
+    return (
+      (mesuresRecyf.length > 0 && referentielsSelectionnes.includes('ReCyf')) ||
+      (mesuresISO.length > 0 &&
+        referentielsSelectionnes.includes('ISO2700X')) ||
+      (mesuresAE.length > 0 && referentielsSelectionnes.includes('AE2690'))
+    );
+  };
+
   let configurationTableau: ConfigurationTableau = $derived.by(() => {
     let config = {
       donnees: [],
       configurationRecherche: { champsRecherche: [] },
-      configurationFiltrage: { options: { categories: [], items: [] } },
+      configurationFiltrage: {
+        options: { categories: [], items: [], predicats: {} },
+      },
     } as ConfigurationTableau;
+
     if (ongletActif === 'generales') {
       config.donnees = $listeModeleMesuresGenerales;
       config.configurationRecherche.champsRecherche = [
@@ -161,6 +210,12 @@
       config.configurationFiltrage.options = {
         categories: $categoriesFiltragePourMesuresGenerales,
         items: $itemsFiltragePourMesuresGenerales,
+        predicats: {
+          referentielsExternes: (
+            referentielsSelectionnes: string[],
+            donnee: object
+          ) => filtreSurReferentielExterne(donnee, referentielsSelectionnes),
+        },
       };
     } else if (ongletActif === 'specifiques') {
       config.donnees = $listeModelesMesureSpecifique;
@@ -168,6 +223,7 @@
       config.configurationFiltrage.options = {
         categories: [groupeCategorie],
         items: [...itemsFiltrageCategories],
+        predicats: {},
       };
     } else if (ongletActif === 'toutes') {
       config.donnees = [
@@ -188,6 +244,12 @@
             idCategorie: 'referentiel',
           },
         ],
+        predicats: {
+          referentielsExternes: (
+            referentielsSelectionnes: string[],
+            donnee: object
+          ) => filtreSurReferentielExterne(donnee, referentielsSelectionnes),
+        },
       };
     }
     config.donnees = seulementCellesDeLaVersion(

--- a/svelte/lib/listeMesures/ListeMesures.svelte
+++ b/svelte/lib/listeMesures/ListeMesures.svelte
@@ -26,7 +26,6 @@
   } from './mesureGenerale/modelesMesureGenerale.store';
   import ModaleRapportModification from './modificationStatutPrecision/rapport/ModaleRapportModification.svelte';
   import { modaleRapportStore } from './modificationStatutPrecision/rapport/modaleRapport.store';
-  import Lien from '../ui/Lien.svelte';
   import Loader from '../ui/Loader.svelte';
   import Toaster from '../ui/Toaster.svelte';
   import { modelesMesureSpecifique } from '../ui/stores/modelesMesureSpecifique.store';
@@ -38,15 +37,14 @@
   import Onglets from '../ui/Onglets.svelte';
   import TiroirAjoutModeleMesureSpecifique from './mesureSpecifique/ajout/TiroirAjoutModeleMesureSpecifique.svelte';
   import TiroirConfigurationModeleMesureSpecifique from './mesureSpecifique/configuration/TiroirConfigurationModeleMesureSpecifique.svelte';
-  import BoutonAvecListeDeroulante from '../ui/BoutonAvecListeDeroulante.svelte';
   import TiroirTeleversementModeleMesureSpecifique from './televersement/TiroirTeleversementModeleMesureSpecifique.svelte';
   import TableauVideMesuresSpecifiques from './mesureSpecifique/TableauVideMesuresSpecifiques.svelte';
-  import Infobulle from '../ui/Infobulle.svelte';
   import FiltreSurV1V2 from './FiltreSurV1V2.svelte';
   import CartoucheThematique from '../ui/CartoucheThematique.svelte';
   import { thematiques } from './thematiques';
   import { derived } from 'svelte/store';
   import { singulierPluriel } from '../outils/string';
+  import ActionsComplementaires from './ActionsComplementaires.svelte';
 
   interface Props {
     statuts: ReferentielStatut;
@@ -77,11 +75,6 @@
       ? ongletDemande
       : 'toutes';
   });
-
-  let peutAjouterModelesMesureSpecifique = derived(
-    modelesMesureSpecifique,
-    ($s) => $s.length < capaciteAjoutDeMesure.nombreMaximum
-  );
 
   const itemsFiltrageReferentiel = [
     { libelle: 'ANSSI', valeur: Referentiel.ANSSI, idCategorie: 'referentiel' },
@@ -325,39 +318,11 @@
     {/if}
   {/snippet}
   {#snippet actionsComplementaires()}
-    <div class="conteneur-actions-complementaires">
-      <Lien
-        type="bouton-tertiaire"
-        href="/mesures/export.csv?version={$storeVersionsDeService.versionSelectionnee}"
-        titre="Télécharger la liste de mesures"
-        target="_blank"
-        icone="telecharger"
-      />
-      <div class="action-ajout-modeles-mesure-specifique">
-        <BoutonAvecListeDeroulante
-          titre="Ajouter une / des mesures"
-          aligneADroite
-          options={[
-            {
-              label: 'Ajouter une mesure',
-              icone: 'add-line',
-              action: afficheTiroirAjout,
-            },
-            {
-              label: 'Téléverser des mesures',
-              icone: 'upload-2-line',
-              action: afficheTiroirTeleversement,
-            },
-          ]}
-          disabled={!$peutAjouterModelesMesureSpecifique}
-        />
-        {#if !$peutAjouterModelesMesureSpecifique}
-          <Infobulle
-            contenu={`Vous avez atteint la limite maximale de ${capaciteAjoutDeMesure.nombreMaximum} mesures. Pour ajouter des mesures, veuillez d'abord en supprimer.`}
-          />
-        {/if}
-      </div>
-    </div>
+    <ActionsComplementaires
+      onajouterunemesureclick={afficheTiroirAjout}
+      onteleverserdesmesuresclick={afficheTiroirTeleversement}
+      {capaciteAjoutDeMesure}
+    />
   {/snippet}
 
   {#snippet onglets()}
@@ -524,18 +489,6 @@
 
   :global(tr.met-en-avant) {
     animation: montre-ligne 2s ease-out 0.5s;
-  }
-
-  .conteneur-actions-complementaires {
-    margin-left: auto;
-    display: flex;
-    gap: 12px;
-
-    .action-ajout-modeles-mesure-specifique {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-    }
   }
 
   @keyframes montre-ligne {

--- a/svelte/lib/listeMesures/listeMesures.d.ts
+++ b/svelte/lib/listeMesures/listeMesures.d.ts
@@ -11,6 +11,7 @@ import {
   Referentiel,
   ReferentielTypesService,
 } from '../ui/types.d';
+import type { ReferentielExterne } from '../referentielsExternesDeMesures/referentielsExternes';
 
 declare global {
   interface HTMLElementEventMap {
@@ -69,6 +70,7 @@ export type ModeleDeMesure = {
   type: 'generale' | 'specifique';
   versionReferentiel?: VersionService;
   thematique?: string;
+  referentielsExternes?: Record<ReferentielExterne, Array<{ id: string }>>;
 };
 
 export type CapaciteAjoutDeMesure = {

--- a/svelte/lib/mesure/contenus/ContenuOngletReferentielsExternes.svelte
+++ b/svelte/lib/mesure/contenus/ContenuOngletReferentielsExternes.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { MesuresReferentielsExternes } from '../mesure';
   import { singulierPluriel } from '../../outils/string';
-  import { LIBELLES_REFERENTIELS_EXTERNES } from '../../tableauDesMesures/referentielsExternes';
+  import {
+    LIBELLES_REFERENTIELS_EXTERNES,
+    type ReferentielExterne,
+  } from '../../referentielsExternesDeMesures/referentielsExternes';
   import ListeDeroulanteRiche from '../../ui/ListeDeroulanteRiche.svelte';
-  import type { ReferentielExterne } from '../../ui/types';
 
   interface Props {
     mesuresReferentielsExternes: MesuresReferentielsExternes;

--- a/svelte/lib/referentielsExternesDeMesures/EncartReferentielsExternes.svelte
+++ b/svelte/lib/referentielsExternesDeMesures/EncartReferentielsExternes.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import {
+    LIBELLES_REFERENTIELS_EXTERNES,
+    type ReferentielExterne,
+  } from './referentielsExternes';
+
+  interface Props {
+    donnees: Record<ReferentielExterne, Array<{ id: string }>>;
+  }
+
+  let { donnees }: Props = $props();
+
+  let nomsDesReferentiels: Array<string> = $derived.by(() => {
+    if (!donnees) return [];
+
+    return Object.entries(donnees)
+      .filter(([, items]) => items.length > 0)
+      .map(
+        ([cle]) => LIBELLES_REFERENTIELS_EXTERNES[cle as ReferentielExterne]
+      );
+  });
+
+  let aDesReferentielsExternes = $derived(nomsDesReferentiels.length > 0);
+</script>
+
+{#if aDesReferentielsExternes}
+  <span class="referentiels-externes">
+    Correspond à {nomsDesReferentiels.join(', ')}
+  </span>
+{/if}
+
+<style lang="scss">
+  .referentiels-externes {
+    font-size: 0.75rem;
+    font-style: italic;
+    font-weight: normal;
+    line-height: 1.125rem;
+  }
+</style>

--- a/svelte/lib/referentielsExternesDeMesures/referentielsExternes.ts
+++ b/svelte/lib/referentielsExternesDeMesures/referentielsExternes.ts
@@ -1,4 +1,4 @@
-import type { ReferentielExterne } from '../ui/types';
+export type ReferentielExterne = 'ReCyf' | 'ISO2700X' | 'AE2690';
 
 export const LIBELLES_REFERENTIELS_EXTERNES: Record<
   ReferentielExterne,

--- a/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
+++ b/svelte/lib/tableauDesMesures/filtres/MenuFiltres.svelte
@@ -20,7 +20,7 @@
   import { rechercheParPartieResponsable } from '../stores/rechercheParPartieResponsable.store';
   import { derived } from 'svelte/store';
   import { rechercheParReferentielExterne } from '../stores/rechercheParReferentielExterne.store';
-  import { LIBELLES_REFERENTIELS_EXTERNES } from '../referentielsExternes';
+  import { LIBELLES_REFERENTIELS_EXTERNES } from '../../referentielsExternesDeMesures/referentielsExternes';
 
   interface Props {
     categories: Record<IdCategorie, string>;

--- a/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
+++ b/svelte/lib/tableauDesMesures/ligne/LigneMesure.svelte
@@ -9,7 +9,6 @@
     type EcheanceMesure,
     type PrioriteMesure,
     Referentiel,
-    type ReferentielExterne,
     type ReferentielPriorite,
     type ReferentielStatut,
   } from '../../ui/types.d';
@@ -32,7 +31,7 @@
   import { partieResponsable } from './mapPartieResponsable';
   import type { IdUtilisateur } from '../../mesure/mesure.d';
   import { ciblage, cibleDeVisiteGuidee } from '../../visiteGuidee/ciblage';
-  import { LIBELLES_REFERENTIELS_EXTERNES } from '../referentielsExternes';
+  import EncartReferentielsExternes from '../../referentielsExternesDeMesures/EncartReferentielsExternes.svelte';
 
   type IdDom = string;
 
@@ -94,22 +93,6 @@
         $nomsDesContributeursParId
       )
   );
-
-  let referentielsExternesExistants: Array<ReferentielExterne> = $derived.by(
-    () => {
-      const mesureGenerale = mesure as MesureGenerale;
-      if (!mesureGenerale.mesuresReferentielsExternes) {
-        return [];
-      }
-      return Object.entries(mesureGenerale.mesuresReferentielsExternes)
-        .filter(([, items]) => items.length > 0)
-        .map(([cle]) => cle) as ReferentielExterne[];
-    }
-  );
-
-  let aDesReferentielsExternes = $derived(
-    referentielsExternesExistants.length > 0
-  );
 </script>
 
 <tr class="ligne-de-mesure">
@@ -137,13 +120,10 @@
       {/if}
       <CartoucheIdentifiantMesure identifiant={mesure.identifiantNumerique} />
     </div>
-    {#if afficheReferentielsExterne && aDesReferentielsExternes}
-      {@const labelsReferentiels = referentielsExternesExistants.map(
-        (id) => LIBELLES_REFERENTIELS_EXTERNES[id]
-      )}
-      <span class="referentiels-externes"
-        >Correspond à {labelsReferentiels.join(', ')}</span
-      >
+    {#if afficheReferentielsExterne}
+      <EncartReferentielsExternes
+        donnees={(mesure as MesureGenerale).mesuresReferentielsExternes!}
+      />
     {/if}
   </td>
   {#if affichePlanAction}
@@ -219,12 +199,6 @@
       font-style: italic;
       color: #3a3a3a;
     }
-  }
-
-  .referentiels-externes {
-    font-style: italic;
-    font-size: 0.75rem;
-    line-height: 1.125rem;
   }
 
   .titre-mesure:hover .titre {

--- a/svelte/lib/tableauDesMesures/stores/rechercheParReferentielExterne.store.ts
+++ b/svelte/lib/tableauDesMesures/stores/rechercheParReferentielExterne.store.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 import type { MesureGenerale, MesureSpecifique } from '../tableauDesMesures.d';
-import type { ReferentielExterne } from '../../ui/types.d';
+import type { ReferentielExterne } from '../../referentielsExternesDeMesures/referentielsExternes';
 
 export const rechercheParReferentielExterne = writable<ReferentielExterne[]>(
   []

--- a/svelte/lib/tableauDesMesures/stores/resultatsDeRecherche.store.ts
+++ b/svelte/lib/tableauDesMesures/stores/resultatsDeRecherche.store.ts
@@ -31,7 +31,7 @@ import {
   appliqueFiltreParPriorite,
   rechercheParPriorite,
 } from './rechercheParPriorite.store';
-import type { PrioriteMesure, ReferentielExterne } from '../../ui/types';
+import type { PrioriteMesure } from '../../ui/types';
 import {
   appliqueFiltreMesMesures,
   rechercheMesMesures,
@@ -49,6 +49,7 @@ import {
   appliqueFiltreParReferentielExterne,
   rechercheParReferentielExterne,
 } from './rechercheParReferentielExterne.store';
+import type { ReferentielExterne } from '../../referentielsExternesDeMesures/referentielsExternes';
 
 type Filtre = (mesure: MesureSpecifique | MesureGenerale) => boolean;
 type Predicats = {

--- a/svelte/lib/ui/Tableau.svelte
+++ b/svelte/lib/ui/Tableau.svelte
@@ -9,11 +9,7 @@
   };
 
   export type ConfigurationSelection<T> = {
-    texteIndicatif: {
-      vide: string;
-      unique: string;
-      multiple: string;
-    };
+    texteIndicatif: { vide: string; unique: string; multiple: string };
     champSelection: string;
     predicatSelectionDesactive?: (donnee: T) => boolean;
   };
@@ -85,9 +81,12 @@
         if (valeurs && valeurs.length)
           filtrees = filtrees.filter((d) => {
             const donnee = d[cleFiltrage];
-            if (Array.isArray(donnee)) {
+            const predicatApplicable =
+              configurationFiltrage.options.predicats?.[cleFiltrage];
+            if (predicatApplicable !== undefined)
+              return predicatApplicable(valeurs, donnee);
+            if (Array.isArray(donnee))
               return donnee.some((v) => valeurs.includes(v));
-            }
             return valeurs.includes(donnee);
           });
       });

--- a/svelte/lib/ui/types.d.ts
+++ b/svelte/lib/ui/types.d.ts
@@ -116,5 +116,3 @@ export type Utilisateur = {
   postes: string[];
   email: string;
 };
-
-export type ReferentielExterne = 'ReCyf' | 'ISO2700X' | 'AE2690';

--- a/svelte/lib/ui/ui.types.d.ts
+++ b/svelte/lib/ui/ui.types.d.ts
@@ -1,23 +1,15 @@
-export type OptionListeDeroulante<T> = {
-  label: string;
-  valeur: T;
-};
+export type OptionListeDeroulante<T> = { label: string; valeur: T };
 
 export type OptionsListeDeroulante<T> = OptionListeDeroulante<T>[];
 
+type IdCategorie = string;
 export type OptionsListeDeroulanteRiche<T> = {
-  categories: {
-    id: string;
-    libelle: string;
-  }[];
-  items: {
-    libelle: string;
-    valeur: T;
-    idCategorie: string;
-  }[];
+  categories: { id: IdCategorie; libelle: string }[];
+  items: { libelle: string; valeur: T; idCategorie: IdCategorie }[];
+  predicats?: Record<
+    IdCategorie,
+    (filtreSelectionne: T[], donnee: object) => boolean
+  >;
 };
 
-export type ItemFilAriane = {
-  label: string;
-  lien?: string;
-};
+export type ItemFilAriane = { label: string; lien?: string };

--- a/test/routes/connecte/routesConnecteApi.spec.js
+++ b/test/routes/connecte/routesConnecteApi.spec.js
@@ -1356,6 +1356,7 @@ describe('Le serveur MSS des routes privées /api/*', () => {
       ...mesuresV2['RECENSEMENT.1'],
       thematique: 'Gouvernance et gestion des risques',
       porteursSinguliers: ['Chef de projet numérique', 'Chef de projet métier'],
+      referentielsExternes: { AE2690: [], ISO2700X: [], ReCyf: [] },
       versionReferentiel: 'v2',
     };
 
@@ -1493,6 +1494,16 @@ describe('Le serveur MSS des routes privées /api/*', () => {
           'Chef de projet métier',
         ],
       });
+    });
+
+    it('ajoute les liens vers les référentiels externes aux mesures v2', async () => {
+      testeur.depotDonnees().versionsServiceUtiliseesParUtilisateur =
+        async () => ['v2'];
+
+      const reponse = await testeur.get('/api/referentiel/mesures');
+
+      const mesureContrat1 = reponse.body['CONTRAT.1'];
+      expect(mesureContrat1.referentielsExternes.ReCyf).to.have.length(1);
     });
   });
 });

--- a/test/routes/connecte/routesConnectePage.spec.js
+++ b/test/routes/connecte/routesConnectePage.spec.js
@@ -276,9 +276,7 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
     it('utilise un adaptateur CSV pour la génération', async () => {
       let donneesRecues;
       testeur.referentiel().recharge({
-        mesures: {
-          uneMesure: {},
-        },
+        mesures: { uneMesure: {} },
       });
       testeur.adaptateurCsv().genereCsvMesures = async (
         donneesMesures,
@@ -379,6 +377,26 @@ describe('Le serveur MSS des pages pour un utilisateur "Connecté"', () => {
           'RECENSEMENT.1'
         )
       ).to.be(true);
+    });
+
+    it("rajoute les données des référentiels externes si c'est demandé", async () => {
+      let demandeReferentielsExternes;
+      testeur.adaptateurCsv().genereCsvMesures = async (
+        _d,
+        _c,
+        _a,
+        _r,
+        _t,
+        avecReferentielsExternes
+      ) => {
+        demandeReferentielsExternes = avecReferentielsExternes;
+      };
+
+      await testeur.get(
+        '/mesures/export.csv?version=v2&avecReferentielsExternes=true'
+      );
+
+      expect(demandeReferentielsExternes).to.be(true);
     });
   });
 });


### PR DESCRIPTION
On rajoute un toggle sur l'écran de la liste centralisée des mesures
On réutilise de la logique d'affichage utilisée sur les pages des mesures de service, là où c'est possible, en extrayant des composants.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/dd87cab2-145f-416b-bd17-98cfe98311f7" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/f4adff0b-d5e0-4f2c-8b7f-a78197c80145" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5fd05546-39bb-41c5-bfc1-855d0c86fb59" />
