### PR TITLE
Imprime proprement la page de statistiques admin

### DIFF
--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -456,4 +456,32 @@
       }
     }
   }
+
+  @media print {
+    @page {
+      size: A4;
+      margin: 1cm;
+    }
+
+    :global(#footer),
+    :global(lab-anssi-centre-aide),
+    .conteneur-filtres {
+      display: none;
+    }
+
+    :global(#conteneur-admin-statistiques) {
+      background: none;
+      padding: 1cm 0;
+      margin: 0;
+    }
+
+    :global(main) {
+      background: none;
+      margin: 0;
+    }
+
+    :global(body) {
+      zoom: 0.8;
+    }
+  }
 </style>

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -482,6 +482,8 @@
 
     :global(body) {
       zoom: 0.8;
+      print-color-adjust: exact;
+      -webkit-print-color-adjust: exact;
     }
   }
 </style>

--- a/svelte/lib/adminStatistiques/AdminStatistiques.svelte
+++ b/svelte/lib/adminStatistiques/AdminStatistiques.svelte
@@ -175,9 +175,22 @@
   });
 </script>
 
-<h1>Statistiques</h1>
+<div class="entete-statistiques">
+  <h1>Statistiques</h1>
+  <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+  <dsfr-button
+    class="invisible-print"
+    kind="tertiary"
+    label="Télécharger en PDF"
+    icon="file-download-line"
+    has-icon
+    onclick={() => {
+      window.print();
+    }}
+  ></dsfr-button>
+</div>
 {#if statistiques}
-  <div class="conteneur-filtres">
+  <div class="conteneur-filtres invisible-print">
     <lab-anssi-multi-select
       label="Besoins de sécurité"
       options={[
@@ -352,10 +365,22 @@
     background: white;
   }
 
-  h1 {
-    font-size: 2.5rem;
-    line-height: 3rem;
-    margin: 0 0 24px;
+  .entete-statistiques {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 1200px;
+
+    dsfr-button {
+      height: fit-content;
+    }
+
+    h1 {
+      font-size: 2.5rem;
+      line-height: 3rem;
+      margin: 0 0 24px;
+    }
   }
 
   .conteneur-filtres {
@@ -465,7 +490,7 @@
 
     :global(#footer),
     :global(lab-anssi-centre-aide),
-    .conteneur-filtres {
+    .invisible-print {
       display: none;
     }
 

--- a/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
+++ b/svelte/lib/adminStatistiques/CarteChiffreCle.svelte
@@ -56,4 +56,11 @@
       }
     }
   }
+
+  @media print {
+    .carte-chiffre {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
+  }
 </style>

--- a/svelte/lib/adminStatistiques/charts/Chart.svelte
+++ b/svelte/lib/adminStatistiques/charts/Chart.svelte
@@ -77,4 +77,11 @@
       }
     }
   }
+
+  @media print {
+    .graphique {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
+  }
 </style>


### PR DESCRIPTION
via du CSS réservé au print

<img width="642" height="909" alt="Capture d’écran 2026-08-05 à 10 58 44" src="https://github.com/user-attachments/assets/5d1dd3a4-6bd0-45c4-a3b3-f9031c9bc9aa" />
<img width="651" height="912" alt="Capture d’écran 2026-08-05 à 10 58 51" src="https://github.com/user-attachments/assets/f93fd31c-3faf-4c8a-9ba3-f14aad61b050" />
