### PR TITLE
[GITHUB ACTIONS] Annule les actions précédentes si une nouvelle démarre

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,10 @@
 name: 'CodeQL'
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/deploiement-dev.yml
+++ b/.github/workflows/deploiement-dev.yml
@@ -1,6 +1,10 @@
 name: Déploiement vers un environnement de DEV
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch: # Pour activer le déclenchement manuel
 

--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -2,6 +2,10 @@ name: Déploiement
 run-name: Déploiement du commit "${{ github.event.head_commit.message }}"
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,10 @@
 name: L'intégration continue
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,10 @@
 name: Renovate
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/securite-ci.yml
+++ b/.github/workflows/securite-ci.yml
@@ -5,6 +5,10 @@
 ---
 name: Sécurité de la CI
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: ['main', 'master']

--- a/.github/workflows/tests-accessibilite.yml
+++ b/.github/workflows/tests-accessibilite.yml
@@ -1,6 +1,10 @@
 name: Tests d'accessibilité
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
... sauf pour les actions de déploiement. 
On crée dans ce cas-là une "fil d'attente" pour éviter un déploiement partiel.