### PR TITLE
[CORRECTION] Utilise le SIRET d'un service si l'organisation n'a pas de nom

### DIFF
--- a/src/adaptateurs/adaptateurPdf.typst.ts
+++ b/src/adaptateurs/adaptateurPdf.typst.ts
@@ -168,7 +168,9 @@ export class AdaptateurPdfTypst implements AdaptateurPdf {
 
     const donnees: DonneesPdfSyntheseSecurite = {
       nomService: service.nomService(),
-      nomEntite: service.descriptionService.organisationResponsable.nom!,
+      nomEntite:
+        service.descriptionService.organisationResponsable.nom ??
+        service.descriptionService.organisationResponsable.siret,
       typeService: service.descriptionTypeService() ?? '',
       localisationDonnees: service.descriptionLocalisationDonnees() ?? '',
       statutDeploiement: service.descriptionStatutDeploiement() ?? '',

--- a/src/routes/connecte/routesConnecteApiServicePdf.js
+++ b/src/routes/connecte/routesConnecteApiServicePdf.js
@@ -48,7 +48,8 @@ const routesConnecteApiServicePdf = ({
       fonctionAutorite: dossierCourant.autorite.fonction,
       indiceCyberTotal: service.indiceCyber().total,
       organisationResponsable:
-        service.descriptionService.organisationResponsable.nom,
+        service.descriptionService.organisationResponsable.nom ??
+        service.descriptionService.organisationResponsable.siret,
       referentiel,
       ...dossierCourant.avis.toJSON(),
       ...dossierCourant.documents.toJSON(),

--- a/test/routes/connecte/routesConnecteApiServicePdf.spec.js
+++ b/test/routes/connecte/routesConnecteApiServicePdf.spec.js
@@ -227,6 +227,32 @@ describe('Le serveur MSS des routes /api/service/:id/pdf/*', () => {
       ]);
       expect(donneesDossier.documents).to.eql(['unDocument']);
     });
+
+    it("utilise le siret si l'organisation n'a pas de nom", async () => {
+      let donneesDossier;
+      const serviceARenvoyer = new Service(
+        {
+          id: '456',
+          descriptionService: {
+            nomService: 'un service',
+            organisationResponsable: { siret: 'UN_SIRET', nom: undefined },
+          },
+          dossiers: [unDossier(referentiel).donnees],
+        },
+        referentiel
+      );
+      serviceARenvoyer.mesures.indiceCyber = () => 3.5;
+      testeur.middleware().reinitialise({ serviceARenvoyer });
+
+      testeur.adaptateurPdf().genereDossierDecision = async (donnees) => {
+        donneesDossier = donnees;
+        return 'Pdf dossier décision';
+      };
+
+      await testeur.get('/api/service/456/pdf/dossierDecision.pdf');
+
+      expect(donneesDossier.organisationResponsable).to.be('UN_SIRET');
+    });
   });
 
   describe('quand requête GET sur `/api/service/:id/pdf/syntheseSecurite.pdf`', () => {


### PR DESCRIPTION
… car c'est le cas pour certains service en production.