### PR TITLE
[GESTION ORGAS] Améliore les performances des pages de supervision

### DIFF
--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -265,6 +265,9 @@ const nouvelAdaptateur = (
 
   const tousUtilisateurs = async () => donnees.utilisateurs;
 
+  const utilisateursAvecIds = async (ids) =>
+    donnees.utilisateurs.filter((u) => ids.includes(u.id));
+
   const autorisation = async (id) =>
     donnees.autorisations.find((a) => a.id === id);
 
@@ -797,6 +800,7 @@ const nouvelAdaptateur = (
     sauvegardeSimulationMigrationReferentiel,
     serviceExisteAvecHashNom,
     servicesComplets,
+    utilisateursAvecIds,
     supprimeAssociationModelesMesureSpecifiquePourUtilisateurSurService,
     supprimeAutorisation,
     supprimeAutorisations,

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -117,7 +117,6 @@ const nouvelAdaptateur = (
   const servicesComplets = async ({
     idUtilisateur,
     idService,
-    hashSiret,
     hashSirets,
     tous,
   }) => {
@@ -129,9 +128,6 @@ const nouvelAdaptateur = (
     } else if (idUtilisateur) {
       const deUtilisateur = await services(idUtilisateur);
       servicesRetenus.push(...deUtilisateur);
-    } else if (hashSiret) {
-      const duSiret = donnees.services.filter((s) => s.siretHash === hashSiret);
-      servicesRetenus.push(...duSiret);
     } else if (hashSirets) {
       const desSirets = donnees.services.filter((s) =>
         hashSirets.includes(s.siretHash)

--- a/src/adaptateurs/adaptateurPersistanceMemoire.js
+++ b/src/adaptateurs/adaptateurPersistanceMemoire.js
@@ -118,6 +118,7 @@ const nouvelAdaptateur = (
     idUtilisateur,
     idService,
     hashSiret,
+    hashSirets,
     tous,
   }) => {
     const servicesRetenus = [];
@@ -131,6 +132,11 @@ const nouvelAdaptateur = (
     } else if (hashSiret) {
       const duSiret = donnees.services.filter((s) => s.siretHash === hashSiret);
       servicesRetenus.push(...duSiret);
+    } else if (hashSirets) {
+      const desSirets = donnees.services.filter((s) =>
+        hashSirets.includes(s.siretHash)
+      );
+      servicesRetenus.push(...desSirets);
     } else if (tous) {
       const tousServices = await Promise.all(
         donnees.services.map((s) => s.id).map(serviceParId)

--- a/src/adaptateurs/adaptateurPersistanceMemoireTS.ts
+++ b/src/adaptateurs/adaptateurPersistanceMemoireTS.ts
@@ -35,24 +35,17 @@ export class AdaptateurPersistanceMemoireTS implements PersistanceTS {
     );
   }
 
-  async lisAdminsOrganisation(
-    siret: string
-  ): Promise<Array<DonneesAdminOrganisations>> {
-    return this.donnees.adminsOrganisations.filter((a) =>
-      a.entitesAdministrees.map((e) => e.siret).includes(siret)
-    );
-  }
-
   async lisAdminsOrganisations(
     sirets: string[]
   ): Promise<Map<string, Array<DonneesAdminOrganisations>>> {
-    const parSiret = new Map<string, Array<DonneesAdminOrganisations>>();
-    await Promise.all(
-      sirets.map(async (siret) => {
-        parSiret.set(siret, await this.lisAdminsOrganisation(siret));
-      })
+    return new Map(
+      sirets.map((siret) => [
+        siret,
+        this.donnees.adminsOrganisations.filter((a) =>
+          a.entitesAdministrees.map((e) => e.siret).includes(siret)
+        ),
+      ])
     );
-    return parSiret;
   }
 
   async sauvegardeAdminOrganisations(

--- a/src/adaptateurs/adaptateurPersistanceMemoireTS.ts
+++ b/src/adaptateurs/adaptateurPersistanceMemoireTS.ts
@@ -43,6 +43,18 @@ export class AdaptateurPersistanceMemoireTS implements PersistanceTS {
     );
   }
 
+  async lisAdminsOrganisations(
+    sirets: string[]
+  ): Promise<Map<string, Array<DonneesAdminOrganisations>>> {
+    const parSiret = new Map<string, Array<DonneesAdminOrganisations>>();
+    await Promise.all(
+      sirets.map(async (siret) => {
+        parSiret.set(siret, await this.lisAdminsOrganisation(siret));
+      })
+    );
+    return parSiret;
+  }
+
   async sauvegardeAdminOrganisations(
     donnees: DonneesAdminOrganisations
   ): Promise<void> {

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -179,8 +179,7 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
     )[0].count >= 1;
 
   const servicesComplets = async (configurationDuWhere) => {
-    const { idUtilisateur, idService, hashSiret, hashSirets, tous } =
-      configurationDuWhere;
+    const { idUtilisateur, idService, hashSirets, tous } = configurationDuWhere;
 
     const erreurDeConfiguration = () => {
       const json = JSON.stringify(configurationDuWhere);
@@ -199,8 +198,6 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
             )`;
 
       if (idService) return `WHERE s.id = :idService`;
-
-      if (hashSiret) return `WHERE s.siret_hash = :hashSiret`;
 
       if (hashSirets) return `WHERE s.siret_hash = ANY(:hashSirets)`;
 
@@ -241,7 +238,7 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
                           GROUP BY id_service) modeles_de_mesure_specifique ON modeles_de_mesure_specifique.id_service = s.id
           ${where()};
       `,
-      { idUtilisateur, idService, hashSiret, hashSirets }
+      { idUtilisateur, idService, hashSirets }
     );
 
     return requete.rows.map((s) => ({

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -320,6 +320,11 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
       tous.map(convertisLigneEnObjetSansMiseAPlatDonnees)
     );
 
+  const utilisateursAvecIds = (ids) =>
+    knex('utilisateurs')
+      .whereIn('id', ids)
+      .then((lignes) => lignes.map(convertisLigneEnObjetSansMiseAPlatDonnees));
+
   const autorisation = (id) => elementDeTable('autorisations', id);
 
   const autorisationPour = (idUtilisateur, idService) =>
@@ -1106,6 +1111,7 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
     sauvegardeSimulationMigrationReferentiel,
     serviceExisteAvecHashNom,
     servicesComplets,
+    utilisateursAvecIds,
     supprimeAssociationModelesMesureSpecifiquePourUtilisateurSurService,
     supprimeAutorisation,
     supprimeAutorisations,

--- a/src/adaptateurs/adaptateurPostgres.js
+++ b/src/adaptateurs/adaptateurPostgres.js
@@ -179,7 +179,8 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
     )[0].count >= 1;
 
   const servicesComplets = async (configurationDuWhere) => {
-    const { idUtilisateur, idService, hashSiret, tous } = configurationDuWhere;
+    const { idUtilisateur, idService, hashSiret, hashSirets, tous } =
+      configurationDuWhere;
 
     const erreurDeConfiguration = () => {
       const json = JSON.stringify(configurationDuWhere);
@@ -200,6 +201,8 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
       if (idService) return `WHERE s.id = :idService`;
 
       if (hashSiret) return `WHERE s.siret_hash = :hashSiret`;
+
+      if (hashSirets) return `WHERE s.siret_hash = ANY(:hashSirets)`;
 
       if (tous) return '';
 
@@ -238,12 +241,13 @@ const nouvelAdaptateur = ({ knexSurcharge }) => {
                           GROUP BY id_service) modeles_de_mesure_specifique ON modeles_de_mesure_specifique.id_service = s.id
           ${where()};
       `,
-      { idUtilisateur, idService, hashSiret }
+      { idUtilisateur, idService, hashSiret, hashSirets }
     );
 
     return requete.rows.map((s) => ({
       ...s,
       versionService: s.version_service,
+      siretHash: s.siret_hash,
       modelesDisponiblesDeMesureSpecifique:
         s.modelesDisponiblesDeMesureSpecifique.map(
           // eslint-disable-next-line camelcase

--- a/src/adaptateurs/adaptateurPostgresTS.ts
+++ b/src/adaptateurs/adaptateurPostgresTS.ts
@@ -134,26 +134,6 @@ export class AdaptateurPostgresTS implements PersistanceTS {
       .delete();
   }
 
-  async lisAdminsOrganisation(
-    siret: string
-  ): Promise<Array<DonneesAdminOrganisations>> {
-    const siretHache = this.chiffrement.hacheSha256(siret);
-    const chaqueLigne: { idUtilisateur: UUID }[] = await this.knex(
-      TABLES.ADMINS_ORGANISATIONS
-    )
-      .select({ idUtilisateur: 'id_utilisateur' })
-      .where({ siret_hash: siretHache });
-
-    return Promise.all(
-      chaqueLigne.map(
-        ({ idUtilisateur }) =>
-          this.lisAdminOrganisations(
-            idUtilisateur
-          ) as unknown as DonneesAdminOrganisations
-      )
-    );
-  }
-
   async lisAdminsOrganisations(
     sirets: string[]
   ): Promise<Map<string, Array<DonneesAdminOrganisations>>> {

--- a/src/adaptateurs/adaptateurPostgresTS.ts
+++ b/src/adaptateurs/adaptateurPostgresTS.ts
@@ -5,7 +5,7 @@ import { DonneesSuperviseur } from '../modeles/superviseur.js';
 import { AdaptateurChiffrement } from './adaptateurChiffrement.interface.js';
 import { PersistanceTS } from './persistanceTS.interface.js';
 import { DonneesNotificationTransactionnelle } from '../modeles/notificationsTransactionnelles/notificationTransactionnelle.js';
-import { UUID } from '../typesBasiques.js';
+import { DonneesChiffrees, UUID } from '../typesBasiques.js';
 
 enum TABLES {
   ADMINS_ORGANISATIONS = 'admins_organisations',
@@ -152,6 +152,60 @@ export class AdaptateurPostgresTS implements PersistanceTS {
           ) as unknown as DonneesAdminOrganisations
       )
     );
+  }
+
+  async lisAdminsOrganisations(
+    sirets: string[]
+  ): Promise<Map<string, Array<DonneesAdminOrganisations>>> {
+    const siretParHash = new Map(
+      sirets.map((siret) => [this.chiffrement.hacheSha256(siret), siret])
+    );
+
+    const parSiret = new Map<string, Array<DonneesAdminOrganisations>>(
+      sirets.map((siret) => [siret, []])
+    );
+    if (sirets.length === 0) return parSiret;
+
+    const lignesDesSirets: { idUtilisateur: UUID; siretHash: string }[] =
+      await this.knex(TABLES.ADMINS_ORGANISATIONS)
+        .select({ idUtilisateur: 'id_utilisateur', siretHash: 'siret_hash' })
+        .whereIn('siret_hash', [...siretParHash.keys()]);
+
+    const idsDesAdmins = [
+      ...new Set(lignesDesSirets.map((l) => l.idUtilisateur)),
+    ];
+    const entitesParAdmin = await this.lisEntitesAdministreesPar(idsDesAdmins);
+
+    lignesDesSirets.forEach(({ idUtilisateur, siretHash }) => {
+      const siret = siretParHash.get(siretHash)!;
+      parSiret.get(siret)!.push({
+        idUtilisateur,
+        entitesAdministrees: entitesParAdmin.get(idUtilisateur) ?? [],
+      });
+    });
+
+    return parSiret;
+  }
+
+  private async lisEntitesAdministreesPar(idsDesAdmins: UUID[]) {
+    const entitesParAdmin = new Map<UUID, DonneesEntite[]>();
+    if (idsDesAdmins.length === 0) return entitesParAdmin;
+
+    const lignes: { idUtilisateur: UUID; donnees: DonneesChiffrees }[] =
+      await this.knex(TABLES.ADMINS_ORGANISATIONS)
+        .select({ idUtilisateur: 'id_utilisateur', donnees: 'donnees' })
+        .whereIn('id_utilisateur', idsDesAdmins);
+
+    await Promise.all(
+      lignes.map(async ({ idUtilisateur, donnees }) => {
+        const entite: DonneesEntite = await this.chiffrement.dechiffre(donnees);
+        if (!entitesParAdmin.has(idUtilisateur))
+          entitesParAdmin.set(idUtilisateur, []);
+        entitesParAdmin.get(idUtilisateur)!.push(entite);
+      })
+    );
+
+    return entitesParAdmin;
   }
 
   async lisNotificationsDe(

--- a/src/adaptateurs/persistanceTS.interface.ts
+++ b/src/adaptateurs/persistanceTS.interface.ts
@@ -10,6 +10,9 @@ export interface PersistanceTS {
   lisAdminsOrganisation: (
     siret: string
   ) => Promise<Array<DonneesAdminOrganisations>>;
+  lisAdminsOrganisations: (
+    sirets: string[]
+  ) => Promise<Map<string, Array<DonneesAdminOrganisations>>>;
   sauvegardeAdminOrganisations: (
     donnees: DonneesAdminOrganisations
   ) => Promise<void>;

--- a/src/adaptateurs/persistanceTS.interface.ts
+++ b/src/adaptateurs/persistanceTS.interface.ts
@@ -7,9 +7,6 @@ export interface PersistanceTS {
   lisAdminOrganisations: (
     idUtilisateur: UUID
   ) => Promise<DonneesAdminOrganisations | undefined>;
-  lisAdminsOrganisation: (
-    siret: string
-  ) => Promise<Array<DonneesAdminOrganisations>>;
   lisAdminsOrganisations: (
     sirets: string[]
   ) => Promise<Map<string, Array<DonneesAdminOrganisations>>>;

--- a/src/depotDonnees.ts
+++ b/src/depotDonnees.ts
@@ -237,6 +237,7 @@ const creeDepot = (config: ConfigDepotDonnees) => {
     supprimeRisqueSpecifiqueV2,
     tousLesServices,
     tousLesServicesAvecSiret,
+    tousLesServicesAvecSirets,
     versionsServiceUtiliseesParUtilisateur,
   } = depotServices;
 
@@ -247,6 +248,7 @@ const creeDepot = (config: ConfigDepotDonnees) => {
     supprimeUtilisateur,
     tousUtilisateurs,
     utilisateur,
+    utilisateurs,
     utilisateurExiste,
     utilisateurAvecEmail,
     utilisateursAdministresPar,
@@ -466,7 +468,9 @@ const creeDepot = (config: ConfigDepotDonnees) => {
     tousUtilisateurs,
     tousLesServices,
     tousLesServicesAvecSiret,
+    tousLesServicesAvecSirets,
     utilisateur,
+    utilisateurs,
     utilisateurExiste,
     utilisateurAvecEmail,
     utilisateursAdministresPar,
@@ -501,6 +505,9 @@ const creeDepot = (config: ConfigDepotDonnees) => {
       depotAdminsOrganisations
     ),
     lisAdminsPour: depotAdminsOrganisations.lisAdminsPour.bind(
+      depotAdminsOrganisations
+    ),
+    lisAdminsPourSirets: depotAdminsOrganisations.lisAdminsPourSirets.bind(
       depotAdminsOrganisations
     ),
     sauvegardeAdminOrganisations:

--- a/src/depots/depotDonneesAdminsOrganisations.ts
+++ b/src/depots/depotDonneesAdminsOrganisations.ts
@@ -24,6 +24,20 @@ export class DepotDonneesAdminsOrganisations {
     return donnees.map((d) => AdminOrganisations.hydrate(d));
   }
 
+  async lisAdminsPourSirets(
+    sirets: string[]
+  ): Promise<Map<string, Array<AdminOrganisations>>> {
+    const donneesParSiret =
+      await this.persistance.lisAdminsOrganisations(sirets);
+
+    return new Map(
+      [...donneesParSiret.entries()].map(([siret, donnees]) => [
+        siret,
+        donnees.map((d) => AdminOrganisations.hydrate(d)),
+      ])
+    );
+  }
+
   async sauvegardeAdminOrganisations(admin: AdminOrganisations) {
     await this.persistance.sauvegardeAdminOrganisations(admin.donnees());
   }

--- a/src/depots/depotDonneesAdminsOrganisations.ts
+++ b/src/depots/depotDonneesAdminsOrganisations.ts
@@ -19,9 +19,7 @@ export class DepotDonneesAdminsOrganisations {
   }
 
   async lisAdminsPour(siret: string): Promise<Array<AdminOrganisations>> {
-    const donnees = await this.persistance.lisAdminsOrganisation(siret);
-
-    return donnees.map((d) => AdminOrganisations.hydrate(d));
+    return (await this.lisAdminsPourSirets([siret])).get(siret)!;
   }
 
   async lisAdminsPourSirets(

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -122,15 +122,8 @@ const fabriquePersistance = (
 
         return parSiret;
       },
-      ceuxAvecSiret: async (siret) => {
-        const hashSiret = adaptateurChiffrement.hacheSha256(siret);
-
-        const donnees = await adaptateurPersistance.servicesComplets({
-          hashSiret,
-        });
-
-        return Promise.all(donnees.map((d) => mappeDonneesVersDomaine(d)));
-      },
+      ceuxAvecSiret: async (siret) =>
+        (await persistance.lis.ceuxAvecSirets([siret])).get(siret),
       ceuxDeUtilisateur: async (idUtilisateur) => {
         const donnees = await adaptateurPersistance.servicesComplets({
           idUtilisateur,

--- a/src/depots/depotDonneesServices.js
+++ b/src/depots/depotDonneesServices.js
@@ -94,6 +94,34 @@ const fabriquePersistance = (
         if (!s) return undefined;
         return mappeDonneesVersDomaine(s);
       },
+      ceuxAvecSirets: async (sirets) => {
+        const siretParHash = new Map(
+          sirets.map((siret) => [
+            adaptateurChiffrement.hacheSha256(siret),
+            siret,
+          ])
+        );
+
+        const parSiret = new Map(sirets.map((siret) => [siret, []]));
+        if (sirets.length === 0) return parSiret;
+
+        const donnees = await adaptateurPersistance.servicesComplets({
+          hashSirets: [...siretParHash.keys()],
+        });
+
+        const services = await Promise.all(
+          donnees.map(async (d) => ({
+            siret: siretParHash.get(d.siretHash),
+            service: await mappeDonneesVersDomaine(d),
+          }))
+        );
+
+        services.forEach(({ siret, service }) => {
+          if (siret) parSiret.get(siret).push(service);
+        });
+
+        return parSiret;
+      },
       ceuxAvecSiret: async (siret) => {
         const hashSiret = adaptateurChiffrement.hacheSha256(siret);
 
@@ -329,6 +357,8 @@ const creeDepot = (config = {}) => {
   const tousLesServices = () => p.lis.tous();
 
   const tousLesServicesAvecSiret = (siret) => p.lis.ceuxAvecSiret(siret);
+
+  const tousLesServicesAvecSirets = (sirets) => p.lis.ceuxAvecSirets(sirets);
 
   const enregistreDossier = (idService, dossier) =>
     ajouteAItemsDuService('dossiers', idService, dossier);
@@ -836,6 +866,7 @@ const creeDepot = (config = {}) => {
     supprimeService,
     tousLesServices,
     tousLesServicesAvecSiret,
+    tousLesServicesAvecSirets,
     trouveIndexDisponible,
     versionsServiceUtiliseesParUtilisateur,
   };

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -111,6 +111,11 @@ function fabriquePersistance({
         const donnees = await adaptateurPersistance.utilisateur(idUtilisateur);
         return dechiffreUtilisateur(donnees);
       },
+      plusieurs: async (idsUtilisateurs) => {
+        const donnees =
+          await adaptateurPersistance.utilisateursAvecIds(idsUtilisateurs);
+        return Promise.all(donnees.map((d) => dechiffreUtilisateur(d)));
+      },
       celuiAvecEmail: async (email) => {
         const emailMinuscule = email.toLowerCase();
         const emailHash = adaptateurChiffrement.hacheSha256(emailMinuscule);
@@ -210,6 +215,8 @@ const creeDepot = (config = {}) => {
     p.dechiffreDonneesContributeur(donneesUtilisateur);
 
   const utilisateur = async (identifiant) => p.lis.un(identifiant);
+
+  const utilisateurs = async (identifiants) => p.lis.plusieurs(identifiants);
 
   const nouvelUtilisateur = async (donneesUtilisateur) => {
     const { email } = donneesUtilisateur;
@@ -372,6 +379,7 @@ const creeDepot = (config = {}) => {
     supprimeUtilisateur,
     tousUtilisateurs,
     utilisateur,
+    utilisateurs,
     utilisateurExiste,
     utilisateurAvecEmail,
     utilisateursAdministresPar,

--- a/src/depots/depotDonneesUtilisateurs.js
+++ b/src/depots/depotDonneesUtilisateurs.js
@@ -108,7 +108,9 @@ function fabriquePersistance({
         },
       },
       un: async (idUtilisateur) => {
-        const donnees = await adaptateurPersistance.utilisateur(idUtilisateur);
+        const [donnees] = await adaptateurPersistance.utilisateursAvecIds([
+          idUtilisateur,
+        ]);
         return dechiffreUtilisateur(donnees);
       },
       plusieurs: async (idsUtilisateurs) => {

--- a/src/supervision/serviceAdministrationOrganisations.ts
+++ b/src/supervision/serviceAdministrationOrganisations.ts
@@ -178,53 +178,66 @@ export class ServiceAdministrationOrganisations {
   ): Promise<Array<DonneesEntiteSupervisee>> {
     const admin = await this.depotDonnees.lisAdminOrganisations(idUtilisateur);
     if (admin) {
-      const toutesEntites = admin.donnees().entitesAdministrees;
-      return Promise.all(
-        toutesEntites.map((e) => this.enrichisEntiteSupervisee(e))
+      return this.enrichisEntitesSupervisees(
+        admin.donnees().entitesAdministrees
       );
     }
 
     const superviseur = await this.depotDonnees.lisSuperviseur(idUtilisateur);
     if (superviseur) {
-      const toutesEntites = superviseur.donnees().entitesSupervisees;
-      return Promise.all(
-        toutesEntites.map((e) => this.enrichisEntiteSupervisee(e))
+      return this.enrichisEntitesSupervisees(
+        superviseur.donnees().entitesSupervisees
       );
     }
 
     return [];
   }
 
-  private async enrichisEntiteSupervisee(
-    uneEntite: DonneesEntite
-  ): Promise<DonneesEntiteSupervisee> {
-    const admins = await this.depotDonnees.lisAdminsPour(uneEntite.siret);
-    const enUtilisateurs = await Promise.all(
-      admins.map((a) =>
-        this.depotDonnees.utilisateur(a.donnees().idUtilisateur)
-      )
-    );
-    const services = await this.depotDonnees.tousLesServicesAvecSiret(
-      uneEntite.siret
-    );
+  private async enrichisEntitesSupervisees(
+    entites: DonneesEntite[]
+  ): Promise<Array<DonneesEntiteSupervisee>> {
+    const sirets = entites.map((e) => e.siret);
 
-    return {
-      siret: uneEntite.siret,
-      nom: uneEntite.nom,
-      departement: uneEntite.departement,
-      nombreServices: services.length,
-      nombreUtilisateurs: new Set(
-        services.flatMap((s) =>
-          s.contributeurs.map((c: Contributeur) => c.idUtilisateur)
-        )
-      ).size,
-      administrateurs: enUtilisateurs.map((u) => ({
-        id: u!.id,
-        prenomNom: u!.prenomNom(),
-        initiales: u!.initiales(),
-        postes: u!.posteDetaille(),
-      })),
-    };
+    const [adminsParSiret, servicesParSiret] = await Promise.all([
+      this.depotDonnees.lisAdminsPourSirets(sirets),
+      this.depotDonnees.tousLesServicesAvecSirets(sirets),
+    ]);
+
+    const idsDesAdmins = [
+      ...new Set(
+        [...adminsParSiret.values()]
+          .flat()
+          .map((a) => a.donnees().idUtilisateur)
+      ),
+    ];
+    const lesAdmins = await this.depotDonnees.utilisateurs(idsDesAdmins);
+    const adminParId = new Map(lesAdmins.map((u) => [u.id, u]));
+
+    return entites.map((uneEntite) => {
+      const services = servicesParSiret.get(uneEntite.siret) ?? [];
+      const admins = adminsParSiret.get(uneEntite.siret) ?? [];
+
+      return {
+        siret: uneEntite.siret,
+        nom: uneEntite.nom,
+        departement: uneEntite.departement,
+        nombreServices: services.length,
+        nombreUtilisateurs: new Set(
+          services.flatMap((s: Service) =>
+            s.contributeurs.map((c: Contributeur) => c.idUtilisateur)
+          )
+        ).size,
+        administrateurs: admins.map((a) => {
+          const u = adminParId.get(a.donnees().idUtilisateur)!;
+          return {
+            id: u.id,
+            prenomNom: u.prenomNom(),
+            initiales: u.initiales(),
+            postes: u.posteDetaille(),
+          };
+        }),
+      };
+    });
   }
 
   async utilisateursDansLePerimetreDe(

--- a/svelte/lib/adminAdministrateurs/AdminAdministrateurs.svelte
+++ b/svelte/lib/adminAdministrateurs/AdminAdministrateurs.svelte
@@ -13,11 +13,13 @@
   import ChampRecherche from '../ui/ChampRecherche.svelte';
   import Bouton from '../ui/Bouton.svelte';
   import ModaleEntitesUtilisateurAdministre from '../adminUtilisateurs/ModaleEntitesUtilisateurAdministre.svelte';
+  import Loader from '../ui/Loader.svelte';
 
   let mesUtilisateurs: UtilisateurAdministre[] = $state([]);
   let mesEntites: Array<EntiteSupervisee> = $state([]);
   let recherche = $state('');
   let utilisateurSelectionne: UtilisateurAdministre | undefined = $state();
+  let enCoursChargement = $state(false);
 
   let modale: ModaleEntitesUtilisateurAdministre | undefined;
 
@@ -26,10 +28,12 @@
   });
 
   const rafraichis = async () => {
+    enCoursChargement = true;
     mesUtilisateurs = (await api.utilisateursDansMonPerimetre()).filter(
       (u) => u.estAdmin
     );
     mesEntites = await apiEntites.entitesDansMonPerimetre();
+    enCoursChargement = false;
   };
 
   let rechercheNormalisee = $derived(chaineNormalisee(recherche));
@@ -55,9 +59,17 @@
 
 <h1>Admins</h1>
 
-<Tuiles nombreAdministrateurs={mesUtilisateurs.length} {mesEntites} />
+<Tuiles
+  nombreAdministrateurs={mesUtilisateurs.length}
+  {mesEntites}
+  {enCoursChargement}
+/>
 
-{#if mesUtilisateurs.length === 0}
+{#if enCoursChargement}
+  <div class="conteneur-loader">
+    <Loader />
+  </div>
+{:else if mesUtilisateurs.length === 0}
   <div class="aucun-resultat">
     <img src="/statique/assets/images/illustration_recherche_vide.svg" alt="" />
     <h2>Aucun admin sur vos entités</h2>
@@ -159,6 +171,13 @@
     width: 100%;
     padding: 32px 20px;
     overflow: auto;
+  }
+
+  .conteneur-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
   }
 
   h1 {

--- a/svelte/lib/adminAdministrateurs/Tuiles.svelte
+++ b/svelte/lib/adminAdministrateurs/Tuiles.svelte
@@ -5,9 +5,11 @@
   interface Props {
     mesEntites: Array<EntiteSupervisee>;
     nombreAdministrateurs: number;
+    enCoursChargement: boolean;
   }
 
-  let { mesEntites, nombreAdministrateurs }: Props = $props();
+  let { mesEntites, nombreAdministrateurs, enCoursChargement }: Props =
+    $props();
 
   let nombreEntites = $derived(mesEntites.length);
   let nombreServicesTotal = $derived(
@@ -20,16 +22,19 @@
     nomSvg="illustration_avatar"
     titre={nombreAdministrateurs.toString()}
     description="Admins"
+    {enCoursChargement}
   />
   <Tuile
     nomSvg="illustration_data_security"
     titre={nombreServicesTotal.toString()}
     description="Services enregistrés"
+    {enCoursChargement}
   />
   <Tuile
     nomSvg="illustration_teacher"
     titre={nombreEntites.toString()}
     description="Entités dans votre périmètre"
+    {enCoursChargement}
   />
 </div>
 

--- a/svelte/lib/adminEntites/AdminEntites.svelte
+++ b/svelte/lib/adminEntites/AdminEntites.svelte
@@ -13,16 +13,20 @@
   import ChampRecherche from '../ui/ChampRecherche.svelte';
   import AucunResultatRecherche from '../ui/AucunResultatRecherche.svelte';
   import NomEntite from '../ui/NomEntite.svelte';
+  import Loader from '../ui/Loader.svelte';
 
   let mesEntites: Array<EntiteSupervisee> = $state([]);
   let recherche = $state('');
+  let enCoursChargement = $state(false);
 
   onMount(async () => {
     await rafraichis();
   });
 
   const rafraichis = async () => {
+    enCoursChargement = true;
     mesEntites = await api.entitesDansMonPerimetre();
+    enCoursChargement = false;
   };
 
   let rechercheNormalisee = $derived(chaineNormalisee(recherche));
@@ -42,11 +46,17 @@
 
 <h1>Entités</h1>
 
-<Tuiles {mesEntites} />
+<Tuiles {mesEntites} {enCoursChargement} />
 
-<ChampRecherche bind:valeur={recherche} />
+{#if !enCoursChargement}
+  <ChampRecherche bind:valeur={recherche} />
+{/if}
 
-{#if recherche.length > 0 && mesEntitesFiltrees.length === 0}
+{#if enCoursChargement}
+  <div class="conteneur-loader">
+    <Loader />
+  </div>
+{:else if recherche.length > 0 && mesEntitesFiltrees.length === 0}
   <AucunResultatRecherche onclick={() => (recherche = '')} />
 {:else}
   <dsfr-table
@@ -98,6 +108,13 @@
 
   :global(main) {
     background: white;
+  }
+
+  .conteneur-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
   }
 
   h1 {

--- a/svelte/lib/adminEntites/Tuiles.svelte
+++ b/svelte/lib/adminEntites/Tuiles.svelte
@@ -4,9 +4,10 @@
 
   interface Props {
     mesEntites: Array<EntiteSupervisee>;
+    enCoursChargement: boolean;
   }
 
-  let { mesEntites }: Props = $props();
+  let { mesEntites, enCoursChargement }: Props = $props();
 
   let nombreEntites = $derived(mesEntites.length);
   let nombreServicesTotal = $derived(
@@ -27,21 +28,25 @@
     nomSvg="illustration_teacher"
     titre={nombreEntites.toString()}
     description="Entités dans votre périmètre"
+    {enCoursChargement}
   />
   <Tuile
     nomSvg="illustration_data_security"
     titre={nombreServicesTotal.toString()}
     description="Services enregistrés"
+    {enCoursChargement}
   />
   <Tuile
     nomSvg="illustration_avatar"
     titre={nombreAdmins.toString()}
     description="Admins"
+    {enCoursChargement}
   />
   <Tuile
     nomSvg="illustration_warning"
     titre={nombreSansAdmins.toString()}
     description="Entités sans admins"
+    {enCoursChargement}
   />
 </div>
 

--- a/svelte/lib/adminUtilisateurs/AdminUtilisateurs.svelte
+++ b/svelte/lib/adminUtilisateurs/AdminUtilisateurs.svelte
@@ -16,11 +16,13 @@
   import AucunResultatRecherche from '../ui/AucunResultatRecherche.svelte';
   import ModaleEntitesUtilisateurAdministre from './ModaleEntitesUtilisateurAdministre.svelte';
   import Bouton from '../ui/Bouton.svelte';
+  import Loader from '../ui/Loader.svelte';
 
   let mesUtilisateurs: UtilisateurAdministre[] = $state([]);
   let mesEntites: Array<EntiteSupervisee> = $state([]);
   let recherche = $state('');
   let utilisateurSelectionne: UtilisateurAdministre | undefined = $state();
+  let enCoursChargement = $state(false);
 
   let modale: ModaleEntitesUtilisateurAdministre | undefined;
 
@@ -29,8 +31,10 @@
   });
 
   const rafraichis = async () => {
+    enCoursChargement = true;
     mesUtilisateurs = await api.utilisateursDansMonPerimetre();
     mesEntites = await apiEntites.entitesDansMonPerimetre();
+    enCoursChargement = false;
   };
 
   const unAdminExisteAutreQueUtilisateurCourant = $derived(
@@ -62,9 +66,17 @@
 
 <h1>Utilisateurs</h1>
 
-<Tuiles nombreUtilisateurs={mesUtilisateurs.length} {mesEntites} />
+<Tuiles
+  nombreUtilisateurs={mesUtilisateurs.length}
+  {mesEntites}
+  {enCoursChargement}
+/>
 
-{#if mesUtilisateurs.length === 0}
+{#if enCoursChargement}
+  <div class="conteneur-loader">
+    <Loader />
+  </div>
+{:else if mesUtilisateurs.length === 0}
   <div class="aucun-resultat">
     <img src="/statique/assets/images/illustration_recherche_vide.svg" alt="" />
     {#if unAdminExisteAutreQueUtilisateurCourant}
@@ -196,6 +208,13 @@
     width: 100%;
     padding: 32px 20px;
     overflow: auto;
+  }
+
+  .conteneur-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
   }
 
   h1 {

--- a/svelte/lib/adminUtilisateurs/Tuiles.svelte
+++ b/svelte/lib/adminUtilisateurs/Tuiles.svelte
@@ -5,9 +5,10 @@
   interface Props {
     mesEntites: Array<EntiteSupervisee>;
     nombreUtilisateurs: number;
+    enCoursChargement: boolean;
   }
 
-  let { mesEntites, nombreUtilisateurs }: Props = $props();
+  let { mesEntites, nombreUtilisateurs, enCoursChargement }: Props = $props();
 
   let nombreEntites = $derived(mesEntites.length);
   let nombreServicesTotal = $derived(
@@ -20,16 +21,19 @@
     nomSvg="illustration_human_cooperation"
     titre={nombreUtilisateurs.toString()}
     description="Utilisateurs"
+    {enCoursChargement}
   />
   <Tuile
     nomSvg="illustration_data_security"
     titre={nombreServicesTotal.toString()}
     description="Services enregistrés"
+    {enCoursChargement}
   />
   <Tuile
     nomSvg="illustration_teacher"
     titre={nombreEntites.toString()}
     description="Entités"
+    {enCoursChargement}
   />
 </div>
 

--- a/svelte/lib/ui/Tuile.svelte
+++ b/svelte/lib/ui/Tuile.svelte
@@ -3,13 +3,14 @@
     nomSvg: string;
     titre: string;
     description: string;
+    enCoursChargement?: boolean;
   }
 
-  let { nomSvg, titre, description }: Props = $props();
+  let { nomSvg, titre, description, enCoursChargement }: Props = $props();
 </script>
 
 <dsfr-tile
-  title={titre}
+  title={enCoursChargement ? '⏳' : titre}
   has-description
   {description}
   horizontal

--- a/test/adaptateurs/adaptateurPostgres.spec.js
+++ b/test/adaptateurs/adaptateurPostgres.spec.js
@@ -222,6 +222,39 @@ describe("L'adaptateur persistance Postgres", () => {
 
       expect(services[0].aUneSimulationMigrationReferentiel).to.be(false);
     });
+
+    it('sait lire en une fois les services de plusieurs SIRET', async () => {
+      const idService1 = await insereService('siret-1');
+      const idService2 = await insereService('siret-2');
+      await insereService('siret-3');
+
+      const services = await persistance.servicesComplets({
+        hashSirets: ['siret-1', 'siret-2'],
+      });
+
+      expect(services.length).to.be(2);
+      expect(services.map((s) => s.id).sort()).to.eql(
+        [idService1, idService2].sort()
+      );
+    });
+
+    it('donne le hash du SIRET de chaque service lu, pour pouvoir les regrouper', async () => {
+      await insereService('siret-1');
+
+      const services = await persistance.servicesComplets({
+        hashSirets: ['siret-1'],
+      });
+
+      expect(services[0].siretHash).to.be('siret-1');
+    });
+
+    it('ne lit aucun service si la liste de SIRET est vide', async () => {
+      await insereService('siret-1');
+
+      const services = await persistance.servicesComplets({ hashSirets: [] });
+
+      expect(services.length).to.be(0);
+    });
   });
 
   describe('concernant la lecture de plusieurs utilisateurs', () => {

--- a/test/adaptateurs/adaptateurPostgres.spec.js
+++ b/test/adaptateurs/adaptateurPostgres.spec.js
@@ -224,6 +224,55 @@ describe("L'adaptateur persistance Postgres", () => {
     });
   });
 
+  describe('concernant la lecture de plusieurs utilisateurs', () => {
+    it('sait lire en une fois les utilisateurs demandés', async () => {
+      const idUtilisateur1 = await insereUtilisateur();
+      const idUtilisateur2 = await insereUtilisateur();
+      await insereUtilisateur();
+
+      const utilisateurs = await persistance.utilisateursAvecIds([
+        idUtilisateur1,
+        idUtilisateur2,
+      ]);
+
+      expect(utilisateurs.length).to.be(2);
+      expect(utilisateurs.map((u) => u.id).sort()).to.eql(
+        [idUtilisateur1, idUtilisateur2].sort()
+      );
+    });
+
+    it('laisse les données chiffrées, comme la lecture unitaire', async () => {
+      const idUtilisateur = await insereUtilisateur();
+
+      const [utilisateur] = await persistance.utilisateursAvecIds([
+        idUtilisateur,
+      ]);
+
+      expect(utilisateur.donnees).to.eql({ email: 'unEmail' });
+      expect(utilisateur.emailHash).to.be('email');
+    });
+
+    it("ne lit aucun utilisateur si la liste d'identifiants est vide", async () => {
+      await insereUtilisateur();
+
+      const utilisateurs = await persistance.utilisateursAvecIds([]);
+
+      expect(utilisateurs.length).to.be(0);
+    });
+
+    it('ignore les identifiants qui ne correspondent à aucun utilisateur', async () => {
+      const idUtilisateur = await insereUtilisateur();
+
+      const utilisateurs = await persistance.utilisateursAvecIds([
+        idUtilisateur,
+        genereUUID(),
+      ]);
+
+      expect(utilisateurs.length).to.be(1);
+      expect(utilisateurs[0].id).to.be(idUtilisateur);
+    });
+  });
+
   describe('concernant la lecture des modèles de mesure spécifique', () => {
     it("sait lire les modèles de mesure spécifique d'un utilisateur", async () => {
       const idModele1 = await insereModeleMesureSpecifique({

--- a/test/adaptateurs/adaptateurPostgresTS.spec.ts
+++ b/test/adaptateurs/adaptateurPostgresTS.spec.ts
@@ -149,6 +149,88 @@ describe("L'adaptateur persistance Postgres", () => {
     });
   });
 
+  describe('sur demande de lecture des admins de plusieurs organisations', () => {
+    const entiteA = { nom: 'entiteA', siret: 'SIRET-A', departement: '75' };
+    const entiteB = { nom: 'entiteB', siret: 'SIRET-B', departement: '44' };
+
+    const ajouteAdminSur = async (idAdmin: string, entite: typeof entiteA) => {
+      await trx.table('admins_organisations').insert({
+        id_utilisateur: idAdmin,
+        siret_hash: chiffrement.hacheSha256(entite.siret),
+        donnees: await chiffrement.chiffre(entite),
+      });
+    };
+
+    it('associe à chaque SIRET demandé ses admins', async () => {
+      const idAdmin1 = unUUIDRandom();
+      const idAdmin2 = unUUIDRandom();
+      await ajouteAdminSur(idAdmin1, entiteA);
+      await ajouteAdminSur(idAdmin2, entiteB);
+
+      const parSiret = await persistance.lisAdminsOrganisations([
+        'SIRET-A',
+        'SIRET-B',
+      ]);
+
+      expect(parSiret.get('SIRET-A')).toEqual([
+        { idUtilisateur: idAdmin1, entitesAdministrees: [entiteA] },
+      ]);
+      expect(parSiret.get('SIRET-B')).toEqual([
+        { idUtilisateur: idAdmin2, entitesAdministrees: [entiteB] },
+      ]);
+    });
+
+    it("donne tout le périmètre d'un admin, pas seulement les SIRET demandés", async () => {
+      const idAdmin = unUUIDRandom();
+      await ajouteAdminSur(idAdmin, entiteA);
+      await ajouteAdminSur(idAdmin, entiteB);
+
+      const parSiret = await persistance.lisAdminsOrganisations(['SIRET-A']);
+
+      expect(parSiret.get('SIRET-A')![0].entitesAdministrees).toEqual([
+        entiteA,
+        entiteB,
+      ]);
+    });
+
+    it('associe une liste vide à un SIRET sans admin', async () => {
+      const parSiret = await persistance.lisAdminsOrganisations([
+        'SIRET-INCONNU',
+      ]);
+
+      expect(parSiret.get('SIRET-INCONNU')).toEqual([]);
+    });
+
+    it('ne lit rien si aucun SIRET est demandé', async () => {
+      const idAdmin = unUUIDRandom();
+      await ajouteAdminSur(idAdmin, entiteA);
+
+      const parSiret = await persistance.lisAdminsOrganisations([]);
+
+      expect(parSiret.size).toBe(0);
+    });
+
+    it('renvoie la même chose que la lecture SIRET par SIRET', async () => {
+      const idAdmin1 = unUUIDRandom();
+      const idAdmin2 = unUUIDRandom();
+      await ajouteAdminSur(idAdmin1, entiteA);
+      await ajouteAdminSur(idAdmin2, entiteA);
+      await ajouteAdminSur(idAdmin2, entiteB);
+
+      const parSiret = await persistance.lisAdminsOrganisations([
+        'SIRET-A',
+        'SIRET-B',
+      ]);
+
+      expect(parSiret.get('SIRET-A')).toEqual(
+        await persistance.lisAdminsOrganisation('SIRET-A')
+      );
+      expect(parSiret.get('SIRET-B')).toEqual(
+        await persistance.lisAdminsOrganisation('SIRET-B')
+      );
+    });
+  });
+
   describe("sur demande de lecture d'un superviseur", () => {
     it("retourne `undefined` s'il n'existe pas", async () => {
       const superviseur = await persistance.lisSuperviseur(unUUIDRandom());

--- a/test/adaptateurs/adaptateurPostgresTS.spec.ts
+++ b/test/adaptateurs/adaptateurPostgresTS.spec.ts
@@ -103,52 +103,6 @@ describe("L'adaptateur persistance Postgres", () => {
     });
   });
 
-  describe("sur demande de lecture des admins d'une organisation", () => {
-    it("retourne une liste vide s'il n'en existe pas", async () => {
-      const admin = await persistance.lisAdminsOrganisation('siret-inconnu');
-
-      expect(admin).toEqual([]);
-    });
-
-    it('peut lire des admins chiffrés', async () => {
-      const idAdmin1 = unUUIDRandom();
-      const idAdmin2 = unUUIDRandom();
-      const donneesEntite1 = { nom: 'nom', siret: 'SIRET', departement: '75' };
-      const donneesEntite2 = {
-        nom: 'nom2',
-        siret: 'SIRET2',
-        departement: '75',
-      };
-      const siretHash = chiffrement.hacheSha256('SIRET');
-      await trx.table('admins_organisations').insert({
-        id_utilisateur: idAdmin1,
-        siret_hash: siretHash,
-        donnees: await chiffrement.chiffre(donneesEntite1),
-      });
-      await trx.table('admins_organisations').insert({
-        id_utilisateur: idAdmin2,
-        siret_hash: siretHash,
-        donnees: await chiffrement.chiffre(donneesEntite1),
-      });
-      await trx.table('admins_organisations').insert({
-        id_utilisateur: idAdmin2,
-        siret_hash: chiffrement.hacheSha256('SIRET2'),
-        donnees: await chiffrement.chiffre(donneesEntite2),
-      });
-
-      const [admin, admin2] = await persistance.lisAdminsOrganisation('SIRET');
-
-      expect(admin).toEqual({
-        idUtilisateur: idAdmin1,
-        entitesAdministrees: [donneesEntite1],
-      });
-      expect(admin2).toEqual({
-        idUtilisateur: idAdmin2,
-        entitesAdministrees: [donneesEntite1, donneesEntite2],
-      });
-    });
-  });
-
   describe('sur demande de lecture des admins de plusieurs organisations', () => {
     const entiteA = { nom: 'entiteA', siret: 'SIRET-A', departement: '75' };
     const entiteB = { nom: 'entiteB', siret: 'SIRET-B', departement: '44' };
@@ -210,24 +164,19 @@ describe("L'adaptateur persistance Postgres", () => {
       expect(parSiret.size).toBe(0);
     });
 
-    it('renvoie la même chose que la lecture SIRET par SIRET', async () => {
+    it('associe à un même SIRET tous ses admins', async () => {
       const idAdmin1 = unUUIDRandom();
       const idAdmin2 = unUUIDRandom();
       await ajouteAdminSur(idAdmin1, entiteA);
       await ajouteAdminSur(idAdmin2, entiteA);
       await ajouteAdminSur(idAdmin2, entiteB);
 
-      const parSiret = await persistance.lisAdminsOrganisations([
-        'SIRET-A',
-        'SIRET-B',
-      ]);
+      const parSiret = await persistance.lisAdminsOrganisations(['SIRET-A']);
 
-      expect(parSiret.get('SIRET-A')).toEqual(
-        await persistance.lisAdminsOrganisation('SIRET-A')
-      );
-      expect(parSiret.get('SIRET-B')).toEqual(
-        await persistance.lisAdminsOrganisation('SIRET-B')
-      );
+      expect(parSiret.get('SIRET-A')).toEqual([
+        { idUtilisateur: idAdmin1, entitesAdministrees: [entiteA] },
+        { idUtilisateur: idAdmin2, entitesAdministrees: [entiteA, entiteB] },
+      ]);
     });
   });
 

--- a/test/depots/depotDonneesAdminsOrganisations.spec.ts
+++ b/test/depots/depotDonneesAdminsOrganisations.spec.ts
@@ -94,23 +94,6 @@ describe("Le dépôt de données « mode OO » des adminitrateurs d'organisation
 
       expect(parSiret.get('siret-A')).toEqual([]);
     });
-
-    it('renvoie la même chose que la lecture entité par entité', async () => {
-      const persistance = unePersistanceMemoireTS()
-        .ajouteAdminSurPerimetre(unUUID('A1'), [{ siret: 'siret-A' }])
-        .ajouteAdminSurPerimetre(unUUID('A3'), [
-          { siret: 'siret-B' },
-          { siret: 'siret-A' },
-        ])
-        .construis();
-      const depot = new DepotDonneesAdminsOrganisations({ persistance });
-
-      const parSiret = await depot.lisAdminsPourSirets(['siret-A']);
-
-      expect(parSiret.get('siret-A')).toEqual(
-        await depot.lisAdminsPour('siret-A')
-      );
-    });
   });
 
   it('sauvegarde un admin', async () => {

--- a/test/depots/depotDonneesAdminsOrganisations.spec.ts
+++ b/test/depots/depotDonneesAdminsOrganisations.spec.ts
@@ -51,6 +51,68 @@ describe("Le dépôt de données « mode OO » des adminitrateurs d'organisation
     expect(admins[1].donnees().idUtilisateur).toBe(unUUID('A3'));
   });
 
+  describe('sur demande des admins de plusieurs entités', () => {
+    it('associe à chaque SIRET ses admins', async () => {
+      const persistance = unePersistanceMemoireTS()
+        .ajouteAdminSurPerimetre(unUUID('A1'), [{ siret: 'siret-A' }])
+        .ajouteAdminSurPerimetre(unUUID('A2'), [{ siret: 'siret-B' }])
+        .ajouteAdminSurPerimetre(unUUID('A3'), [
+          { siret: 'siret-B' },
+          { siret: 'siret-A' },
+        ])
+        .construis();
+      const depot = new DepotDonneesAdminsOrganisations({ persistance });
+
+      const parSiret = await depot.lisAdminsPourSirets(['siret-A', 'siret-B']);
+
+      expect(
+        parSiret.get('siret-A')!.map((a) => a.donnees().idUtilisateur)
+      ).toEqual([unUUID('A1'), unUUID('A3')]);
+      expect(
+        parSiret.get('siret-B')!.map((a) => a.donnees().idUtilisateur)
+      ).toEqual([unUUID('A2'), unUUID('A3')]);
+    });
+
+    it('instancie bien des admins du domaine', async () => {
+      const persistance = unePersistanceMemoireTS()
+        .ajouteAdminSurPerimetre(unUUID('A1'), [{ siret: 'siret-A' }])
+        .construis();
+      const depot = new DepotDonneesAdminsOrganisations({ persistance });
+
+      const parSiret = await depot.lisAdminsPourSirets(['siret-A']);
+
+      expect(parSiret.get('siret-A')![0]).toBeInstanceOf(AdminOrganisations);
+    });
+
+    it('associe une liste vide à une entité sans admin', async () => {
+      const persistanceVide = unePersistanceMemoireTS().construis();
+      const depot = new DepotDonneesAdminsOrganisations({
+        persistance: persistanceVide,
+      });
+
+      const parSiret = await depot.lisAdminsPourSirets(['siret-A']);
+
+      expect(parSiret.get('siret-A')).toEqual([]);
+    });
+
+    it('renvoie la même chose que la lecture entité par entité', async () => {
+      const persistance = unePersistanceMemoireTS()
+        .ajouteAdminSurPerimetre(unUUID('A1'), [{ siret: 'siret-A' }])
+        .ajouteAdminSurPerimetre(unUUID('A3'), [
+          { siret: 'siret-B' },
+          { siret: 'siret-A' },
+        ])
+        .construis();
+      const depot = new DepotDonneesAdminsOrganisations({ persistance });
+
+      const parSiret = await depot.lisAdminsPourSirets(['siret-A']);
+
+      expect(parSiret.get('siret-A')).toEqual(
+        await depot.lisAdminsPour('siret-A')
+      );
+    });
+  });
+
   it('sauvegarde un admin', async () => {
     const persistance = unePersistanceMemoireTS()
       .ajouteAdminSurPerimetre(idAdmin, [

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -2422,6 +2422,114 @@ describe('Le dépôt de données des services', () => {
     });
   });
 
+  describe('sur demande de tous les services associés à plusieurs SIRET', () => {
+    let depot;
+    let referentiel;
+
+    beforeEach(() => {
+      referentiel = creeReferentielVide();
+      const adaptateurPersistance = unePersistanceMemoire()
+        .ajouteUnUtilisateur(unUtilisateur().avecId('moi').donnees)
+        .ajouteUnService(
+          unService(referentiel)
+            .avecId('S1')
+            .avecOrganisationResponsable({ siret: 'SIRET-A' }).donnees
+        )
+        .ajouteUnService(
+          unService(referentiel)
+            .avecId('S2')
+            .avecOrganisationResponsable({ siret: 'SIRET-A' }).donnees
+        )
+        .ajouteUnService(
+          unService(referentiel)
+            .avecId('S3')
+            .avecOrganisationResponsable({ siret: 'SIRET-B' }).donnees
+        )
+        .ajouteUneAutorisation(
+          uneAutorisation().deProprietaire('moi', 'S1').donnees
+        )
+        .construis();
+      const depotDonneesUtilisateurs = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurPersistance,
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
+      });
+      depot = DepotDonneesServices.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
+        adaptateurPersistance,
+        depotDonneesUtilisateurs,
+        referentiel,
+      });
+    });
+
+    it('délègue à la persistance la lecture de ces services, en une fois', async () => {
+      let hashSiretsRecus;
+      depot = DepotDonneesServices.creeDepot({
+        adaptateurChiffrement: {
+          hacheSha256: (chaine) => `${chaine}-SHA256`,
+        },
+        adaptateurPersistance: {
+          servicesComplets: async ({ hashSirets }) => {
+            hashSiretsRecus = hashSirets;
+            return [];
+          },
+        },
+      });
+
+      await depot.tousLesServicesAvecSirets(['SIRET-A', 'SIRET-B']);
+
+      expect(hashSiretsRecus).to.eql(['SIRET-A-SHA256', 'SIRET-B-SHA256']);
+    });
+
+    it('associe à chaque SIRET ses services', async () => {
+      const parSiret = await depot.tousLesServicesAvecSirets([
+        'SIRET-A',
+        'SIRET-B',
+      ]);
+
+      expect(parSiret.get('SIRET-A').map((s) => s.id)).to.eql(['S1', 'S2']);
+      expect(parSiret.get('SIRET-B').map((s) => s.id)).to.eql(['S3']);
+    });
+
+    it('associe une liste vide à un SIRET sans service', async () => {
+      const parSiret = await depot.tousLesServicesAvecSirets(['SIRET-INCONNU']);
+
+      expect(parSiret.get('SIRET-INCONNU')).to.eql([]);
+    });
+
+    it('enrichis les services récupérés', async () => {
+      const parSiret = await depot.tousLesServicesAvecSirets(['SIRET-A']);
+
+      expect(parSiret.get('SIRET-A')[0].contributeurs.length).to.be(1);
+    });
+
+    it('ne lit pas la persistance si aucun SIRET est demandé', async () => {
+      let persistanceLue = false;
+      depot = DepotDonneesServices.creeDepot({
+        adaptateurChiffrement: fauxAdaptateurChiffrement(),
+        adaptateurPersistance: {
+          servicesComplets: async () => {
+            persistanceLue = true;
+            return [];
+          },
+        },
+      });
+
+      const parSiret = await depot.tousLesServicesAvecSirets([]);
+
+      expect(persistanceLue).to.be(false);
+      expect(parSiret.size).to.be(0);
+    });
+
+    it('renvoie les mêmes services que la lecture SIRET par SIRET', async () => {
+      const parSiret = await depot.tousLesServicesAvecSirets(['SIRET-A']);
+      const unParUn = await depot.tousLesServicesAvecSiret('SIRET-A');
+
+      expect(parSiret.get('SIRET-A').map((s) => s.id)).to.eql(
+        unParUn.map((s) => s.id)
+      );
+    });
+  });
+
   describe("sur demande d'ajout de mesure spécifique", () => {
     let depot;
     let adaptateurPersistance;

--- a/test/depots/depotDonneesServices.spec.js
+++ b/test/depots/depotDonneesServices.spec.js
@@ -2396,28 +2396,10 @@ describe('Le dépôt de données des services', () => {
       });
     });
 
-    it('délègue à la persistance la lecture de ces services', async () => {
-      let hashSiretRecu;
-      depot = DepotDonneesServices.creeDepot({
-        adaptateurChiffrement: {
-          hacheSha256: (chaine) => `${chaine}-SHA256`,
-        },
-        adaptateurPersistance: {
-          servicesComplets: async ({ hashSiret }) => {
-            hashSiretRecu = hashSiret;
-            return [];
-          },
-        },
-      });
-
-      await depot.tousLesServicesAvecSiret('unSIRET');
-
-      expect(hashSiretRecu).to.be('unSIRET-SHA256');
-    });
-
-    it('enrichis les services récupérés', async () => {
+    it('retourne les services enrichis de ce SIRET', async () => {
       const services = await depot.tousLesServicesAvecSiret('unSIRET');
 
+      expect(services.map((s) => s.id)).to.eql(['S1']);
       expect(services[0].contributeurs.length).to.be(1);
     });
   });

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -512,6 +512,44 @@ describe('Le dépôt de données des utilisateurs', () => {
     expect(utilisateur.dateCreation).to.eql(date);
   });
 
+  describe("sur demande d'un utilisateur", () => {
+    it("retourne l'utilisateur déchiffré", async () => {
+      const depot = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurChiffrement,
+        adaptateurJWT,
+        adaptateurPersistance: AdaptateurPersistanceMemoire.nouvelAdaptateur({
+          utilisateurs: [
+            {
+              id: '123',
+              donnees: { prenom: 'Jean', nom: 'Dupont', email: 'jean@mail.fr' },
+              emailHash: 'jean@mail.fr-haché256',
+            },
+          ],
+        }),
+      });
+
+      const utilisateur = await depot.utilisateur('123');
+
+      expect(utilisateur).to.be.an(Utilisateur);
+      expect(utilisateur.id).to.equal('123');
+      expect(utilisateur.prenom).to.equal('Jean');
+    });
+
+    it("ne retourne rien si l'utilisateur n'existe pas", async () => {
+      const depot = DepotDonneesUtilisateurs.creeDepot({
+        adaptateurChiffrement,
+        adaptateurJWT,
+        adaptateurPersistance: AdaptateurPersistanceMemoire.nouvelAdaptateur({
+          utilisateurs: [],
+        }),
+      });
+
+      const utilisateur = await depot.utilisateur('inconnu');
+
+      expect(utilisateur).to.be(undefined);
+    });
+  });
+
   describe('sur demande de plusieurs utilisateurs', () => {
     const troisUtilisateurs = () =>
       AdaptateurPersistanceMemoire.nouvelAdaptateur({

--- a/test/depots/depotDonneesUtilisateurs.spec.js
+++ b/test/depots/depotDonneesUtilisateurs.spec.js
@@ -512,6 +512,71 @@ describe('Le dépôt de données des utilisateurs', () => {
     expect(utilisateur.dateCreation).to.eql(date);
   });
 
+  describe('sur demande de plusieurs utilisateurs', () => {
+    const troisUtilisateurs = () =>
+      AdaptateurPersistanceMemoire.nouvelAdaptateur({
+        utilisateurs: [
+          {
+            id: '1',
+            donnees: { prenom: 'Jean', nom: 'Dupont', email: 'jean@mail.fr' },
+            emailHash: 'jean@mail.fr-haché256',
+          },
+          {
+            id: '2',
+            donnees: { prenom: 'Alice', nom: 'Martin', email: 'alice@mail.fr' },
+            emailHash: 'alice@mail.fr-haché256',
+          },
+          {
+            id: '3',
+            donnees: { prenom: 'Bob', nom: 'Durand', email: 'bob@mail.fr' },
+            emailHash: 'bob@mail.fr-haché256',
+          },
+        ],
+      });
+
+    const depotAvecTroisUtilisateurs = () =>
+      DepotDonneesUtilisateurs.creeDepot({
+        adaptateurChiffrement,
+        adaptateurJWT,
+        adaptateurPersistance: troisUtilisateurs(),
+      });
+
+    it('retourne les utilisateurs demandés', async () => {
+      const depot = depotAvecTroisUtilisateurs();
+
+      const utilisateurs = await depot.utilisateurs(['1', '3']);
+
+      expect(utilisateurs.length).to.be(2);
+      expect(utilisateurs.map((u) => u.id)).to.eql(['1', '3']);
+    });
+
+    it('déchiffre les utilisateurs comme la lecture unitaire', async () => {
+      const depot = depotAvecTroisUtilisateurs();
+
+      const [utilisateur] = await depot.utilisateurs(['1']);
+
+      expect(utilisateur).to.be.an(Utilisateur);
+      expect(utilisateur.prenom).to.equal('Jean');
+      expect(utilisateur.adaptateurJWT).to.equal(adaptateurJWT);
+    });
+
+    it("retourne une liste vide si aucun identifiant n'est demandé", async () => {
+      const depot = depotAvecTroisUtilisateurs();
+
+      const utilisateurs = await depot.utilisateurs([]);
+
+      expect(utilisateurs).to.eql([]);
+    });
+
+    it('ignore les identifiants inconnus', async () => {
+      const depot = depotAvecTroisUtilisateurs();
+
+      const utilisateurs = await depot.utilisateurs(['1', 'inconnu']);
+
+      expect(utilisateurs.map((u) => u.id)).to.eql(['1']);
+    });
+  });
+
   describe("sur réception d'une demande d'enregistrement d'un nouvel utilisateur", () => {
     let depot;
 

--- a/test/supervision/serviceAdministrationOrganisations.spec.ts
+++ b/test/supervision/serviceAdministrationOrganisations.spec.ts
@@ -438,6 +438,151 @@ describe("Le service de gestion des admins d'organisation", () => {
       expect(entitesDe[0].nombreUtilisateurs).toBe(1);
     });
 
+    const mairieDeY = { siret: 'SIRET-456', nom: 'Une autre entité' };
+
+    const superviseLesDeuxEntites = async () => {
+      await adaptateurPersistanceTS.sauvegardeSuperviseur({
+        idUtilisateur: unUUID('S'),
+        entitesSupervisees: [
+          { siret: 'SIRET-123', nom: 'Mon entité' },
+          mairieDeY,
+        ],
+      });
+    };
+
+    const ajouteUnServiceSur = async (
+      idNouveauService: string,
+      siretHache: string,
+      idProprietaire: string
+    ) => {
+      await adaptateurPersistance.sauvegardeService(
+        idNouveauService,
+        unServiceV2().donnees,
+        '',
+        siretHache
+      );
+      await adaptateurPersistance.ajouteAutorisation(
+        unUUIDRandom(),
+        uneAutorisation().deProprietaire(idProprietaire, idNouveauService)
+          .donnees
+      );
+      await adaptateurPersistance.ajouteUtilisateur(
+        idProprietaire,
+        unUtilisateur().donnees
+      );
+    };
+
+    it('associe à chaque entité ses propres services', async () => {
+      await superviseLesDeuxEntites();
+      await ajouteUnServiceSur(
+        unUUID('S3'),
+        'SIRET-456-haché256',
+        unUUID('P2')
+      );
+      await ajouteUnServiceSur(
+        unUUID('S4'),
+        'SIRET-456-haché256',
+        unUUID('P3')
+      );
+
+      const entitesDe = await serviceAdministrationOrganisations.entitesDe(
+        unUUID('S')
+      );
+
+      expect(entitesDe).toHaveLength(2);
+      expect(entitesDe[0].siret).toBe('SIRET-123');
+      expect(entitesDe[0].nombreServices).toBe(1);
+      expect(entitesDe[0].nombreUtilisateurs).toBe(1);
+      expect(entitesDe[1].siret).toBe('SIRET-456');
+      expect(entitesDe[1].nombreServices).toBe(2);
+      expect(entitesDe[1].nombreUtilisateurs).toBe(2);
+    });
+
+    it('associe à chaque entité ses propres admins', async () => {
+      await superviseLesDeuxEntites();
+      await adaptateurPersistanceTS.sauvegardeAdminOrganisations({
+        idUtilisateur: unUUID('A2'),
+        entitesAdministrees: [mairieDeY],
+      });
+      await adaptateurPersistance.ajouteUtilisateur(
+        unUUID('A2'),
+        unUtilisateur().quiSAppelle('Alice Martin').avecPostes(['DPO']).donnees
+      );
+
+      const entitesDe = await serviceAdministrationOrganisations.entitesDe(
+        unUUID('S')
+      );
+
+      expect(entitesDe[0].administrateurs).toEqual([
+        {
+          id: unUUID('A'),
+          prenomNom: 'Jean Dujardin',
+          initiales: 'JD',
+          postes: 'RSSI',
+        },
+      ]);
+      expect(entitesDe[1].administrateurs).toEqual([
+        {
+          id: unUUID('A2'),
+          prenomNom: 'Alice Martin',
+          initiales: 'AM',
+          postes: 'DPO',
+        },
+      ]);
+    });
+
+    it("fait apparaître un admin de plusieurs entités dans chacune d'elles", async () => {
+      await superviseLesDeuxEntites();
+      await adaptateurPersistanceTS.sauvegardeAdminOrganisations({
+        idUtilisateur: unUUID('A'),
+        entitesAdministrees: [
+          { siret: 'SIRET-123', nom: 'Mon entité' },
+          mairieDeY,
+        ],
+      });
+
+      const entitesDe = await serviceAdministrationOrganisations.entitesDe(
+        unUUID('S')
+      );
+
+      expect(entitesDe[0].administrateurs.map((a) => a.id)).toEqual([
+        unUUID('A'),
+      ]);
+      expect(entitesDe[1].administrateurs.map((a) => a.id)).toEqual([
+        unUUID('A'),
+      ]);
+    });
+
+    it("renvoie une entité sans service ni admin plutôt que de l'omettre", async () => {
+      await superviseLesDeuxEntites();
+
+      const entitesDe = await serviceAdministrationOrganisations.entitesDe(
+        unUUID('S')
+      );
+
+      expect(entitesDe[1].siret).toBe('SIRET-456');
+      expect(entitesDe[1].nom).toBe('Une autre entité');
+      expect(entitesDe[1].nombreServices).toBe(0);
+      expect(entitesDe[1].nombreUtilisateurs).toBe(0);
+      expect(entitesDe[1].administrateurs).toEqual([]);
+    });
+
+    it("conserve l'ordre des entités du périmètre", async () => {
+      await adaptateurPersistanceTS.sauvegardeSuperviseur({
+        idUtilisateur: unUUID('S'),
+        entitesSupervisees: [
+          mairieDeY,
+          { siret: 'SIRET-123', nom: 'Mon entité' },
+        ],
+      });
+
+      const entitesDe = await serviceAdministrationOrganisations.entitesDe(
+        unUUID('S')
+      );
+
+      expect(entitesDe.map((e) => e.siret)).toEqual(['SIRET-456', 'SIRET-123']);
+    });
+
     it("renvoie un tableau vide s'il n'est ni admin ni superviseur", async () => {
       const service = leServiceDAdministrationDesOrgas();
 


### PR DESCRIPTION
... en commençant par afficher des "loaders".

Ensuite, on s'attache à transformer en "batch" toutes les méthodes qui doivent être appelées aujourd'hui :
- Lire plusieurs utilisateurs
- Lire plusieurs services pour plusieurs SIRET
- Lire plusieurs admins pour plusieurs SIRET