### PR TITLE
Affiche le département de l'entité dans les pages d'administration

### DIFF
--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -211,6 +211,7 @@ export class ServiceAdministrationOrganisations {
     return {
       siret: uneEntite.siret,
       nom: uneEntite.nom,
+      departement: uneEntite.departement,
       nombreServices: services.length,
       nombreUtilisateurs: new Set(
         services.flatMap((s) =>

--- a/svelte/lib/ui/NomEntite.svelte
+++ b/svelte/lib/ui/NomEntite.svelte
@@ -6,6 +6,8 @@
   }
 
   let { entite }: Props = $props();
+  console.log(entite);
 </script>
 
-{entite.nom ?? entite.siret}
+{entite.departement ? `(${entite.departement}) ` : ''}{entite.nom ??
+  entite.siret}

--- a/svelte/lib/ui/NomEntite.svelte
+++ b/svelte/lib/ui/NomEntite.svelte
@@ -6,7 +6,6 @@
   }
 
   let { entite }: Props = $props();
-  console.log(entite);
 </script>
 
 {entite.departement ? `(${entite.departement}) ` : ''}{entite.nom ??


### PR DESCRIPTION
afin de faciliter l'identification lorsque plusieurs entités ont le même nom

<img width="1628" height="565" alt="Capture d’écran 2026-08-25 à 15 59 46" src="https://github.com/user-attachments/assets/75a3d445-0102-47b4-b806-d4f2de722b2f" />
