### PR TITLE
Modifie les couleurs des matrices de risque

### DIFF
--- a/src/vuesPdf/annexe.risques.typ
+++ b/src/vuesPdf/annexe.risques.typ
@@ -24,7 +24,7 @@
     width: 100%,
     height: 100%,
     fill: couleurCellule(classe),
-    align(center + horizon)[#text(size: 8pt, weight: "bold", fill: white)[#contenu]],
+    align(center + horizon)[#text(size: 8pt, weight: "bold", fill: encre)[#contenu]],
   )
 }
 
@@ -123,23 +123,11 @@
   )),
 )
 
-
-
-#let pastilleIdentifiant(id, niveau) = {
-  let couleur = couleursPastilleRisque.at(niveau, default: rgb("#667892"))
-  box(
-    stroke: 1.5pt + couleur,
-    radius: 20pt,
-    inset: (x: 8pt, y: 5pt),
-    fill: white,
-  )[#text(size: 10pt, weight: "bold", fill: couleur)[#id]]
-}
-
 #let blocRisque(risque) = grid(
   columns: (56pt, 1fr),
   column-gutter: 10pt,
   align: top,
-  pastilleIdentifiant(risque.identifiantNumerique, risque.niveauRisque),
+  pastilleIdentifiantRisque(risque.identifiantNumerique, risque.niveauRisque),
   [
     #text(weight: "bold")[#risque.intitule]
     #v(8pt)

--- a/src/vuesPdf/annexe.risquesV2.typ
+++ b/src/vuesPdf/annexe.risquesV2.typ
@@ -17,8 +17,8 @@
   let contenu = box(
     width: largeur,
     height: hauteurCelluleV2 - margeVerticaleCelluleV2,
-    fill: couleursNiveauRisqueV2.at(niveau),
-    align(center + horizon)[#text(size: 7pt, weight: "bold", fill: white)[#idRisques]],
+    fill: couleursNiveauRisque.at(niveau),
+    align(center + horizon)[#text(size: 7pt, weight: "bold", fill: encre)[#idRisques]],
   )
   if avecMargeGauche { align(right, contenu) } else { contenu }
 }
@@ -106,20 +106,10 @@
     columns: (11pt, auto),
     column-gutter: 6pt,
     align: horizon,
-    box(width: 11pt, height: 11pt, fill: couleursNiveauRisqueV2.at(niveau.id)),
+    box(width: 11pt, height: 11pt, fill: couleursNiveauRisque.at(niveau.id)),
     [#text(size: 8pt)[#text(weight: "bold")[#niveau.libelle :] #niveau.description]],
   )),
 )
-
-#let pastilleIdentifiantV2(id, niveau) = {
-  let couleur = couleursPastilleRisque.at(niveau, default: rgb("#667892"))
-  box(
-    stroke: 1.5pt + couleur,
-    radius: 20pt,
-    inset: (x: 8pt, y: 5pt),
-    fill: white,
-  )[#text(size: 10pt, weight: "bold", fill: couleur)[#id]]
-}
 
 #let blocRisqueV2(risque, idAffiche) = {
   let niveau = niveauRisqueV2(risque.gravite, risque.vraisemblance)
@@ -127,7 +117,7 @@
     columns: (56pt, 1fr),
     column-gutter: 10pt,
     align: top,
-    pastilleIdentifiantV2(idAffiche, niveau),
+    pastilleIdentifiantRisque(idAffiche, niveau),
     [
       #text(weight: "bold")[#risque.intitule]
       #v(8pt)

--- a/src/vuesPdf/commun.typ
+++ b/src/vuesPdf/commun.typ
@@ -19,34 +19,48 @@
 #let bordBleu     = rgb("#b5c1d2")
 #let orange       = rgb("#faa72c")
 #let orangeClair  = rgb("#fff2de")
-#let vert        = rgb("#4cb963")
-#let rouge       = rgb("#e32630")
-#let vertFonce   = rgb("#0c8626")
-#let rougeClair  = rgb("#ff6584")
 #let grisAxe     = rgb("#cbd5e1")
+#let grisAxeV2 = rgb("#929292")
+#let vertFondRisque = rgb("#fcc63a")
+#let orangeFondRisque = rgb("#7fc04b")
+#let rougeFondRisque = rgb("#fa7659")
+#let vertFondPastilleRisque = rgb("#C9FCAC")
+#let orangeFondPastilleRisque = rgb("#FEEBD0")
+#let rougeFondPastilleRisque = rgb("#FEE9E6")
+#let grisFondPastilleRisque = rgb("#EEEEEE")
+#let vertTextePastilleRisque = rgb("#447049")
+#let orangeTextePastilleRisque = rgb("#695240")
+#let rougeTextePastilleRisque = rgb("#A94645")
+#let grisTextePastilleRisque = rgb("#3A3A3A")
+
 
 #let couleursNiveauRisque = (
-  faible: vert,
-  moyen: orange,
-  eleve: rouge,
+  faible: vertFondRisque,
+  moyen: orangeFondRisque,
+  eleve: rougeFondRisque,
 )
 
