### PR TITLE
[CORRECTION] N'affiche pas en doublon le titre de la modale dans la visite guidée

### DIFF
--- a/svelte/lib/visiteGuideeSPA/ModaleAccueilVisiteGuidee.svelte
+++ b/svelte/lib/visiteGuideeSPA/ModaleAccueilVisiteGuidee.svelte
@@ -21,18 +21,23 @@
     await termineVisiteGuidee();
     estOuverte = false;
   };
+
+  const titreModale = $derived(
+    aDejaVuEntierementVisiteGuidee
+      ? 'Choisissez votre visite guidée'
+      : `Bonjour${profilUtilisateurComplet && prenomNom ? ` ${prenomNom}` : ''}, bienvenue sur MonServiceSécurisé !`
+  );
 </script>
 
 <dsfr-modal
   id="modale-accueil-visite-guidee"
   has-footer
-  title="Accueil de la visite guidée"
+  title={titreModale}
   opened={estOuverte}
   onclose={() => ignore()}
 >
   {#if aDejaVuEntierementVisiteGuidee}
     <div>
-      <h4>Choisissez votre visite guidée</h4>
       <p>
         Découvrez MonServiceSécurisé à votre rythme. Commencez par l'essentiel
         ou explorez les fonctionnalités avancées.
@@ -77,10 +82,6 @@
     </div>
   {:else}
     <div>
-      <h4>
-        Bonjour{profilUtilisateurComplet && prenomNom ? ` ${prenomNom}` : ''},
-        bienvenue sur MonServiceSécurisé !
-      </h4>
       <p>
         Pilotez la sécurité de vos services numériques et homologuez-les
         rapidement. MonServiceSécurisé est gratuit, 100 % en ligne et
@@ -105,14 +106,6 @@
 </dsfr-modal>
 
 <style lang="scss">
-  h4 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    line-height: 2rem;
-    margin: 0 0 16px;
-    padding: 0;
-  }
-
   p {
     font-size: 1rem;
     font-weight: 400;

--- a/svelte/lib/visiteGuideeSPA/ModaleChoixVisiteAvancee.svelte
+++ b/svelte/lib/visiteGuideeSPA/ModaleChoixVisiteAvancee.svelte
@@ -11,10 +11,9 @@
   id="modale-choix-visite-avancee"
   has-footer
   opened={estOuverte}
-  title="Choix de la visite avancée"
+  title="Que souhaitez-vous découvrir ?"
 >
   <div>
-    <h4>Que souhaitez-vous découvrir ?</h4>
     <p>Choisissez la fonctionnalité qui vous intéresse.</p>
     <div class="selection-etape-suivante">
       <dsfr-card
@@ -78,14 +77,6 @@
 </dsfr-modal>
 
 <style lang="scss">
-  h4 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    line-height: 2rem;
-    margin: 0 0 16px;
-    padding: 0;
-  }
-
   p {
     font-size: 1rem;
     font-weight: 400;

--- a/svelte/lib/visiteGuideeSPA/ModaleFinVisiteGuidee.svelte
+++ b/svelte/lib/visiteGuideeSPA/ModaleFinVisiteGuidee.svelte
@@ -16,10 +16,9 @@
   id="modale-fin-visite-guidee"
   has-footer
   opened={estOuverte}
-  title="Choix après la visite guidée"
+  title="À vous de jouer !"
 >
   <div>
-    <h4>À vous de jouer !</h4>
     <p>
       <b>Retrouvez ici une vision synthétique de tous vos services.</b>
       <br /><br />
@@ -84,14 +83,6 @@
 </dsfr-modal>
 
 <style lang="scss">
-  h4 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    line-height: 2rem;
-    margin: 0 0 16px;
-    padding: 0;
-  }
-
   p {
     font-size: 1rem;
     font-weight: 400;

--- a/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
+++ b/test/adaptateurs/serviceStatistiquesAdmin.spec.ts
@@ -526,10 +526,21 @@ describe("L'adaptateur des statistiques admin", () => {
 
     it('génère les mois sans nouveau dossier entre deux dates avec dossier', async () => {
       const aujourdhui = new Date();
-      const ilYA1Mois = new Date();
-      ilYA1Mois.setMonth(ilYA1Mois.getMonth() - 1);
-      const ilYA2Mois = new Date();
-      ilYA2Mois.setMonth(ilYA2Mois.getMonth() - 2);
+      const ceDebutDeMois = new Date(
+        aujourdhui.getFullYear(),
+        aujourdhui.getMonth(),
+        2
+      );
+      const ilYA1MoisDebutMois = new Date(
+        aujourdhui.getFullYear(),
+        aujourdhui.getMonth() - 1,
+        2
+      );
+      const ilYA2MoisDebutMois = new Date(
+        aujourdhui.getFullYear(),
+        aujourdhui.getMonth() - 2,
+        2
+      );
       const adaptateur = new ServiceStatistiquesAdmin(
         adaptateurChiffrement,
         adaptateurJournal,
@@ -538,23 +549,23 @@ describe("L'adaptateur des statistiques admin", () => {
 
       const resultat = await adaptateur.statistiques(
         [
-          unServiceV2AvecDossierHomologueLe(aujourdhui),
-          unServiceV2AvecDossierHomologueLe(ilYA2Mois),
+          unServiceV2AvecDossierHomologueLe(ceDebutDeMois),
+          unServiceV2AvecDossierHomologueLe(ilYA2MoisDebutMois),
         ],
         sansFiltre
       );
 
       expect(resultat.evolutionNombreHomologations).toEqual([
         {
-          mois: `${ilYA2Mois.getFullYear()}-${moisAvecRemplissage(ilYA2Mois)}`,
+          mois: `${ilYA2MoisDebutMois.getFullYear()}-${moisAvecRemplissage(ilYA2MoisDebutMois)}`,
           total: 1,
         },
         {
-          mois: `${ilYA1Mois.getFullYear()}-${moisAvecRemplissage(ilYA1Mois)}`,
+          mois: `${ilYA1MoisDebutMois.getFullYear()}-${moisAvecRemplissage(ilYA1MoisDebutMois)}`,
           total: 1,
         },
         {
-          mois: `${aujourdhui.getFullYear()}-${moisAvecRemplissage(aujourdhui)}`,
+          mois: `${ceDebutDeMois.getFullYear()}-${moisAvecRemplissage(ceDebutDeMois)}`,
           total: 2,
         },
       ]);


### PR DESCRIPTION
Suite à l'utilisation de l'attribut "title" de `dsfr-modal`, afin de corriger le bouton de fermeture qui affichait "Fermer la modale undefined", un second titre s'affichait. Ce commit permet d'utiliser correctement cet attribut pour passer le titre attendu de la modale et pas un "titre d'accessibilité"