### PR TITLE
Gestion du pixel de suivi Brevo pour être conforme avec les directives de la CNIL

### DIFF
--- a/migrations/20260717130839_ajoutePixelDeSuiviDansTableUtilisateurs.js
+++ b/migrations/20260717130839_ajoutePixelDeSuiviDansTableUtilisateurs.js
@@ -1,0 +1,33 @@
+import { fabriqueAdaptateurChiffrement } from '../src/adaptateurs/fabriqueAdaptateurChiffrement.js';
+
+const chiffrement = fabriqueAdaptateurChiffrement();
+
+export const up = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const utilisateurs = await trx('utilisateurs');
+
+    const ajoutePixelDeSuivi = utilisateurs.map(async ({ id, donnees }) => {
+      const enClair = await chiffrement.dechiffre(donnees);
+      enClair.pixelDeSuiviAccepte = true;
+      const chiffrees = await chiffrement.chiffre(enClair);
+      await trx('utilisateurs').where({ id }).update({ donnees: chiffrees });
+    });
+
+    await Promise.all(ajoutePixelDeSuivi);
+  });
+};
+
+export const down = async (knex) => {
+  await knex.transaction(async (trx) => {
+    const utilisateurs = await trx('utilisateurs');
+
+    const retirePixelDeSuivi = utilisateurs.map(async ({ id, donnees }) => {
+      const enClair = await chiffrement.dechiffre(donnees);
+      delete enClair.pixelDeSuiviAccepte;
+      const chiffrees = await chiffrement.chiffre(enClair);
+      await trx('utilisateurs').where({ id }).update({ donnees: chiffrees });
+    });
+
+    await Promise.all(retirePixelDeSuivi);
+  });
+};