-#let couleursPastilleRisque = (
-  faible: vertFonce,
-  moyen: orange,
-  eleve: rougeClair,
+#let couleursFondPastilleRisque = (
+  faible: vertFondPastilleRisque,
+  moyen: orangeFondPastilleRisque,
+  eleve: rougeFondPastilleRisque,
 )
 
-#let vertV2  = rgb("#77b645")
-#let orangeV2 = rgb("#fa7a35")
-#let rougeV2 = rgb("#e1000f")
-#let grisAxeV2 = rgb("#929292")
-
-#let couleursNiveauRisqueV2 = (
-  faible: vertV2,
-  moyen: orangeV2,
-  eleve: rougeV2,
+#let couleursTextePastilleRisque = (
+  faible: vertTextePastilleRisque,
+  moyen: orangeTextePastilleRisque,
+  eleve: rougeTextePastilleRisque,
 )
+
+#let pastilleIdentifiantRisque(id, niveau) = {
+  let couleurFond = couleursFondPastilleRisque.at(niveau, default: grisFondPastilleRisque)
+  let couleurTexte = couleursTextePastilleRisque.at(niveau, default: grisTextePastilleRisque)
+  box(
+    radius: 5pt,
+    inset: (x: 5pt, y: 5pt),
+    fill: couleurFond,
+  )[#text(size: 10pt, weight: "bold", fill: couleurTexte)[#id]]
+}
 
 #let niveauRisqueV2(gravite, vraisemblance) = {
   let niveau = gravite * vraisemblance

