### PR TITLE
[CORRECTION] Empêche un service v1 de passer à l'étape 2

### DIFF
--- a/public/modules/interactions/validation.mjs
+++ b/public/modules/interactions/validation.mjs
@@ -11,12 +11,38 @@ const EVENEMENT_FORMULAIRE_MULTIPLE_VALIDE =
 // Au moment de la validation du formulaire, on ajoute la classe `.touche` sur tous les champs,
 // afin de forcer l'affichage des champs en erreur.
 
+const renseigneLongueurActuelle = (champ, longueurActuelle) => {
+  const $message = $(champ).siblings('.message-erreur[data-gabarit]');
+  if (!$message.length) return;
+
+  $message.text(
+    $message.data('gabarit').replace('{longueur}', longueurActuelle)
+  );
+};
+
+const valideMaxLength = (champ) => {
+  const longueurMaximale = champ.maxLength;
+  if (longueurMaximale < 0) return;
+
+  const longueurActuelle = champ.value.length;
+  champ.setCustomValidity(
+    longueurActuelle > longueurMaximale ? 'Erreur de saisie' : ''
+  );
+  renseigneLongueurActuelle(champ, longueurActuelle);
+};
+
 const brancheConteneur = (selecteurConteneur) => {
   $('input, select, textarea', selecteurConteneur).each((_index, champ) => {
-    $(champ).on('input', () => $(champ).addClass('touche'));
+    valideMaxLength(champ);
+    $(champ).on('input', () => {
+      $(champ).addClass('touche');
+      valideMaxLength(champ);
+    });
+
     if (champ.type === 'radio' || champ.type === 'checkbox') {
       $(champ).on('change', (e) => $(e.target).siblings().addClass('touche'));
     }
+
     $(champ).on('invalid', (e) => e.preventDefault());
   });
 };
@@ -28,7 +54,7 @@ const brancheValidation = (selecteurFormulaire) => {
 
 const declencheScrollSurErreur = (selecteurFormulaire) => {
   const champAvecErreur = $(
-    'input:invalid, select:invalid',
+    'input:invalid, select:invalid, textarea:invalid',
     selecteurFormulaire
   );
   if (champAvecErreur.length) {

--- a/src/vues/fragments/formulaireDescriptionService.pug
+++ b/src/vues/fragments/formulaireDescriptionService.pug
@@ -151,14 +151,18 @@ mixin formulaireDescriptionService(idService)
             lectureSeule: estLectureSeule
           })
 
+        - const longueurMaximalePresentation = 2_000
         label Présentation
           textarea(
             id = 'presentation',
             name = 'presentation',
             placeholder = 'ex : site internet de la médiathèque permettant de créer un compte utilisateur, de réserver, prolonger leur réservation de contenus multimédia.',
             readonly = estLectureSeule
-            maxlength = 2000
+            maxlength = longueurMaximalePresentation
           )= service.descriptionService.presentation
+          .message-erreur(
+            data-gabarit = `La présentation ne doit pas dépasser ${longueurMaximalePresentation} caractères. Elle en contient actuellement {longueur}. Veuillez la raccourcir.`
+          )
 
         label(id='label-acces') Accès
           br


### PR DESCRIPTION
… si sa présentation est trop longue.

Reproduction :
 - j'ai un service v1 avec une description de 2 500 chars, car je l'ai créé avant qu'on mette en place les `maxlength`
 - je vais sur /descriptionService
 - je ne modifie pas la présentation
 - je clique sur "Suivant"

Attendu : je vois une erreur liée à la présentation, et je reste sur l'étape 1.

Observé : l'utilisateur passait à l'étape 2, puis pouvait passer à l'estimation du niveau de sécurité. Mais arrivé sur cet écran, le backend renvoyait une 400 (car présentation trop longue) et l'utilisateur voyait un "loader" à l'infini, sans explications.

Avec ce commit, on force le navigateur à évaluer la contrainte de maxlength avant de quitter l'étape 1.
Ce n'était pas fait par le code en place, car la contrainte "maxlength" n'invalide un champ que si sa valeur a été **saisie par l'utilisateur.**
Donc dans notre reproduction, où l'utilisateur ne touche pas le formulaire de l'étape 1, il n'y avait aucune erreur affichée.
Maintenant, on force le navigateur à évaluer la contrainte.
