### PR TITLE
[STATS ADMIN] Ajoute de nouveaux graphiques au tableau de statistiques

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -91,7 +91,8 @@ const adaptateurStatistiques = fabriqueAdaptateurStatistiques();
 const serviceStatistiquesAdmin = fabriqueServiceStatistiquesAdmin(
   depotDonnees,
   adaptateurChiffrement,
-  adaptateurJournal
+  adaptateurJournal,
+  referentielV2
 );
 
 cableTousLesAbonnes(busEvenements, {

--- a/src/adaptateurs/adaptateurJournalMSS.interface.ts
+++ b/src/adaptateurs/adaptateurJournalMSS.interface.ts
@@ -14,4 +14,7 @@ export interface AdaptateurJournalMSS {
   evolutionNombreOrganisations(
     services: Array<{ idServiceHache: string; siretHache: string }>
   ): Promise<EvolutionMensuelle>;
+  dateDerniereMiseAJourServices: (
+    idsServicesHaches: Array<string>
+  ) => Promise<Date[]>;
 }

--- a/src/adaptateurs/adaptateurJournalMSSMemoire.ts
+++ b/src/adaptateurs/adaptateurJournalMSSMemoire.ts
@@ -17,6 +17,7 @@ const nouvelAdaptateur = (): AdaptateurJournalMSS => {
 
   return {
     consigneEvenement,
+    dateDerniereMiseAJourServices: async () => [],
     evolutionNombreServices: async () => [],
     evolutionNombreOrganisations: async () => [],
   };

--- a/src/adaptateurs/adaptateurJournalMSSPostgres.ts
+++ b/src/adaptateurs/adaptateurJournalMSSPostgres.ts
@@ -74,4 +74,23 @@ export class AdaptateurJournalMSSPostgres implements AdaptateurJournalMSS {
       date: new Date(date).toISOString(),
     });
   }
+
+  async dateDerniereMiseAJourServices(idsServicesHaches: Array<string>) {
+    const resultat = await this.knex.raw(
+      `
+        SELECT donnees->>'idService' AS id_service,
+               MAX(date) AS derniere_date
+        FROM journal_mss.evenements
+        WHERE donnees->>'idService' IS NOT NULL
+          AND donnees->>'idService' = ANY(:idsServicesHaches)
+        GROUP BY 1
+        ORDER BY derniere_date DESC;
+      `,
+      { idsServicesHaches }
+    );
+
+    return resultat.rows.map(
+      ({ derniere_date: date }: { derniere_date: Date }) => date
+    );
+  }
 }

--- a/src/adaptateurs/fabriqueServiceStatistiquesAdmin.ts
+++ b/src/adaptateurs/fabriqueServiceStatistiquesAdmin.ts
@@ -2,14 +2,17 @@ import { DepotDonnees } from '../depotDonnees.interface.js';
 import { ServiceStatistiquesAdmin } from './serviceStatistiquesAdmin.js';
 import { AdaptateurChiffrement } from './adaptateurChiffrement.interface.js';
 import { AdaptateurJournalMSS } from './adaptateurJournalMSS.interface.js';
+import { TousReferentiels } from '../referentiel.interface.js';
 
 export const fabriqueServiceStatistiquesAdmin = (
   depotDonnees: DepotDonnees,
   adaptateurChiffrement: AdaptateurChiffrement,
-  adaptateurJournalMSS: AdaptateurJournalMSS
+  adaptateurJournalMSS: AdaptateurJournalMSS,
+  referentiel: TousReferentiels
 ) =>
   new ServiceStatistiquesAdmin(
     { servicesDeUtilisateur: depotDonnees.services },
     adaptateurChiffrement,
-    adaptateurJournalMSS
+    adaptateurJournalMSS,
+    referentiel
   );

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -4,11 +4,13 @@ import {
   TypeDeService,
 } from '../../donneesReferentielMesuresV2.js';
 import { UUID } from '../typesBasiques.js';
-import { IdTypeService } from '../referentiel.types.js';
+import { IdCategorieMesure, IdTypeService } from '../referentiel.types.js';
 import { AdaptateurChiffrement } from './adaptateurChiffrement.interface.js';
 import { AdaptateurJournalMSS } from './adaptateurJournalMSS.interface.js';
 import Dossiers from '../modeles/dossiers.js';
 import Dossier from '../modeles/dossier.js';
