### PR TITLE
Relaxe les erreurs 400 sur le pixel de suivi

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,6 +11,7 @@ SENDINBLUE_TEMPLATE_NOTIFICATION_HOMOLOGATION_EXPIREE= # id de template
 SENDINBLUE_TEMPLATE_FELICITATION_HOMOLOGATION= # id de template
 SENDINBLUE_TEMPLATE_NOUVEL_ADMIN= # id de template
 SENDINBLUE_ID_LISTE_POUR_INFOLETTRE= # l'ID de la liste de contacts utilisée pour les mails d'informations (newsletter)
+SENDINBLUE_ADRESSES_IP_APPELANT_NOS_WEBHOOKS= # Plages IP côté Brevo qui appellent nos webhooks, séparées par des virgules
 
 ADRESSES_IP_AUTORISEES= # Seules ces IP seront autorisées. Les autres ne seront pas servies. Séparées par des ',' s'il y en a plusieurs. Supprimer la variable d'env pour désactiver le filtrage.
 

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -35,6 +35,10 @@ const sendinblue = () => ({
   clefAPITracking: () => process.env.SENDINBLUE_TRACKING_CLEF_API,
   logEvenementsTrackingEnConsole: () =>
     process.env.AVEC_TRACKING_SENDINGBLUE_QUI_LOG_CONSOLE === 'true',
+  adressesIpAppelantNosWebhooks: () =>
+    (
+      process.env.SENDINBLUE_ADRESSES_IP_APPELANT_NOS_WEBHOOKS?.split(',') ?? []
+    ).map((a) => a.trim()),
 });
 
 const sentry = () => ({

--- a/src/mss.js
+++ b/src/mss.js
@@ -134,6 +134,7 @@ const creeServeur = ({
       depotDonnees,
       serviceAnnuaire,
       adaptateurGestionErreur,
+      adaptateurEnvironnement,
       adaptateurJWT,
       inscriptionUtilisateur,
       serviceCgu,
@@ -142,7 +143,11 @@ const creeServeur = ({
   app.use(
     '/webhooks',
     middleware.chargeTypeRequete(TYPES_REQUETES.API),
-    routesNonConnecteWebhooks({ middleware, depotDonnees })
+    routesNonConnecteWebhooks({
+      adaptateurEnvironnement,
+      middleware,
+      depotDonnees,
+    })
   );
   app.use(
     '/oidc',

--- a/src/routes/nonConnecte/routesNonConnecteApi.ts
+++ b/src/routes/nonConnecte/routesNonConnecteApi.ts
@@ -21,6 +21,7 @@ import {
 } from '../../modeles/utilisateur.types.js';
 
 import { TokenMSSPourCreationUtilisateur } from '../../utilisateur/tokenMSSPourCreationUtilisateur.js';
+import { AdaptateurEnvironnement } from '../../adaptateurs/adaptateurEnvironnement.interface.js';
 
 const routesNonConnecteApi = ({
   middleware,
@@ -29,6 +30,7 @@ const routesNonConnecteApi = ({
   adaptateurJWT,
   inscriptionUtilisateur,
   adaptateurGestionErreur,
+  adaptateurEnvironnement,
   serviceCgu,
 }: {
   middleware: Middleware;
@@ -37,6 +39,7 @@ const routesNonConnecteApi = ({
   adaptateurJWT: AdaptateurJWT;
   inscriptionUtilisateur: InscriptionUtilisateur;
   adaptateurGestionErreur: AdaptateurGestionErreur;
+  adaptateurEnvironnement: AdaptateurEnvironnement;
   serviceCgu: ServiceCgu;
 }) => {
   const routes = express.Router();
@@ -98,7 +101,9 @@ const routesNonConnecteApi = ({
 
   routes.post(
     '/desinscriptionInfolettre',
-    middleware.verificationAddresseIP(['1.179.112.0/20', '172.246.240.0/20']),
+    middleware.verificationAddresseIP(
+      adaptateurEnvironnement.sendinblue().adressesIpAppelantNosWebhooks()
+    ),
     valideBody(z.looseObject(reglesValidationDesinscriptionInfolettre)),
     async (requete, reponse) => {
       const { email } = requete.body;

--- a/src/routes/nonConnecte/routesNonConnecteWebhooks.schema.ts
+++ b/src/routes/nonConnecte/routesNonConnecteWebhooks.schema.ts
@@ -2,10 +2,8 @@ import { z } from 'zod';
 
 // Côté Brevo ce webhook sera appelé sur l'événement `contact_updated`
 // … donc potentiellement bcp de fois, pour toutes sortes de mises à jour.
-// On laisse volontairement passer la validation même sans `_PIXEL_TRACKING_CONSENT` :
-// c'est la route qui fait un early return quand l'attribut est absent, pour ne pas
-// déclencher notre code métier sur une mise à jour qui ne nous intéresse pas
-// ni envoyer des erreurs 400 à tout va qui seront loguées dans Sentry pour rien.
+// Si ce schéma valide la payload entrante, alors on est sûr qu'il s'agit d'une
+// mise à jour de pixel de suivi.
 export const schemaPostConsentementPixelDeSuivi = z.object({
   event: z.literal('contact_updated'),
   email: z.email(),

--- a/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
+++ b/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import { valideBody } from '../../http/validePayloads.js';
 import { Middleware } from '../../http/middleware.interface.js';
 import { DepotDonnees } from '../../depotDonnees.interface.js';
 import { schemaPostConsentementPixelDeSuivi } from './routesNonConnecteWebhooks.schema.js';
@@ -23,8 +22,17 @@ const routesNonConnecteWebhooks = ({
     middleware.verificationAddresseIP(
       adaptateurEnvironnement.sendinblue().adressesIpAppelantNosWebhooks()
     ),
-    valideBody(schemaPostConsentementPixelDeSuivi),
     async (requete, reponse) => {
+      // On valide ici et pas dans `valideBody` car on ne veut pas renvoyer 400 (et polluer nos logs)
+      // sur tous les appels qui ne sont pas explicitement du pixel de suivi.
+      const concerneLePixelDeSuivi =
+        schemaPostConsentementPixelDeSuivi.safeParse(requete.body);
+
+      if (!concerneLePixelDeSuivi.success) {
+        reponse.sendStatus(204);
+        return;
+      }
+
       const { email } = requete.body;
       const pixelDeSuiviAccepte =
         requete.body.content[0].attributes._PIXEL_TRACKING_CONSENT;

--- a/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
+++ b/src/routes/nonConnecte/routesNonConnecteWebhooks.ts
@@ -3,13 +3,16 @@ import { valideBody } from '../../http/validePayloads.js';
 import { Middleware } from '../../http/middleware.interface.js';
 import { DepotDonnees } from '../../depotDonnees.interface.js';
 import { schemaPostConsentementPixelDeSuivi } from './routesNonConnecteWebhooks.schema.js';
+import { AdaptateurEnvironnement } from '../../adaptateurs/adaptateurEnvironnement.interface.js';
 
 /* eslint-disable no-underscore-dangle */
 
 const routesNonConnecteWebhooks = ({
+  adaptateurEnvironnement,
   middleware,
   depotDonnees,
 }: {
+  adaptateurEnvironnement: AdaptateurEnvironnement;
   middleware: Middleware;
   depotDonnees: DepotDonnees;
 }) => {
@@ -17,7 +20,9 @@ const routesNonConnecteWebhooks = ({
 
   routes.post(
     '/updateConsentementPixelDeSuivi',
-    middleware.verificationAddresseIP(['1.179.112.0/20', '172.246.240.0/20']),
+    middleware.verificationAddresseIP(
+      adaptateurEnvironnement.sendinblue().adressesIpAppelantNosWebhooks()
+    ),
     valideBody(schemaPostConsentementPixelDeSuivi),
     async (requete, reponse) => {
       const { email } = requete.body;

--- a/test/routes/nonConnecte/routesNonConnecteApi.spec.ts
+++ b/test/routes/nonConnecte/routesNonConnecteApi.spec.ts
@@ -557,17 +557,14 @@ describe('Le serveur MSS des routes publiques /api/*', () => {
     });
 
     it("vérifie l'adresse IP de la requête", async () => {
+      // Voir dans testeurMSS pour la définition en dur de l'IP.
       await testeur
         .middleware()
-        .verifieAdresseIP(
-          ['1.179.112.0/20', '172.246.240.0/20'],
-          testeur.app(),
-          {
-            method: 'post',
-            url: '/api/desinscriptionInfolettre',
-            data: donneesRequete,
-          }
-        );
+        .verifieAdresseIP(['1.2.3.4/20'], testeur.app(), {
+          method: 'post',
+          url: '/api/desinscriptionInfolettre',
+          data: donneesRequete,
+        });
     });
 
     it("désabonne l'utilisateur des mails marketing", async () => {

--- a/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
+++ b/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
@@ -52,24 +52,48 @@ describe('Les routes non connectées des webhooks', () => {
         });
     });
 
-    it("ne fait rien et renvoie une 204 s'il ne s'agit pas d'une mise à jour du pixel de suivi", async () => {
-      let miseAJourFaite = false;
-      testeur.depotDonnees().metsAJourUtilisateur = async () => {
-        miseAJourFaite = true;
-      };
+    it.each([
+      // Changement de numéro de téléphone
+      {
+        event: 'contact_updated',
+        email: 'jean.dujardin@beta.gouv.fr',
+        content: [
+          {
+            email: 'jean.dujardin@beta.gouv.fr',
+            attributes: { work_phone: '0102030405' },
+          },
+        ],
+      },
+      // Changement d'une liste de diffusion
+      {
+        event: 'contact_updated',
+        content: { emails: ['jean.dujardin@brevo.fr'], link_list_ids: [41] },
+      },
+      // Changement de la préférence blacklist
+      {
+        event: 'contact_updated',
+        email: 'jean.dujardin@beta.gouv.fr',
+        content: [
+          { email: 'jean.dujardin@beta.gouv.fr', emailBlacklist: true },
+        ],
+      },
+    ])(
+      "ne fait rien et renvoie une 204 s'il ne s'agit pas d'une mise à jour du pixel de suivi",
+      async (payloadBrevo) => {
+        let miseAJourFaite = false;
+        testeur.depotDonnees().metsAJourUtilisateur = async () => {
+          miseAJourFaite = true;
+        };
 
-      const bodyPourAutreDonnee = bodyBrevo();
-      // @ts-expect-error On force un autre attribut
-      bodyPourAutreDonnee.content[0].attributes = { work_phone: '0102030405' };
+        const { status } = await testeur.post(
+          '/webhooks/updateConsentementPixelDeSuivi',
+          payloadBrevo
+        );
 
-      const { status } = await testeur.post(
-        '/webhooks/updateConsentementPixelDeSuivi',
-        bodyPourAutreDonnee
-      );
-
-      expect(status).toBe(204);
-      expect(miseAJourFaite).toBe(false);
-    });
+        expect(status).toBe(204);
+        expect(miseAJourFaite).toBe(false);
+      }
+    );
 
     describe("quand l'appel Brevo est correct", () => {
       beforeEach(() => {

--- a/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
+++ b/test/routes/nonConnecte/routesNonConnecteWebhooks.spec.ts
@@ -42,17 +42,14 @@ describe('Les routes non connectées des webhooks', () => {
     });
 
     it("vérifie l'adresse IP de la requête", async () => {
+      // Voir dans testeurMSS pour la définition en dur de l'IP.
       await testeur
         .middleware()
-        .verifieAdresseIP(
-          ['1.179.112.0/20', '172.246.240.0/20'],
-          testeur.app(),
-          {
-            method: 'post',
-            url: '/webhooks/updateConsentementPixelDeSuivi',
-            data: bodyBrevo(),
-          }
-        );
+        .verifieAdresseIP(['1.2.3.4/20'], testeur.app(), {
+          method: 'post',
+          url: '/webhooks/updateConsentementPixelDeSuivi',
+          data: bodyBrevo(),
+        });
     });
 
     it("ne fait rien et renvoie une 204 s'il ne s'agit pas d'une mise à jour du pixel de suivi", async () => {

--- a/test/routes/testeurMSS.js
+++ b/test/routes/testeurMSS.js
@@ -131,6 +131,9 @@ const testeurMss = () => {
         avecGestionDesOrganisations: () => true,
       }),
       oidc: () => ({ fournisseursAvecMFA: () => [] }),
+      sendinblue: () => ({
+        adressesIpAppelantNosWebhooks: () => ['1.2.3.4/20'],
+      }),
     };
     adaptateurProtection = {
       protectionCsrf: () => (_requete, _reponse, suite) => suite(),


### PR DESCRIPTION
En PROD, nous avons des 400 qui sont loguées, et elles ne nous intéressent pas.
On ne veut pas que MSS nous alerte d'une 400 sur des cas non pris en charge, car on **sait** que le webhook va être appelé sur plein de cas non pris en charge.
Le code existant ignorait certains cas, mais pas tous.
Avec ce commit, en cessant d'utiliser `valideBody` : on est plus relaxé sur les 400.