--- a/src/adaptateurs/adaptateurMail.interface.ts
+++ b/src/adaptateurs/adaptateurMail.interface.ts
@@ -9,7 +9,8 @@ export interface AdaptateurMail {
     nom: string,
     telephone: string,
     bloqueNewsletter: boolean,
-    bloqueMarketing: boolean
+    bloqueMarketing: boolean,
+    pixelDeSuiviAccepte: boolean
   ): Promise<void>;
 
   creeEntreprise(

--- a/src/adaptateurs/adaptateurMail.interface.ts
+++ b/src/adaptateurs/adaptateurMail.interface.ts
@@ -23,6 +23,11 @@ export interface AdaptateurMail {
 
   desinscrisInfolettre(destinataire: string): Promise<void>;
 
+  changeConsentementPixelDeSuivi(
+    emailDuContact: string,
+    nouvelleValeur: boolean
+  ): Promise<void>;
+
   envoieMessageFelicitationHomologation(
     destinataire: string,
     idService: UUID

--- a/src/adaptateurs/adaptateurMailMemoire.ts
+++ b/src/adaptateurs/adaptateurMailMemoire.ts
@@ -25,6 +25,17 @@ const fabriqueAdaptateurMailMemoire = () => {
     envoyer("Désinscription de l'infolettre MSS", args);
   };
 
+  const changeConsentementPixelDeSuivi = async (
+    emailDuContact: string,
+    nouvelleValeur: boolean
+  ) => {
+    envoyer(
+      'Changement du consentement au pixel de suivi',
+      emailDuContact,
+      nouvelleValeur
+    );
+  };
+
   const inscrisInfolettre = async (...args: unknown[]) => {
     envoyer("Inscription à l'infolettre MSS", args);
   };
@@ -122,6 +133,7 @@ const fabriqueAdaptateurMailMemoire = () => {
     creeContact,
     metAJourContact,
     metAJourDonneesContact,
+    changeConsentementPixelDeSuivi,
     creeEntreprise,
     desinscrisEmailsTransactionnels,
     desinscrisInfolettre,

--- a/src/adaptateurs/adaptateurMailSendinblue.ts
+++ b/src/adaptateurs/adaptateurMailSendinblue.ts
@@ -74,7 +74,8 @@ const creeContact = async (
   nom: string,
   telephone: string,
   bloqueNewsletter: boolean,
-  bloqueMarketing: boolean
+  bloqueMarketing: boolean,
+  pixelDeSuiviAccepte: boolean
 ) => {
   const codesErreurTelephone = ['duplicate_parameter', 'invalid_parameter'];
 
@@ -88,6 +89,7 @@ const creeContact = async (
       ...(inclutTelephone && {
         SMS: numeroTelephoneAvecIndicatif(telephone),
       }),
+      _PIXEL_TRACKING_CONSENT: pixelDeSuiviAccepte,
     },
     ...(!bloqueNewsletter && { listIds: [idListeInfolettre] }),
   });

--- a/src/adaptateurs/adaptateurMailSendinblue.ts
+++ b/src/adaptateurs/adaptateurMailSendinblue.ts
@@ -161,6 +161,14 @@ const metAJourContact = (
     SMS: numeroTelephoneAvecIndicatif(telephone),
   });
 
+const changeConsentementPixelDeSuivi = (
+  emailDuContact: string,
+  nouvelleValeur: boolean
+) =>
+  metAJourDonneesContact(emailDuContact, {
+    _PIXEL_TRACKING_CONSENT: nouvelleValeur,
+  });
+
 const basculeEmailsTransactionnels = async (
   destinataire: string,
   etat: boolean
@@ -442,6 +450,7 @@ export const adaptateurMailSendinblue = {
   creeContact,
   metAJourContact,
   metAJourDonneesContact: metAJourDonneesContactCadencee,
+  changeConsentementPixelDeSuivi,
   creeEntreprise,
   desinscrisEmailsTransactionnels,
   desinscrisInfolettre,

--- a/src/http/configurationServeur.js
+++ b/src/http/configurationServeur.js
@@ -12,6 +12,7 @@ const ENDPOINTS_SANS_CSRF = [
   { path: '/api/utilisateur', type: 'exact' },
   // La désinscription est appelée par un webhook coté Brevo
   { path: '/api/desinscriptionInfolettre', type: 'exact' },
+  { path: '/webhooks/updateConsentementPixelDeSuivi', type: 'exact' },
   // Les événements Matomo partent vers l'infra beta : on ne fait que passe-plat donc on ne protège pas.
   { path: '/bibliotheques/evenementMatomo', type: 'exact' },
 ];

--- a/src/modeles/inscriptionUtilisateur.js
+++ b/src/modeles/inscriptionUtilisateur.js
@@ -19,7 +19,8 @@ function fabriqueInscriptionUtilisateur(config = {}) {
         utilisateur.nom ?? '',
         utilisateur.telephone ?? '',
         !utilisateur.infolettreAcceptee,
-        false
+        false,
+        utilisateur.pixelDeSuiviAccepte
       )
     );
   };

--- a/src/modeles/utilisateur.ts
+++ b/src/modeles/utilisateur.ts
@@ -47,6 +47,7 @@ class Utilisateur extends Base {
   private readonly cguAcceptees!: string;
   private readonly infolettreAcceptee!: boolean;
   private readonly transactionnelAccepte!: boolean;
+  private readonly pixelDeSuiviAccepte!: boolean;
   private readonly estimationNombreServices!: EstimationNombreServices;
   readonly postes!: Array<string>;
   readonly entite: Entite;
@@ -234,6 +235,7 @@ class Utilisateur extends Base {
     nouvellesPreferences: {
       infolettreAcceptee?: boolean;
       transactionnelAccepte?: boolean;
+      pixelDeSuiviAccepte?: boolean;
     },
     adaptateurEmail: AdaptateurMail
   ) {
@@ -254,6 +256,16 @@ class Utilisateur extends Base {
       await adaptateurEmail.inscrisEmailsTransactionnels(this.email);
     if (desinscrisTransac)
       await adaptateurEmail.desinscrisEmailsTransactionnels(this.email);
+
+    const pixelDeSuiviActuel = this.pixelDeSuiviAccepte;
+    const nouveauPixelDeSuivi = nouvellesPreferences.pixelDeSuiviAccepte;
+    const acceptePixel = !pixelDeSuiviActuel && nouveauPixelDeSuivi === true;
+    const refusePixel = pixelDeSuiviActuel && nouveauPixelDeSuivi === false;
+
+    if (acceptePixel)
+      await adaptateurEmail.changeConsentementPixelDeSuivi(this.email, true);
+    if (refusePixel)
+      await adaptateurEmail.changeConsentementPixelDeSuivi(this.email, false);
   }
 }
 

--- a/src/modeles/utilisateur.ts
+++ b/src/modeles/utilisateur.ts
@@ -25,6 +25,7 @@ export type DonneesUtilisateur = {
   cguAcceptees: string;
   infolettreAcceptee: boolean;
   transactionnelAccepte: boolean;
+  pixelDeSuiviAccepte: boolean;
   estimationNombreServices: EstimationNombreServices;
   postes: Array<string>;
   entite: Partial<DonneesEntite>;
@@ -71,6 +72,7 @@ class Utilisateur extends Base {
         'cguAcceptees',
         'infolettreAcceptee',
         'transactionnelAccepte',
+        'pixelDeSuiviAccepte',
         'estimationNombreServices',
       ],
       proprietesListes: ['postes'],

--- a/src/modeles/utilisateur.types.ts
+++ b/src/modeles/utilisateur.types.ts
@@ -7,6 +7,7 @@ export type PartieModifiableProfilUtilisateur = {
   };
   infolettreAcceptee: boolean;
   transactionnelAccepte: boolean;
+  pixelDeSuiviAccepte: boolean;
   postes: string[];
   cguAcceptees?: string;
 };

--- a/src/mss.js
+++ b/src/mss.js
@@ -13,6 +13,7 @@ import routesNonConnecteApiStyles from './routes/nonConnecte/routesNonConnecteAp
 import routesNonConnectePage from './routes/nonConnecte/routesNonConnectePage.js';
 import routesConnectePage from './routes/connecte/routesConnectePage.js';
 import routesNonConnecteOidc from './routes/nonConnecte/routesNonConnecteOidc.js';
+import routesNonConnecteWebhooks from './routes/nonConnecte/routesNonConnecteWebhooks.js';
 import { ajouteHtmlEntitiesEncode } from './http/encodeEntitesHTML.js';
 
 const creeServeur = ({
@@ -132,6 +133,11 @@ const creeServeur = ({
       inscriptionUtilisateur,
       serviceCgu,
     })
+  );
+  app.use(
+    '/webhooks',
+    middleware.chargeTypeRequete(TYPES_REQUETES.API),
+    routesNonConnecteWebhooks({ middleware, depotDonnees })
   );
   app.use(
     '/oidc',

--- a/src/routes/connecte/routesConnecteApiUtilisateur.ts
+++ b/src/routes/connecte/routesConnecteApiUtilisateur.ts
@@ -83,6 +83,7 @@ export const routesConnecteApiUtilisateur = ({
             {
               infolettreAcceptee: donnees.infolettreAcceptee,
               transactionnelAccepte: donnees.transactionnelAccepte,
+              pixelDeSuiviAccepte: donnees.pixelDeSuiviAccepte,
             },
             adaptateurMail
           )

--- a/src/routes/mappeur/utilisateur.ts
+++ b/src/routes/mappeur/utilisateur.ts
@@ -17,6 +17,7 @@ const obtentionDonneesDeBaseUtilisateur = (
     estimationNombreServices: corps.estimationNombreServices,
     infolettreAcceptee: corps.infolettreAcceptee,
     transactionnelAccepte: corps.transactionnelAccepte,
+    pixelDeSuiviAccepte: corps.pixelDeSuiviAccepte,
     postes: corps.postes,
   };
   if (corps.cguAcceptees) {

--- a/src/routes/nonConnecte/routesNonConnecteApi.schema.ts
+++ b/src/routes/nonConnecte/routesNonConnecteApi.schema.ts
@@ -18,6 +18,7 @@ export const schemaCommunPutPostUtilisateur = {
     .or(z.literal('')),
   transactionnelAccepte: z.boolean(),
   infolettreAcceptee: z.boolean(),
+  pixelDeSuiviAccepte: z.boolean(),
   agentConnect: z.literal(true).optional(),
 };
 

--- a/src/routes/nonConnecte/routesNonConnecteApi.ts
+++ b/src/routes/nonConnecte/routesNonConnecteApi.ts
@@ -98,7 +98,7 @@ const routesNonConnecteApi = ({
 
   routes.post(
     '/desinscriptionInfolettre',
-    middleware.verificationAddresseIP(['185.107.232.1/24', '1.179.112.1/20']),
+    middleware.verificationAddresseIP(['1.179.112.0/20', '172.246.240.0/20']),
     valideBody(z.looseObject(reglesValidationDesinscriptionInfolettre)),
     async (requete, reponse) => {
       const { email } = requete.body;

--- a/src/routes/nonConnecte/routesNonConnecteWebhooks.schema.ts
+++ b/src/routes/nonConnecte/routesNonConnecteWebhooks.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+// Côté Brevo ce webhook sera appelé sur l'événement `contact_updated`
+// … donc potentiellement bcp de fois.
+// Volontairement, on force zod à ne laisser passer que du _PIXEL_TRACKING_CONSENT
+// pour ne pas déclencher notre code métier sur un attribut qui ne nous intéresse
+// pas.
+export const schemaPostConsentementPixelDeSuivi = z.object({
+  event: z.literal('contact_updated'),
+  email: z.email(),
+  content: z
+    .array(
+      z.object({
+        attributes: z.object({ _PIXEL_TRACKING_CONSENT: z.boolean() }),
+      })
+    )
+    .min(1)
+    .max(1),
+});

--- a/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
+++ b/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
@@ -1,0 +1,43 @@
+import express from 'express';
+import { valideBody } from '../../http/validePayloads.js';
+import { Middleware } from '../../http/middleware.interface.js';
+import { DepotDonnees } from '../../depotDonnees.interface.js';
+import { schemaPostConsentementPixelDeSuivi } from './routesNonConnecteWebhooks.schema.js';
+
+const routesNonConnecteWebhooks = ({
+  middleware,
+  depotDonnees,
+}: {
+  middleware: Middleware;
+  depotDonnees: DepotDonnees;
+}) => {
+  const routes = express.Router();
+
+  routes.post(
+    '/updateConsentementPixelDeSuivi',
+    middleware.verificationAddresseIP(['1.179.112.0/20', '172.246.240.0/20']),
+    valideBody(schemaPostConsentementPixelDeSuivi),
+    async (requete, reponse) => {
+      const { email } = requete.body;
+
+      const utilisateur = await depotDonnees.utilisateurAvecEmail(email);
+      if (!utilisateur) {
+        reponse.status(424).json({ erreur: `L'email fourni est introuvable` });
+        return;
+      }
+
+      /* eslint-disable no-underscore-dangle */
+      const pixelDeSuiviAccepte =
+        requete.body.content[0].attributes._PIXEL_TRACKING_CONSENT;
+      await depotDonnees.metsAJourUtilisateur(utilisateur.id, {
+        pixelDeSuiviAccepte,
+      });
+
+      reponse.sendStatus(200);
+    }
+  );
+
+  return routes;
+};
+
+export default routesNonConnecteWebhooks;

--- a/svelte/lib/inscription/Inscription.svelte
+++ b/svelte/lib/inscription/Inscription.svelte
@@ -99,6 +99,7 @@
     cguAcceptees: false,
     infolettreAcceptee: false,
     transactionnelAccepte: true,
+    pixelDeSuiviAccepte: false,
     token: untrack(() => token),
   });
 
@@ -276,6 +277,18 @@
             <label for="cguAcceptees" class="requis">
               J'accepte les <a href="/cgu">conditions générales d'utilisation</a
               > de MonServiceSécurisé
+            </label>
+          </div>
+          <div class="case-a-cocher">
+            <input
+              id="pixelDeSuiviAccepte"
+              type="checkbox"
+              bind:checked={formulaireInscription.pixelDeSuiviAccepte}
+              name="pixelDeSuiviAccepte"
+            />
+            <label for="pixelDeSuiviAccepte">
+              J'accepte que l'ouverture des emails qui me sont adressés puisse
+              être mesurée afin d'en améliorer la pertinence.
             </label>
           </div>
         </div>

--- a/svelte/lib/inscription/inscription.d.ts
+++ b/svelte/lib/inscription/inscription.d.ts
@@ -52,5 +52,6 @@ export type FormulaireInscription = {
   cguAcceptees: boolean;
   infolettreAcceptee: boolean;
   transactionnelAccepte: boolean;
+  pixelDeSuiviAccepte: boolean;
   token: string;
 };

--- a/svelte/lib/profil/Profil.svelte
+++ b/svelte/lib/profil/Profil.svelte
@@ -55,6 +55,7 @@
           postes: $utilisateur.postes,
           telephone: $utilisateur.telephone,
           transactionnelAccepte: $utilisateur.transactionnelAccepte,
+          pixelDeSuiviAccepte: $utilisateur.pixelDeSuiviAccepte,
           siretEntite: entite.siret,
         });
         window.location.href = '/tableauDeBord';
@@ -210,6 +211,18 @@
         <label for="transactionnelAccepte">
           J'accepte de recevoir des informations relatives à l'utilisation de
           MonServiceSécurisé
+        </label>
+      </div>
+      <div class="case-a-cocher">
+        <input
+          id="pixelDeSuiviAccepte"
+          type="checkbox"
+          bind:checked={$utilisateur.pixelDeSuiviAccepte}
+          name="pixelDeSuiviAccepte"
+        />
+        <label for="pixelDeSuiviAccepte">
+          J'accepte que l'ouverture des emails qui me sont adressés puisse être
+          mesurée afin d'en améliorer la pertinence.
         </label>
       </div>
     </div>

--- a/svelte/lib/profil/profil.d.ts
+++ b/svelte/lib/profil/profil.d.ts
@@ -23,6 +23,7 @@ export type Utilisateur = {
   postes: string[];
   infolettreAcceptee: boolean;
   transactionnelAccepte: boolean;
+  pixelDeSuiviAccepte: boolean;
   estimationNombreServices: {
     borneBasse: string;
     borneHaute: string;

--- a/test/constructeurs/constructeurUtilisateur.js
+++ b/test/constructeurs/constructeurUtilisateur.js
@@ -15,6 +15,7 @@ class ConstructeurUtilisateur {
       estimationNombreServices: { borneBasse: '1', borneHaute: '10' },
       infolettreAcceptee: '',
       transactionnelAccepte: '',
+      pixelDeSuiviAccepte: false,
     };
   }
 
@@ -112,6 +113,16 @@ class ConstructeurUtilisateur {
 
   quiRefuseEmailsTransactionnels() {
     this.donnees.transactionnelAccepte = false;
+    return this;
+  }
+
+  quiAcceptePixelDeSuivi() {
+    this.donnees.pixelDeSuiviAccepte = true;
+    return this;
+  }
+
+  quiRefusePixelDeSuivi() {
+    this.donnees.pixelDeSuiviAccepte = false;
     return this;
   }
 

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -955,8 +955,10 @@ describe('Le dépôt de données des utilisateurs', () => {
         estimationNombreServices: { borneBasse: '1', borneHaute: '10' },
         infolettreAcceptee: '',
         transactionnelAccepte: '',
+        pixelDeSuiviAccepte: false,
       });
     });
+
     it("n'écrase pas le téléphone si MPA ne l'a pas", async () => {
       adaptateurProfilAnssi.recupere = async () => ({
         email: 'email2',

--- a/test/modeles/utilisateur.spec.ts
+++ b/test/modeles/utilisateur.spec.ts
@@ -43,6 +43,7 @@ describe('Un utilisateur', () => {
     postes: [],
     infolettreAcceptee: true,
     transactionnelAccepte: true,
+    pixelDeSuiviAccepte: true,
     ...surcharge,
   });
 
@@ -259,6 +260,26 @@ describe('Un utilisateur', () => {
       adaptateursParDefaut
     );
     expect(autreUtilisateur.accepteInfolettre()).toBe(false);
+  });
+
+  it('sait détecter le consentement au pixel de suivi', () => {
+    // On teste en passant par toJSON() car c'est ce que le pug va appeler
+    // quand il va sérialiser l'objet dans le DOM pour que Svelte le récupère.
+    const avec = new Utilisateur(
+      donneesUtilisateur({ pixelDeSuiviAccepte: true }),
+      adaptateursParDefaut
+    );
+    expect((avec.toJSON() as DonneesUtilisateur).pixelDeSuiviAccepte).toBe(
+      true
+    );
+
+    const sans = new Utilisateur(
+      donneesUtilisateur({ pixelDeSuiviAccepte: false }),
+      adaptateursParDefaut
+    );
+    expect((sans.toJSON() as DonneesUtilisateur).pixelDeSuiviAccepte).toBe(
+      false
+    );
   });
 
   it("exige que l'adresse électronique soit renseignée", () => {

--- a/test/modeles/utilisateur.spec.ts
+++ b/test/modeles/utilisateur.spec.ts
@@ -513,6 +513,62 @@ describe('Un utilisateur', () => {
       expect(desinscriptionEffectuee).toBe('jean.dupont@mail.fr');
     });
 
+    it("modifie le consentement au pixel de suivi s'il passe de « non » à « oui »", async () => {
+      let emailTransmis;
+      let valeurTransmise;
+      adaptateurEmail.changeConsentementPixelDeSuivi = async (
+        email,
+        valeur
+      ) => {
+        emailTransmis = email;
+        valeurTransmise = valeur;
+      };
+
+      const refusait = jeanDupont().quiRefusePixelDeSuivi().construis();
+      await refusait.changePreferencesCommunication(
+        { pixelDeSuiviAccepte: true },
+        adaptateurEmail
+      );
+
+      expect(emailTransmis).toBe('jean.dupont@mail.fr');
+      expect(valeurTransmise).toBe(true);
+    });
+
+    it("modifie le consentement au pixel de suivi s'il passe de « oui » à « non »", async () => {
+      let emailTransmis;
+      let valeurTransmise;
+      adaptateurEmail.changeConsentementPixelDeSuivi = async (
+        email,
+        valeur
+      ) => {
+        emailTransmis = email;
+        valeurTransmise = valeur;
+      };
+
+      const acceptait = jeanDupont().quiAcceptePixelDeSuivi().construis();
+      await acceptait.changePreferencesCommunication(
+        { pixelDeSuiviAccepte: false },
+        adaptateurEmail
+      );
+
+      expect(emailTransmis).toBe('jean.dupont@mail.fr');
+      expect(valeurTransmise).toBe(false);
+    });
+
+    it('ne transmet aucun changement de consentement au pixel de suivi si le choix reste identique', async () => {
+      adaptateurEmail.changeConsentementPixelDeSuivi = async () => {
+        throw new Error(
+          'Ce test ne devrait pas déclencher de changement de consentement au pixel de suivi'
+        );
+      };
+
+      const acceptait = jeanDupont().quiAcceptePixelDeSuivi().construis();
+      await acceptait.changePreferencesCommunication(
+        { pixelDeSuiviAccepte: true },
+        adaptateurEmail
+      );
+    });
+
     it('sait dire si un utilisateur a toutes les informations fournies par AgentConnect', () => {
       const utilisateurComplet = unUtilisateur()
         .avecEmail('jean.dujardin@beta.gouv.fr')

--- a/test/modeles/utilisateur.spec.ts
+++ b/test/modeles/utilisateur.spec.ts
@@ -435,7 +435,7 @@ describe('Un utilisateur', () => {
 
     const jeanDupont = () => unUtilisateur().avecEmail('jean.dupont@mail.fr');
 
-    it("s'inscrit à l'infolettre s'il passe de « non » à « oui » sur ce canal de communication", async () => {
+    it("s'inscrit à l'infolettre s'il passe de « non » à « oui »", async () => {
       let inscriptionEffectuee;
       adaptateurEmail.inscrisInfolettre = async (email) => {
         inscriptionEffectuee = email;
@@ -453,7 +453,7 @@ describe('Un utilisateur', () => {
       expect(inscriptionEffectuee).toBe('jean.dupont@mail.fr');
     });
 
-    it("se désinscrit de l'infolettre s'il passe de « oui » à « non » sur ce canal de communication", async () => {
+    it("se désinscrit de l'infolettre s'il passe de « oui » à « non »", async () => {
       let desinscriptionEffectuee;
       adaptateurEmail.desinscrisInfolettre = async (email) => {
         desinscriptionEffectuee = email;
@@ -471,7 +471,7 @@ describe('Un utilisateur', () => {
       expect(desinscriptionEffectuee).toBe('jean.dupont@mail.fr');
     });
 
-    it("s'inscrit aux emails transactionnels s'il passe de « non » à « oui » sur ce canal de communications", async () => {
+    it("s'inscrit aux emails transactionnels s'il passe de « non » à « oui »", async () => {
       let inscriptionEffectuee;
       adaptateurEmail.inscrisEmailsTransactionnels = async (email) => {
         inscriptionEffectuee = email;
@@ -492,7 +492,7 @@ describe('Un utilisateur', () => {
       expect(inscriptionEffectuee).toBe('jean.dupont@mail.fr');
     });
 
-    it("se déinscrit des emails transactionnels s'il passe de « oui » à « non » sur ce canal de communications", async () => {
+    it("se déinscrit des emails transactionnels s'il passe de « oui » à « non »", async () => {
       let desinscriptionEffectuee;
       adaptateurEmail.desinscrisEmailsTransactionnels = async (email) => {
         desinscriptionEffectuee = email;

--- a/test/routes/connecte/routesConnecteApiUtilisateur.spec.ts
+++ b/test/routes/connecte/routesConnecteApiUtilisateur.spec.ts
@@ -82,6 +82,7 @@ describe("Les routes connectées d'API pour l'utilisateur", () => {
         estimationNombreServices: { borneBasse: '1', borneHaute: '10' },
         infolettreAcceptee: true,
         transactionnelAccepte: true,
+        pixelDeSuiviAccepte: true,
         cguAcceptees: true,
       };
 

--- a/test/routes/connecte/routesConnecteApiUtilisateur.spec.ts
+++ b/test/routes/connecte/routesConnecteApiUtilisateur.spec.ts
@@ -156,6 +156,16 @@ describe("Les routes connectées d'API pour l'utilisateur", () => {
         }
       );
 
+      it.each([null, undefined, 'abc', 10])(
+        `refuse le consentement au pixel de suivi "%s"`,
+        async (pixelDeSuiviAccepte) => {
+          // @ts-expect-error On force des valeurs invalides pour le test.
+          donneesRequete.pixelDeSuiviAccepte = pixelDeSuiviAccepte;
+          const reponse = await testeur.put(`/api/utilisateur`, donneesRequete);
+          expect(reponse.status).toBe(400);
+        }
+      );
+
       it("valide le champ `token` s'il est présent", async () => {
         // @ts-expect-error On force un valeur invalide pour le test.
         donneesRequete.token = 123;
@@ -196,6 +206,7 @@ describe("Les routes connectées d'API pour l'utilisateur", () => {
       expect(donneesRecues!.entite.siret).toEqual('13000766900018');
       expect(donneesRecues!.infolettreAcceptee).toEqual(true);
       expect(donneesRecues!.transactionnelAccepte).toEqual(true);
+      expect(donneesRecues!.pixelDeSuiviAccepte).toEqual(true);
       expect(donneesRecues!.postes).to.eql([
         'RSSI',
         "Chargé des systèmes d'informations",
@@ -285,11 +296,13 @@ describe("Les routes connectées d'API pour l'utilisateur", () => {
 
       donneesRequete.infolettreAcceptee = true;
       donneesRequete.transactionnelAccepte = true;
+      donneesRequete.pixelDeSuiviAccepte = true;
       await testeur.put('/api/utilisateur', donneesRequete);
 
       expect(preferencesChangees).to.eql({
         infolettreAcceptee: true,
         transactionnelAccepte: true,
+        pixelDeSuiviAccepte: true,
       });
     });
   });

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.ts
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.ts
@@ -560,7 +560,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
       await testeur
         .middleware()
         .verifieAdresseIP(
-          ['185.107.232.1/24', '1.179.112.1/20'],
+          ['1.179.112.0/20', '172.246.240.0/20'],
           testeur.app(),
           {
             method: 'post',

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.ts
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.ts
@@ -45,6 +45,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         cguAcceptees: true,
         infolettreAcceptee: true,
         transactionnelAccepte: true,
+        pixelDeSuiviAccepte: true,
         token: tokenJWT,
       };
 
@@ -164,6 +165,21 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         }
       );
 
+      it.each([{ valeurErronee: '1' }, { valeurErronee: undefined }])(
+        "renvoie une erreur 400 car $valeurErronee est une valeur invalide pour l'acceptation du pixel de suivi",
+        async ({ valeurErronee }) => {
+          // @ts-expect-error On force des "mauvaises" valeurs pour tester la validation
+          donneesRequete.pixelDeSuiviAccepte = valeurErronee;
+
+          const reponse = await testeur.post(
+            '/api/utilisateur',
+            donneesRequete
+          );
+
+          expect(reponse.status).toEqual(400);
+        }
+      );
+
       it.each([
         { valeurErronee: [] },
         { valeurErronee: [uneChaineDeCaracteres(201, 'a')] },
@@ -198,7 +214,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         { valeurErronee: { borneBasse: '10', borneHaute: '42' } },
         { valeurErronee: undefined },
       ])(
-        "renvoie une erreur 400 car $valeurErronee est une valeur invalide pour l'acceptation du transactionnel",
+        "renvoie une erreur 400 car $valeurErronee est une valeur invalide pour l'estimation du nombre de services",
         async ({ valeurErronee }) => {
           // @ts-expect-error On force des "mauvaises" valeurs pour tester la validation
           donneesRequete.estimationNombreServices = valeurErronee;
@@ -364,6 +380,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         estimationNombreServices: { borneBasse: '1', borneHaute: '10' },
         infolettreAcceptee: true,
         transactionnelAccepte: true,
+        pixelDeSuiviAccepte: true,
         postes: ['RSSI', "Chargé des systèmes d'informations"],
         cguAcceptees: true,
         email: 'jean.dupont@mail.fr',
@@ -396,7 +413,8 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         nom: string,
         telephone: string,
         bloqueEmails: boolean,
-        bloqueMarketing: boolean
+        bloqueMarketing: boolean,
+        pixelDeSuiviAccepte: boolean
       ) => {
         expect(destinataire).toEqual('jean.dupont@mail.fr');
         expect(prenom).toEqual('Jean');
@@ -404,6 +422,7 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
         expect(telephone).toEqual('0100000000');
         expect(bloqueEmails).toEqual(false);
         expect(bloqueMarketing).toBe(false);
+        expect(pixelDeSuiviAccepte).toBe(true);
         contactCree = true;
       };
 

--- a/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
+++ b/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach } from 'vitest';
+import { unUtilisateur } from '../../constructeurs/constructeurUtilisateur.js';
+import { UUID } from '../../../src/typesBasiques.ts';
+import testeurMSS from '../testeurMSS.js';
+
+describe('Les routes non connectées des webhooks', () => {
+  const testeur = testeurMSS();
+
+  beforeEach(() => testeur.initialise());
+
+  describe('quand requête POST sur `/webhooks/updateConsentementPixelDeSuivi`', () => {
+    /* eslint-disable no-underscore-dangle */
+    const bodyBrevo = () => ({
+      id: 2086247,
+      event: 'contact_updated',
+      email: 'jean.dujardin@beta.gouv.fr',
+      date: '2026-07-17 14:24:30',
+      ts: 1784298270,
+      content: [
+        {
+          email: 'jean.dujardin@beta.gouv.fr',
+          attributes: {
+            _PIXEL_TRACKING_CONSENT: true,
+            _PIXEL_TRACKING_CONSENT_DATE: '2026-07-17T14:24:30.070Z',
+          },
+        },
+      ],
+    });
+
+    it("retourne une erreur HTTP 424 si l'adresse email est introuvable", async () => {
+      testeur.depotDonnees().utilisateurAvecEmail = async () => undefined;
+
+      await testeur.verifieRequeteGenereErreurHTTP(
+        424,
+        { erreur: "L'email fourni est introuvable" },
+        {
+          method: 'post',
+          url: '/webhooks/updateConsentementPixelDeSuivi',
+          data: bodyBrevo(),
+        }
+      );
+    });
+
+    it("vérifie l'adresse IP de la requête", async () => {
+      await testeur
+        .middleware()
+        .verifieAdresseIP(
+          ['1.179.112.0/20', '172.246.240.0/20'],
+          testeur.app(),
+          {
+            method: 'post',
+            url: '/webhooks/updateConsentementPixelDeSuivi',
+            data: bodyBrevo(),
+          }
+        );
+    });
+
+    it("renvoie une 400 s'il ne s'agit pas d'une mise à jour du pixel de suivi", async () => {
+      const bodyPourAutreDonnee = bodyBrevo();
+      // @ts-expect-error On force un autre attribut
+      bodyPourAutreDonnee.content[0].attributes = { work_phone: '0102030405' };
+
+      const { status } = await testeur.post(
+        '/webhooks/updateConsentementPixelDeSuivi',
+        bodyPourAutreDonnee
+      );
+
+      expect(status).toBe(400);
+    });
+
+    describe("quand l'appel Brevo est correct", () => {
+      beforeEach(() => {
+        const utilisateur = unUtilisateur()
+          .avecId('123')
+          .quiAcceptePixelDeSuivi()
+          .construis();
+
+        testeur.depotDonnees().utilisateurAvecEmail = async () => utilisateur;
+      });
+
+      it("peut enlever le consentement de l'utilisateur au pixel de suivi", async () => {
+        let miseAJourFaite = false;
+        testeur.depotDonnees().metsAJourUtilisateur = async (
+          id: UUID,
+          donnees: Record<string, unknown>
+        ) => {
+          expect(id).toBe('123');
+          expect(donnees).toEqual({ pixelDeSuiviAccepte: false });
+          miseAJourFaite = true;
+        };
+
+        const bodyQuiEnleve = bodyBrevo();
+        bodyQuiEnleve.content[0].attributes._PIXEL_TRACKING_CONSENT = false;
+
+        await testeur.post(
+          '/webhooks/updateConsentementPixelDeSuivi',
+          bodyQuiEnleve
+        );
+
+        expect(miseAJourFaite).toBe(true);
+      });
+
+      it("peut activer le consentement de l'utilisateur au pixel de suivi", async () => {
+        let miseAJourFaite = false;
+        testeur.depotDonnees().metsAJourUtilisateur = async (
+          id: UUID,
+          donnees: Record<string, unknown>
+        ) => {
+          expect(id).toBe('123');
+          expect(donnees).toEqual({ pixelDeSuiviAccepte: true });
+          miseAJourFaite = true;
+        };
+
+        const bodyQuiActive = bodyBrevo();
+        bodyQuiActive.content[0].attributes._PIXEL_TRACKING_CONSENT = true;
+
+        await testeur.post(
+          '/webhooks/updateConsentementPixelDeSuivi',
+          bodyQuiActive
+        );
+
+        expect(miseAJourFaite).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Cette PR :
 - change le modèle `Utilisateur` pour ajouter le consentement du pixel de suivi
 - montre un checkbox sur l'inscription et sur la page profil qui commande ce consentement
 - répercute jusqu'à Brevo les changements fait depuis MSS par un utilisateur connecté
 - écoute les appels Brevo faits à MSS lorsqu'un contact est mis à jour : le but est de répercuter le consentement utilisateur lorsque celui-ci le modifie en cliquant en bas d'un mail Brevo