### PR TITLE
[CORRECTION] Envoi bien vers Sentry si une erreur intervient dans le rapport hebdomadaire

### DIFF
--- a/scripts/taches/tacheEnvoiRapportHebdomadaire.ts
+++ b/scripts/taches/tacheEnvoiRapportHebdomadaire.ts
@@ -72,6 +72,7 @@ const main = async () => {
     rapport.push(...rapportTache);
   } catch (error: unknown) {
     const e = error as Error;
+    fabriqueAdaptateurGestionErreur().logueErreur(e);
     rapport.push(`💥 Erreur ! Elle a été envoyée dans Sentry… : ${e.message}`);
     codeRetour = 1;
   } finally {


### PR DESCRIPTION
… car on ne le logguait pas volontairement.