+import { StatutMesure } from '../modeles/mesure.js';
+import { TousReferentiels } from '../referentiel.interface.js';
 
 export interface LecteurServices {
   servicesDeUtilisateur(idUtilisateur: UUID): Promise<Array<Service>>;
@@ -49,7 +51,8 @@ export class ServiceStatistiquesAdmin {
   constructor(
     private readonly lecteurServices: LecteurServices,
     private readonly adaptateurChiffrement: AdaptateurChiffrement,
-    private readonly adaptateurJournalMSS: AdaptateurJournalMSS
+    private readonly adaptateurJournalMSS: AdaptateurJournalMSS,
+    private readonly referentiel: TousReferentiels
   ) {}
 
   private static servicesParNiveauSecurite(
@@ -244,6 +247,37 @@ export class ServiceStatistiquesAdmin {
     }, tranchesVides);
   }
 
+  private nombreMesuresParStatutEtCategorie(
+    services: Array<Service>
+  ): Record<IdCategorieMesure, Record<StatutMesure, number>> {
+    const categories = this.referentiel.identifiantsCategoriesMesures();
+    const statuts = this.referentiel.identifiantsStatutsMesures();
+
+    const repartitionVide = Object.fromEntries(
+      categories.map((categorie) => [
+        categorie,
+        Object.fromEntries(statuts.map((statut) => [statut, 0])),
+      ])
+    ) as Record<IdCategorieMesure, Record<StatutMesure, number>>;
+
+    return services.reduce((repartition, service) => {
+      const mesuresParStatutEtCategorie = service.mesuresParStatutEtCategorie();
+      Object.entries(mesuresParStatutEtCategorie).forEach(
+        ([statut, mesuresParCategorie]) => {
+          Object.entries(mesuresParCategorie).forEach(
+            ([categorie, mesures]) => {
+              // eslint-disable-next-line no-param-reassign
+              repartition[categorie as IdCategorieMesure][
+                statut as StatutMesure
+              ] += mesures.length;
+            }
+          );
+        }
+      );
+      return repartition;
+    }, repartitionVide);
+  }
+
   private async evolutionNombreServices(services: Array<Service>) {
     const idsHaches = services.map((s) =>
       this.adaptateurChiffrement.hacheSha256(s.id)
@@ -305,6 +339,8 @@ export class ServiceStatistiquesAdmin {
         ServiceStatistiquesAdmin.nombreServicesCompletudeSuperieur80(services),
       servicesParTrancheCompletudeMesures:
         ServiceStatistiquesAdmin.servicesParTrancheCompletudeMesures(services),
+      nombreMesuresParStatutEtCategorie:
+        this.nombreMesuresParStatutEtCategorie(services),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -24,9 +24,9 @@ export class ServiceStatistiquesAdmin {
     private readonly adaptateurJournalMSS: AdaptateurJournalMSS
   ) {}
 
-  private static async servicesParNiveauSecurite(
+  private static servicesParNiveauSecurite(
     services: Array<Service>
-  ): Promise<Partial<Record<NiveauSecurite, number>>> {
+  ): Partial<Record<NiveauSecurite, number>> {
     const parNiveau = Object.groupBy(
       services,
       (s) => s.descriptionService.niveauSecurite
@@ -40,9 +40,9 @@ export class ServiceStatistiquesAdmin {
     );
   }
 
-  private static async servicesParType(
+  private static servicesParType(
     services: Array<Service>
-  ): Promise<Partial<Record<TypeDeService | IdTypeService, number>>> {
+  ): Partial<Record<TypeDeService | IdTypeService, number>> {
     const tousTypes = services.flatMap((s) => s.descriptionService.typeService);
     const parType = Object.groupBy(tousTypes, (t) => t);
 
@@ -94,9 +94,9 @@ export class ServiceStatistiquesAdmin {
     );
 
     return {
-      servicesParType: await ServiceStatistiquesAdmin.servicesParType(services),
+      servicesParType: ServiceStatistiquesAdmin.servicesParType(services),
       servicesParNiveauSecurite:
-        await ServiceStatistiquesAdmin.servicesParNiveauSecurite(services),
+        ServiceStatistiquesAdmin.servicesParNiveauSecurite(services),
       evolutionNombreServices: await this.evolutionNombreServices(services),
       evolutionNombreOrganisations:
         await this.evolutionNombreOrganisations(services),

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -8,6 +8,7 @@ import { IdTypeService } from '../referentiel.types.js';
 import { AdaptateurChiffrement } from './adaptateurChiffrement.interface.js';
 import { AdaptateurJournalMSS } from './adaptateurJournalMSS.interface.js';
 import Dossiers from '../modeles/dossiers.js';
+import Dossier from '../modeles/dossier.js';
 
 export interface LecteurServices {
   servicesDeUtilisateur(idUtilisateur: UUID): Promise<Array<Service>>;
@@ -20,6 +21,16 @@ type FiltresStatistiques = {
 
 const TRANCHES_INDICE_CYBER = ['< 1', '< 2', '< 3', '< 4', '≥ 4'] as const;
 type TrancheIndiceCyber = (typeof TRANCHES_INDICE_CYBER)[number];
+
+const TRANCHES_EXPIRATION_HOMOLOGATION = [
+  'expire',
+  '< 6',
+  '< 12',
+  '< 24',
+  '< 36',
+] as const;
+type TrancheExpirationHomologation =
+  (typeof TRANCHES_EXPIRATION_HOMOLOGATION)[number];
 
 type CleMoisAnnee = `${number}-${number}`;
 
@@ -143,6 +154,48 @@ export class ServiceStatistiquesAdmin {
     );
   }
 
+  private static trancheExpirationHomologationDe(
+    dossier: Dossier
+  ): TrancheExpirationHomologation {
+    if (dossier.estExpire()) return 'expire';
+
+    const dateProchaineHomologation =
+      dossier.decision.dateProchaineHomologation();
+    const dans6Mois = new Date();
+    dans6Mois.setMonth(dans6Mois.getMonth() + 6);
+    if (dateProchaineHomologation < dans6Mois) return '< 6';
+
+    const dans12Mois = new Date();
+    dans12Mois.setMonth(dans12Mois.getMonth() + 12);
+    if (dateProchaineHomologation < dans12Mois) return '< 12';
+
+    const dans24Mois = new Date();
+    dans24Mois.setMonth(dans24Mois.getMonth() + 24);
+    if (dateProchaineHomologation < dans24Mois) return '< 24';
+
+    return '< 36';
+  }
+
+  private static servicesParTrancheExpirationHomologation(
+    services: Array<Service>
+  ): Record<TrancheExpirationHomologation, number> {
+    const tranchesVides = Object.fromEntries(
+      TRANCHES_EXPIRATION_HOMOLOGATION.map((tranche) => [tranche, 0])
+    ) as Record<TrancheExpirationHomologation, number>;
+
+    return services
+      .filter((s) => !!s.dossiers.dossierActif())
+      .reduce((repartition, s) => {
+        const tranche =
+          ServiceStatistiquesAdmin.trancheExpirationHomologationDe(
+            s.dossiers.dossierActif()
+          );
+        // eslint-disable-next-line no-param-reassign
+        repartition[tranche] += 1;
+        return repartition;
+      }, tranchesVides);
+  }
+
   private async evolutionNombreServices(services: Array<Service>) {
     const idsHaches = services.map((s) =>
       this.adaptateurChiffrement.hacheSha256(s.id)
@@ -196,6 +249,10 @@ export class ServiceStatistiquesAdmin {
         ServiceStatistiquesAdmin.nombreServicesHomologues(services),
       evolutionNombreHomologations:
         ServiceStatistiquesAdmin.evolutionNombreHomologations(services),
+      servicesParTrancheExpirationHomologation:
+        ServiceStatistiquesAdmin.servicesParTrancheExpirationHomologation(
+          services
+        ),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -42,6 +42,15 @@ const TRANCHES_COMPLETUDE_MESURES = [
 ] as const;
 type TrancheCompletudeMesures = (typeof TRANCHES_COMPLETUDE_MESURES)[number];
 
+const TRANCHES_DATE_DERNIERE_MODIFICATION = [
+  '< 1 mois',
+  '< 6 mois',
+  '< 1 an',
+  '≥ 1 an',
+] as const;
+type TrancheDateDerniereModification =
+  (typeof TRANCHES_DATE_DERNIERE_MODIFICATION)[number];
+
 type CleMoisAnnee = `${number}-${number}`;
 
 const moisAvecRemplissage = (date: Date) =>
@@ -297,6 +306,47 @@ export class ServiceStatistiquesAdmin {
     );
   }
 
+  private static trancheDateDerniereModification(
+    date: Date
+  ): TrancheDateDerniereModification {
+    const ilYA1Mois = new Date();
+    ilYA1Mois.setMonth(ilYA1Mois.getMonth() - 1);
+    if (date > ilYA1Mois) return '< 1 mois';
+
+    const ilYA6Mois = new Date();
+    ilYA6Mois.setMonth(ilYA6Mois.getMonth() - 6);
+    if (date > ilYA6Mois) return '< 6 mois';
+
+    const ilYA12Mois = new Date();
+    ilYA12Mois.setMonth(ilYA12Mois.getMonth() - 12);
+    if (date > ilYA12Mois) return '< 1 an';
+
+    return '≥ 1 an';
+  }
+
+  private async servicesParTrancheDateDerniereModification(
+    services: Service[]
+  ) {
+    const idsHaches = services.map((s) =>
+      this.adaptateurChiffrement.hacheSha256(s.id)
+    );
+
+    const toutesDates =
+      await this.adaptateurJournalMSS.dateDerniereMiseAJourServices(idsHaches);
+
+    const tranchesVides = Object.fromEntries(
+      TRANCHES_DATE_DERNIERE_MODIFICATION.map((tranche) => [tranche, 0])
+    ) as Record<TrancheDateDerniereModification, number>;
+
+    return toutesDates.reduce((repartition, d) => {
+      const tranche =
+        ServiceStatistiquesAdmin.trancheDateDerniereModification(d);
+      // eslint-disable-next-line no-param-reassign
+      repartition[tranche] += 1;
+      return repartition;
+    }, tranchesVides);
+  }
+
   private static filtre(
     services: Array<Service>,
     { filtreNiveauxSecurite, filtreEntites }: FiltresStatistiques
@@ -341,6 +391,8 @@ export class ServiceStatistiquesAdmin {
         ServiceStatistiquesAdmin.servicesParTrancheCompletudeMesures(services),
       nombreMesuresParStatutEtCategorie:
         this.nombreMesuresParStatutEtCategorie(services),
+      servicesParTrancheDateDerniereModification:
+        await this.servicesParTrancheDateDerniereModification(services),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -32,6 +32,14 @@ const TRANCHES_EXPIRATION_HOMOLOGATION = [
 type TrancheExpirationHomologation =
   (typeof TRANCHES_EXPIRATION_HOMOLOGATION)[number];
 
+const TRANCHES_COMPLETUDE_MESURES = [
+  '< 25%',
+  '< 50%',
+  '< 75%',
+  '≤ 100%',
+] as const;
+type TrancheCompletudeMesures = (typeof TRANCHES_COMPLETUDE_MESURES)[number];
+
 type CleMoisAnnee = `${number}-${number}`;
 
 const moisAvecRemplissage = (date: Date) =>
@@ -206,6 +214,36 @@ export class ServiceStatistiquesAdmin {
       }, tranchesVides);
   }
 
+  private static trancheCompletudeMesures(completudeMesure: {
+    nombreTotalMesures: number;
+    nombreMesuresCompletes: number;
+  }): TrancheCompletudeMesures {
+    const pourcentage =
+      completudeMesure.nombreMesuresCompletes /
+      completudeMesure.nombreTotalMesures;
+    if (pourcentage < 0.25) return '< 25%';
+    if (pourcentage < 0.5) return '< 50%';
+    if (pourcentage < 0.75) return '< 75%';
+    return '≤ 100%';
+  }
+
+  private static servicesParTrancheCompletudeMesures(
+    services: Array<Service>
+  ): Record<TrancheCompletudeMesures, number> {
+    const tranchesVides = Object.fromEntries(
+      TRANCHES_COMPLETUDE_MESURES.map((tranche) => [tranche, 0])
+    ) as Record<TrancheCompletudeMesures, number>;
+
+    return services.reduce((repartition, s) => {
+      const tranche = ServiceStatistiquesAdmin.trancheCompletudeMesures(
+        s.completudeMesures()
+      );
+      // eslint-disable-next-line no-param-reassign
+      repartition[tranche] += 1;
+      return repartition;
+    }, tranchesVides);
+  }
+
   private async evolutionNombreServices(services: Array<Service>) {
     const idsHaches = services.map((s) =>
       this.adaptateurChiffrement.hacheSha256(s.id)
@@ -265,6 +303,8 @@ export class ServiceStatistiquesAdmin {
         ),
       nombreServicesCompletudeSuperieur80:
         ServiceStatistiquesAdmin.nombreServicesCompletudeSuperieur80(services),
+      servicesParTrancheCompletudeMesures:
+        ServiceStatistiquesAdmin.servicesParTrancheCompletudeMesures(services),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -54,6 +54,13 @@ export class ServiceStatistiquesAdmin {
     );
   }
 
+  private static indiceCyberMoyen(services: Service[]) {
+    const indicesCyber = services.map((s) => s.indiceCyber().total);
+    if (!indicesCyber.length) return 0;
+
+    return indicesCyber.reduce((acc, i) => acc + i, 0) / indicesCyber.length;
+  }
+
   private async evolutionNombreServices(services: Array<Service>) {
     const idsHaches = services.map((s) =>
       this.adaptateurChiffrement.hacheSha256(s.id)
@@ -100,6 +107,7 @@ export class ServiceStatistiquesAdmin {
       evolutionNombreServices: await this.evolutionNombreServices(services),
       evolutionNombreOrganisations:
         await this.evolutionNombreOrganisations(services),
+      indiceCyberMoyen: ServiceStatistiquesAdmin.indiceCyberMoyen(services),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -21,6 +21,11 @@ type FiltresStatistiques = {
 const TRANCHES_INDICE_CYBER = ['< 1', '< 2', '< 3', '< 4', '≥ 4'] as const;
 type TrancheIndiceCyber = (typeof TRANCHES_INDICE_CYBER)[number];
 
+type CleMoisAnnee = `${number}-${number}`;
+
+const moisAvecRemplissage = (date: Date) =>
+  String(date.getMonth() + 1).padStart(2, '0');
+
 export class ServiceStatistiquesAdmin {
   constructor(
     private readonly lecteurServices: LecteurServices,
@@ -96,6 +101,48 @@ export class ServiceStatistiquesAdmin {
     ).length;
   }
 
+  private static clesMois(debut: Date, fin: Date): CleMoisAnnee[] {
+    const cles: string[] = [];
+    const curseur = new Date(debut.getFullYear(), debut.getMonth(), 1);
+    const borne = new Date(fin.getFullYear(), fin.getMonth(), 1);
+
+    while (curseur <= borne) {
+      cles.push(`${curseur.getFullYear()}-${moisAvecRemplissage(curseur)}`);
+      curseur.setMonth(curseur.getMonth() + 1);
+    }
+    return cles as CleMoisAnnee[];
+  }
+
+  private static evolutionNombreHomologations(services: Service[]) {
+    const datesDhomologation = services
+      .map((s) => s.dossiers.dossierActif()?.decision.dateHomologation)
+      .filter(Boolean)
+      .map((d) => new Date(d));
+    const premiereHomologation = new Date(
+      Math.min(...datesDhomologation.map((d) => d.getTime()))
+    );
+    const listeMoisAnnee = ServiceStatistiquesAdmin.clesMois(
+      premiereHomologation,
+      new Date()
+    );
+    const datesParMoisAnnee = Object.groupBy(
+      datesDhomologation,
+      (d) => `${d.getFullYear()}-${moisAvecRemplissage(d)}`
+    );
+    const nombreHomologueeParMoisAnnee = listeMoisAnnee.map((moisAnnee) => ({
+      mois: moisAnnee,
+      total: datesParMoisAnnee[moisAnnee]?.length || 0,
+    }));
+
+    return nombreHomologueeParMoisAnnee.reduce(
+      (acc, { mois, total }) => {
+        const precedent = acc.at(-1)?.total || 0;
+        return [...acc, { mois, total: precedent + total }];
+      },
+      [] as Array<{ mois: CleMoisAnnee; total: number }>
+    );
+  }
+
   private async evolutionNombreServices(services: Array<Service>) {
     const idsHaches = services.map((s) =>
       this.adaptateurChiffrement.hacheSha256(s.id)
@@ -147,6 +194,8 @@ export class ServiceStatistiquesAdmin {
         ServiceStatistiquesAdmin.servicesParTrancheIndiceCyber(services),
       nombreServicesHomologues:
         ServiceStatistiquesAdmin.nombreServicesHomologues(services),
+      evolutionNombreHomologations:
+        ServiceStatistiquesAdmin.evolutionNombreHomologations(services),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -112,6 +112,16 @@ export class ServiceStatistiquesAdmin {
     ).length;
   }
 
+  private static nombreServicesCompletudeSuperieur80(services: Service[]) {
+    return services.filter((s) => {
+      const completude = s.completudeMesures();
+
+      return (
+        completude.nombreMesuresCompletes / completude.nombreTotalMesures > 0.8
+      );
+    }).length;
+  }
+
   private static clesMois(debut: Date, fin: Date): CleMoisAnnee[] {
     const cles: string[] = [];
     const curseur = new Date(debut.getFullYear(), debut.getMonth(), 1);
@@ -253,6 +263,8 @@ export class ServiceStatistiquesAdmin {
         ServiceStatistiquesAdmin.servicesParTrancheExpirationHomologation(
           services
         ),
+      nombreServicesCompletudeSuperieur80:
+        ServiceStatistiquesAdmin.nombreServicesCompletudeSuperieur80(services),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -17,6 +17,9 @@ type FiltresStatistiques = {
   filtreEntites: Array<string>;
 };
 
+const TRANCHES_INDICE_CYBER = ['< 1', '< 2', '< 3', '< 4', '≥ 4'] as const;
+type TrancheIndiceCyber = (typeof TRANCHES_INDICE_CYBER)[number];
+
 export class ServiceStatistiquesAdmin {
   constructor(
     private readonly lecteurServices: LecteurServices,
@@ -59,6 +62,29 @@ export class ServiceStatistiquesAdmin {
     if (!indicesCyber.length) return 0;
 
     return indicesCyber.reduce((acc, i) => acc + i, 0) / indicesCyber.length;
+  }
+
+  private static trancheDe(indiceCyber: number): TrancheIndiceCyber {
+    if (indiceCyber < 1) return '< 1';
+    if (indiceCyber < 2) return '< 2';
+    if (indiceCyber < 3) return '< 3';
+    if (indiceCyber < 4) return '< 4';
+    return '≥ 4';
+  }
+
+  private static servicesParTrancheIndiceCyber(
+    services: Array<Service>
+  ): Record<TrancheIndiceCyber, number> {
+    const tranchesVides = Object.fromEntries(
+      TRANCHES_INDICE_CYBER.map((tranche) => [tranche, 0])
+    ) as Record<TrancheIndiceCyber, number>;
+
+    return services.reduce((repartition, s) => {
+      const tranche = ServiceStatistiquesAdmin.trancheDe(s.indiceCyber().total);
+      // eslint-disable-next-line no-param-reassign
+      repartition[tranche] += 1;
+      return repartition;
+    }, tranchesVides);
   }
 
   private async evolutionNombreServices(services: Array<Service>) {
@@ -108,6 +134,8 @@ export class ServiceStatistiquesAdmin {
       evolutionNombreOrganisations:
         await this.evolutionNombreOrganisations(services),
       indiceCyberMoyen: ServiceStatistiquesAdmin.indiceCyberMoyen(services),
+      servicesParTrancheIndiceCyber:
+        ServiceStatistiquesAdmin.servicesParTrancheIndiceCyber(services),
     };
   }
 }

--- a/src/adaptateurs/serviceStatistiquesAdmin.ts
+++ b/src/adaptateurs/serviceStatistiquesAdmin.ts
@@ -7,6 +7,7 @@ import { UUID } from '../typesBasiques.js';
 import { IdTypeService } from '../referentiel.types.js';
 import { AdaptateurChiffrement } from './adaptateurChiffrement.interface.js';
 import { AdaptateurJournalMSS } from './adaptateurJournalMSS.interface.js';
+import Dossiers from '../modeles/dossiers.js';
 
 export interface LecteurServices {
   servicesDeUtilisateur(idUtilisateur: UUID): Promise<Array<Service>>;
@@ -87,6 +88,14 @@ export class ServiceStatistiquesAdmin {
     }, tranchesVides);
   }
 
+  private static nombreServicesHomologues(services: Service[]) {
+    return services.filter(
+      (s) =>
+        s.dossiers.statutHomologation() === Dossiers.ACTIVEE ||
+        s.dossiers.statutHomologation() === Dossiers.BIENTOT_EXPIREE
+    ).length;
+  }
+
   private async evolutionNombreServices(services: Array<Service>) {
     const idsHaches = services.map((s) =>
       this.adaptateurChiffrement.hacheSha256(s.id)
@@ -136,6 +145,8 @@ export class ServiceStatistiquesAdmin {
       indiceCyberMoyen: ServiceStatistiquesAdmin.indiceCyberMoyen(services),
       servicesParTrancheIndiceCyber:
         ServiceStatistiquesAdmin.servicesParTrancheIndiceCyber(services),
+      nombreServicesHomologues:
+        ServiceStatistiquesAdmin.nombreServicesHomologues(services),
     };
   }
 }

--- a/src/referentiel.ts
+++ b/src/referentiel.ts
@@ -187,6 +187,7 @@ const creeReferentiel = (
   const statutDeploiementValide = (id: IdStatutDeploiement) =>
     Object.keys(statutsDeploiement()).includes(id);
   const statutsMesures = () => donnees.statutsMesures;
+  const identifiantsStatutsMesures = () => Object.keys(donnees.statutsMesures);
   const descriptionStatutMesure = (idStatut: IdStatutMesure) =>
     statutsMesures()[idStatut];
   const prioritesMesures = () => donnees.prioritesMesures;
@@ -542,7 +543,7 @@ const creeReferentiel = (
   };
 
   const estStatutMesureConnu = (statut: IdStatutMesure) =>
-    Object.keys(statutsMesures()).includes(statut);
+    identifiantsStatutsMesures().includes(statut);
 
   const nombreMaximumDeModelesMesureSpecifiqueParUtilisateur = () =>
     donnees.modelesMesureSpecifique.nombreMaximumParUtilisateur;
@@ -615,6 +616,7 @@ const creeReferentiel = (
     identifiantsNiveauxVraisemblance,
     identifiantNumeriqueRisque,
     identifiantsRisques,
+    identifiantsStatutsMesures,
     idEtapeSuivante,
     infosNiveauxGravite,
     infosNiveauxGraviteConcernes,

--- a/src/vues/admin/statistiques.pug
+++ b/src/vues/admin/statistiques.pug
@@ -10,6 +10,8 @@ block append scripts
   script(type = 'module', src = '/statique/adminStatistiques.mjs')
   +composantSvelte('adminStatistiques.js')
   +donneesPartagees('referentiel', {
+    categoriesMesures: referentiel.categoriesMesures(),
+    statutsMesures: referentiel.statutsMesures(),
     typesService: {
       ...Object.fromEntries(Object.entries(referentiel.typesService()).map(([id, { description }]) => [id, description])),
       ...Object.fromEntries(Object.entries(referentielV2.typesService()).map(([id, { nom }]) => [id, nom])),

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -71,6 +71,16 @@
     };
   });
 
+  let parDateHomologation = $derived.by(() => {
+    if (!statistiques) return { x: [], y: [] };
+
+    const donnees = statistiques.evolutionNombreHomologations;
+    return {
+      x: donnees.map((donnee) => donnee.mois),
+      y: donnees.map((donnee) => donnee.total),
+    };
+  });
+
   let parEntite = $derived.by(() => {
     if (!statistiques) return { x: [], y: [] };
 
@@ -196,6 +206,13 @@
           statistiques.nombreServicesHomologues
         )}
         icone="success"
+      />
+      <LineChart
+        titre="Évolution du nombre d'homologations"
+        x={parDateHomologation.x}
+        y={parDateHomologation.y}
+        nom="Nombre d'homologations"
+        unite="homologations"
       />
     </div>
 

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -242,6 +242,7 @@
         x={parTrancheIndiceCyber.x}
         y={[parTrancheIndiceCyber.y]}
         unite="services"
+        name={['nombre de services']}
       />
     </div>
 
@@ -285,6 +286,7 @@
         x={parTrancheCompletude.x}
         y={[parTrancheCompletude.y]}
         unite="services"
+        name={['nombre de services']}
       />
       <BarChart
         titre="Répartition des mesures par catégorie et statut"

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -294,7 +294,7 @@
           'Service',
           'Services',
           statistiques.nombreServicesCompletudeSuperieur80
-        )} dont les mesures de sécurités sont remplies à plus de 80%"
+        )} dont les mesures de sécurité sont remplies à plus de 80%"
         icone="data_security"
       />
       <BarChart

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -155,6 +155,16 @@
     };
   });
 
+  let parTrancheDateModification = $derived.by(() => {
+    if (!statistiques) return { x: [], y: [] };
+
+    const donnees = statistiques.servicesParTrancheDateDerniereModification;
+    return {
+      x: Object.keys(donnees),
+      y: Object.values(donnees),
+    };
+  });
+
   let nombreTotalServices = $derived(parDateCreation.y.at(-1) ?? 0);
   let nombreTotalEntites = $derived(parEntite.y.at(-1) ?? 0);
 
@@ -304,19 +314,28 @@
         horizontal
       />
     </div>
-
-    <PieChart
-      titre="Besoins de sécurité"
-      x={parNiveauDeSecurite.x}
-      y={parNiveauDeSecurite.y}
-      unite="services"
-    />
-    <PieChart
-      titre="Types de services"
-      x={parType.x}
-      y={parType.y}
-      unite="services"
-    />
+    <div class="ligne-trois-items-egaux">
+      <PieChart
+        titre="Besoins de sécurité"
+        x={parNiveauDeSecurite.x}
+        y={parNiveauDeSecurite.y}
+        unite="services"
+      />
+      <PieChart
+        titre="Types de services"
+        x={parType.x}
+        y={parType.y}
+        unite="services"
+      />
+      <BarChart
+        titre="Répartitions des services en fonction de la dernière mise à jour"
+        x={parTrancheDateModification.x}
+        y={[parTrancheDateModification.y]}
+        name={['nombre de services']}
+        unite="services"
+        horizontal
+      />
+    </div>
   </div>
 {/if}
 
@@ -367,6 +386,13 @@
       grid-column: 1 / -1;
       display: grid;
       grid-template-columns: 1fr 2fr 2fr;
+      gap: 24px;
+    }
+
+    .ligne-trois-items-egaux {
+      grid-column: 1 / -1;
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
       gap: 24px;
     }
 

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -186,6 +186,19 @@
         unite="services"
       />
     </div>
+
+    <div class="ligne-un-tiers-deux-tiers">
+      <CarteChiffreCle
+        chiffre={statistiques.nombreServicesHomologues}
+        description={singulierPluriel(
+          'Service homologué',
+          'Services homologués',
+          statistiques.nombreServicesHomologues
+        )}
+        icone="success"
+      />
+    </div>
+
     <PieChart
       titre="Besoins de sécurité"
       x={parNiveauDeSecurite.x}

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -7,6 +7,7 @@
   import type {
     ReferentielStatistiques,
     Statistiques,
+    TrancheExpirationHomologation,
   } from './adminStatistiques.types';
   import donneesNiveauxDeSecurite from '../niveauxDeSecurite/donneesNiveauxDeSecurite';
   import PieChart from './charts/PieChart.svelte';
@@ -97,6 +98,30 @@
     const donnees = statistiques.servicesParTrancheIndiceCyber;
     return {
       x: Object.keys(donnees),
+      y: Object.values(donnees),
+    };
+  });
+
+  const LIBELLES_TRANCHES_EXPIRATION: Record<
+    TrancheExpirationHomologation,
+    string
+  > = {
+    expire: 'Expirée',
+    '< 6': 'Expire dans 6 mois',
+    '< 12': 'Expire dans 1 an',
+    '< 24': 'Expire dans 2 ans',
+    '< 36': 'Expire dans 3 ans',
+  };
+
+  let parTrancheDureeExpirationHomologation = $derived.by(() => {
+    if (!statistiques) return { x: [], y: [] };
+
+    const donnees = statistiques.servicesParTrancheExpirationHomologation;
+    return {
+      x: Object.keys(donnees).map(
+        (tranche) =>
+          LIBELLES_TRANCHES_EXPIRATION[tranche as TrancheExpirationHomologation]
+      ),
       y: Object.values(donnees),
     };
   });
@@ -197,7 +222,7 @@
       />
     </div>
 
-    <div class="ligne-un-tiers-deux-tiers">
+    <div class="ligne-trois-items">
       <CarteChiffreCle
         chiffre={statistiques.nombreServicesHomologues}
         description={singulierPluriel(
@@ -213,6 +238,12 @@
         y={parDateHomologation.y}
         nom="Nombre d'homologations"
         unite="homologations"
+      />
+      <PieChart
+        titre="Répartition des dates d’expiration des homologations "
+        x={parTrancheDureeExpirationHomologation.x}
+        y={parTrancheDureeExpirationHomologation.y}
+        unite="services"
       />
     </div>
 
@@ -271,6 +302,13 @@
       grid-column: 1 / -1;
       display: grid;
       grid-template-columns: 1fr 2fr;
+      gap: 24px;
+    }
+
+    .ligne-trois-items {
+      grid-column: 1 / -1;
+      display: grid;
+      grid-template-columns: 1fr 2fr 2fr;
       gap: 24px;
     }
 

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -102,6 +102,16 @@
     };
   });
 
+  let parTrancheCompletude = $derived.by(() => {
+    if (!statistiques) return { x: [], y: [] };
+
+    const donnees = statistiques.servicesParTrancheCompletudeMesures;
+    return {
+      x: Object.keys(donnees),
+      y: Object.values(donnees),
+    };
+  });
+
   const LIBELLES_TRANCHES_EXPIRATION: Record<
     TrancheExpirationHomologation,
     string
@@ -256,6 +266,12 @@
           statistiques.nombreServicesCompletudeSuperieur80
         )} dont les mesures de sécurités sont remplies à plus de 80%"
         icone="data_security"
+      />
+      <BarChart
+        titre="Taux de complétion moyen des mesures"
+        x={parTrancheCompletude.x}
+        y={parTrancheCompletude.y}
+        unite="services"
       />
     </div>
 

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -13,10 +13,11 @@
   import PieChart from './charts/PieChart.svelte';
   import LineChart from './charts/LineChart.svelte';
   import { singulierPluriel } from '../outils/string';
-  import type { IdNiveauDeSecurite } from '../ui/types';
+  import { CategorieMesure, type IdNiveauDeSecurite } from '../ui/types.d';
   import type { EntiteSupervisee } from '../adminEntites/adminEntites.types';
   import CarteChiffreCle from './CarteChiffreCle.svelte';
   import BarChart from './charts/BarChart.svelte';
+  import type { StatutMesure } from '../modeles/modeleMesure';
 
   interface Props {
     referentiel: ReferentielStatistiques;
@@ -116,12 +117,17 @@
     if (!statistiques) return { x: [], y: [] };
 
     const donnees = statistiques.nombreMesuresParStatutEtCategorie;
+    const statuts = Object.keys(referentiel.statutsMesures);
     return {
-      x: Object.keys(donnees),
-      y: Object.values(donnees).map((nombreMesuresParStatutPourCategorie) =>
-        Object.values(nombreMesuresParStatutPourCategorie)
+      x: Object.keys(donnees).map(
+        (c) => referentiel.categoriesMesures[c as CategorieMesure]
       ),
-      libelles: ['fait', 'partiel', 'non prise en compte', 'à lancer'],
+      y: Object.values(donnees).map((nombreMesuresParStatutPourCategorie) =>
+        statuts.map(
+          (s) => nombreMesuresParStatutPourCategorie[s as StatutMesure]
+        )
+      ),
+      libelles: Object.values(referentiel.statutsMesures),
     };
   });
 

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -112,6 +112,19 @@
     };
   });
 
+  let mesuresParCategorieEtStatut = $derived.by(() => {
+    if (!statistiques) return { x: [], y: [] };
+
+    const donnees = statistiques.nombreMesuresParStatutEtCategorie;
+    return {
+      x: Object.keys(donnees),
+      y: Object.values(donnees).map((nombreMesuresParStatutPourCategorie) =>
+        Object.values(nombreMesuresParStatutPourCategorie)
+      ),
+      libelles: ['fait', 'partiel', 'non prise en compte', 'à lancer'],
+    };
+  });
+
   const LIBELLES_TRANCHES_EXPIRATION: Record<
     TrancheExpirationHomologation,
     string
@@ -227,7 +240,7 @@
       <BarChart
         titre="Répartition des Indices Cybers"
         x={parTrancheIndiceCyber.x}
-        y={parTrancheIndiceCyber.y}
+        y={[parTrancheIndiceCyber.y]}
         unite="services"
       />
     </div>
@@ -270,8 +283,17 @@
       <BarChart
         titre="Taux de complétion moyen des mesures"
         x={parTrancheCompletude.x}
-        y={parTrancheCompletude.y}
+        y={[parTrancheCompletude.y]}
         unite="services"
+      />
+      <BarChart
+        titre="Répartition des mesures par catégorie et statut"
+        x={mesuresParCategorieEtStatut.x}
+        y={mesuresParCategorieEtStatut.y}
+        name={mesuresParCategorieEtStatut.libelles}
+        unite="mesures"
+        empile
+        horizontal
       />
     </div>
 

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -14,6 +14,7 @@
   import { singulierPluriel } from '../outils/string';
   import type { IdNiveauDeSecurite } from '../ui/types';
   import type { EntiteSupervisee } from '../adminEntites/adminEntites.types';
+  import CarteChiffreCle from './CarteChiffreCle.svelte';
 
   interface Props {
     referentiel: ReferentielStatistiques;
@@ -160,6 +161,11 @@
       y={parDateCreation.y}
       nom="Nombre de services"
       unite="services"
+    />
+    <CarteChiffreCle
+      chiffre={statistiques.indiceCyberMoyen.toFixed(1)}
+      description="Moyenne Indice Cyber"
+      icone="data_visualization"
     />
     <PieChart
       titre="Besoins de sécurité"

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -15,6 +15,7 @@
   import type { IdNiveauDeSecurite } from '../ui/types';
   import type { EntiteSupervisee } from '../adminEntites/adminEntites.types';
   import CarteChiffreCle from './CarteChiffreCle.svelte';
+  import BarChart from './charts/BarChart.svelte';
 
   interface Props {
     referentiel: ReferentielStatistiques;
@@ -77,6 +78,16 @@
     return {
       x: donnees.map((donnee) => donnee.mois),
       y: donnees.map((donnee) => donnee.total),
+    };
+  });
+
+  let parTrancheIndiceCyber = $derived.by(() => {
+    if (!statistiques) return { x: [], y: [] };
+
+    const donnees = statistiques.servicesParTrancheIndiceCyber;
+    return {
+      x: Object.keys(donnees),
+      y: Object.values(donnees),
     };
   });
 
@@ -162,11 +173,19 @@
       nom="Nombre de services"
       unite="services"
     />
-    <CarteChiffreCle
-      chiffre={statistiques.indiceCyberMoyen.toFixed(1)}
-      description="Moyenne Indice Cyber"
-      icone="data_visualization"
-    />
+    <div class="ligne-un-tiers-deux-tiers">
+      <CarteChiffreCle
+        chiffre={statistiques.indiceCyberMoyen.toFixed(1)}
+        description="Moyenne Indice Cyber"
+        icone="data_visualization"
+      />
+      <BarChart
+        titre="Répartition des Indices Cybers"
+        x={parTrancheIndiceCyber.x}
+        y={parTrancheIndiceCyber.y}
+        unite="services"
+      />
+    </div>
     <PieChart
       titre="Besoins de sécurité"
       x={parNiveauDeSecurite.x}
@@ -217,6 +236,13 @@
     padding: 24px 0;
     box-sizing: border-box;
     max-width: 1200px;
+
+    .ligne-un-tiers-deux-tiers {
+      grid-column: 1 / -1;
+      display: grid;
+      grid-template-columns: 1fr 2fr;
+      gap: 24px;
+    }
 
     /* Les graphiques DSFR se mettent en page en supposant le reset et les classes
        utilitaires du DSFR, que MSS ne charge pas. On les redéfinit ici, à l'identique,

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -247,6 +247,18 @@
       />
     </div>
 
+    <div class="ligne-trois-items">
+      <CarteChiffreCle
+        chiffre={statistiques.nombreServicesCompletudeSuperieur80}
+        description="{singulierPluriel(
+          'Service',
+          'Services',
+          statistiques.nombreServicesCompletudeSuperieur80
+        )} dont les mesures de sécurités sont remplies à plus de 80%"
+        icone="data_security"
+      />
+    </div>
+
     <PieChart
       titre="Besoins de sécurité"
       x={parNiveauDeSecurite.x}

--- a/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
+++ b/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
@@ -31,7 +31,8 @@
     align-items: center;
 
     img {
-      max-width: 80px;
+      width: 80px;
+      height: 80px;
     }
 
     & > div {

--- a/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
+++ b/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   interface Props {
-    icone: 'data_visualization' | 'success';
+    icone: 'data_visualization' | 'success' | 'data_security';
     chiffre: number | string;
     description: string;
   }

--- a/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
+++ b/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   interface Props {
-    icone: 'data_visualization';
+    icone: 'data_visualization' | 'success';
     chiffre: number | string;
     description: string;
   }

--- a/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
+++ b/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  interface Props {
+    icone: 'data_visualization';
+    chiffre: number | string;
+    description: string;
+  }
+
+  let { icone, chiffre, description }: Props = $props();
+</script>
+
+<div class="carte-chiffre">
+  <img
+    src="/statique/assets/images/illustration_{icone}.svg"
+    alt="Illustration de l'indice cyber moyen"
+  />
+  <div>
+    <span class="chiffre-carte">{chiffre}</span>
+    <span class="chiffre-carte-description">{description}</span>
+  </div>
+</div>
+
+<style lang="scss">
+  .carte-chiffre {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 32px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    justify-content: center;
+    align-items: center;
+
+    img {
+      max-width: 80px;
+    }
+
+    & > div {
+      display: flex;
+      flex-direction: column;
+
+      .chiffre-carte {
+        color: #161616;
+        text-align: center;
+        font-size: 1.25rem;
+        font-weight: 700;
+        line-height: 1.75rem;
+      }
+
+      .chiffre-carte-description {
+        color: #666;
+        text-align: center;
+        font-size: 1rem;
+        font-weight: 400;
+        line-height: 1.5rem;
+      }
+    }
+  }
+</style>

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -6,13 +6,14 @@ declare global {
   }
 }
 
-type EvolutionMensurelle = Array<{ mois: string; total: number }>;
+type EvolutionMensuelle = Array<{ mois: string; total: number }>;
 
 export type Statistiques = {
+  nombreServicesHomologues: number;
   servicesParNiveauSecurite: Partial<Record<IdNiveauDeSecurite, number>>;
   servicesParType: Partial<Record<IdTypeService, number>>;
-  evolutionNombreServices: EvolutionMensurelle;
-  evolutionNombreOrganisations: EvolutionMensurelle;
+  evolutionNombreServices: EvolutionMensuelle;
+  evolutionNombreOrganisations: EvolutionMensuelle;
   indiceCyberMoyen: number;
   servicesParTrancheIndiceCyber: Record<
     '< 1' | '< 2' | '< 3' | '< 4' | '≥ 4',

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -8,6 +8,13 @@ declare global {
 
 type EvolutionMensuelle = Array<{ mois: string; total: number }>;
 
+export type TrancheExpirationHomologation =
+  | 'expire'
+  | '< 6'
+  | '< 12'
+  | '< 24'
+  | '< 36';
+
 export type Statistiques = {
   nombreServicesHomologues: number;
   servicesParNiveauSecurite: Partial<Record<IdNiveauDeSecurite, number>>;
@@ -16,6 +23,10 @@ export type Statistiques = {
   evolutionNombreOrganisations: EvolutionMensuelle;
   evolutionNombreHomologations: EvolutionMensuelle;
   indiceCyberMoyen: number;
+  servicesParTrancheExpirationHomologation: Record<
+    TrancheExpirationHomologation,
+    number
+  >;
   servicesParTrancheIndiceCyber: Record<
     '< 1' | '< 2' | '< 3' | '< 4' | '≥ 4',
     number

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -14,6 +14,7 @@ export type Statistiques = {
   servicesParType: Partial<Record<IdTypeService, number>>;
   evolutionNombreServices: EvolutionMensuelle;
   evolutionNombreOrganisations: EvolutionMensuelle;
+  evolutionNombreHomologations: EvolutionMensuelle;
   indiceCyberMoyen: number;
   servicesParTrancheIndiceCyber: Record<
     '< 1' | '< 2' | '< 3' | '< 4' | '≥ 4',

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -1,4 +1,9 @@
-import type { IdNiveauDeSecurite, IdTypeService } from '../ui/types.d';
+import {
+  CategorieMesure,
+  type IdNiveauDeSecurite,
+  type IdTypeService,
+} from '../ui/types.d';
+import type { StatutMesure } from '../modeles/modeleMesure';
 
 declare global {
   interface HTMLElementEventMap {
@@ -35,6 +40,10 @@ export type Statistiques = {
   servicesParTrancheCompletudeMesures: Record<
     '< 25%' | '< 50%' | '< 75%' | '≤ 100%',
     number
+  >;
+  nombreMesuresParStatutEtCategorie: Record<
+    CategorieMesure,
+    Record<StatutMesure, number>
   >;
 };
 

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -14,6 +14,10 @@ export type Statistiques = {
   evolutionNombreServices: EvolutionMensurelle;
   evolutionNombreOrganisations: EvolutionMensurelle;
   indiceCyberMoyen: number;
+  servicesParTrancheIndiceCyber: Record<
+    '< 1' | '< 2' | '< 3' | '< 4' | '≥ 4',
+    number
+  >;
 };
 
 export type ReferentielStatistiques = {

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -13,6 +13,7 @@ export type Statistiques = {
   servicesParType: Partial<Record<IdTypeService, number>>;
   evolutionNombreServices: EvolutionMensurelle;
   evolutionNombreOrganisations: EvolutionMensurelle;
+  indiceCyberMoyen: number;
 };
 
 export type ReferentielStatistiques = {

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -32,6 +32,10 @@ export type Statistiques = {
     '< 1' | '< 2' | '< 3' | '< 4' | '≥ 4',
     number
   >;
+  servicesParTrancheCompletudeMesures: Record<
+    '< 25%' | '< 50%' | '< 75%' | '≤ 100%',
+    number
+  >;
 };
 
 export type ReferentielStatistiques = {

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -16,6 +16,7 @@ export type TrancheExpirationHomologation =
   | '< 36';
 
 export type Statistiques = {
+  nombreServicesCompletudeSuperieur80: number;
   nombreServicesHomologues: number;
   servicesParNiveauSecurite: Partial<Record<IdNiveauDeSecurite, number>>;
   servicesParType: Partial<Record<IdTypeService, number>>;

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -45,6 +45,10 @@ export type Statistiques = {
     CategorieMesure,
     Record<StatutMesure, number>
   >;
+  servicesParTrancheDateDerniereModification: Record<
+    '< 1 mois' | '< 6 mois' | '< 1 an' | '≥ 1 an',
+    number
+  >;
 };
 
 export type ReferentielStatistiques = {

--- a/svelte/lib/adminStatistiques/adminStatistiques.types.ts
+++ b/svelte/lib/adminStatistiques/adminStatistiques.types.ts
@@ -49,6 +49,8 @@ export type Statistiques = {
 
 export type ReferentielStatistiques = {
   typesService: Record<string, string>;
+  statutsMesures: Record<StatutMesure, string>;
+  categoriesMesures: Record<CategorieMesure, string>;
 };
 
 export type AdminStatistiquesProps = {

--- a/svelte/lib/adminStatistiques/charts/BarChart.svelte
+++ b/svelte/lib/adminStatistiques/charts/BarChart.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Chart from './Chart.svelte';
+
+  interface Props {
+    titre: string;
+    x: Array<string>;
+    y: Array<number>;
+    unite: string;
+    palette?: 'categorical';
+  }
+
+  let { titre, x, y, unite, palette = 'categorical' }: Props = $props();
+</script>
+
+<Chart {titre}>
+  <bar-chart
+    x={JSON.stringify([x])}
+    y={JSON.stringify([y])}
+    name={JSON.stringify(x)}
+    unit-tooltip={unite}
+    selected-palette={palette}
+  ></bar-chart>
+</Chart>

--- a/svelte/lib/adminStatistiques/charts/BarChart.svelte
+++ b/svelte/lib/adminStatistiques/charts/BarChart.svelte
@@ -4,20 +4,34 @@
   interface Props {
     titre: string;
     x: Array<string>;
-    y: Array<number>;
+    y: Array<Array<number>>;
     unite: string;
+    name?: Array<string>;
     palette?: 'categorical';
+    empile?: boolean;
+    horizontal?: boolean;
   }
 
-  let { titre, x, y, unite, palette = 'categorical' }: Props = $props();
+  let {
+    titre,
+    x,
+    y,
+    unite,
+    name = undefined,
+    palette = 'categorical',
+    empile = false,
+    horizontal = false,
+  }: Props = $props();
 </script>
 
 <Chart {titre}>
   <bar-chart
     x={JSON.stringify([x])}
-    y={JSON.stringify([y])}
-    name={JSON.stringify(x)}
+    y={JSON.stringify(y)}
+    name={JSON.stringify(name || x)}
     unit-tooltip={unite}
     selected-palette={palette}
+    stacked={empile}
+    {horizontal}
   ></bar-chart>
 </Chart>

--- a/svelte/lib/adminStatistiques/charts/LineChart.svelte
+++ b/svelte/lib/adminStatistiques/charts/LineChart.svelte
@@ -27,5 +27,6 @@
     name={JSON.stringify([nom])}
     unit-tooltip={unite}
     selected-palette={palette}
+    y-min="0"
   ></line-chart>
 </Chart>

--- a/test/adaptateurs/adaptateurJournalMSSPostgres.spec.ts
+++ b/test/adaptateurs/adaptateurJournalMSSPostgres.spec.ts
@@ -230,4 +230,85 @@ describe("L'adaptateur Postgres du Journal MSS", () => {
       expect(await journalMSS.evolutionNombreOrganisations([])).toEqual([]);
     });
   });
+
+  describe('sur demande de la date de dernière mise à jour des services', () => {
+    const unServiceModifie = (idService: string, date: string) => ({
+      date,
+      type: 'COMPLETUDE_SERVICE_MODIFIEE',
+      donnees: { idService },
+    });
+
+    it('renvoie la date du dernier évènement pour un service', async () => {
+      await trx('journal_mss.evenements').insert([
+        unServiceModifie('S1', '2026-01-01T00:00:00.000Z'),
+        unServiceModifie('S1', '2026-02-01T00:00:00.000Z'),
+      ]);
+      const journalMSS = new AdaptateurJournalMSSPostgres(trx);
+
+      const resultat = await journalMSS.dateDerniereMiseAJourServices(['S1']);
+
+      expect(resultat).toEqual([new Date('2026-02-01T00:00:00.000Z')]);
+    });
+
+    it('renvoie la date du dernier évènement pour chaque service', async () => {
+      await trx('journal_mss.evenements').insert([
+        unServiceModifie('S1', '2026-01-01T00:00:00.000Z'),
+        unServiceModifie('S1', '2026-02-01T00:00:00.000Z'),
+        unServiceModifie('S2', '2026-03-01T00:00:00.000Z'),
+        unServiceModifie('S2', '2026-04-01T00:00:00.000Z'),
+      ]);
+      const journalMSS = new AdaptateurJournalMSSPostgres(trx);
+
+      const resultat = await journalMSS.dateDerniereMiseAJourServices([
+        'S1',
+        'S2',
+      ]);
+
+      expect(resultat).toHaveLength(2);
+      expect(resultat).toContainEqual(new Date('2026-02-01T00:00:00.000Z'));
+      expect(resultat).toContainEqual(new Date('2026-04-01T00:00:00.000Z'));
+    });
+
+    it('renvoie plusieurs fois la même date si plusieurs service on été modifié en même temps', async () => {
+      await trx('journal_mss.evenements').insert([
+        unServiceModifie('S1', '2026-01-01T00:00:00.000Z'),
+        unServiceModifie('S2', '2026-01-01T00:00:00.000Z'),
+      ]);
+      const journalMSS = new AdaptateurJournalMSSPostgres(trx);
+
+      const resultat = await journalMSS.dateDerniereMiseAJourServices([
+        'S1',
+        'S2',
+      ]);
+
+      expect(resultat).toEqual([
+        new Date('2026-01-01T00:00:00.000Z'),
+        new Date('2026-01-01T00:00:00.000Z'),
+      ]);
+    });
+
+    it('ne considere que les services passés en paramètres', async () => {
+      await trx('journal_mss.evenements').insert([
+        unServiceModifie('S1', '2026-01-01T00:00:00.000Z'),
+        unServiceModifie('S-AUTRE', '2026-03-01T00:00:00.000Z'),
+      ]);
+      const journalMSS = new AdaptateurJournalMSSPostgres(trx);
+
+      const resultat = await journalMSS.dateDerniereMiseAJourServices(['S1']);
+
+      expect(resultat).toEqual([new Date('2026-01-01T00:00:00.000Z')]);
+    });
+
+    it("reste robuste si aucun service n'est passé en paramètre", async () => {
+      await trx('journal_mss.evenements').insert([
+        unServiceModifie('S1', '2026-01-01T00:00:00.000Z'),
+        unServiceModifie('S2', '2026-03-01T00:00:00.000Z'),
+      ]);
+      const journalMSS = new AdaptateurJournalMSSPostgres(trx);
+
+      const resultat = await journalMSS.dateDerniereMiseAJourServices([]);
+
+      expect(resultat).toEqual([]);
+    });
+  });
 });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -702,6 +702,58 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  describe('sur demande de la repartition des dates de dernière mise à jour de services', () => {
+    it("délègue à l'adaptateur journal la récupération des dates de dernières mise à jour de chaque service", async () => {
+      adaptateurJournal.dateDerniereMiseAJourServices = vi.fn(async () => []);
+
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([unServiceV2().avecId('S1').construis()]),
+        adaptateurChiffrement,
+        adaptateurJournal,
+        referentiel
+      );
+
+      await adaptateur.statistiques(unUUIDRandom(), sansFiltre);
+
+      expect(
+        adaptateurJournal.dateDerniereMiseAJourServices
+      ).toHaveBeenCalledWith(['S1-haché256']);
+    });
+
+    it('groupe les dates par tranches', async () => {
+      const ilYaNMois = (nombreMois: number) => {
+        const date = new Date();
+        date.setMonth(date.getMonth() - nombreMois);
+        return date;
+      };
+
+      adaptateurJournal.dateDerniereMiseAJourServices = async () => [
+        ilYaNMois(0),
+        ilYaNMois(3),
+        ilYaNMois(4),
+        ilYaNMois(8),
+        ilYaNMois(14),
+      ];
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([]),
+        adaptateurChiffrement,
+        adaptateurJournal,
+        referentiel
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheDateDerniereModification;
+
+      expect(resultat).toEqual({
+        '< 1 mois': 1,
+        '< 6 mois': 2,
+        '< 1 an': 1,
+        '≥ 1 an': 1,
+      });
+    });
+  });
+
   describe('sur demande de toutes les statistiques', () => {
     it('retourne toutes les statistiques', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
@@ -729,6 +781,7 @@ describe("L'adaptateur des statistiques admin", () => {
         nombreServicesCompletudeSuperieur80: expect.any(Number),
         servicesParTrancheCompletudeMesures: expect.any(Object),
         nombreMesuresParStatutEtCategorie: expect.any(Object),
+        servicesParTrancheDateDerniereModification: expect.any(Object),
       });
     });
   });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -152,6 +152,86 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  describe('sur demande de la répartition des indices cyber par tranche', () => {
+    const unServiceAvecIndiceCyber = (indiceCyber: number) => {
+      const s = unServiceV2().construis();
+      s.indiceCyber = () => ({ total: indiceCyber });
+      return s;
+    };
+
+    it('compte les services de chaque tranche', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          unServiceAvecIndiceCyber(0),
+          unServiceAvecIndiceCyber(1.5),
+          unServiceAvecIndiceCyber(2.5),
+          unServiceAvecIndiceCyber(2.9),
+          unServiceAvecIndiceCyber(3.2),
+          unServiceAvecIndiceCyber(4.7),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheIndiceCyber;
+
+      expect(resultat).toEqual({
+        '< 1': 1,
+        '< 2': 1,
+        '< 3': 2,
+        '< 4': 1,
+        '≥ 4': 1,
+      });
+    });
+
+    it('range chaque borne dans la tranche supérieure', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          unServiceAvecIndiceCyber(1),
+          unServiceAvecIndiceCyber(2),
+          unServiceAvecIndiceCyber(3),
+          unServiceAvecIndiceCyber(4),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheIndiceCyber;
+
+      expect(resultat).toEqual({
+        '< 1': 0,
+        '< 2': 1,
+        '< 3': 1,
+        '< 4': 1,
+        '≥ 4': 1,
+      });
+    });
+
+    it('conserve les tranches vides', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheIndiceCyber;
+
+      expect(resultat).toEqual({
+        '< 1': 0,
+        '< 2': 0,
+        '< 3': 0,
+        '< 4': 0,
+        '≥ 4': 0,
+      });
+    });
+  });
+
   it("délègue à l'adaptateur journal le calcul de l'évolution du nombre de services", async () => {
     adaptateurJournal.evolutionNombreServices = async () => [
       { mois: '2026-01', total: 1 },
@@ -320,6 +400,7 @@ describe("L'adaptateur des statistiques admin", () => {
         evolutionNombreServices: expect.any(Object),
         evolutionNombreOrganisations: expect.any(Object),
         indiceCyberMoyen: expect.any(Number),
+        servicesParTrancheIndiceCyber: expect.any(Object),
       });
     });
   });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -15,12 +15,17 @@ import * as adaptateurJournalMemoire from '../../src/adaptateurs/adaptateurJourn
 import { AdaptateurJournalMSS } from '../../src/adaptateurs/adaptateurJournalMSS.interface.ts';
 import { unDossier } from '../constructeurs/constructeurDossier.ts';
 import { creeReferentielV2 } from '../../src/referentielV2.ts';
+import Mesures from '../../src/modeles/mesures.js';
+import { IdCategorieMesure } from '../../src/referentiel.types.ts';
+import { StatutMesure } from '../../src/modeles/mesure.ts';
 
 const unLecteurDeServices = (services: Array<Service>): LecteurServices => ({
   servicesDeUtilisateur: async () => services,
 });
 
 const sansFiltre = { filtreNiveauxSecurite: [], filtreEntites: [] };
+
+const referentiel = creeReferentielV2();
 
 const serviceAvecCompletude = (pourcentageCompletude: number) => {
   const serviceV2Plus80 = unServiceV2().construis();
@@ -31,6 +36,20 @@ const serviceAvecCompletude = (pourcentageCompletude: number) => {
     indiceCyber: {},
   });
   return serviceV2Plus80;
+};
+
+const unServiceV2AvecMesureDeStatutEtCategorie = (
+  id: string,
+  statut: StatutMesure,
+  categorie: IdCategorieMesure
+) => {
+  const mesures = new Mesures(
+    { mesuresGenerales: [{ id, statut }] },
+    // @ts-expect-error mesures est en js pour l'instant
+    referentiel,
+    { [id]: { categorie } }
+  );
+  return unServiceV2(referentiel).avecMesures(mesures).construis();
 };
 
 describe("L'adaptateur des statistiques admin", () => {
@@ -60,7 +79,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceDeNiveau('niveau3'),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -81,7 +101,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceDeNiveau('niveau3'),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -111,7 +132,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceDeType(['applicationMobile']),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -140,7 +162,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceAvecIndiceCyber(3),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -154,7 +177,8 @@ describe("L'adaptateur des statistiques admin", () => {
       const adaptateur = new ServiceStatistiquesAdmin(
         unLecteurDeServices([]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -183,7 +207,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceAvecIndiceCyber(4.7),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -208,7 +233,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceAvecIndiceCyber(4),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -228,7 +254,8 @@ describe("L'adaptateur des statistiques admin", () => {
       const adaptateur = new ServiceStatistiquesAdmin(
         unLecteurDeServices([]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -252,7 +279,8 @@ describe("L'adaptateur des statistiques admin", () => {
     const adaptateur = new ServiceStatistiquesAdmin(
       unLecteurDeServices([]),
       adaptateurChiffrement,
-      adaptateurJournal
+      adaptateurJournal,
+      referentiel
     );
 
     const resultat = (await adaptateur.statistiques(unUUIDRandom(), sansFiltre))
@@ -277,7 +305,8 @@ describe("L'adaptateur des statistiques admin", () => {
     const adaptateur = new ServiceStatistiquesAdmin(
       unLecteurDeServices([service]),
       adaptateurChiffrement,
-      adaptateurJournal
+      adaptateurJournal,
+      referentiel
     );
 
     const resultat = (await adaptateur.statistiques(unUUIDRandom(), sansFiltre))
@@ -307,7 +336,8 @@ describe("L'adaptateur des statistiques admin", () => {
       new ServiceStatistiquesAdmin(
         unLecteurDeServices(services),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
     it('ne garde que les services des niveaux de sécurité demandés', async () => {
@@ -439,7 +469,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceV2().construis(),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = await adaptateur.statistiques(
@@ -463,7 +494,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceV2AvecDossierHomologueLe(aujourdhui),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = await adaptateur.statistiques(
@@ -491,7 +523,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceV2AvecDossierHomologueLe(ilYA2Mois),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = await adaptateur.statistiques(
@@ -528,7 +561,8 @@ describe("L'adaptateur des statistiques admin", () => {
           unServiceV2AvecDossierQuiExpireDans(37),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -548,7 +582,8 @@ describe("L'adaptateur des statistiques admin", () => {
       const adaptateur = new ServiceStatistiquesAdmin(
         unLecteurDeServices([]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -573,7 +608,8 @@ describe("L'adaptateur des statistiques admin", () => {
           serviceAvecCompletude(90),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = await adaptateur.statistiques(
@@ -596,7 +632,8 @@ describe("L'adaptateur des statistiques admin", () => {
           serviceAvecCompletude(100),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -615,7 +652,8 @@ describe("L'adaptateur des statistiques admin", () => {
       const adaptateur = new ServiceStatistiquesAdmin(
         unLecteurDeServices([]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -635,11 +673,20 @@ describe("L'adaptateur des statistiques admin", () => {
     it('compte les services de chaque tranche', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
         unLecteurDeServices([
-          // un service avec 1 mesure faite pour gouvernance
-          // un service avec 1 mesure partielle pour gouvernance
+          unServiceV2AvecMesureDeStatutEtCategorie(
+            'RECENSEMENT.1',
+            'fait',
+            'gouvernance'
+          ),
+          unServiceV2AvecMesureDeStatutEtCategorie(
+            'RECENSEMENT.2',
+            'enCours',
+            'gouvernance'
+          ),
         ]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = (
@@ -660,7 +707,8 @@ describe("L'adaptateur des statistiques admin", () => {
       const adaptateur = new ServiceStatistiquesAdmin(
         unLecteurDeServices([]),
         adaptateurChiffrement,
-        adaptateurJournal
+        adaptateurJournal,
+        referentiel
       );
 
       const resultat = await adaptateur.statistiques(

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -13,6 +13,8 @@ import { unUUIDRandom } from '../constructeurs/UUID.ts';
 import fauxAdaptateurChiffrement from '../mocks/adaptateurChiffrement.js';
 import * as adaptateurJournalMemoire from '../../src/adaptateurs/adaptateurJournalMSSMemoire.ts';
 import { AdaptateurJournalMSS } from '../../src/adaptateurs/adaptateurJournalMSS.interface.ts';
+import { unDossier } from '../constructeurs/constructeurDossier.ts';
+import { creeReferentielV2 } from '../../src/referentielV2.ts';
 
 const unLecteurDeServices = (services: Array<Service>): LecteurServices => ({
   servicesDeUtilisateur: async () => services,
@@ -381,6 +383,42 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  const unServiceV2AvecDossierActif = () =>
+    unServiceV2()
+      .avecDossiers([
+        unDossier(creeReferentielV2()).quiEstComplet().quiEstActif().donnees,
+      ])
+      .construis();
+  const unServiceV2AvecDossierBientotExpire = () =>
+    unServiceV2()
+      .avecDossiers([
+        unDossier(creeReferentielV2())
+          .quiEstComplet()
+          .quiVaExpirer(2, 'sixMois').donnees,
+      ])
+      .construis();
+
+  describe('sur demande du nombre de services homologués', async () => {
+    it('retourne la valeur', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          unServiceV2AvecDossierActif(),
+          unServiceV2AvecDossierBientotExpire(),
+          unServiceV2().construis(),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = await adaptateur.statistiques(
+        unUUIDRandom(),
+        sansFiltre
+      );
+
+      expect(resultat.nombreServicesHomologues).toEqual(2);
+    });
+  });
+
   describe('sur demande de toutes les statistiques', () => {
     it('retourne toutes les statistiques', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
@@ -395,6 +433,7 @@ describe("L'adaptateur des statistiques admin", () => {
       );
 
       expect(resultat).toEqual({
+        nombreServicesHomologues: expect.any(Number),
         servicesParType: expect.any(Object),
         servicesParNiveauSecurite: expect.any(Object),
         evolutionNombreServices: expect.any(Object),

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -408,6 +408,17 @@ describe("L'adaptateur des statistiques admin", () => {
       ])
       .construis();
 
+  const unServiceV2AvecDossierQuiExpireDans = (
+    nombreMoisDiciExpiration: number
+  ) =>
+    unServiceV2()
+      .avecDossiers([
+        unDossier(creeReferentielV2())
+          .quiEstComplet()
+          .quiVaExpirer(nombreMoisDiciExpiration * 30, 'unAn').donnees,
+      ])
+      .construis();
+
   describe('sur demande du nombre de services homologués', async () => {
     it('retourne la valeur', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
@@ -494,6 +505,55 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  describe("sur demande de la répartition des dates d'expiration d'homologation par tranche", () => {
+    it('compte les services de chaque tranche', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          unServiceV2AvecDossierQuiExpireDans(-13),
+          unServiceV2AvecDossierQuiExpireDans(1),
+          unServiceV2AvecDossierQuiExpireDans(7),
+          unServiceV2AvecDossierQuiExpireDans(13),
+          unServiceV2AvecDossierQuiExpireDans(25),
+          unServiceV2AvecDossierQuiExpireDans(37),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheExpirationHomologation;
+
+      expect(resultat).toEqual({
+        expire: 1,
+        '< 6': 1,
+        '< 12': 1,
+        '< 24': 1,
+        '< 36': 2,
+      });
+    });
+
+    it('conserve les tranches vides', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheExpirationHomologation;
+
+      expect(resultat).toEqual({
+        expire: 0,
+        '< 6': 0,
+        '< 12': 0,
+        '< 24': 0,
+        '< 36': 0,
+      });
+    });
+  });
+
   describe('sur demande de toutes les statistiques', () => {
     it('retourne toutes les statistiques', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
@@ -515,7 +575,8 @@ describe("L'adaptateur des statistiques admin", () => {
         evolutionNombreServices: expect.any(Array),
         evolutionNombreOrganisations: expect.any(Array),
         indiceCyberMoyen: expect.any(Number),
-        servicesParTrancheIndiceCyber: expect.any(Array),
+        servicesParTrancheIndiceCyber: expect.any(Object),
+        servicesParTrancheExpirationHomologation: expect.any(Object),
       });
     });
   });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -554,6 +554,30 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  describe('sur demande du nombre de services complété à plus de 80%', async () => {
+    it('retourne la valeur', async () => {
+      const serviceV2Plus80 = unServiceV2().construis();
+      serviceV2Plus80.completudeMesures = () => ({
+        nombreTotalMesures: 10,
+        nombreMesuresCompletes: 9,
+        detailMesures: [],
+        indiceCyber: {},
+      });
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([unServiceV2().construis(), serviceV2Plus80]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = await adaptateur.statistiques(
+        unUUIDRandom(),
+        sansFiltre
+      );
+
+      expect(resultat.nombreServicesCompletudeSuperieur80).toEqual(1);
+    });
+  });
+
   describe('sur demande de toutes les statistiques', () => {
     it('retourne toutes les statistiques', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
@@ -577,6 +601,7 @@ describe("L'adaptateur des statistiques admin", () => {
         indiceCyberMoyen: expect.any(Number),
         servicesParTrancheIndiceCyber: expect.any(Object),
         servicesParTrancheExpirationHomologation: expect.any(Object),
+        nombreServicesCompletudeSuperieur80: expect.any(Number),
       });
     });
   });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -1,6 +1,6 @@
 import {
-  ServiceStatistiquesAdmin,
   LecteurServices,
+  ServiceStatistiquesAdmin,
 } from '../../src/adaptateurs/serviceStatistiquesAdmin.ts';
 import { unServiceV2 } from '../constructeurs/constructeurService.js';
 import { uneDescriptionV2Valide } from '../constructeurs/constructeurDescriptionServiceV2.ts';
@@ -21,6 +21,17 @@ const unLecteurDeServices = (services: Array<Service>): LecteurServices => ({
 });
 
 const sansFiltre = { filtreNiveauxSecurite: [], filtreEntites: [] };
+
+const serviceAvecCompletude = (pourcentageCompletude: number) => {
+  const serviceV2Plus80 = unServiceV2().construis();
+  serviceV2Plus80.completudeMesures = () => ({
+    nombreTotalMesures: 100,
+    nombreMesuresCompletes: pourcentageCompletude,
+    detailMesures: [],
+    indiceCyber: {},
+  });
+  return serviceV2Plus80;
+};
 
 describe("L'adaptateur des statistiques admin", () => {
   let adaptateurJournal: AdaptateurJournalMSS;
@@ -556,15 +567,11 @@ describe("L'adaptateur des statistiques admin", () => {
 
   describe('sur demande du nombre de services complété à plus de 80%', async () => {
     it('retourne la valeur', async () => {
-      const serviceV2Plus80 = unServiceV2().construis();
-      serviceV2Plus80.completudeMesures = () => ({
-        nombreTotalMesures: 10,
-        nombreMesuresCompletes: 9,
-        detailMesures: [],
-        indiceCyber: {},
-      });
       const adaptateur = new ServiceStatistiquesAdmin(
-        unLecteurDeServices([unServiceV2().construis(), serviceV2Plus80]),
+        unLecteurDeServices([
+          serviceAvecCompletude(10),
+          serviceAvecCompletude(90),
+        ]),
         adaptateurChiffrement,
         adaptateurJournal
       );
@@ -575,6 +582,52 @@ describe("L'adaptateur des statistiques admin", () => {
       );
 
       expect(resultat.nombreServicesCompletudeSuperieur80).toEqual(1);
+    });
+  });
+
+  describe('sur demande de la répartition des complétudes de mesure par tranche', () => {
+    it('compte les services de chaque tranche', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          serviceAvecCompletude(10),
+          serviceAvecCompletude(30),
+          serviceAvecCompletude(60),
+          serviceAvecCompletude(90),
+          serviceAvecCompletude(100),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheCompletudeMesures;
+
+      expect(resultat).toEqual({
+        '< 25%': 1,
+        '< 50%': 1,
+        '< 75%': 1,
+        '≤ 100%': 2,
+      });
+    });
+
+    it('conserve les tranches vides', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).servicesParTrancheCompletudeMesures;
+
+      expect(resultat).toEqual({
+        '< 25%': 0,
+        '< 50%': 0,
+        '< 75%': 0,
+        '≤ 100%': 0,
+      });
     });
   });
 
@@ -602,6 +655,7 @@ describe("L'adaptateur des statistiques admin", () => {
         servicesParTrancheIndiceCyber: expect.any(Object),
         servicesParTrancheExpirationHomologation: expect.any(Object),
         nombreServicesCompletudeSuperieur80: expect.any(Number),
+        servicesParTrancheCompletudeMesures: expect.any(Object),
       });
     });
   });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -389,6 +389,16 @@ describe("L'adaptateur des statistiques admin", () => {
         unDossier(creeReferentielV2()).quiEstComplet().quiEstActif().donnees,
       ])
       .construis();
+
+  const unServiceV2AvecDossierHomologueLe = (date: Date) =>
+    unServiceV2()
+      .avecDossiers([
+        unDossier(creeReferentielV2())
+          .quiEstComplet()
+          .avecDateHomologation(date).donnees,
+      ])
+      .construis();
+
   const unServiceV2AvecDossierBientotExpire = () =>
     unServiceV2()
       .avecDossiers([
@@ -419,6 +429,71 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  const moisAvecRemplissage = (date: Date) =>
+    String(date.getMonth() + 1).padStart(2, '0');
+
+  describe("sur demande de l'évolution du nombre d'homologations", async () => {
+    it("cumule les dates d'homologation des dossiers de chaque service", async () => {
+      const aujourdhui = new Date();
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          unServiceV2AvecDossierHomologueLe(aujourdhui),
+          unServiceV2AvecDossierHomologueLe(aujourdhui),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = await adaptateur.statistiques(
+        unUUIDRandom(),
+        sansFiltre
+      );
+
+      expect(resultat.evolutionNombreHomologations).toEqual([
+        {
+          mois: `${aujourdhui.getFullYear()}-${moisAvecRemplissage(aujourdhui)}`,
+          total: 2,
+        },
+      ]);
+    });
+
+    it('génère les mois sans nouveau dossier entre deux dates avec dossier', async () => {
+      const aujourdhui = new Date();
+      const ilYA1Mois = new Date();
+      ilYA1Mois.setMonth(ilYA1Mois.getMonth() - 1);
+      const ilYA2Mois = new Date();
+      ilYA2Mois.setMonth(ilYA2Mois.getMonth() - 2);
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          unServiceV2AvecDossierHomologueLe(aujourdhui),
+          unServiceV2AvecDossierHomologueLe(ilYA2Mois),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = await adaptateur.statistiques(
+        unUUIDRandom(),
+        sansFiltre
+      );
+
+      expect(resultat.evolutionNombreHomologations).toEqual([
+        {
+          mois: `${ilYA2Mois.getFullYear()}-${moisAvecRemplissage(ilYA2Mois)}`,
+          total: 1,
+        },
+        {
+          mois: `${ilYA1Mois.getFullYear()}-${moisAvecRemplissage(ilYA1Mois)}`,
+          total: 1,
+        },
+        {
+          mois: `${aujourdhui.getFullYear()}-${moisAvecRemplissage(aujourdhui)}`,
+          total: 2,
+        },
+      ]);
+    });
+  });
+
   describe('sur demande de toutes les statistiques', () => {
     it('retourne toutes les statistiques', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
@@ -434,12 +509,13 @@ describe("L'adaptateur des statistiques admin", () => {
 
       expect(resultat).toEqual({
         nombreServicesHomologues: expect.any(Number),
+        evolutionNombreHomologations: expect.any(Array),
         servicesParType: expect.any(Object),
         servicesParNiveauSecurite: expect.any(Object),
-        evolutionNombreServices: expect.any(Object),
-        evolutionNombreOrganisations: expect.any(Object),
+        evolutionNombreServices: expect.any(Array),
+        evolutionNombreOrganisations: expect.any(Array),
         indiceCyberMoyen: expect.any(Number),
-        servicesParTrancheIndiceCyber: expect.any(Object),
+        servicesParTrancheIndiceCyber: expect.any(Array),
       });
     });
   });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -113,6 +113,45 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  describe("sur demande de l'indice cyber moyen", () => {
+    const unServiceAvecIndiceCyber = (indiceCyber: number) => {
+      const s = unServiceV2().construis();
+      s.indiceCyber = () => ({ total: indiceCyber });
+      return s;
+    };
+
+    it('retourne la moyenne', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          unServiceAvecIndiceCyber(1),
+          unServiceAvecIndiceCyber(3),
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).indiceCyberMoyen;
+
+      expect(resultat).toEqual(2);
+    });
+
+    it("reste robuste s'il n'y a aucun service", async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).indiceCyberMoyen;
+
+      expect(resultat).toEqual(0);
+    });
+  });
+
   it("délègue à l'adaptateur journal le calcul de l'évolution du nombre de services", async () => {
     adaptateurJournal.evolutionNombreServices = async () => [
       { mois: '2026-01', total: 1 },
@@ -280,6 +319,7 @@ describe("L'adaptateur des statistiques admin", () => {
         servicesParNiveauSecurite: expect.any(Object),
         evolutionNombreServices: expect.any(Object),
         evolutionNombreOrganisations: expect.any(Object),
+        indiceCyberMoyen: expect.any(Number),
       });
     });
   });

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -631,6 +631,30 @@ describe("L'adaptateur des statistiques admin", () => {
     });
   });
 
+  describe('sur demande de la répartition des statuts de mesure par catégorie de mesure', () => {
+    it('compte les services de chaque tranche', async () => {
+      const adaptateur = new ServiceStatistiquesAdmin(
+        unLecteurDeServices([
+          // un service avec 1 mesure faite pour gouvernance
+          // un service avec 1 mesure partielle pour gouvernance
+        ]),
+        adaptateurChiffrement,
+        adaptateurJournal
+      );
+
+      const resultat = (
+        await adaptateur.statistiques(unUUIDRandom(), sansFiltre)
+      ).nombreMesuresParStatutEtCategorie;
+
+      expect(resultat).toEqual({
+        gouvernance: { fait: 1, nonFait: 0, enCours: 1, aLancer: 0 },
+        resilience: { fait: 0, nonFait: 0, enCours: 0, aLancer: 0 },
+        protection: { fait: 0, nonFait: 0, enCours: 0, aLancer: 0 },
+        defense: { fait: 0, nonFait: 0, enCours: 0, aLancer: 0 },
+      });
+    });
+  });
+
   describe('sur demande de toutes les statistiques', () => {
     it('retourne toutes les statistiques', async () => {
       const adaptateur = new ServiceStatistiquesAdmin(
@@ -656,6 +680,7 @@ describe("L'adaptateur des statistiques admin", () => {
         servicesParTrancheExpirationHomologation: expect.any(Object),
         nombreServicesCompletudeSuperieur80: expect.any(Number),
         servicesParTrancheCompletudeMesures: expect.any(Object),
+        nombreMesuresParStatutEtCategorie: expect.any(Object),
       });
     });
   });


### PR DESCRIPTION
... afin de compléter les données, en se basant sur ce qui existe déjà côté Metabase.

<img width="514" height="755" alt="image" src="https://github.com/user-attachments/assets/818b37bf-3782-4d10-82c2-35d51d8c4ed2" />


On aimerait continuer et afficher le reste de la maquette initiale :
<img width="703" height="708" alt="image" src="https://github.com/user-attachments/assets/cc785ec0-829d-4fb1-9cc2-fd5a232997c9" />