--- a/svelte/lib/risques/IdentifiantRisque.svelte
+++ b/svelte/lib/risques/IdentifiantRisque.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Risque } from './risques.d';
+  import { IdentifiantNiveauRisque, type Risque } from './risques.d';
 
   interface Props {
     risque: Risque;
@@ -14,47 +14,30 @@
         })`
       : `Risque spécifique ${risque.identifiantNumerique.substring(2)}`
   );
+
+  export const mappingCouleursDSFR: Record<IdentifiantNiveauRisque, string> = {
+    faible: 'green-bourgeon',
+    moyen: 'yellow-moutarde',
+    eleve: 'pink-macaron',
+    indeterminable: '',
+    negligeable: '',
+  };
 </script>
 
-<span
+<dsfr-badge
   class:inactif={risque.desactive}
-  class={`identifiant-numerique ${risque.niveauRisque || ''}`}
->
-  {libelle}
-</span>
+  label={libelle}
+  type="accent"
+  accent={risque.desactive ? '' : mappingCouleursDSFR[risque.niveauRisque]}
+></dsfr-badge>
 
-<style>
-  .identifiant-numerique {
-    font-size: 14px;
-    font-weight: 700;
-    line-height: 20px;
-    display: flex;
-    padding: 1px 8px 3px;
-    align-items: center;
-    gap: 4px;
-    border-radius: 40px;
-    border: 1.5px solid var(--couleur-identifiant-numerique);
-    width: fit-content;
-    color: var(--couleur-identifiant-numerique);
-    background: white;
+<style lang="scss">
+  dsfr-badge {
+    height: fit-content;
     white-space: nowrap;
-    --couleur-identifiant-numerique: var(--role-inconnu-texte);
-  }
 
-  .identifiant-numerique.faible {
-    --couleur-identifiant-numerique: var(--role-personnalise-texte);
-  }
-
-  .identifiant-numerique.moyen {
-    --couleur-identifiant-numerique: var(--role-proprietaire-texte);
-  }
-
-  .identifiant-numerique.eleve {
-    --couleur-identifiant-numerique: var(--rose-anssi);
-  }
-
-  .identifiant-numerique.inactif {
-    --couleur-identifiant-numerique: #f1f5f9;
-    color: #cbd5e1;
+    &.inactif {
+      opacity: 0.5;
+    }
   }
 </style>

--- a/svelte/lib/risques/LegendeMatriceRisques.svelte
+++ b/svelte/lib/risques/LegendeMatriceRisques.svelte
@@ -26,6 +26,9 @@
 
 <style>
   .legende-matrice {
+    --rouge: #fa7659;
+    --orange: #fcc63a;
+    --vert: #7fc04b;
     margin-top: 32px;
   }
 
@@ -54,15 +57,15 @@
   }
 
   li.faible:before {
-    --couleur-fond: #4cb963;
+    --couleur-fond: var(--vert);
   }
 
   li.moyen:before {
-    --couleur-fond: #faa72c;
+    --couleur-fond: var(--orange);
   }
 
   li.eleve:before {
-    --couleur-fond: #e32630;
+    --couleur-fond: var(--rouge);
   }
 
   .niveau {

--- a/svelte/lib/risques/MatriceRisques.svelte
+++ b/svelte/lib/risques/MatriceRisques.svelte
@@ -101,6 +101,10 @@
 
 <style>
   .matrice {
+    --rouge: #fa7659;
+    --orange: #fcc63a;
+    --vert: #7fc04b;
+    --texte: #161616;
     position: relative;
     width: fit-content;
   }
@@ -191,19 +195,19 @@
     font-size: 10px;
     font-weight: 700;
     line-height: 16px;
-    color: white;
+    color: var(--texte);
     text-align: center;
   }
 
   .cellule-matrice.faible {
-    --couleur-fond: #4cb963;
+    --couleur-fond: var(--vert);
   }
 
   .cellule-matrice.moyen {
-    --couleur-fond: #faa72c;
+    --couleur-fond: var(--orange);
   }
 
   .cellule-matrice.eleve {
-    --couleur-fond: #e32630;
+    --couleur-fond: var(--rouge);
   }
 </style>

--- a/svelte/lib/risquesV2/kit/kit.ts
+++ b/svelte/lib/risquesV2/kit/kit.ts
@@ -15,7 +15,7 @@ export const couleur = (
 };
 
 export const mappingCouleursDSFR: Record<CouleurNiveauRisque, string> = {
-  vert: 'green-emeraude',
+  vert: 'green-bourgeon',
   orange: 'yellow-moutarde',
   rouge: 'pink-macaron',
 };

--- a/svelte/lib/risquesV2/matrice/LegendeMatrice.svelte
+++ b/svelte/lib/risquesV2/matrice/LegendeMatrice.svelte
@@ -17,6 +17,9 @@
 
 <style lang="scss">
   .conteneur-legende {
+    --rouge: #fa7659;
+    --orange: #fcc63a;
+    --vert: #7fc04b;
     display: flex;
     padding: 16px;
     gap: 24px;
@@ -32,15 +35,15 @@
         height: 13px;
 
         &.vert {
-          background: #77b645;
+          background: var(--vert);
         }
 
         &.orange {
-          background: #fa7a35;
+          background: var(--orange);
         }
 
         &.rouge {
-          background: #e1000f;
+          background: var(--rouge);
         }
       }
 

--- a/svelte/lib/risquesV2/matrice/MatriceRisquesV2.svelte
+++ b/svelte/lib/risquesV2/matrice/MatriceRisquesV2.svelte
@@ -80,9 +80,10 @@
   table {
     border-collapse: collapse;
     --bordure: #929292;
-    --rouge: #e1000f;
-    --orange: #fa7a35;
-    --vert: #77b645;
+    --rouge: #fa7659;
+    --orange: #fcc63a;
+    --vert: #7fc04b;
+    --texte: #161616;
 
     &.en-attente {
       --bordure: #dddddd;
@@ -117,13 +118,14 @@
         }
 
         .contenu-cellule {
-          color: #fff;
+          color: var(--texte);
           font-size: 0.875rem;
           font-weight: bold;
           line-height: 1rem;
           display: flex;
           align-items: center;
           justify-content: center;
+          text-align: center;
 
           &.md {
             width: 123px;


### PR DESCRIPTION
...suite à une décision métier
<img width="739" height="382" alt="Capture d’écran 2026-08-05 à 15 45 32" src="https://github.com/user-attachments/assets/be6b5fa0-336c-4b8e-addb-ef0451498e9d" />

J'en ai profité pour factoriser du code dans les templates PDFs, vu que les couleurs et pastilles de risque sont maintenant identiques entre v1 et v2
