### PR TITLE
Cesse d'envoyer des 400 pour rien

### DIFF
--- a/src/routes/nonConnecte/routesNonConnecteWebhooks.schema.ts
+++ b/src/routes/nonConnecte/routesNonConnecteWebhooks.schema.ts
@@ -1,17 +1,20 @@
 import { z } from 'zod';
 
 // Côté Brevo ce webhook sera appelé sur l'événement `contact_updated`
-// … donc potentiellement bcp de fois.
-// Volontairement, on force zod à ne laisser passer que du _PIXEL_TRACKING_CONSENT
-// pour ne pas déclencher notre code métier sur un attribut qui ne nous intéresse
-// pas.
+// … donc potentiellement bcp de fois, pour toutes sortes de mises à jour.
+// On laisse volontairement passer la validation même sans `_PIXEL_TRACKING_CONSENT` :
+// c'est la route qui fait un early return quand l'attribut est absent, pour ne pas
+// déclencher notre code métier sur une mise à jour qui ne nous intéresse pas
+// ni envoyer des erreurs 400 à tout va qui seront loguées dans Sentry pour rien.
 export const schemaPostConsentementPixelDeSuivi = z.object({
   event: z.literal('contact_updated'),
   email: z.email(),
   content: z
     .array(
       z.object({
-        attributes: z.object({ _PIXEL_TRACKING_CONSENT: z.boolean() }),
+        attributes: z.object({
+          _PIXEL_TRACKING_CONSENT: z.boolean().optional(),
+        }),
       })
     )
     .min(1)

--- a/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
+++ b/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
@@ -4,6 +4,8 @@ import { Middleware } from '../../http/middleware.interface.js';
 import { DepotDonnees } from '../../depotDonnees.interface.js';
 import { schemaPostConsentementPixelDeSuivi } from './routesNonConnecteWebhooks.schema.js';
 
+/* eslint-disable no-underscore-dangle */
+
 const routesNonConnecteWebhooks = ({
   middleware,
   depotDonnees,
@@ -19,6 +21,14 @@ const routesNonConnecteWebhooks = ({
     valideBody(schemaPostConsentementPixelDeSuivi),
     async (requete, reponse) => {
       const { email } = requete.body;
+      const pixelDeSuiviAccepte =
+        requete.body.content[0].attributes._PIXEL_TRACKING_CONSENT;
+
+      const concerneAutreChoseQueLePixel = pixelDeSuiviAccepte === undefined;
+      if (concerneAutreChoseQueLePixel) {
+        reponse.sendStatus(204);
+        return;
+      }
 
       const utilisateur = await depotDonnees.utilisateurAvecEmail(email);
       if (!utilisateur) {
@@ -26,9 +36,6 @@ const routesNonConnecteWebhooks = ({
         return;
       }
 
-      /* eslint-disable no-underscore-dangle */
-      const pixelDeSuiviAccepte =
-        requete.body.content[0].attributes._PIXEL_TRACKING_CONSENT;
       await depotDonnees.metsAJourUtilisateur(utilisateur.id, {
         pixelDeSuiviAccepte,
       });

--- a/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
+++ b/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
@@ -55,7 +55,12 @@ describe('Les routes non connectées des webhooks', () => {
         );
     });
 
-    it("renvoie une 400 s'il ne s'agit pas d'une mise à jour du pixel de suivi", async () => {
+    it("ne fait rien et renvoie une 204 s'il ne s'agit pas d'une mise à jour du pixel de suivi", async () => {
+      let miseAJourFaite = false;
+      testeur.depotDonnees().metsAJourUtilisateur = async () => {
+        miseAJourFaite = true;
+      };
+
       const bodyPourAutreDonnee = bodyBrevo();
       // @ts-expect-error On force un autre attribut
       bodyPourAutreDonnee.content[0].attributes = { work_phone: '0102030405' };
@@ -65,7 +70,8 @@ describe('Les routes non connectées des webhooks', () => {
         bodyPourAutreDonnee
       );
 
-      expect(status).toBe(400);
+      expect(status).toBe(204);
+      expect(miseAJourFaite).toBe(false);
     });
 
     describe("quand l'appel Brevo est correct", () => {


### PR DESCRIPTION
On change de stratégie car sans ce commit chaque appel Brevo pour autre chose que le pixel faisait une 400 et donc un log Sentry.
Ce log est inutile : on sait que Brevo va nous appeler pour autre chose que le pixel.
Donc, on laisse entrer la requête et on early return.
