### PR TITLE
[CORRECTION] Supprime la clause de concurrence pour les déploiements

### DIFF
--- a/.github/workflows/deploiement-dev.yml
+++ b/.github/workflows/deploiement-dev.yml
@@ -1,10 +1,6 @@
 name: Déploiement vers un environnement de DEV
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: false
-
 on:
   workflow_dispatch: # Pour activer le déclenchement manuel
 

--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -2,10 +2,6 @@ name: Déploiement
 run-name: Déploiement du commit "${{ github.event.head_commit.message }}"
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: false
-
 on:
   push:
     branches: [master]


### PR DESCRIPTION
... sinon, un déploiement qui n'a pas été encore validé empêche les suivants de partir en Prod.